### PR TITLE
fix(render-worker): build with Go 1.26

### DIFF
--- a/cmd/render-worker/Dockerfile
+++ b/cmd/render-worker/Dockerfile
@@ -6,7 +6,7 @@ RUN npm pack @sparticuz/chromium@143.0.4 --silent \
   && mkdir -p /opt/chromium \
   && cp package/bin/*.br /opt/chromium/
 
-FROM golang:1.25 AS build
+FROM golang:1.26 AS build
 
 WORKDIR /src
 COPY go.mod go.sum ./


### PR DESCRIPTION
Fixes live deploy failure: render-worker Docker asset was building with `golang:1.25` but `go.mod` requires Go 1.26.

Change:
- Use `golang:1.26` in `cmd/render-worker/Dockerfile`

Unblocks:
```bash
AWS_PROFILE=Lesser theory app up --stage live --execute
```
