### PR TITLE
Stage-aware tip config + SSM RPC URLs

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -9,6 +9,21 @@
 
     "bootstrapWalletAddress": "0x80189edB676D51b2FB2257B2AD38e018B20CA46E",
 
+    "tipEnabledLab": "true",
+    "tipChainIdLab": "11155111",
+    "tipContractAddressLab": "0xf5Fecc44276dBc1Bf45c40dC7f3cCb1aAfb2AAfe",
+    "tipRpcUrlSsmParamLab": "/lesser-host/api/infura/sepolia",
+
+    "tipEnabledLive": "false",
+    "tipChainIdLive": "1",
+    "tipContractAddressLive": "",
+    "tipRpcUrlSsmParamLive": "/lesser-host/api/infura/mainnet",
+
+    "tipAdminSafeAddress": "0xfE63333F303D4f7b2354f7E3eca752C812D65907",
+    "tipDefaultHostWalletAddress": "0x80189edB676D51b2FB2257B2AD38e018B20CA46E",
+    "tipDefaultHostFeeBps": "500",
+    "tipTxMode": "safe",
+
     "webauthnRpId": "lesser.host",
     "webauthnOrigins": "https://lab.lesser.host,https://lesser.host",
 

--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -130,15 +130,24 @@ export class LesserHostStack extends cdk.Stack {
 		const managedLesserGitHubTokenSsmParam =
 			(this.node.tryGetContext('managedLesserGitHubTokenSsmParam') as string | undefined) ?? '';
 
-		const tipEnabled = (this.node.tryGetContext('tipEnabled') as string | undefined) ?? '';
-		const tipChainId = (this.node.tryGetContext('tipChainId') as string | undefined) ?? '';
-		const tipRpcUrl = (this.node.tryGetContext('tipRpcUrl') as string | undefined) ?? '';
-		const tipContractAddress = (this.node.tryGetContext('tipContractAddress') as string | undefined) ?? '';
-		const tipAdminSafeAddress = (this.node.tryGetContext('tipAdminSafeAddress') as string | undefined) ?? '';
-		const tipDefaultHostWalletAddress =
-			(this.node.tryGetContext('tipDefaultHostWalletAddress') as string | undefined) ?? '';
-		const tipDefaultHostFeeBps = (this.node.tryGetContext('tipDefaultHostFeeBps') as string | undefined) ?? '';
-		const tipTxMode = (this.node.tryGetContext('tipTxMode') as string | undefined) ?? '';
+		const tipStageSuffix = stage === 'live' ? 'Live' : 'Lab';
+		const tipContext = (key: string): string =>
+			(this.node.tryGetContext(`${key}${tipStageSuffix}`) as string | undefined) ??
+			(this.node.tryGetContext(key) as string | undefined) ??
+			'';
+
+		const tipEnabled = tipContext('tipEnabled');
+		const tipChainId = tipContext('tipChainId');
+		const tipContractAddress = tipContext('tipContractAddress');
+		const tipAdminSafeAddress = tipContext('tipAdminSafeAddress');
+		const tipDefaultHostWalletAddress = tipContext('tipDefaultHostWalletAddress');
+		const tipDefaultHostFeeBps = tipContext('tipDefaultHostFeeBps');
+		const tipTxMode = tipContext('tipTxMode');
+
+		const tipRpcUrlSsmParam = tipContext('tipRpcUrlSsmParam');
+		const tipRpcUrl = tipRpcUrlSsmParam.trim()
+			? cdk.SecretValue.ssmSecure(tipRpcUrlSsmParam.trim()).toString()
+			: tipContext('tipRpcUrl');
 
 		const paymentsProvider = (this.node.tryGetContext('paymentsProvider') as string | undefined) ?? '';
 		const paymentsCentsPer1000Credits =


### PR DESCRIPTION
## Summary
- add stage-aware tip context selection (lab vs live)
- read Sepolia/Mainnet RPC URLs from SSM SecureString
- set lab defaults for Sepolia in `cdk/cdk.json`

## Testing
- not run