### PR TITLE
Fix soul email and phone provisioning

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -932,6 +932,9 @@ export class LesserHostStack extends cdk.Stack {
 		const migaduSsmParamArns = [
 			`arn:aws:ssm:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:parameter/lesser-host/migadu`,
 		];
+		const telnyxSsmParamArns = [
+			`arn:aws:ssm:${cdk.Aws.REGION}:${cdk.Aws.ACCOUNT_ID}:parameter/lesser-host/telnyx`,
+		];
 		const soulCommSsmParamArns = [
 			cdk.Stack.of(this).formatArn({
 				service: 'ssm',
@@ -943,6 +946,12 @@ export class LesserHostStack extends cdk.Stack {
 			new iam.PolicyStatement({
 				actions: ['ssm:GetParameter', 'ssm:GetParameters'],
 				resources: migaduSsmParamArns,
+			}),
+		);
+		controlPlaneFn.addToRolePolicy(
+			new iam.PolicyStatement({
+				actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+				resources: telnyxSsmParamArns,
 			}),
 		);
 		controlPlaneFn.addToRolePolicy(

--- a/internal/controlplane/deps_http_internal_test.go
+++ b/internal/controlplane/deps_http_internal_test.go
@@ -327,7 +327,7 @@ func TestDefaultTelnyxSendSMS(t *testing.T) {
 }
 
 func TestDefaultMigaduCreateMailbox_SuccessConflictAndErrors(t *testing.T) {
-	seedControlplaneSSMParam(t, secrets.MigaduAPITokenSSMParameterName, `{"token":"migadu-token"}`)
+	seedControlplaneSSMParam(t, secrets.MigaduAPITokenSSMParameterName, `{"username":"aron@equal-to.ai","token":"migadu-token"}`)
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/domains/lessersoul.ai/mailboxes" {
@@ -335,7 +335,7 @@ func TestDefaultMigaduCreateMailbox_SuccessConflictAndErrors(t *testing.T) {
 			return
 		}
 		user, pass, ok := r.BasicAuth()
-		if !ok || user != "api" || pass != "migadu-token" {
+		if !ok || user != "aron@equal-to.ai" || pass != "migadu-token" {
 			t.Fatalf("unexpected basic auth: user=%q ok=%v", user, ok)
 		}
 

--- a/internal/controlplane/deps_migadu.go
+++ b/internal/controlplane/deps_migadu.go
@@ -45,9 +45,15 @@ func defaultMigaduCreateMailbox(ctx context.Context, localPart string, name stri
 		name = localPart
 	}
 
-	token, err := secrets.MigaduAPIToken(ctx, nil)
+	creds, err := secrets.MigaduCreds(ctx, nil)
 	if err != nil {
 		return err
+	}
+	if strings.TrimSpace(creds.APIToken) == "" {
+		return fmt.Errorf("migadu api key missing")
+	}
+	if strings.TrimSpace(creds.Username) == "" {
+		return fmt.Errorf("migadu username missing")
 	}
 
 	//nolint:gosec // Password must be sent in the outbound Migadu mailbox creation request body.
@@ -67,7 +73,7 @@ func defaultMigaduCreateMailbox(ctx context.Context, localPart string, name stri
 		return fmt.Errorf("migadu request build: %w", err)
 	}
 	req.Header.Set("content-type", "application/json")
-	req.SetBasicAuth("api", token)
+	req.SetBasicAuth(strings.TrimSpace(creds.Username), strings.TrimSpace(creds.APIToken))
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	//nolint:gosec // Request target is the fixed Migadu HTTPS API host.

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -216,6 +217,7 @@ func (s *Server) finalizeSoulProvisionEmailChannel(
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "email provider is not configured"}
 	}
 	if provisionErr := s.migaduCreateEmail(ctx.Context(), localNorm, identity.LocalID, password); provisionErr != nil {
+		log.Printf("controlplane: soul email provision failed agent=%s address=%s: %v", agentIDHex, address, provisionErr)
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to provision email"}
 	}
 

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -64,6 +65,9 @@ func (s *Server) handleSoulBeginProvisionPhoneChannel(ctx *apptheory.Context) (*
 			return nil, &apptheory.AppError{Code: "app.conflict", Message: "phone provider is not configured"}
 		}
 		nums, err := s.telnyxSearchNums(ctx.Context(), strings.TrimSpace(req.CountryCode), 5)
+		if err != nil {
+			log.Printf("controlplane: soul phone search failed agent=%s country=%s: %v", agentIDHex, strings.TrimSpace(req.CountryCode), err)
+		}
 		if err != nil || len(nums) == 0 {
 			return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to find available phone numbers"}
 		}
@@ -221,6 +225,7 @@ func (s *Server) finalizeSoulProvisionPhoneChannel(
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "phone provider is not configured"}
 	}
 	if _, orderErr := s.telnyxOrderNumber(ctx.Context(), number); orderErr != nil {
+		log.Printf("controlplane: soul phone provision failed agent=%s number=%s: %v", agentIDHex, number, orderErr)
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to provision phone number"}
 	}
 

--- a/internal/secrets/keys.go
+++ b/internal/secrets/keys.go
@@ -61,11 +61,32 @@ func StripeWebhookSecret(ctx context.Context, client SSMAPI) (string, error) {
 
 // MigaduAPIToken loads the Migadu API token from SSM.
 func MigaduAPIToken(ctx context.Context, client SSMAPI) (string, error) {
-	raw, err := GetSSMParameterCached(ctx, client, MigaduAPITokenSSMParameterName, 10*time.Minute)
+	creds, err := MigaduCreds(ctx, client)
 	if err != nil {
 		return "", err
 	}
-	return parseAPIKeyValue(raw)
+	return creds.APIToken, nil
+}
+
+type MigaduCredentials struct {
+	// #nosec G101,G117 -- runtime-loaded credential value; the field name is part of the stable internal API.
+	Username string
+	// #nosec G101,G117 -- runtime-loaded credential value; the field name is part of the stable internal API.
+	APIToken string
+}
+
+// MigaduCreds loads the Migadu API credentials from SSM.
+// The parameter may be either:
+// - a raw API key string (legacy; username must come from env), or
+// - a JSON object including:
+//   - username/email/user (required unless MIGADU_USERNAME is set)
+//   - token/api_key/apiKey/key/value (required)
+func MigaduCreds(ctx context.Context, client SSMAPI) (MigaduCredentials, error) {
+	raw, err := GetSSMParameterCached(ctx, client, MigaduAPITokenSSMParameterName, 10*time.Minute)
+	if err != nil {
+		return MigaduCredentials{}, err
+	}
+	return parseMigaduCredentials(raw)
 }
 
 type TelnyxCredentials struct {
@@ -73,6 +94,68 @@ type TelnyxCredentials struct {
 	APIKey             string
 	MessagingProfileID string
 	ConnectionID       string
+}
+
+func parseMigaduCredentials(raw string) (MigaduCredentials, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return MigaduCredentials{}, fmt.Errorf("migadu credentials are empty")
+	}
+
+	if !looksLikeJSONObject(raw) {
+		return MigaduCredentials{
+			Username: migaduUsernameFromEnv(),
+			APIToken: raw,
+		}, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(raw), &obj); err != nil {
+		return MigaduCredentials{}, fmt.Errorf("migadu credentials invalid JSON: %w", err)
+	}
+
+	readString := func(keys ...string) string {
+		for _, key := range keys {
+			v, ok := obj[key]
+			if !ok {
+				continue
+			}
+			s, ok := v.(string)
+			if !ok {
+				continue
+			}
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			return s
+		}
+		return ""
+	}
+
+	apiToken := readString("api_key", "apiKey", "key", "token", "value")
+	if apiToken == "" {
+		return MigaduCredentials{}, fmt.Errorf("migadu api_key is missing")
+	}
+
+	username := readString("username", "user", "email", "account_email")
+	if username == "" {
+		username = migaduUsernameFromEnv()
+	}
+
+	return MigaduCredentials{
+		Username: username,
+		APIToken: apiToken,
+	}, nil
+}
+
+func migaduUsernameFromEnv() string {
+	for _, key := range []string{"MIGADU_USERNAME", "MIGADU_API_USERNAME"} {
+		if value := strings.TrimSpace(os.Getenv(key)); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // TelnyxCreds loads the Telnyx platform credentials from SSM.

--- a/internal/secrets/keys_more_test.go
+++ b/internal/secrets/keys_more_test.go
@@ -10,6 +10,8 @@ import (
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 )
 
+const migaduTestUsername = "aron@equal-to.ai"
+
 func TestParseTelnyxCredentials(t *testing.T) {
 	t.Parallel()
 
@@ -55,6 +57,42 @@ func TestParseTelnyxCredentials(t *testing.T) {
 	})
 }
 
+func TestParseMigaduCredentials(t *testing.T) {
+	t.Run("plain key uses env username", func(t *testing.T) {
+		t.Setenv("MIGADU_USERNAME", "  "+migaduTestUsername+" ")
+		got, err := parseMigaduCredentials("  migadu-key  ")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Username != migaduTestUsername || got.APIToken != "migadu-key" {
+			t.Fatalf("unexpected creds: %#v", got)
+		}
+	})
+
+	t.Run("json payload", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := parseMigaduCredentials(`{"username":" ` + migaduTestUsername + ` ","token":" key "}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Username != migaduTestUsername || got.APIToken != "key" {
+			t.Fatalf("unexpected creds: %#v", got)
+		}
+	})
+
+	t.Run("errors", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := parseMigaduCredentials(" "); err == nil {
+			t.Fatalf("expected empty credentials error")
+		}
+		if _, err := parseMigaduCredentials(`{"username":"a@example.com"}`); err == nil {
+			t.Fatalf("expected missing api key error")
+		}
+	})
+}
+
 func TestMigaduAndTelnyxLoaders(t *testing.T) {
 	t.Parallel()
 
@@ -64,7 +102,7 @@ func TestMigaduAndTelnyxLoaders(t *testing.T) {
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 			switch aws.ToString(params.Name) {
 			case MigaduAPITokenSSMParameterName:
-				return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String(`{"token":" migadu-token "}`)}}, nil
+				return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String(`{"username":" ` + migaduTestUsername + ` ","token":" migadu-token "}`)}}, nil
 			case TelnyxAPITokenSSMParameterName:
 				return &ssm.GetParameterOutput{Parameter: &ssmtypes.Parameter{Value: aws.String(`{"apiKey":" telnyx-token ","messagingProfileId":" mp-1 "}`)}}, nil
 			default:
@@ -77,6 +115,13 @@ func TestMigaduAndTelnyxLoaders(t *testing.T) {
 	got, err := MigaduAPIToken(context.Background(), client)
 	if err != nil || got != "migadu-token" {
 		t.Fatalf("MigaduAPIToken: got=%q err=%v", got, err)
+	}
+	migaduCreds, err := MigaduCreds(context.Background(), client)
+	if err != nil {
+		t.Fatalf("MigaduCreds: %v", err)
+	}
+	if migaduCreds.Username != migaduTestUsername || migaduCreds.APIToken != "migadu-token" {
+		t.Fatalf("unexpected migadu creds: %#v", migaduCreds)
 	}
 
 	creds, err := TelnyxCreds(context.Background(), client)


### PR DESCRIPTION
## Summary
- restore Migadu mailbox provisioning by loading username + API key credentials and authenticating with the account email
- grant the control-plane Lambda access to the Telnyx SSM parameter and log provider errors for soul channel provisioning failures
- add regression coverage for Migadu credential parsing and HTTP auth handling

## Validation
- `env GOTOOLCHAIN=go1.26.1 go test ./internal/secrets ./internal/controlplane`
- `env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/secrets ./internal/controlplane`
- `env GOTOOLCHAIN=go1.26.1 bash gov-infra/verifiers/gov-verify-rubric.sh`

## Operational follow-up already applied in lab
- updated `/lesser-host/migadu` to include the Migadu username alongside the API token
- updated `/lesser-host/telnyx` to include `messaging_profile_id` and `connection_id`
- deployed `lesser-host-lab` successfully and verified email + phone provisioning now succeed in the portal