### PR TITLE
Docs: client-side tipping integration guide (TipSplitter)

### DIFF
--- a/docs/tip-registry.md
+++ b/docs/tip-registry.md
@@ -36,6 +36,8 @@ Updates that **increase** wallet/fee require **both** proofs.
 ## API (control-plane)
 
 Public:
+- `GET /api/v1/tip-registry/config`
+  - returns `{ enabled, chain_id, contract_address }` for client integrations
 - `POST /api/v1/tip-registry/registrations/begin`
   - body: `{ kind?, domain, wallet_address, host_fee_bps }`
   - response includes:
@@ -73,4 +75,3 @@ TIP_DEFAULT_HOST_WALLET_ADDRESS=0x...
 TIP_DEFAULT_HOST_FEE_BPS=500
 TIP_TX_MODE=safe
 ```
-

--- a/docs/tipping-client-integration.md
+++ b/docs/tipping-client-integration.md
@@ -1,0 +1,157 @@
+# Client-Side Tipping Integration Guide (TipSplitter)
+
+This guide is for client implementers integrating `lesser.host` tipping into an instance frontend (for example, UI served
+under `/l/*` on an instance domain).
+
+References:
+- TipSplitter contract: `contracts/contracts/TipSplitter.sol`
+- Tip registry + `hostId` rules: `docs/tip-registry.md`
+
+---
+
+## Overview
+
+Tips are sent on-chain to the `TipSplitter` contract, which splits the payment between:
+- the Lesser org wallet (fixed 1% fee),
+- the host instance wallet (configurable host fee),
+- the actor wallet (remainder).
+
+Client transactions call one of:
+- `tipETH(bytes32 hostId, address actor, bytes32 contentHash)` (native ETH)
+- `tipToken(address token, bytes32 hostId, address actor, uint256 amount, bytes32 contentHash)` (ERC-20)
+
+The emitted `TipSent` event includes:
+- `hostId` (bytes32) — identifies the instance domain being tipped through
+- `actor` (address) — the recipient actor wallet
+- `contentHash` (bytes32) — links the tip to the content being tipped for
+
+---
+
+## 1) Compute `hostId` (domain → bytes32)
+
+`hostId` must use the **canonical lesser.host normalization + hashing rule**.
+
+At a high level:
+1. Normalize the domain (trim, strip trailing `.`, lowercase, reject scheme/path/port, IDNA → ASCII).
+2. Hash: `hostId = keccak256(utf8(normalizedDomain))`.
+
+Full canonical rules (and the server implementation) are documented in `docs/tip-registry.md`.
+
+### Practical client guidance
+
+- If you are tipping for the current instance domain, prefer `window.location.hostname` as the input domain.
+  - It is already scheme/path/port-free, and is typically already ASCII (punycode) for IDNs.
+- Always apply the final canonical rule: lowercase + `keccak256(utf8(...))`.
+
+Example (TypeScript, ethers v6):
+
+```ts
+import { keccak256, toUtf8Bytes } from "ethers";
+
+const normalizedDomain = window.location.hostname.replace(/\.$/, "").trim().toLowerCase();
+const hostId = keccak256(toUtf8Bytes(normalizedDomain)); // 0x… (bytes32)
+```
+
+---
+
+## 2) Discover tip config (chain + contract) for managed instances
+
+Do not hardcode the chain or contract address.
+
+Managed instances should fetch the current platform tip config from the control plane:
+
+- `GET /api/v1/tip-registry/config`
+
+Response shape:
+
+```json
+{
+  "enabled": true,
+  "chain_id": 11155111,
+  "contract_address": "0xf5Fecc44276dBc1Bf45c40dC7f3cCb1aAfb2AAfe"
+}
+```
+
+Notes:
+- If `enabled` is false (or the endpoint returns 404), the instance should hide/disable tipping UI.
+- Clients should treat this as cacheable configuration (it rarely changes).
+
+---
+
+## 3) Recommended `contentHash` convention (`TipSent.contentHash`)
+
+`contentHash` is intended for ecosystem-wide analytics and attribution. To avoid fragmentation, clients should use a
+single convention.
+
+### Canonical convention (recommended)
+
+Use the ActivityPub object ID URI (`object.id`) for the content being tipped, and compute:
+
+`contentHash = keccak256(utf8(object.id.trim()))`
+
+Guidelines:
+- Use the **canonical ActivityPub ID** (`object.id`), not the HTML URL.
+- Do not reserialize or normalize the URI beyond `trim()` (avoid library-specific canonicalization differences).
+- If there is no specific object (e.g., “tip this actor” from a profile page), use `bytes32(0)` and rely on `actor`.
+
+Example (TypeScript, ethers v6):
+
+```ts
+import { keccak256, toUtf8Bytes, ZeroHash } from "ethers";
+
+const contentHash = objectId ? keccak256(toUtf8Bytes(objectId.trim())) : ZeroHash;
+```
+
+---
+
+## 4) Resolving ActivityPub actor → EVM address (until first-class API exists)
+
+The `TipSplitter` contract requires an EVM address for `actor`. Until there is a first-class resolution API, clients
+need a convention.
+
+### Recommended convention
+
+Prefer a **CAIP-10** account ID in the actor’s profile metadata:
+
+- Field name: `Wallet` (or `Ethereum`)
+- Field value: `eip155:<chainId>:<0xAddress>`
+  - Example: `eip155:8453:0x1234…abcd`
+
+Fallbacks (in order):
+1. A plain `0x…` address in the same profile field (interpreted on the platform tip chain).
+2. If no address is present, disable tipping for that actor and prompt the user/actor to add a wallet field.
+
+Important:
+- Treat profile-provided wallet addresses as **self-asserted** (not verified).
+- Always display the resolved address to the tipper before sending.
+
+---
+
+## Suggested UX flows
+
+### Wallet connect (EIP-1193)
+- Detect an injected provider (`window.ethereum`), and request accounts with `eth_requestAccounts`.
+- Persist only the selected account address; re-check on each page load.
+- Handle user rejection explicitly (do not treat as an error state).
+
+### Chain switching
+- Fetch current chain via `eth_chainId`.
+- If mismatch, attempt `wallet_switchEthereumChain`.
+- If the chain isn’t installed (common error code `4902`), fall back to `wallet_addEthereumChain` then retry switch.
+
+### Token selection / allowlist display
+- Always offer ETH (native token).
+- Optionally offer a curated set of ERC-20s (e.g. stablecoins) and hide any that are not allowed by the contract:
+  - Query `TipSplitter.allowedTokens(tokenAddress)` before rendering token options.
+- For ERC-20 tips:
+  - Check allowance and guide the user through `approve` (or `permit` if you implement it) before sending the tip.
+
+### Transaction status + error handling
+- Show clear states: “waiting for wallet”, “submitted”, “confirmed”, “failed”.
+- Provide an explorer link from the tx hash.
+- Handle common revert reasons gracefully:
+  - “host not active” (domain not registered/active)
+  - “token not allowed”
+  - “amount below minimum”
+  - “cannot tip yourself”
+

--- a/internal/controlplane/handlers_tip_registry_config.go
+++ b/internal/controlplane/handlers_tip_registry_config.go
@@ -1,0 +1,41 @@
+package controlplane
+
+import (
+	"net/http"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+type tipRegistryConfigResponse struct {
+	Enabled         bool   `json:"enabled"`
+	ChainID         int64  `json:"chain_id"`
+	ContractAddress string `json:"contract_address"`
+}
+
+func (s *Server) handleTipRegistryConfig(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if s == nil || ctx == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	contractAddr := strings.TrimSpace(s.cfg.TipContractAddress)
+	if !s.cfg.TipEnabled || s.cfg.TipChainID <= 0 || contractAddr == "" {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+
+	resp, err := apptheory.JSON(http.StatusOK, tipRegistryConfigResponse{
+		Enabled:         true,
+		ChainID:         s.cfg.TipChainID,
+		ContractAddress: contractAddr,
+	})
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	if resp.Headers == nil {
+		resp.Headers = map[string][]string{}
+	}
+	resp.Headers["cache-control"] = []string{"public, max-age=3600"}
+	resp.Headers["access-control-allow-origin"] = []string{"*"}
+	return resp, nil
+}

--- a/internal/controlplane/handlers_tip_registry_config_internal_test.go
+++ b/internal/controlplane/handlers_tip_registry_config_internal_test.go
@@ -1,0 +1,49 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+)
+
+func TestHandleTipRegistryConfig_NotFoundWhenNotConfigured(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{}}
+	if _, err := s.handleTipRegistryConfig(&apptheory.Context{}); err == nil {
+		t.Fatalf("expected not_found")
+	} else if appErr, ok := err.(*apptheory.AppError); !ok || appErr.Code != "app.not_found" {
+		t.Fatalf("expected app.not_found, got %#v", err)
+	}
+}
+
+func TestHandleTipRegistryConfig_Success(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		cfg: config.Config{
+			TipEnabled:         true,
+			TipChainID:         11155111,
+			TipContractAddress: "0xf5Fecc44276dBc1Bf45c40dC7f3cCb1aAfb2AAfe",
+		},
+	}
+
+	resp, err := s.handleTipRegistryConfig(&apptheory.Context{})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, 200, resp.Status)
+
+	var out tipRegistryConfigResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.True(t, out.Enabled)
+	require.Equal(t, int64(11155111), out.ChainID)
+	require.Equal(t, "0xf5Fecc44276dBc1Bf45c40dC7f3cCb1aAfb2AAfe", out.ContractAddress)
+
+	require.Equal(t, []string{"public, max-age=3600"}, resp.Headers["cache-control"])
+	require.Equal(t, []string{"*"}, resp.Headers["access-control-allow-origin"])
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -136,6 +136,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Delete("/api/v1/instances/{slug}/domains/{domain}", s.handleDeleteInstanceDomain, apptheory.RequireAuth())
 
 	// Tip registry (public registration flow + admin reconciliation).
+	app.Get("/api/v1/tip-registry/config", s.handleTipRegistryConfig)
 	app.Post("/api/v1/tip-registry/registrations/begin", s.handleTipHostRegistrationBegin)
 	app.Post("/api/v1/tip-registry/registrations/{id}/verify", s.handleTipHostRegistrationVerify)
 	app.Get("/api/v1/tip-registry/operations", s.handleListTipRegistryOperations, apptheory.RequireAuth())


### PR DESCRIPTION
Adds a client-side TipSplitter tipping integration guide and a public endpoint for discovering the current tip chain + contract for managed instances.

- New guide: `docs/tipping-client-integration.md`
- New public config endpoint: `GET /api/v1/tip-registry/config`

Closes #9.