### PR TITLE
Fix budget debit conditions

### DIFF
--- a/internal/ai/service.go
+++ b/internal/ai/service.go
@@ -534,13 +534,17 @@ func (s *Service) queueWithDebit(ctx context.Context, prepared getOrQueuePrepare
 
 	pk := fmt.Sprintf("INSTANCE#%s", prepared.InstanceSlug)
 	sk := fmt.Sprintf("BUDGET#%s", prepared.Month)
+	maxUsed := int64(0)
+	if budget != nil {
+		maxUsed = budget.IncludedCredits - prepared.CreditsRequested
+	}
 
 	err := s.store.DB.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 		tx.Create(job)
 		tx.Put(ledger)
 		tx.Put(auditBudget)
 		tx.Put(auditJob)
-		return s.applyBudgetDebit(tx, updateBudget, prepared.Now, prepared.CreditsRequested, req.AllowOverage)
+		return s.applyBudgetDebit(tx, updateBudget, prepared.Now, maxUsed, prepared.CreditsRequested, req.AllowOverage)
 	})
 	if theoryErrors.IsConditionFailed(err) {
 		return s.handleDebitConditionFailed(ctx, prepared, pk, sk, prepared.CreditsRequested)
@@ -553,7 +557,7 @@ func (s *Service) queueWithDebit(ctx context.Context, prepared getOrQueuePrepare
 	return queuedWithDebitResponse(prepared, latest, overageDebited), nil
 }
 
-func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.InstanceBudgetMonth, now time.Time, creditsRequested int64, allowOverage bool) error {
+func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.InstanceBudgetMonth, now time.Time, maxUsed int64, creditsRequested int64, allowOverage bool) error {
 	if tx == nil || budget == nil {
 		return nil
 	}
@@ -574,10 +578,9 @@ func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.In
 	},
 		tabletheory.IfExists(),
 		tabletheory.ConditionExpression(
-			"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+			"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 			map[string]any{
-				":zero":  int64(0),
-				":delta": creditsRequested,
+				":max": maxUsed,
 			},
 		),
 	)

--- a/internal/ai/service_internal_test.go
+++ b/internal/ai/service_internal_test.go
@@ -295,6 +295,44 @@ func TestServiceGetOrQueue_QueueNoChargeAndDebit(t *testing.T) {
 	}
 }
 
+func TestServiceGetOrQueue_AllowOverage_DebitsAndReturnsOverageReason(t *testing.T) {
+	t.Parallel()
+
+	tdb := newAIServiceTestDB()
+	svc := NewService(store.New(tdb.db))
+
+	tdb.qRes.On("First", mock.AnythingOfType("*models.AIResult")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qJob.On("First", mock.AnythingOfType("*models.AIJob")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{IncludedCredits: 0, UsedCredits: 0}
+		_ = dest.UpdateKeys()
+	}).Once()
+	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{IncludedCredits: 0, UsedCredits: 10}
+		_ = dest.UpdateKeys()
+	}).Once()
+
+	resp, err := svc.GetOrQueue(context.Background(), Request{
+		InstanceSlug:  "inst",
+		RequestID:     "rid",
+		Module:        "moderation_text_llm",
+		PolicyVersion: "v1",
+		ModelSet:      "deterministic",
+		Inputs:        map[string]any{"text": "hello"},
+		BaseCredits:   10,
+		AllowOverage:  true,
+	})
+	require.NoError(t, err)
+	require.Equal(t, JobStatusQueued, resp.Status)
+	require.True(t, resp.Budget.Allowed)
+	require.True(t, resp.Budget.OverBudget)
+	require.Equal(t, "overage", resp.Budget.Reason)
+	require.Equal(t, int64(0), resp.Budget.IncludedCredits)
+	require.Equal(t, int64(10), resp.Budget.UsedCredits)
+}
+
 func TestServiceHandleDebitConditionFailed_CoversBranches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/models/ai_job.go
+++ b/internal/store/models/ai_job.go
@@ -21,36 +21,36 @@ type AIJob struct {
 	SK  string `theorydb:"sk,attr:SK" json:"-"`
 	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
 
-	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK" json:"-"`
-	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK" json:"-"`
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
 
 	ID string `theorydb:"attr:id" json:"id"`
 
-	InstanceSlug string `theorydb:"attr:instanceSlug" json:"instance_slug,omitempty"`
+	InstanceSlug string `theorydb:"attr:instanceSlug,omitempty" json:"instance_slug,omitempty"`
 
 	Module        string `theorydb:"attr:module" json:"module"`
 	PolicyVersion string `theorydb:"attr:policyVersion" json:"policy_version"`
 	ModelSet      string `theorydb:"attr:modelSet" json:"model_set"`
 
-	CacheScope string `theorydb:"attr:cacheScope" json:"cache_scope,omitempty"`
-	ScopeKey   string `theorydb:"attr:scopeKey" json:"scope_key,omitempty"`
+	CacheScope string `theorydb:"attr:cacheScope,omitempty" json:"cache_scope,omitempty"`
+	ScopeKey   string `theorydb:"attr:scopeKey,omitempty" json:"scope_key,omitempty"`
 	InputsHash string `theorydb:"attr:inputsHash" json:"inputs_hash"`
 
-	InputsJSON string          `theorydb:"attr:inputsJson" json:"inputs_json,omitempty"`
-	Evidence   []AIEvidenceRef `theorydb:"attr:evidence" json:"evidence,omitempty"`
+	InputsJSON string          `theorydb:"attr:inputsJson,omitempty" json:"inputs_json,omitempty"`
+	Evidence   []AIEvidenceRef `theorydb:"attr:evidence,omitempty" json:"evidence,omitempty"`
 
 	Status string `theorydb:"attr:status" json:"status"` // queued|ok|error
 
 	Attempts    int64 `theorydb:"attr:attempts" json:"attempts"`
 	MaxAttempts int64 `theorydb:"attr:maxAttempts" json:"max_attempts,omitempty"`
 
-	ErrorCode    string `theorydb:"attr:errorCode" json:"error_code,omitempty"`
-	ErrorMessage string `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
+	ErrorCode    string `theorydb:"attr:errorCode,omitempty" json:"error_code,omitempty"`
+	ErrorMessage string `theorydb:"attr:errorMessage,omitempty" json:"error_message,omitempty"`
 
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
 	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
 	ExpiresAt time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
-	RequestID string    `theorydb:"attr:requestId" json:"request_id,omitempty"`
+	RequestID string    `theorydb:"attr:requestId,omitempty" json:"request_id,omitempty"`
 }
 
 // TableName returns the database table name for AIJob.

--- a/internal/store/models/ai_shared.go
+++ b/internal/store/models/ai_shared.go
@@ -5,18 +5,18 @@ type AIEvidenceRef struct {
 	_ struct{} `theorydb:"naming:camelCase"`
 
 	Kind        string `theorydb:"attr:kind" json:"kind"`
-	Ref         string `theorydb:"attr:ref" json:"ref,omitempty"`
-	Hash        string `theorydb:"attr:hash" json:"hash,omitempty"`
+	Ref         string `theorydb:"attr:ref,omitempty" json:"ref,omitempty"`
+	Hash        string `theorydb:"attr:hash,omitempty" json:"hash,omitempty"`
 	Bytes       int64  `theorydb:"attr:bytes" json:"bytes,omitempty"`
-	ContentType string `theorydb:"attr:contentType" json:"content_type,omitempty"`
+	ContentType string `theorydb:"attr:contentType,omitempty" json:"content_type,omitempty"`
 }
 
 // AIUsage captures provider usage metadata for an AI request.
 type AIUsage struct {
 	_ struct{} `theorydb:"naming:camelCase"`
 
-	Provider string `theorydb:"attr:provider" json:"provider,omitempty"`
-	Model    string `theorydb:"attr:model" json:"model,omitempty"`
+	Provider string `theorydb:"attr:provider,omitempty" json:"provider,omitempty"`
+	Model    string `theorydb:"attr:model,omitempty" json:"model,omitempty"`
 
 	InputTokens  int64 `theorydb:"attr:inputTokens" json:"input_tokens,omitempty"`
 	OutputTokens int64 `theorydb:"attr:outputTokens" json:"output_tokens,omitempty"`

--- a/internal/store/models/link_safety_basic_result.go
+++ b/internal/store/models/link_safety_basic_result.go
@@ -26,14 +26,14 @@ type LinkSafetyBasicLinkResult struct {
 	_ struct{} `theorydb:"naming:camelCase"`
 
 	URL           string   `theorydb:"attr:url" json:"url"`
-	NormalizedURL string   `theorydb:"attr:normalizedUrl" json:"normalized_url,omitempty"`
-	Host          string   `theorydb:"attr:host" json:"host,omitempty"`
-	Flags         []string `theorydb:"attr:flags" json:"flags,omitempty"`
+	NormalizedURL string   `theorydb:"attr:normalizedUrl,omitempty" json:"normalized_url,omitempty"`
+	Host          string   `theorydb:"attr:host,omitempty" json:"host,omitempty"`
+	Flags         []string `theorydb:"attr:flags,omitempty" json:"flags,omitempty"`
 
 	Risk string `theorydb:"attr:risk" json:"risk"`
 
-	ErrorCode    string `theorydb:"attr:errorCode" json:"error_code,omitempty"`
-	ErrorMessage string `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
+	ErrorCode    string `theorydb:"attr:errorCode,omitempty" json:"error_code,omitempty"`
+	ErrorMessage string `theorydb:"attr:errorMessage,omitempty" json:"error_message,omitempty"`
 }
 
 // LinkSafetyBasicResult stores the output of the link-safety-basic analysis module.

--- a/internal/store/models/usage_ledger_entry.go
+++ b/internal/store/models/usage_ledger_entry.go
@@ -26,11 +26,11 @@ type UsageLedgerEntry struct {
 	Month        string `theorydb:"attr:month" json:"month"` // YYYY-MM
 
 	Module string `theorydb:"attr:module" json:"module"`
-	Target string `theorydb:"attr:target" json:"target,omitempty"`
+	Target string `theorydb:"attr:target,omitempty" json:"target,omitempty"`
 
 	Cached    bool   `theorydb:"attr:cached" json:"cached"`
-	Reason    string `theorydb:"attr:reason" json:"reason,omitempty"`
-	RequestID string `theorydb:"attr:requestId" json:"request_id,omitempty"`
+	Reason    string `theorydb:"attr:reason,omitempty" json:"reason,omitempty"`
+	RequestID string `theorydb:"attr:requestId,omitempty" json:"request_id,omitempty"`
 
 	RequestedCredits int64 `theorydb:"attr:requestedCredits" json:"requested_credits"`
 	ListCredits      int64 `theorydb:"attr:listCredits" json:"list_credits,omitempty"`
@@ -44,10 +44,10 @@ type UsageLedgerEntry struct {
 
 	BillingType string `theorydb:"attr:billingType" json:"billing_type"` // included|overage|none|mixed
 
-	ActorURI    string `theorydb:"attr:actorUri" json:"actor_uri,omitempty"`
-	ObjectURI   string `theorydb:"attr:objectUri" json:"object_uri,omitempty"`
-	ContentHash string `theorydb:"attr:contentHash" json:"content_hash,omitempty"`
-	LinksHash   string `theorydb:"attr:linksHash" json:"links_hash,omitempty"`
+	ActorURI    string `theorydb:"attr:actorUri,omitempty" json:"actor_uri,omitempty"`
+	ObjectURI   string `theorydb:"attr:objectUri,omitempty" json:"object_uri,omitempty"`
+	ContentHash string `theorydb:"attr:contentHash,omitempty" json:"content_hash,omitempty"`
+	LinksHash   string `theorydb:"attr:linksHash,omitempty" json:"links_hash,omitempty"`
 
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
 }

--- a/internal/trust/handlers_ai_claims.go
+++ b/internal/trust/handlers_ai_claims.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -189,6 +190,7 @@ func (s *Server) handleAIClaimVerify(ctx *apptheory.Context) (*apptheory.Respons
 		MaxInflightJobs:      instCfg.AIMaxInflightJobs,
 	})
 	if err != nil {
+		fmt.Printf("ai.GetOrQueue error request_id=%s instance=%s module=%s err=%v\n", strings.TrimSpace(ctx.RequestID), instanceSlug, ai.ClaimVerifyLLMModule, err)
 		s.emitAIRequestMetrics(instanceSlug, ai.ClaimVerifyLLMModule, ai.Response{Status: ai.JobStatusError}, err)
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to queue job"}
 	}

--- a/internal/trust/handlers_ai_claims_internal_test.go
+++ b/internal/trust/handlers_ai_claims_internal_test.go
@@ -359,3 +359,32 @@ func TestHandleAIClaimVerify_OpenAIWebSearchRequiresOpenAIModel(t *testing.T) {
 		t.Fatalf("expected bad_request, got %T: %v", err, err)
 	}
 }
+
+func TestHandleAIClaimVerify_ReturnsInternalErrorWhenAIServiceNotReady(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		ai:    ai.NewService(nil),
+		store: store.New(nil), // trust config store not ready -> default config
+	}
+
+	body, _ := json.Marshal(claimVerifyRequest{
+		Claims: []string{"hello"},
+		Evidence: []claimVerifyEvidenceRequest{
+			{SourceID: "s1", Text: "evidence"},
+		},
+	})
+	ctx := &apptheory.Context{
+		AuthIdentity: "inst",
+		RequestID:    "rid",
+		Request:      apptheory.Request{Body: body},
+	}
+
+	_, err := s.handleAIClaimVerify(ctx)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if appErr, ok := err.(*apptheory.AppError); !ok || appErr.Code != "app.internal" {
+		t.Fatalf("expected app.internal, got %T: %v", err, err)
+	}
+}

--- a/internal/trust/handlers_budget.go
+++ b/internal/trust/handlers_budget.go
@@ -86,7 +86,8 @@ func (s *Server) handleBudgetDebit(ctx *apptheory.Context) (*apptheory.Response,
 	ledger := buildBudgetDebitLedgerEntry(prepared, now, billingType, includedDebited, overageDebited)
 	audit := buildBudgetDebitAuditEntry(prepared, now)
 
-	err = s.transactBudgetDebit(ctx.Context(), update, prepared.AllowOverage, prepared.Credits, now, ledger, audit)
+	maxUsed := budget.IncludedCredits - prepared.Credits
+	err = s.transactBudgetDebit(ctx.Context(), update, prepared.AllowOverage, maxUsed, prepared.Credits, now, ledger, audit)
 	if theoryErrors.IsConditionFailed(err) {
 		latest, _, _ := s.loadInstanceBudgetMonth(ctx.Context(), prepared.PK, prepared.SK)
 		remaining = latest.IncludedCredits - latest.UsedCredits
@@ -212,6 +213,7 @@ func (s *Server) transactBudgetDebit(
 	ctx context.Context,
 	update *models.InstanceBudgetMonth,
 	allowOverage bool,
+	maxUsed int64,
 	credits int64,
 	now time.Time,
 	ledger *models.UsageLedgerEntry,
@@ -226,10 +228,9 @@ func (s *Server) transactBudgetDebit(
 		if !allowOverage {
 			conditions = append(conditions,
 				tabletheory.ConditionExpression(
-					"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+					"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 					map[string]any{
-						":zero":  int64(0),
-						":delta": credits,
+						":max": maxUsed,
 					},
 				),
 			)

--- a/internal/trust/handlers_budget_internal_test.go
+++ b/internal/trust/handlers_budget_internal_test.go
@@ -150,10 +150,10 @@ func TestTransactBudgetDebit(t *testing.T) {
 	audit := &models.AuditLogEntry{Actor: testBudgetInstanceSlug, Action: "budget.debit", Target: "x"}
 	_ = audit.UpdateKeys()
 
-	if err := s.transactBudgetDebit(context.Background(), update, false, 5, now, ledger, audit); err != nil {
+	if err := s.transactBudgetDebit(context.Background(), update, false, 5, 5, now, ledger, audit); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if err := s.transactBudgetDebit(context.Background(), update, true, 5, now, ledger, audit); err != nil {
+	if err := s.transactBudgetDebit(context.Background(), update, true, 5, 5, now, ledger, audit); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 }

--- a/internal/trust/handlers_previews.go
+++ b/internal/trust/handlers_previews.go
@@ -520,14 +520,14 @@ func (s *Server) debitBudgetForPreviewRender(ctx *apptheory.Context, instanceSlu
 	}
 	_ = auditBudget.UpdateKeys()
 
+	maxUsed := budget.IncludedCredits - linkRenderCreditCost
 	budgetUpdateConditions := []core.TransactCondition{tabletheory.IfExists()}
 	if !allowOverage {
 		budgetUpdateConditions = append(budgetUpdateConditions,
 			tabletheory.ConditionExpression(
-				"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+				"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 				map[string]any{
-					":zero":  int64(0),
-					":delta": linkRenderCreditCost,
+					":max": maxUsed,
 				},
 			),
 		)

--- a/internal/trust/handlers_previews_more_internal_test.go
+++ b/internal/trust/handlers_previews_more_internal_test.go
@@ -295,7 +295,7 @@ func TestLinkPreviewResponseFromModel_StatusAndImageURL(t *testing.T) {
 
 	item.ErrorCode = "fetch_failed"
 	resp = linkPreviewResponseFromModel(ctx, item, true)
-	if resp.Status != "error" {
+	if resp.Status != statusError {
 		t.Fatalf("expected error, got %#v", resp)
 	}
 

--- a/internal/trust/handlers_publish_jobs.go
+++ b/internal/trust/handlers_publish_jobs.go
@@ -479,6 +479,7 @@ func (s *Server) precheckLinkSafetyBasicBudget(
 func (s *Server) transactDebitBudgetAndStoreLinkSafetyBasic(
 	ctx *apptheory.Context,
 	allowOverage bool,
+	maxUsed int64,
 	update *models.InstanceBudgetMonth,
 	ledger *models.UsageLedgerEntry,
 	item *models.LinkSafetyBasicResult,
@@ -510,10 +511,9 @@ func (s *Server) transactDebitBudgetAndStoreLinkSafetyBasic(
 		},
 			tabletheory.IfExists(),
 			tabletheory.ConditionExpression(
-				"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+				"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 				map[string]any{
-					":zero":  int64(0),
-					":delta": creditsPriced,
+					":max": maxUsed,
 				},
 			),
 		)
@@ -778,7 +778,8 @@ func (s *Server) runLinkSafetyBasicJob(
 	_ = auditScan.UpdateKeys()
 
 	allowOverage := strings.ToLower(strings.TrimSpace(overagePolicy)) == overagePolicyAllow
-	txnErr := s.transactDebitBudgetAndStoreLinkSafetyBasic(ctx, allowOverage, update, ledger, item, auditBudget, auditScan, creditsPriced, now)
+	maxUsed := budget.IncludedCredits - creditsPriced
+	txnErr := s.transactDebitBudgetAndStoreLinkSafetyBasic(ctx, allowOverage, maxUsed, update, ledger, item, auditBudget, auditScan, creditsPriced, now)
 	if theoryErrors.IsConditionFailed(txnErr) {
 		return s.handleLinkSafetyBasicConditionFailed(
 			ctx,
@@ -798,6 +799,7 @@ func (s *Server) runLinkSafetyBasicJob(
 		)
 	}
 	if txnErr != nil {
+		fmt.Printf("link_safety_basic transact error request_id=%s instance=%s job_id=%s err=%v\n", strings.TrimSpace(ctx.RequestID), instanceSlug, jobID, txnErr)
 		return publishJobModuleResponse{
 			Name:          "link_safety_basic",
 			PolicyVersion: linkSafetyBasicPolicyVersion,

--- a/internal/trust/handlers_publish_jobs_internal_test.go
+++ b/internal/trust/handlers_publish_jobs_internal_test.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 	"time"
@@ -236,6 +237,31 @@ func TestRunLinkSafetyBasicJob_DebitedSuccess(t *testing.T) {
 	jobID := strings.Repeat("c", 64)
 	got := s.runLinkSafetyBasicJob(ctx, "inst", jobID, "", "", "", "lh", []string{"https://example.com"}, overagePolicyBlock, 10000)
 	if got.Status != "ok" || got.Budget.Reason == "" || got.Budget.DebitedCredits <= 0 {
+		t.Fatalf("unexpected response: %#v", got)
+	}
+}
+
+func TestRunLinkSafetyBasicJob_TransactError_ReturnsInternalErrorResponse(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPublishJobsTestDB()
+	s := NewServer(config.Config{}, store.New(tdb.db))
+
+	ctx := &apptheory.Context{RequestID: "rid"}
+
+	tdb.qLSB.On("First", mock.AnythingOfType("*models.LinkSafetyBasicResult")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{IncludedCredits: 10, UsedCredits: 0}
+		_ = dest.UpdateKeys()
+	}).Once()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tb.On("Execute").Return(errors.New("boom")).Once()
+	tdb.db.TransactWriteBuilder = tb
+
+	jobID := strings.Repeat("e", 64)
+	got := s.runLinkSafetyBasicJob(ctx, "inst", jobID, "", "", "", "lh", []string{"https://example.com"}, overagePolicyBlock, 10000)
+	if got.Status != statusError || got.Budget.Reason != "internal error" || got.Budget.DebitedCredits != 0 {
 		t.Fatalf("unexpected response: %#v", got)
 	}
 }

--- a/internal/trust/handlers_publish_jobs_renders.go
+++ b/internal/trust/handlers_publish_jobs_renders.go
@@ -479,6 +479,7 @@ func (s *Server) debitLinkRenderBudget(
 	}
 	_ = auditBudget.UpdateKeys()
 
+	maxUsed := budget.IncludedCredits - creditsNeededPriced
 	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
 		if allowOverage {
 			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
@@ -494,10 +495,9 @@ func (s *Server) debitLinkRenderBudget(
 			},
 				tabletheory.IfExists(),
 				tabletheory.ConditionExpression(
-					"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+					"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 					map[string]any{
-						":zero":  int64(0),
-						":delta": creditsNeededPriced,
+						":max": maxUsed,
 					},
 				),
 			)

--- a/internal/trust/handlers_renders.go
+++ b/internal/trust/handlers_renders.go
@@ -345,6 +345,7 @@ func (s *Server) debitBudgetForCreateRender(
 	}
 	_ = auditBudget.UpdateKeys()
 
+	maxUsed := budget.IncludedCredits - linkRenderCreditCost
 	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
 		if allowOverage {
 			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
@@ -360,10 +361,9 @@ func (s *Server) debitBudgetForCreateRender(
 			},
 				tabletheory.IfExists(),
 				tabletheory.ConditionExpression(
-					"if_not_exists(usedCredits, :zero) + :delta <= if_not_exists(includedCredits, :zero)",
+					"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 					map[string]any{
-						":zero":  int64(0),
-						":delta": linkRenderCreditCost,
+						":max": maxUsed,
 					},
 				),
 			)

--- a/internal/trust/handlers_renders_internal_test.go
+++ b/internal/trust/handlers_renders_internal_test.go
@@ -137,7 +137,7 @@ func TestRenderArtifactResponseFromModel_StatusAndURLs(t *testing.T) {
 		NormalizedURL: "https://example.com",
 		ErrorCode:     "boom",
 	}, true)
-	if errResp.Status != "error" || errResp.ErrorCode != "boom" {
+	if errResp.Status != statusError || errResp.ErrorCode != "boom" {
 		t.Fatalf("unexpected error response: %#v", errResp)
 	}
 }


### PR DESCRIPTION
## Summary
- Use maxUsed guards for conditional budget debits across trust + AI (avoid arithmetic condition expressions).
- Mark optional TableTheory attrs/GSI keys as omitempty to avoid storing empty values.
- Add/adjust tests for new debit signature and overage/error branches.

## Verification
- GovTheory rubric: PASS (2026-02-16)