### PR TITLE
Add soul voice calling and generated comm contract coverage

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -271,6 +271,18 @@ components:
     SoulCommStatusErrorEnvelope:
       $ref: "../spec/v3/schemas/soul-comm-status.error.schema.json"
 
+    SoulAgentCommActivityItem:
+      $ref: "../spec/v3/schemas/soul-agent-comm-activity-item.schema.json"
+
+    SoulAgentCommActivityResponse:
+      $ref: "../spec/v3/schemas/soul-agent-comm-activity.response.schema.json"
+
+    SoulAgentCommQueueItem:
+      $ref: "../spec/v3/schemas/soul-agent-comm-queue-item.schema.json"
+
+    SoulAgentCommQueueResponse:
+      $ref: "../spec/v3/schemas/soul-agent-comm-queue.response.schema.json"
+
 paths:
   /api/v1/soul/agents/{agentId}/channels:
     get:
@@ -637,3 +649,159 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SoulCommStatusErrorEnvelope"
+
+  /api/v1/soul/agents/{agentId}/comm/activity:
+    get:
+      operationId: soulAgentCommActivity
+      summary: List communication activity for a soul agent
+      security:
+        - sessionAuth: []
+      parameters:
+        - name: agentId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^0x[0-9a-fA-F]{64}$"
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulAgentCommActivityResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /api/v1/soul/agents/{agentId}/comm/queue:
+    get:
+      operationId: soulAgentCommQueue
+      summary: List queued inbound communications for a soul agent
+      security:
+        - sessionAuth: []
+      parameters:
+        - name: agentId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^0x[0-9a-fA-F]{64}$"
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulAgentCommQueueResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+
+  /api/v1/soul/agents/{agentId}/comm/status/{messageId}:
+    get:
+      operationId: soulAgentCommStatus
+      summary: Get outbound comm delivery status for a soul agent
+      security:
+        - sessionAuth: []
+      parameters:
+        - name: agentId
+          in: path
+          required: true
+          schema:
+            type: string
+            pattern: "^0x[0-9a-fA-F]{64}$"
+        - name: messageId
+          in: path
+          required: true
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 128
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulCommStatusResponse"
+        "400":
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+        "500":
+          description: Internal error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"

--- a/docs/spec/v3/schemas/soul-agent-comm-activity-item.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-activity-item.schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/soul-agent-comm-activity-item.schema.json",
+  "title": "Soul agent communication activity item",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["agent_id", "activity_id", "channel_type", "direction", "timestamp"],
+  "properties": {
+    "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+    "activity_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "channel_type": { "type": "string", "enum": ["email", "sms", "voice"] },
+    "direction": { "type": "string", "enum": ["inbound", "outbound"] },
+    "counterparty": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "action": { "type": "string", "minLength": 1, "maxLength": 64 },
+    "message_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "in_reply_to": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "boundary_check": { "type": "string", "enum": ["passed", "violated", "skipped"] },
+    "preference_respected": { "type": "boolean" },
+    "timestamp": { "type": "string", "format": "date-time" }
+  }
+}

--- a/docs/spec/v3/schemas/soul-agent-comm-activity.response.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-activity.response.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/soul-agent-comm-activity.response.schema.json",
+  "title": "GET /api/v1/soul/agents/{agentId}/comm/activity response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "activities", "count"],
+  "properties": {
+    "version": { "type": "string", "enum": ["1"] },
+    "activities": {
+      "type": "array",
+      "items": {
+        "$ref": "./soul-agent-comm-activity-item.schema.json"
+      }
+    },
+    "count": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/docs/spec/v3/schemas/soul-agent-comm-queue-item.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-queue-item.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/soul-agent-comm-queue-item.schema.json",
+  "title": "Soul agent queued communication item",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["agent_id", "message_id", "channel_type", "body", "received_at", "scheduled_delivery_time", "status"],
+  "properties": {
+    "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+    "message_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "channel_type": { "type": "string", "enum": ["email", "sms", "voice"] },
+    "from_address": { "type": "string", "format": "email" },
+    "from_number": { "type": "string", "pattern": "^\\+[1-9]\\d{1,14}$" },
+    "from_soul_agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+    "from_display_name": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "subject": { "type": "string", "minLength": 1, "maxLength": 998 },
+    "body": { "type": "string", "minLength": 1 },
+    "in_reply_to": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "received_at": { "type": "string", "format": "date-time" },
+    "scheduled_delivery_time": { "type": "string", "format": "date-time" },
+    "status": { "type": "string", "enum": ["queued", "delivered", "expired"] }
+  }
+}

--- a/docs/spec/v3/schemas/soul-agent-comm-queue.response.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-queue.response.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/soul-agent-comm-queue.response.schema.json",
+  "title": "GET /api/v1/soul/agents/{agentId}/comm/queue response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "items", "count"],
+  "properties": {
+    "version": { "type": "string", "enum": ["1"] },
+    "items": {
+      "type": "array",
+      "items": {
+        "$ref": "./soul-agent-comm-queue-item.schema.json"
+      }
+    },
+    "count": { "type": "integer", "minimum": 0 }
+  }
+}

--- a/docs/spec/v3/schemas/soul-comm-status.response.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-status.response.schema.json
@@ -15,6 +15,10 @@
     "providerMessageId": { "type": "string", "minLength": 1, "maxLength": 256 },
     "errorCode": { "type": "string", "minLength": 1, "maxLength": 128 },
     "errorMessage": { "type": "string", "minLength": 1, "maxLength": 2048 },
+    "replyMessageId": { "type": "string", "minLength": 1, "maxLength": 256 },
+    "replyBody": { "type": "string", "minLength": 1, "maxLength": 4096 },
+    "replyConfidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "replyReceivedAt": { "type": "string", "format": "date-time" },
     "createdAt": { "type": "string", "format": "date-time" },
     "updatedAt": { "type": "string", "format": "date-time" }
   }

--- a/docs/spec/v3/schemas/soul-resolve.response.schema.json
+++ b/docs/spec/v3/schemas/soul-resolve.response.schema.json
@@ -8,7 +8,7 @@
   "properties": {
     "version": { "type": "string", "enum": ["1"] },
     "agent": {
-      "$ref": "https://lesser.host/spec/v3/schemas/soul-agent-identity.schema.json"
+      "$ref": "./soul-agent-identity.schema.json"
     }
   }
 }

--- a/docs/spec/v3/schemas/soul-search.response.schema.json
+++ b/docs/spec/v3/schemas/soul-search.response.schema.json
@@ -10,7 +10,7 @@
     "results": {
       "type": "array",
       "items": {
-        "$ref": "https://lesser.host/spec/v3/schemas/soul-search.result.schema.json"
+        "$ref": "./soul-search.result.schema.json"
       }
     },
     "count": { "type": "integer", "minimum": 0 },

--- a/internal/controlplane/deps_http_internal_test.go
+++ b/internal/controlplane/deps_http_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -99,6 +100,8 @@ func newTelnyxHTTPTestServer(t *testing.T) (*httptest.Server, *telnyxHTTPTestSta
 			w.WriteHeader(http.StatusNoContent)
 		case r.Method == http.MethodPost && r.URL.Path == "/v2/messages":
 			handleTelnyxMessageRequest(t, w, r)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/texml/calls/conn-1":
+			handleTelnyxVoiceCallRequest(t, w, r)
 		default:
 			http.NotFound(w, r)
 		}
@@ -155,6 +158,38 @@ func handleTelnyxMessageRequest(t *testing.T, w http.ResponseWriter, r *http.Req
 	}
 	w.WriteHeader(http.StatusAccepted)
 	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"id": "msg-1"}})
+}
+
+func handleTelnyxVoiceCallRequest(t *testing.T, w http.ResponseWriter, r *http.Request) {
+	t.Helper()
+	if got := r.Header.Get("authorization"); got != "Bearer telnyx-key" {
+		t.Fatalf("unexpected auth header: %q", got)
+	}
+	if got := r.Header.Get("content-type"); !strings.Contains(got, "application/x-www-form-urlencoded") {
+		t.Fatalf("unexpected content-type: %q", got)
+	}
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 8192))
+	if err != nil {
+		t.Fatalf("read voice form: %v", err)
+	}
+	form, err := url.ParseQuery(string(raw))
+	if err != nil {
+		t.Fatalf("parse voice form: %v", err)
+	}
+	if got := form.Get("From"); got != "+15551234567" {
+		t.Fatalf("unexpected From: %q", got)
+	}
+	if got := form.Get("To"); got != "+15557654321" {
+		t.Fatalf("unexpected To: %q", got)
+	}
+	if got := form.Get("Url"); got != "https://lab.lesser.host/webhooks/comm/voice/texml/comm-msg-1" {
+		t.Fatalf("unexpected Url: %q", got)
+	}
+	if got := form.Get("StatusCallback"); got != "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-1" {
+		t.Fatalf("unexpected StatusCallback: %q", got)
+	}
+	w.WriteHeader(http.StatusAccepted)
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"call_control_id": "call-control-1"}})
 }
 
 type smtpCapture struct {
@@ -323,6 +358,23 @@ func TestDefaultTelnyxSendSMS(t *testing.T) {
 	msgID, err := defaultTelnyxSendSMS(context.Background(), "+15551234567", "+15557654321", " hello there ")
 	if err != nil || msgID != "msg-1" {
 		t.Fatalf("send sms: id=%q err=%v", msgID, err)
+	}
+}
+
+func TestDefaultTelnyxCreateVoiceCall(t *testing.T) {
+	seedControlplaneSSMParam(t, secrets.TelnyxAPITokenSSMParameterName, `{"api_key":"telnyx-key","messaging_profile_id":"profile-1","connection_id":"conn-1"}`)
+
+	server, _ := newTelnyxHTTPTestServer(t)
+	defer server.Close()
+
+	rewriteDefaultTransport(t, "api.telnyx.com", server.URL)
+
+	if _, err := defaultTelnyxCreateVoiceCall(context.Background(), "", "+15557654321", "https://lab.lesser.host/webhooks/comm/voice/texml/comm-msg-1", "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-1"); err == nil {
+		t.Fatalf("expected validation error for empty sender")
+	}
+	callID, err := defaultTelnyxCreateVoiceCall(context.Background(), "+15551234567", "+15557654321", "https://lab.lesser.host/webhooks/comm/voice/texml/comm-msg-1", "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-1")
+	if err != nil || callID != "call-control-1" {
+		t.Fatalf("create voice call: id=%q err=%v", callID, err)
 	}
 }
 

--- a/internal/controlplane/deps_telnyx.go
+++ b/internal/controlplane/deps_telnyx.go
@@ -280,6 +280,23 @@ type telnyxSendMessageResponse struct {
 	} `json:"data"`
 }
 
+type telnyxCreateVoiceCallResponse struct {
+	Data struct {
+		ID            string `json:"id"`
+		CallControlID string `json:"call_control_id"`
+		CallLegID     string `json:"call_leg_id"`
+		CallSessionID string `json:"call_session_id"`
+		SID           string `json:"sid"`
+		CallSID       string `json:"call_sid"`
+	} `json:"data"`
+	ID            string `json:"id"`
+	CallControlID string `json:"call_control_id"`
+	CallLegID     string `json:"call_leg_id"`
+	CallSessionID string `json:"call_session_id"`
+	SID           string `json:"sid"`
+	CallSID       string `json:"call_sid"`
+}
+
 func defaultTelnyxSendSMS(ctx context.Context, from string, to string, text string) (string, error) {
 	from = strings.TrimSpace(from)
 	to = strings.TrimSpace(to)
@@ -335,4 +352,83 @@ func defaultTelnyxSendSMS(ctx context.Context, from string, to string, text stri
 		return "", fmt.Errorf("telnyx sms send: decode: %w", err)
 	}
 	return strings.TrimSpace(parsed.Data.ID), nil
+}
+
+func defaultTelnyxCreateVoiceCall(ctx context.Context, from string, to string, texmlURL string, statusCallbackURL string) (string, error) {
+	from = strings.TrimSpace(from)
+	to = strings.TrimSpace(to)
+	texmlURL = strings.TrimSpace(texmlURL)
+	statusCallbackURL = strings.TrimSpace(statusCallbackURL)
+	if from == "" || to == "" || texmlURL == "" || statusCallbackURL == "" {
+		return "", fmt.Errorf("telnyx voice call requires from, to, texmlURL, and statusCallbackURL")
+	}
+
+	creds, err := secrets.TelnyxCreds(ctx, nil)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(creds.APIKey) == "" {
+		return "", fmt.Errorf("telnyx api key missing")
+	}
+	if strings.TrimSpace(creds.ConnectionID) == "" {
+		return "", fmt.Errorf("telnyx connection_id missing")
+	}
+
+	form := url.Values{}
+	form.Set("From", from)
+	form.Set("To", to)
+	form.Set("Url", texmlURL)
+	form.Set("StatusCallback", statusCallbackURL)
+
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		telnyxBaseURL+"/texml/calls/"+url.PathEscape(strings.TrimSpace(creds.ConnectionID)),
+		strings.NewReader(form.Encode()),
+	)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("accept", "application/json")
+	req.Header.Set("content-type", "application/x-www-form-urlencoded")
+	req.Header.Set("authorization", "Bearer "+strings.TrimSpace(creds.APIKey))
+
+	client := &http.Client{Timeout: 10 * time.Second}
+	//nolint:gosec // Request target is the fixed Telnyx HTTPS API host.
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("telnyx voice call: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusAccepted:
+		// ok
+	default:
+		return "", fmt.Errorf("telnyx voice call: status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(body)))
+	}
+
+	var parsed telnyxCreateVoiceCallResponse
+	if err := json.Unmarshal(body, &parsed); err == nil {
+		for _, candidate := range []string{
+			strings.TrimSpace(parsed.Data.CallControlID),
+			strings.TrimSpace(parsed.Data.CallLegID),
+			strings.TrimSpace(parsed.Data.CallSessionID),
+			strings.TrimSpace(parsed.Data.CallSID),
+			strings.TrimSpace(parsed.Data.SID),
+			strings.TrimSpace(parsed.Data.ID),
+			strings.TrimSpace(parsed.CallControlID),
+			strings.TrimSpace(parsed.CallLegID),
+			strings.TrimSpace(parsed.CallSessionID),
+			strings.TrimSpace(parsed.CallSID),
+			strings.TrimSpace(parsed.SID),
+			strings.TrimSpace(parsed.ID),
+		} {
+			if candidate != "" {
+				return candidate, nil
+			}
+		}
+	}
+	return "", nil
 }

--- a/internal/controlplane/handlers_comm_voice_outbound.go
+++ b/internal/controlplane/handlers_comm_voice_outbound.go
@@ -1,0 +1,524 @@
+package controlplane
+
+import (
+	"bytes"
+	"encoding/json"
+	"encoding/xml"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/commworker"
+	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const telnyxDefaultOutboundVoice = "Polly.Amy-Neural"
+const telnyxDefaultOutboundReplyPrompt = "If you would like to reply, speak now. Otherwise, you may hang up."
+
+type telnyxVoiceGatherCallback struct {
+	CallSID      string
+	From         string
+	To           string
+	Digits       string
+	SpeechResult string
+	Confidence   string
+}
+
+type voiceGatherCapture struct {
+	replyMessageID  string
+	replyBody       string
+	replyConfidence *float64
+	replyReceivedAt time.Time
+	fromNumber      string
+	toNumber        string
+}
+
+func normalizeSoulCommPublicBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil || u == nil {
+		return ""
+	}
+	if u.User != nil {
+		return ""
+	}
+	scheme := strings.ToLower(strings.TrimSpace(u.Scheme))
+	if scheme != "https" && scheme != "http" {
+		return ""
+	}
+	host := strings.TrimSpace(u.Host)
+	if !safeSoulCommHost(host) {
+		return ""
+	}
+	return scheme + "://" + host
+}
+
+func safeSoulCommHost(host string) bool {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		return false
+	}
+	if strings.ContainsAny(host, " \t\r\n/\\") {
+		return false
+	}
+	if strings.Contains(host, "@") {
+		return false
+	}
+	return true
+}
+
+func soulCommRequestBaseURL(ctx *apptheory.Context, publicBaseURL string) string {
+	if base := normalizeSoulCommPublicBaseURL(publicBaseURL); base != "" {
+		return base
+	}
+	if ctx == nil {
+		return ""
+	}
+	host := strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, "host"))
+	if !safeSoulCommHost(host) {
+		return ""
+	}
+	return "https://" + host
+}
+
+func (s *Server) handleCommVoiceTeXML(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if !s.cfg.SoulEnabled {
+		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
+	}
+
+	messageID := strings.TrimSpace(ctx.Param("messageId"))
+	if messageID == "" {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "messageId is required"}
+	}
+
+	item, ok, err := s.loadSoulCommVoiceInstruction(ctx, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return nil, apptheory.NewAppTheoryError("app.not_found", "not found").WithStatusCode(http.StatusNotFound)
+	}
+
+	baseURL := soulCommRequestBaseURL(ctx, s.cfg.PublicBaseURL)
+	if baseURL == "" {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	actionURL := baseURL + "/webhooks/comm/voice/gather/" + url.PathEscape(messageID)
+
+	payload, buildErr := buildSoulCommVoiceTeXML(strings.TrimSpace(item.Body), strings.TrimSpace(item.Voice), actionURL)
+	if buildErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return &apptheory.Response{
+		Status: http.StatusOK,
+		Headers: map[string][]string{
+			"content-type": {"application/xml; charset=utf-8"},
+		},
+		Body: payload,
+	}, nil
+}
+
+func (s *Server) loadSoulCommVoiceInstruction(ctx *apptheory.Context, messageID string) (models.SoulCommVoiceInstruction, bool, error) {
+	instruction := &models.SoulCommVoiceInstruction{MessageID: messageID}
+	_ = instruction.UpdateKeys()
+	var item models.SoulCommVoiceInstruction
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulCommVoiceInstruction{}).
+		Where("PK", "=", instruction.PK).
+		Where("SK", "=", instruction.SK).
+		First(&item)
+	if theoryErrors.IsNotFound(err) {
+		return models.SoulCommVoiceInstruction{}, false, nil
+	}
+	if err != nil {
+		return models.SoulCommVoiceInstruction{}, false, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return item, true, nil
+}
+
+func buildSoulCommVoiceTeXML(body string, voice string, actionURL string) ([]byte, error) {
+	body = strings.TrimSpace(body)
+	voice = strings.TrimSpace(voice)
+	actionURL = strings.TrimSpace(actionURL)
+	if body == "" {
+		body = "No message provided."
+	}
+	if voice == "" {
+		voice = telnyxDefaultOutboundVoice
+	}
+	if actionURL == "" {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "action url is required"}
+	}
+
+	var escaped bytes.Buffer
+	if err := xml.EscapeText(&escaped, []byte(body)); err != nil {
+		return nil, err
+	}
+	var escapedVoice bytes.Buffer
+	if err := xml.EscapeText(&escapedVoice, []byte(voice)); err != nil {
+		return nil, err
+	}
+	var escapedAction bytes.Buffer
+	if err := xml.EscapeText(&escapedAction, []byte(actionURL)); err != nil {
+		return nil, err
+	}
+	var escapedReplyPrompt bytes.Buffer
+	if err := xml.EscapeText(&escapedReplyPrompt, []byte(telnyxDefaultOutboundReplyPrompt)); err != nil {
+		return nil, err
+	}
+
+	payload := `<Response><Gather input="speech" action="` + escapedAction.String() + `" method="POST" timeout="5" speechTimeout="auto"><Say voice="` + escapedVoice.String() + `">` + escaped.String() + `</Say><Say voice="` + escapedVoice.String() + `">` + escapedReplyPrompt.String() + `</Say></Gather><Say voice="` + escapedVoice.String() + `">No reply was captured. Goodbye.</Say><Hangup/></Response>`
+	return []byte(payload), nil
+}
+
+func (s *Server) handleCommVoiceGatherWebhook(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil || s.enqueueCommMessage == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if !s.cfg.SoulEnabled {
+		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
+	}
+
+	messageID := strings.TrimSpace(ctx.Param("messageId"))
+	if messageID == "" {
+		messageID = strings.TrimSpace(queryFirst(ctx, "messageId"))
+	}
+	if messageID == "" {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "messageId is required"}
+	}
+
+	instruction, ok, err := s.loadSoulCommVoiceInstruction(ctx, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if !ok {
+		return apptheory.JSON(http.StatusOK, map[string]any{"ok": true, "captured": false})
+	}
+
+	callback, appErr := parseTelnyxVoiceGatherCallback(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+	capture, ok := buildVoiceGatherCapture(messageID, instruction, callback)
+	if !ok {
+		return apptheory.JSON(http.StatusOK, map[string]any{"ok": true, "captured": false})
+	}
+	if appErr := s.enqueueVoiceGatherCapture(ctx, messageID, capture); appErr != nil {
+		return nil, appErr
+	}
+	_ = s.recordOutboundVoiceReply(ctx, messageID, capture.replyMessageID, capture.replyBody, capture.replyConfidence, capture.replyReceivedAt)
+
+	return apptheory.JSON(http.StatusOK, map[string]any{
+		"ok":         true,
+		"captured":   true,
+		"messageId":  capture.replyMessageID,
+		"inReplyTo":  messageID,
+		"replyBody":  capture.replyBody,
+		"receivedAt": capture.replyReceivedAt.Format(time.RFC3339Nano),
+		"confidence": capture.replyConfidence,
+	})
+}
+
+func buildVoiceGatherCapture(messageID string, instruction models.SoulCommVoiceInstruction, callback telnyxVoiceGatherCallback) (voiceGatherCapture, bool) {
+	replyBody := normalizeTelnyxVoiceGatherReply(callback.SpeechResult, callback.Digits)
+	if replyBody == "" {
+		return voiceGatherCapture{}, false
+	}
+
+	fromNumber := strings.TrimSpace(instruction.To)
+	toNumber := strings.TrimSpace(instruction.From)
+	if fromNumber == "" {
+		fromNumber = strings.TrimSpace(callback.To)
+	}
+	if toNumber == "" {
+		toNumber = strings.TrimSpace(callback.From)
+	}
+
+	return voiceGatherCapture{
+		replyMessageID:  voiceReplyMessageID(messageID, callback.CallSID),
+		replyBody:       replyBody,
+		replyConfidence: parseTelnyxVoiceGatherConfidence(callback.Confidence),
+		replyReceivedAt: time.Now().UTC(),
+		fromNumber:      fromNumber,
+		toNumber:        toNumber,
+	}, true
+}
+
+func (s *Server) enqueueVoiceGatherCapture(ctx *apptheory.Context, messageID string, capture voiceGatherCapture) *apptheory.AppError {
+	inReplyTo := messageID
+	notif := commworker.InboundNotification{
+		Type:       "communication:inbound",
+		Channel:    commChannelVoice,
+		From:       commworker.InboundParty{Number: capture.fromNumber},
+		To:         &commworker.InboundParty{Number: capture.toNumber},
+		Body:       capture.replyBody,
+		ReceivedAt: capture.replyReceivedAt.Format(time.RFC3339Nano),
+		MessageID:  capture.replyMessageID,
+		InReplyTo:  &inReplyTo,
+	}
+	msg := commworker.QueueMessage{
+		Kind:         commworker.QueueMessageKindInbound,
+		Provider:     commDeliveryProviderTelnyx,
+		Notification: notif,
+	}
+	if err := msg.Validate(); err != nil {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid gather payload"}
+	}
+	if err := s.enqueueCommMessage(ctx.Context(), msg); err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue"}
+	}
+	return nil
+}
+
+func parseTelnyxVoiceGatherCallback(ctx *apptheory.Context) (telnyxVoiceGatherCallback, *apptheory.AppError) {
+	if ctx == nil {
+		return telnyxVoiceGatherCallback{}, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	body := bytes.TrimSpace(ctx.Request.Body)
+	if len(body) > 0 {
+		var payload map[string]any
+		if err := json.Unmarshal(body, &payload); err == nil && len(payload) > 0 {
+			cb := telnyxVoiceGatherCallback{
+				CallSID:      mapStringFirst(payload, "CallSid", "callSid", "call_sid"),
+				From:         mapStringFirst(payload, "From", "from"),
+				To:           mapStringFirst(payload, "To", "to"),
+				Digits:       mapStringFirst(payload, "Digits", "digits"),
+				SpeechResult: mapStringFirst(payload, "SpeechResult", "speechResult", "speech_result"),
+				Confidence:   mapStringFirst(payload, "Confidence", "confidence"),
+			}
+			if hasTelnyxVoiceGatherContent(cb) {
+				return cb, nil
+			}
+		}
+
+		if values, err := url.ParseQuery(string(body)); err == nil && len(values) > 0 {
+			cb := telnyxVoiceGatherCallback{
+				CallSID:      firstNonEmpty(values.Get("CallSid"), values.Get("callSid"), values.Get("call_sid")),
+				From:         firstNonEmpty(values.Get("From"), values.Get("from")),
+				To:           firstNonEmpty(values.Get("To"), values.Get("to")),
+				Digits:       firstNonEmpty(values.Get("Digits"), values.Get("digits")),
+				SpeechResult: firstNonEmpty(values.Get("SpeechResult"), values.Get("speechResult"), values.Get("speech_result")),
+				Confidence:   firstNonEmpty(values.Get("Confidence"), values.Get("confidence")),
+			}
+			if hasTelnyxVoiceGatherContent(cb) {
+				return cb, nil
+			}
+		}
+	}
+
+	cb := telnyxVoiceGatherCallback{
+		CallSID:      strings.TrimSpace(queryFirst(ctx, "CallSid")),
+		From:         strings.TrimSpace(firstNonEmpty(queryFirst(ctx, "From"), queryFirst(ctx, "from"))),
+		To:           strings.TrimSpace(firstNonEmpty(queryFirst(ctx, "To"), queryFirst(ctx, "to"))),
+		Digits:       strings.TrimSpace(firstNonEmpty(queryFirst(ctx, "Digits"), queryFirst(ctx, "digits"))),
+		SpeechResult: strings.TrimSpace(firstNonEmpty(queryFirst(ctx, "SpeechResult"), queryFirst(ctx, "speechResult"), queryFirst(ctx, "speech_result"))),
+		Confidence:   strings.TrimSpace(firstNonEmpty(queryFirst(ctx, "Confidence"), queryFirst(ctx, "confidence"))),
+	}
+	if !hasTelnyxVoiceGatherContent(cb) {
+		return telnyxVoiceGatherCallback{}, &apptheory.AppError{Code: "app.bad_request", Message: "invalid gather payload"}
+	}
+	return cb, nil
+}
+
+func mapStringFirst(m map[string]any, keys ...string) string {
+	for _, key := range keys {
+		raw, ok := m[key]
+		if !ok {
+			continue
+		}
+		switch v := raw.(type) {
+		case string:
+			if s := strings.TrimSpace(v); s != "" {
+				return s
+			}
+		case json.Number:
+			if s := strings.TrimSpace(v.String()); s != "" {
+				return s
+			}
+		case float64:
+			return strings.TrimSpace(strconv.FormatFloat(v, 'f', -1, 64))
+		}
+	}
+	return ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func hasTelnyxVoiceGatherContent(cb telnyxVoiceGatherCallback) bool {
+	return strings.TrimSpace(cb.CallSID) != "" ||
+		strings.TrimSpace(cb.From) != "" ||
+		strings.TrimSpace(cb.To) != "" ||
+		strings.TrimSpace(cb.Digits) != "" ||
+		strings.TrimSpace(cb.SpeechResult) != "" ||
+		strings.TrimSpace(cb.Confidence) != ""
+}
+
+func normalizeTelnyxVoiceGatherReply(speechResult string, digits string) string {
+	speechResult = strings.TrimSpace(speechResult)
+	digits = strings.TrimSpace(digits)
+	if speechResult != "" {
+		return speechResult
+	}
+	if digits != "" {
+		return "Digits: " + digits
+	}
+	return ""
+}
+
+func voiceReplyMessageID(messageID string, callSID string) string {
+	messageID = strings.TrimSpace(messageID)
+	callSID = strings.TrimSpace(callSID)
+	if messageID == "" {
+		return ""
+	}
+	if callSID == "" {
+		return messageID + "-reply"
+	}
+	return messageID + "-reply-" + callSID
+}
+
+func parseTelnyxVoiceGatherConfidence(raw string) *float64 {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil {
+		return nil
+	}
+	return &v
+}
+
+func (s *Server) recordOutboundVoiceReply(ctx *apptheory.Context, messageID string, replyMessageID string, replyBody string, replyConfidence *float64, replyReceivedAt time.Time) error {
+	statusKey := &models.SoulCommMessageStatus{MessageID: messageID}
+	_ = statusKey.UpdateKeys()
+
+	var statusItem models.SoulCommMessageStatus
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulCommMessageStatus{}).
+		Where("PK", "=", statusKey.PK).
+		Where("SK", "=", statusKey.SK).
+		First(&statusItem)
+	if theoryErrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	statusItem.ReplyMessageID = strings.TrimSpace(replyMessageID)
+	statusItem.ReplyBody = strings.TrimSpace(replyBody)
+	statusItem.ReplyConfidence = replyConfidence
+	statusItem.ReplyReceivedAt = replyReceivedAt.UTC()
+	if strings.TrimSpace(statusItem.Status) == models.SoulCommMessageStatusAccepted {
+		statusItem.Status = models.SoulCommMessageStatusSent
+	}
+	return s.store.DB.WithContext(ctx.Context()).Model(&statusItem).IfExists().Update("Status", "ReplyMessageID", "ReplyBody", "ReplyConfidence", "ReplyReceivedAt", "UpdatedAt")
+}
+
+func (s *Server) maybeHandleOutboundVoiceStatusWebhook(ctx *apptheory.Context) (*apptheory.Response, bool, error) {
+	messageID := strings.TrimSpace(ctx.Param("messageId"))
+	if messageID == "" {
+		messageID = strings.TrimSpace(queryFirst(ctx, "messageId"))
+	}
+	if messageID == "" {
+		return nil, false, nil
+	}
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
+		return nil, true, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	var tel telnyxVoiceWebhook
+	if err := httpx.ParseJSON(ctx, &tel); err != nil {
+		return nil, true, &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
+	}
+
+	if err := s.updateOutboundVoiceStatusFromWebhook(ctx, messageID, &tel); err != nil {
+		return nil, true, err
+	}
+	resp, err := apptheory.JSON(http.StatusOK, map[string]any{"ok": true})
+	return resp, true, err
+}
+
+func (s *Server) updateOutboundVoiceStatusFromWebhook(ctx *apptheory.Context, messageID string, tel *telnyxVoiceWebhook) error {
+	statusKey := &models.SoulCommMessageStatus{MessageID: messageID}
+	_ = statusKey.UpdateKeys()
+
+	var statusItem models.SoulCommMessageStatus
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulCommMessageStatus{}).
+		Where("PK", "=", statusKey.PK).
+		Where("SK", "=", statusKey.SK).
+		First(&statusItem)
+	if theoryErrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	_, to, callID, _, durationSeconds := extractTelnyxVoiceFields(tel)
+	if durationSeconds > 0 {
+		_ = s.meterTelnyxVoiceCall(ctx, to, callID, durationSeconds)
+	}
+
+	nextStatus, errorCode, errorMessage, shouldUpdate := mapTelnyxVoiceEventToSoulStatus(strings.TrimSpace(tel.Data.EventType), durationSeconds, strings.TrimSpace(statusItem.Status))
+	if !shouldUpdate && strings.TrimSpace(callID) == "" {
+		return nil
+	}
+
+	if strings.TrimSpace(callID) != "" {
+		statusItem.ProviderMessageID = strings.TrimSpace(callID)
+	}
+	if shouldUpdate {
+		statusItem.Status = nextStatus
+		statusItem.ErrorCode = errorCode
+		statusItem.ErrorMessage = errorMessage
+	}
+	if err := s.store.DB.WithContext(ctx.Context()).Model(&statusItem).IfExists().Update("ProviderMessageID", "Status", "ErrorCode", "ErrorMessage", "UpdatedAt"); err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return nil
+}
+
+func mapTelnyxVoiceEventToSoulStatus(eventType string, durationSeconds int64, currentStatus string) (status string, errorCode string, errorMessage string, shouldUpdate bool) {
+	eventType = strings.ToLower(strings.TrimSpace(eventType))
+	currentStatus = strings.ToLower(strings.TrimSpace(currentStatus))
+	switch {
+	case strings.Contains(eventType, "answered"), strings.Contains(eventType, "speak.ended"), strings.Contains(eventType, "call.playback.ended"):
+		return models.SoulCommMessageStatusSent, "", "", true
+	case strings.Contains(eventType, "hangup"), strings.Contains(eventType, "ended"), strings.Contains(eventType, "completed"):
+		if durationSeconds > 0 || currentStatus == models.SoulCommMessageStatusSent {
+			return models.SoulCommMessageStatusSent, "", "", currentStatus != models.SoulCommMessageStatusSent
+		}
+		return models.SoulCommMessageStatusFailed, "call.hangup", "call ended before delivery", true
+	case strings.Contains(eventType, "busy"), strings.Contains(eventType, "failed"), strings.Contains(eventType, "error"), strings.Contains(eventType, "no_answer"), strings.Contains(eventType, "no-answer"), strings.Contains(eventType, "rejected"), strings.Contains(eventType, "canceled"):
+		if currentStatus == models.SoulCommMessageStatusSent {
+			return "", "", "", false
+		}
+		return models.SoulCommMessageStatusFailed, eventType, "provider reported call failure", true
+	default:
+		return "", "", "", false
+	}
+}

--- a/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
+++ b/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
@@ -1,0 +1,498 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/equaltoai/lesser-host/internal/commworker"
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+const (
+	commVoiceReplyBody      = "Yes, please call back tomorrow."
+	commVoiceReplyMessageID = "comm-msg-1-reply-call-1"
+)
+
+func voiceInstructionFixture() models.SoulCommVoiceInstruction {
+	return models.SoulCommVoiceInstruction{
+		MessageID: "comm-msg-1",
+		AgentID:   "0xabc",
+		From:      "+15550142",
+		To:        "+15550143",
+		Body:      "Hello from the soul",
+		Voice:     telnyxDefaultOutboundVoice,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+func newVoiceGatherCaptureServer(t *testing.T) (*Server, func() *commworker.QueueMessage) {
+	t.Helper()
+
+	db := ttmocks.NewMockExtendedDB()
+	qVoice := new(ttmocks.MockQuery)
+	qStatus := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Run(func(args mock.Arguments) {
+		if item := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0); strings.TrimSpace(item.MessageID) == "comm-msg-1" && strings.TrimSpace(item.ReplyBody) != "" {
+			if item.ReplyMessageID != commVoiceReplyMessageID {
+				t.Fatalf("unexpected reply message id: %#v", item)
+			}
+			if item.ReplyBody != commVoiceReplyBody {
+				t.Fatalf("unexpected reply body: %#v", item)
+			}
+			if item.ReplyConfidence == nil || *item.ReplyConfidence != 0.83 {
+				t.Fatalf("unexpected reply confidence: %#v", item.ReplyConfidence)
+			}
+			if item.Status != models.SoulCommMessageStatusSent {
+				t.Fatalf("expected status sent, got %#v", item)
+			}
+		}
+	}).Maybe()
+	qVoice.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qVoice).Maybe()
+	qStatus.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qStatus).Maybe()
+	qStatus.On("IfExists").Return(qStatus).Maybe()
+	qStatus.On("Update", mock.Anything).Return(nil).Once()
+	qVoice.On("First", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommVoiceInstruction](t, args, 0)
+		*dest = voiceInstructionFixture()
+	}).Once()
+	qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+		*dest = models.SoulCommMessageStatus{
+			MessageID: "comm-msg-1",
+			AgentID:   "0xabc",
+			To:        "+15550143",
+			Status:    models.SoulCommMessageStatusAccepted,
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+	}).Once()
+
+	var queued *commworker.QueueMessage
+	s := &Server{
+		store: store.New(db),
+		cfg:   config.Config{SoulEnabled: true},
+		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
+			cp := msg
+			queued = &cp
+			return nil
+		},
+	}
+	return s, func() *commworker.QueueMessage { return queued }
+}
+
+func TestNormalizeSoulCommPublicBaseURL(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "https host", input: " https://lab.lesser.host/path?q=1 ", want: "https://lab.lesser.host"},
+		{name: "http localhost", input: "http://localhost:5173/portal", want: "http://localhost:5173"},
+		{name: "invalid scheme", input: "ftp://lab.lesser.host", want: ""},
+		{name: "invalid host", input: "https://user@lab.lesser.host", want: ""},
+		{name: "blank", input: "  ", want: ""},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizeSoulCommPublicBaseURL(tc.input); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSafeSoulCommHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		host string
+		want bool
+	}{
+		{host: "lab.lesser.host", want: true},
+		{host: "localhost:5173", want: true},
+		{host: "bad host", want: false},
+		{host: "bad/host", want: false},
+		{host: "user@lab.lesser.host", want: false},
+		{host: "", want: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.host, func(t *testing.T) {
+			t.Parallel()
+			if got := safeSoulCommHost(tc.host); got != tc.want {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestSoulCommRequestBaseURL(t *testing.T) {
+	t.Parallel()
+
+	t.Run("prefers configured public base url", func(t *testing.T) {
+		t.Parallel()
+		ctx := &apptheory.Context{
+			Request: apptheory.Request{Headers: map[string][]string{"host": {"ignored.example"}}},
+		}
+		if got := soulCommRequestBaseURL(ctx, "https://lab.lesser.host/path"); got != "https://lab.lesser.host" {
+			t.Fatalf("expected configured base url, got %q", got)
+		}
+	})
+
+	t.Run("falls back to request host", func(t *testing.T) {
+		t.Parallel()
+		ctx := &apptheory.Context{
+			Request: apptheory.Request{Headers: map[string][]string{"host": {"portal.lesser.host"}}},
+		}
+		if got := soulCommRequestBaseURL(ctx, ""); got != "https://portal.lesser.host" {
+			t.Fatalf("expected request host fallback, got %q", got)
+		}
+	})
+
+	t.Run("rejects unsafe request host", func(t *testing.T) {
+		t.Parallel()
+		ctx := &apptheory.Context{
+			Request: apptheory.Request{Headers: map[string][]string{"host": {"bad host"}}},
+		}
+		if got := soulCommRequestBaseURL(ctx, ""); got != "" {
+			t.Fatalf("expected blank base url, got %q", got)
+		}
+	})
+}
+
+func TestBuildSoulCommVoiceTeXML(t *testing.T) {
+	t.Parallel()
+
+	t.Run("defaults and escaping", func(t *testing.T) {
+		t.Parallel()
+		payload, err := buildSoulCommVoiceTeXML(" hello <world> & friends ", "", "https://lab.lesser.host/webhooks/comm/voice/gather/comm-msg-1")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		got := string(payload)
+		if !strings.Contains(got, `<Gather input="speech" action="https://lab.lesser.host/webhooks/comm/voice/gather/comm-msg-1" method="POST" timeout="5" speechTimeout="auto">`) {
+			t.Fatalf("expected gather action, got %q", got)
+		}
+		if !strings.Contains(got, `hello &lt;world&gt; &amp; friends`) {
+			t.Fatalf("expected escaped body, got %q", got)
+		}
+		if !strings.Contains(got, telnyxDefaultOutboundReplyPrompt) {
+			t.Fatalf("expected reply prompt, got %q", got)
+		}
+	})
+
+	t.Run("blank body uses placeholder", func(t *testing.T) {
+		t.Parallel()
+		payload, err := buildSoulCommVoiceTeXML("   ", "Polly.Joanna-Neural", "https://lab.lesser.host/webhooks/comm/voice/gather/comm-msg-1")
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		if !strings.Contains(string(payload), `No message provided.`) {
+			t.Fatalf("expected placeholder body, got %q", string(payload))
+		}
+		if !strings.Contains(string(payload), `voice="Polly.Joanna-Neural"`) {
+			t.Fatalf("expected custom voice, got %q", string(payload))
+		}
+	})
+}
+
+func TestHandleCommVoiceTeXML_Disabled(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{store: store.New(ttmocks.NewMockExtendedDB()), cfg: config.Config{SoulEnabled: false}}
+	resp, err := s.handleCommVoiceTeXML(&apptheory.Context{Params: map[string]string{"messageId": "comm-msg-1"}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.Status)
+	}
+}
+
+func TestHandleCommVoiceTeXML_MissingMessageID(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{store: store.New(ttmocks.NewMockExtendedDB()), cfg: config.Config{SoulEnabled: true}}
+	_, err := s.handleCommVoiceTeXML(&apptheory.Context{})
+	appErr := requireAppError(t, err)
+	if appErr.Code != appErrCodeBadRequest || appErr.Message != "messageId is required" {
+		t.Fatalf("unexpected error: %#v", appErr)
+	}
+}
+
+func TestHandleCommVoiceTeXML_NotFound(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qVoice := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	qVoice.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qVoice).Maybe()
+	qVoice.On("First", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{SoulEnabled: true}}
+	_, err := s.handleCommVoiceTeXML(&apptheory.Context{Params: map[string]string{"messageId": "comm-msg-1"}})
+	appErr := requireCommTheoryError(t, err)
+	if appErr.Code != appErrCodeNotFound || appErr.StatusCode != http.StatusNotFound {
+		t.Fatalf("unexpected error: %#v", appErr)
+	}
+}
+
+func TestHandleCommVoiceTeXML_Success(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qVoice := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	qVoice.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qVoice).Maybe()
+	qVoice.On("First", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommVoiceInstruction](t, args, 0)
+		*dest = models.SoulCommVoiceInstruction{
+			MessageID: "comm-msg-1",
+			AgentID:   "0xabc",
+			From:      "+15550142",
+			To:        "+15550143",
+			Body:      "Voice <test>",
+			Voice:     "Polly.Joanna-Neural",
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{SoulEnabled: true, PublicBaseURL: "https://lab.lesser.host"}}
+	resp, err := s.handleCommVoiceTeXML(&apptheory.Context{
+		Params:  map[string]string{"messageId": "comm-msg-1"},
+		Request: apptheory.Request{Headers: map[string][]string{"host": {"ignored.example"}}},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+	if got := resp.Headers["content-type"]; len(got) != 1 || got[0] != "application/xml; charset=utf-8" {
+		t.Fatalf("unexpected headers: %#v", resp.Headers)
+	}
+	if !strings.Contains(string(resp.Body), `voice="Polly.Joanna-Neural"`) || !strings.Contains(string(resp.Body), `Voice &lt;test&gt;`) {
+		t.Fatalf("unexpected xml body: %q", string(resp.Body))
+	}
+	if !strings.Contains(string(resp.Body), `/webhooks/comm/voice/gather/comm-msg-1`) {
+		t.Fatalf("expected gather action in xml body: %q", string(resp.Body))
+	}
+}
+
+func TestHandleCommVoiceGatherWebhook_CapturesSpeechReplyAndUpdatesStatus(t *testing.T) {
+	t.Parallel()
+
+	s, getQueued := newVoiceGatherCaptureServer(t)
+
+	body, err := json.Marshal(map[string]any{
+		"CallSid":      "call-1",
+		"From":         "+15550142",
+		"To":           "+15550143",
+		"SpeechResult": commVoiceReplyBody,
+		"Confidence":   "0.83",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp, callErr := s.handleCommVoiceGatherWebhook(&apptheory.Context{
+		Params:  map[string]string{"messageId": "comm-msg-1"},
+		Request: apptheory.Request{Body: body},
+	})
+	if callErr != nil {
+		t.Fatalf("unexpected err: %v", callErr)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+	queued := getQueued()
+	if queued == nil {
+		t.Fatalf("expected queued reply notification")
+	}
+	if queued.Notification.Channel != commChannelVoice || queued.Notification.Body != commVoiceReplyBody {
+		t.Fatalf("unexpected queued notification: %#v", queued.Notification)
+	}
+	if queued.Notification.From.Number != "+15550143" || queued.Notification.To == nil || queued.Notification.To.Number != "+15550142" {
+		t.Fatalf("unexpected notification routing: %#v", queued.Notification)
+	}
+	if queued.Notification.InReplyTo == nil || *queued.Notification.InReplyTo != "comm-msg-1" {
+		t.Fatalf("expected inReplyTo comm-msg-1, got %#v", queued.Notification.InReplyTo)
+	}
+}
+
+func TestHandleCommVoiceGatherWebhook_EmptyGatherResultAcknowledges(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qVoice := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	qVoice.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qVoice).Maybe()
+	qVoice.On("First", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommVoiceInstruction](t, args, 0)
+		*dest = voiceInstructionFixture()
+	}).Once()
+
+	s := &Server{
+		store: store.New(db),
+		cfg:   config.Config{SoulEnabled: true},
+		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
+			t.Fatalf("enqueue should not be called for empty gather result")
+			return nil
+		},
+	}
+
+	body, err := json.Marshal(map[string]any{
+		"CallSid": "call-1",
+		"From":    "+15550142",
+		"To":      "+15550143",
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	resp, callErr := s.handleCommVoiceGatherWebhook(&apptheory.Context{
+		Params:  map[string]string{"messageId": "comm-msg-1"},
+		Request: apptheory.Request{Body: body},
+	})
+	if callErr != nil {
+		t.Fatalf("unexpected err: %v", callErr)
+	}
+	if resp.Status != http.StatusOK || !strings.Contains(string(resp.Body), `"captured":false`) {
+		t.Fatalf("unexpected response: %#v body=%s", resp, string(resp.Body))
+	}
+}
+
+func TestMaybeHandleOutboundVoiceStatusWebhook(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no message id falls through", func(t *testing.T) {
+		t.Parallel()
+		resp, handled, err := (&Server{}).maybeHandleOutboundVoiceStatusWebhook(&apptheory.Context{})
+		if err != nil || handled || resp != nil {
+			t.Fatalf("expected no-op, got resp=%#v handled=%v err=%v", resp, handled, err)
+		}
+	})
+
+	t.Run("invalid payload", func(t *testing.T) {
+		t.Parallel()
+		db := ttmocks.NewMockExtendedDB()
+		s := &Server{store: store.New(db)}
+		_, handled, err := s.maybeHandleOutboundVoiceStatusWebhook(&apptheory.Context{
+			Params:  map[string]string{"messageId": "comm-msg-1"},
+			Request: apptheory.Request{Body: []byte("{")},
+		})
+		if !handled {
+			t.Fatalf("expected handled=true")
+		}
+		appErr := requireAppError(t, err)
+		if appErr.Code != appErrCodeBadRequest || appErr.Message != "invalid webhook payload" {
+			t.Fatalf("unexpected error: %#v", appErr)
+		}
+	})
+
+	t.Run("accepted status transitions to sent", func(t *testing.T) {
+		t.Parallel()
+		db := ttmocks.NewMockExtendedDB()
+		qStatus := new(ttmocks.MockQuery)
+		db.On("WithContext", mock.Anything).Return(db).Maybe()
+		db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
+		qStatus.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qStatus).Maybe()
+		qStatus.On("IfExists").Return(qStatus).Maybe()
+		qStatus.On("Update", mock.Anything).Return(nil).Once()
+		qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+			*dest = models.SoulCommMessageStatus{
+				MessageID: "comm-msg-1",
+				AgentID:   "0xabc",
+				To:        "+15550143",
+				Status:    models.SoulCommMessageStatusAccepted,
+				CreatedAt: time.Now().UTC(),
+				UpdatedAt: time.Now().UTC(),
+			}
+		}).Once()
+
+		body, err := json.Marshal(map[string]any{
+			"data": map[string]any{
+				"event_type": "call.answered",
+				"payload": map[string]any{
+					"call_control_id": "call-control-1",
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		s := &Server{store: store.New(db)}
+		resp, handled, callErr := s.maybeHandleOutboundVoiceStatusWebhook(&apptheory.Context{
+			Params:  map[string]string{"messageId": "comm-msg-1"},
+			Request: apptheory.Request{Body: body},
+		})
+		if callErr != nil {
+			t.Fatalf("unexpected err: %v", callErr)
+		}
+		if !handled {
+			t.Fatalf("expected handled=true")
+		}
+		if resp == nil || resp.Status != http.StatusOK {
+			t.Fatalf("expected 200 response, got %#v", resp)
+		}
+	})
+}
+
+func TestMapTelnyxVoiceEventToSoulStatus(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		eventType     string
+		duration      int64
+		currentStatus string
+		wantStatus    string
+		wantCode      string
+		wantUpdate    bool
+	}{
+		{name: "answered becomes sent", eventType: "call.answered", wantStatus: models.SoulCommMessageStatusSent, wantUpdate: true},
+		{name: "ended with duration stays sent", eventType: "call.ended", duration: 12, wantStatus: models.SoulCommMessageStatusSent, wantUpdate: true},
+		{name: "hangup before delivery fails", eventType: "call.hangup", wantStatus: models.SoulCommMessageStatusFailed, wantCode: "call.hangup", wantUpdate: true},
+		{name: "failure after sent ignored", eventType: "call.failed", currentStatus: models.SoulCommMessageStatusSent, wantUpdate: false},
+		{name: "unknown event ignored", eventType: "call.ringing", wantUpdate: false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gotStatus, gotCode, _, gotUpdate := mapTelnyxVoiceEventToSoulStatus(tc.eventType, tc.duration, tc.currentStatus)
+			if gotStatus != tc.wantStatus || gotCode != tc.wantCode || gotUpdate != tc.wantUpdate {
+				t.Fatalf("expected status=%q code=%q update=%v, got status=%q code=%q update=%v", tc.wantStatus, tc.wantCode, tc.wantUpdate, gotStatus, gotCode, gotUpdate)
+			}
+		})
+	}
+}

--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -248,6 +248,9 @@ func (s *Server) handleCommVoiceStatusWebhook(ctx *apptheory.Context) (*apptheor
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
 	}
+	if resp, handled, err := s.maybeHandleOutboundVoiceStatusWebhook(ctx); handled || err != nil {
+		return resp, err
+	}
 	return s.handleCommVoiceInboundWebhook(ctx)
 }
 

--- a/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
@@ -342,7 +342,7 @@ func TestExtractTelnyxVoiceFields_CoversAlternateShapes(t *testing.T) {
 
 	t.Run("fallback event type and string duration", func(t *testing.T) {
 		tel := &telnyxVoiceWebhook{}
-		tel.Data.EventType = "call.hangup"
+		tel.Data.EventType = commWebhookCallHangup
 		tel.Data.Payload = map[string]any{
 			"from":     map[string]any{"number": "+15550144"},
 			"to":       map[string]any{"phone_number": "+15550145"},

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -275,7 +275,7 @@ func upsertProvisionedPhoneChannel(ctx context.Context, s *Server, agentIDHex st
 		VerifiedAt:    now,
 		Status:        models.SoulChannelStatusActive,
 		ProvisionedAt: now,
-		Capabilities:  []string{"sms-receive", "sms-send", "voice-receive"},
+		Capabilities:  []string{"sms-receive", "sms-send", "voice-receive", "voice-send"},
 		UpdatedAt:     now,
 	}
 	_ = channel.UpdateKeys()
@@ -394,7 +394,7 @@ func (s *Server) buildSoulProvisionPhoneRegistration(ctx context.Context, base m
 	ch["phone"] = map[string]any{
 		"number":       strings.TrimSpace(input.PhoneNumber),
 		"provider":     "telnyx",
-		"capabilities": []any{"sms-receive", "sms-send", "voice-receive"},
+		"capabilities": []any{"sms-receive", "sms-send", "voice-receive", "voice-send"},
 		"verified":     true,
 		"verifiedAt":   issuedAt,
 	}

--- a/internal/controlplane/handlers_soul_comm_portal.go
+++ b/internal/controlplane/handlers_soul_comm_portal.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -180,23 +179,7 @@ func (s *Server) handleSoulAgentCommStatus(ctx *apptheory.Context) (*apptheory.R
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "message not found"}
 	}
 
-	out := soulCommStatusResponse{
-		MessageID:         strings.TrimSpace(item.MessageID),
-		Status:            strings.TrimSpace(item.Status),
-		Channel:           strings.TrimSpace(item.ChannelType),
-		AgentID:           strings.ToLower(strings.TrimSpace(item.AgentID)),
-		To:                strings.TrimSpace(item.To),
-		Provider:          strings.TrimSpace(item.Provider),
-		ProviderMessageID: strings.TrimSpace(item.ProviderMessageID),
-		ErrorCode:         strings.TrimSpace(item.ErrorCode),
-		ErrorMessage:      strings.TrimSpace(item.ErrorMessage),
-		CreatedAt:         item.CreatedAt.UTC().Format(time.RFC3339Nano),
-	}
-	if !item.UpdatedAt.IsZero() {
-		out.UpdatedAt = item.UpdatedAt.UTC().Format(time.RFC3339Nano)
-	}
-
-	resp, err := apptheory.JSON(http.StatusOK, out)
+	resp, err := apptheory.JSON(http.StatusOK, soulCommStatusJSON(item))
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"net/mail"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -73,17 +74,21 @@ type soulCommSendResponse struct {
 }
 
 type soulCommStatusResponse struct {
-	MessageID         string `json:"messageId"`
-	Status            string `json:"status"`
-	Channel           string `json:"channel"`
-	AgentID           string `json:"agentId"`
-	To                string `json:"to"`
-	Provider          string `json:"provider,omitempty"`
-	ProviderMessageID string `json:"providerMessageId,omitempty"`
-	ErrorCode         string `json:"errorCode,omitempty"`
-	ErrorMessage      string `json:"errorMessage,omitempty"`
-	CreatedAt         string `json:"createdAt"`
-	UpdatedAt         string `json:"updatedAt,omitempty"`
+	MessageID         string   `json:"messageId"`
+	Status            string   `json:"status"`
+	Channel           string   `json:"channel"`
+	AgentID           string   `json:"agentId"`
+	To                string   `json:"to"`
+	Provider          string   `json:"provider,omitempty"`
+	ProviderMessageID string   `json:"providerMessageId,omitempty"`
+	ErrorCode         string   `json:"errorCode,omitempty"`
+	ErrorMessage      string   `json:"errorMessage,omitempty"`
+	ReplyMessageID    string   `json:"replyMessageId,omitempty"`
+	ReplyBody         string   `json:"replyBody,omitempty"`
+	ReplyConfidence   *float64 `json:"replyConfidence,omitempty"`
+	ReplyReceivedAt   string   `json:"replyReceivedAt,omitempty"`
+	CreatedAt         string   `json:"createdAt"`
+	UpdatedAt         string   `json:"updatedAt,omitempty"`
 }
 
 type soulCommSendMetrics struct {
@@ -114,6 +119,7 @@ type soulCommSendRoute struct {
 type soulCommSendDelivery struct {
 	provider          string
 	providerMessageID string
+	initialStatus     string
 }
 
 func newSoulCommSendMetrics(stage string, instance string) *soulCommSendMetrics {
@@ -415,6 +421,8 @@ func (s *Server) dispatchSoulCommSend(ctx *apptheory.Context, key *models.Instan
 		return s.sendSoulCommEmail(ctx, req, channel, now, messageID, metrics)
 	case commChannelSMS:
 		return s.sendSoulCommSMS(ctx, key, req, channel, now, messageID, metrics)
+	case commChannelVoice:
+		return s.sendSoulCommVoice(ctx, key, req, channel, now, messageID, metrics)
 	default:
 		metrics.status = commMetricProviderUnavailable
 		return soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeProviderUnavailable, "channel not supported").WithStatusCode(http.StatusServiceUnavailable)
@@ -465,6 +473,7 @@ func (s *Server) sendSoulCommEmail(ctx *apptheory.Context, req validatedSoulComm
 	return soulCommSendDelivery{
 		provider:          commDeliveryProviderMigadu,
 		providerMessageID: providerMessageID,
+		initialStatus:     models.SoulCommMessageStatusSent,
 	}, nil
 }
 
@@ -494,6 +503,54 @@ func (s *Server) sendSoulCommSMS(ctx *apptheory.Context, key *models.InstanceKey
 	return soulCommSendDelivery{
 		provider:          commDeliveryProviderTelnyx,
 		providerMessageID: providerMessageID,
+		initialStatus:     models.SoulCommMessageStatusSent,
+	}, nil
+}
+
+func (s *Server) sendSoulCommVoice(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, channel *models.SoulAgentChannel, now time.Time, messageID string, metrics *soulCommSendMetrics) (soulCommSendDelivery, *apptheory.AppTheoryError) {
+	if s.telnyxCallVoice == nil {
+		metrics.status = commMetricProviderUnavailable
+		return soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeProviderUnavailable, "provider not configured").WithStatusCode(http.StatusServiceUnavailable)
+	}
+
+	voiceInstruction := &models.SoulCommVoiceInstruction{
+		MessageID: messageID,
+		AgentID:   req.agentIDHex,
+		From:      strings.TrimSpace(channel.Identifier),
+		To:        req.to,
+		Body:      req.body,
+		Voice:     telnyxDefaultOutboundVoice,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := voiceInstruction.UpdateKeys(); err != nil {
+		metrics.status = commMetricInternalError
+		return soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	if err := s.store.DB.WithContext(ctx.Context()).Model(voiceInstruction).Create(); err != nil {
+		metrics.status = commMetricInternalError
+		return soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeInternal, "failed to store voice instruction").WithStatusCode(http.StatusInternalServerError)
+	}
+
+	baseURL := soulCommRequestBaseURL(ctx, s.cfg.PublicBaseURL)
+	if baseURL == "" {
+		metrics.status = commMetricInternalError
+		return soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeInternal, "public base url is unavailable").WithStatusCode(http.StatusInternalServerError)
+	}
+	texmlURL := baseURL + "/webhooks/comm/voice/texml/" + url.PathEscape(messageID)
+	statusCallbackURL := baseURL + "/webhooks/comm/voice/status/" + url.PathEscape(messageID)
+
+	providerMessageID, err := s.telnyxCallVoice(ctx.Context(), strings.TrimSpace(channel.Identifier), req.to, texmlURL, statusCallbackURL)
+	if err != nil {
+		metrics.provider = commDeliveryProviderTelnyx
+		metrics.status = commMetricProviderRejected
+		return soulCommSendDelivery{}, apptheory.NewAppTheoryError("comm.provider_rejected", "provider rejected call").WithStatusCode(http.StatusBadGateway)
+	}
+
+	return soulCommSendDelivery{
+		provider:          commDeliveryProviderTelnyx,
+		providerMessageID: providerMessageID,
+		initialStatus:     models.SoulCommMessageStatusAccepted,
 	}, nil
 }
 
@@ -605,6 +662,10 @@ func (s *Server) debitSoulSMSCredits(ctx context.Context, instanceSlug string, a
 }
 
 func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, delivery soulCommSendDelivery, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+	statusValue := strings.TrimSpace(delivery.initialStatus)
+	if statusValue == "" {
+		statusValue = models.SoulCommMessageStatusSent
+	}
 	status := &models.SoulCommMessageStatus{
 		MessageID:         messageID,
 		AgentID:           req.agentIDHex,
@@ -612,7 +673,7 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 		To:                req.to,
 		Provider:          delivery.provider,
 		ProviderMessageID: delivery.providerMessageID,
-		Status:            models.SoulCommMessageStatusSent,
+		Status:            statusValue,
 		CreatedAt:         now,
 		UpdatedAt:         now,
 	}
@@ -652,9 +713,13 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 }
 
 func soulCommSendJSON(messageID string, req validatedSoulCommSendRequest, delivery soulCommSendDelivery, now time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
+	statusValue := strings.TrimSpace(delivery.initialStatus)
+	if statusValue == "" {
+		statusValue = models.SoulCommMessageStatusSent
+	}
 	resp, err := apptheory.JSON(http.StatusOK, soulCommSendResponse{
 		MessageID:         messageID,
-		Status:            models.SoulCommMessageStatusSent,
+		Status:            statusValue,
 		Channel:           req.channel,
 		AgentID:           req.agentIDHex,
 		To:                req.to,
@@ -666,6 +731,31 @@ func soulCommSendJSON(messageID string, req validatedSoulCommSendRequest, delive
 		return nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 	return resp, nil
+}
+
+func soulCommStatusJSON(item models.SoulCommMessageStatus) soulCommStatusResponse {
+	out := soulCommStatusResponse{
+		MessageID:         strings.TrimSpace(item.MessageID),
+		Status:            strings.TrimSpace(item.Status),
+		Channel:           strings.TrimSpace(item.ChannelType),
+		AgentID:           strings.ToLower(strings.TrimSpace(item.AgentID)),
+		To:                strings.TrimSpace(item.To),
+		Provider:          strings.TrimSpace(item.Provider),
+		ProviderMessageID: strings.TrimSpace(item.ProviderMessageID),
+		ErrorCode:         strings.TrimSpace(item.ErrorCode),
+		ErrorMessage:      strings.TrimSpace(item.ErrorMessage),
+		ReplyMessageID:    strings.TrimSpace(item.ReplyMessageID),
+		ReplyBody:         strings.TrimSpace(item.ReplyBody),
+		ReplyConfidence:   item.ReplyConfidence,
+		CreatedAt:         item.CreatedAt.UTC().Format(time.RFC3339Nano),
+	}
+	if !item.ReplyReceivedAt.IsZero() {
+		out.ReplyReceivedAt = item.ReplyReceivedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !item.UpdatedAt.IsZero() {
+		out.UpdatedAt = item.UpdatedAt.UTC().Format(time.RFC3339Nano)
+	}
+	return out
 }
 
 func normalizeCommPhoneE164(raw string) string {
@@ -722,23 +812,7 @@ func (s *Server) handleSoulCommStatus(ctx *apptheory.Context) (*apptheory.Respon
 		return nil, appErr
 	}
 
-	out := soulCommStatusResponse{
-		MessageID:         strings.TrimSpace(item.MessageID),
-		Status:            strings.TrimSpace(item.Status),
-		Channel:           strings.TrimSpace(item.ChannelType),
-		AgentID:           strings.ToLower(strings.TrimSpace(item.AgentID)),
-		To:                strings.TrimSpace(item.To),
-		Provider:          strings.TrimSpace(item.Provider),
-		ProviderMessageID: strings.TrimSpace(item.ProviderMessageID),
-		ErrorCode:         strings.TrimSpace(item.ErrorCode),
-		ErrorMessage:      strings.TrimSpace(item.ErrorMessage),
-		CreatedAt:         item.CreatedAt.UTC().Format(time.RFC3339Nano),
-	}
-	if !item.UpdatedAt.IsZero() {
-		out.UpdatedAt = item.UpdatedAt.UTC().Format(time.RFC3339Nano)
-	}
-
-	resp, err := apptheory.JSON(http.StatusOK, out)
+	resp, err := apptheory.JSON(http.StatusOK, soulCommStatusJSON(item))
 	if err != nil {
 		return nil, apptheory.NewAppTheoryError("comm.internal", "internal error").WithStatusCode(http.StatusInternalServerError)
 	}

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -424,6 +424,120 @@ func TestHandleSoulCommSend_SendsSMSAndDebitsCredits(t *testing.T) {
 	assertSoulCommSendResponse(t, resp, commMetricSent, commDeliveryProviderTelnyx, commChannelSMS, commSendTelnyxMessageID)
 }
 
+func TestHandleSoulCommSend_StartsVoiceCallAndStoresInstruction(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qKey := new(ttmocks.MockQuery)
+	qDomain := new(ttmocks.MockQuery)
+	qIdentity := new(ttmocks.MockQuery)
+	qChannel := new(ttmocks.MockQuery)
+	qCommActivity := new(ttmocks.MockQuery)
+	qStatus := new(ttmocks.MockQuery)
+	qVoice := new(ttmocks.MockQuery)
+	qAudit := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qIdentity).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qCommActivity).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
+
+	allowCommQueryOps(qKey, qDomain, qIdentity, qChannel, qCommActivity, qStatus, qVoice, qAudit)
+
+	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceKey](t, args, 0)
+		*dest = models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()}
+	}).Once()
+
+	agentID := soulLifecycleTestAgentIDHex
+
+	qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{
+			AgentID:         agentID,
+			Domain:          "example.com",
+			LocalID:         "agent-alice",
+			Status:          models.SoulAgentStatusActive,
+			LifecycleStatus: models.SoulAgentStatusActive,
+			UpdatedAt:       time.Now().UTC(),
+		}
+	}).Once()
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}
+	}).Once()
+
+	qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:       agentID,
+			ChannelType:   models.SoulChannelTypePhone,
+			Identifier:    "+15550142",
+			Verified:      true,
+			ProvisionedAt: time.Now().Add(-time.Hour).UTC(),
+			Status:        models.SoulChannelStatusActive,
+			UpdatedAt:     time.Now().UTC(),
+		}
+	}).Once()
+
+	qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		*dest = []*models.SoulAgentCommActivity{}
+	}).Twice()
+
+	var voiceCalled bool
+	s := &Server{
+		store: store.New(db),
+		cfg:   config.Config{SoulEnabled: true, Stage: "lab", PublicBaseURL: "https://lab.lesser.host"},
+		telnyxCallVoice: func(ctx context.Context, from string, to string, texmlURL string, statusCallbackURL string) (string, error) {
+			voiceCalled = true
+			if from != "+15550142" || to != "+15550143" {
+				t.Fatalf("unexpected voice args from=%q to=%q", from, to)
+			}
+			if !strings.HasPrefix(texmlURL, "https://lab.lesser.host/webhooks/comm/voice/texml/comm-msg-") {
+				t.Fatalf("unexpected texmlURL: %q", texmlURL)
+			}
+			if !strings.HasPrefix(statusCallbackURL, "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-") {
+				t.Fatalf("unexpected statusCallbackURL: %q", statusCallbackURL)
+			}
+			return "call-control-1", nil
+		},
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"channel":   "voice",
+		"agentId":   agentID,
+		"to":        "+15550143",
+		"body":      "Test by voice",
+		"inReplyTo": "call-back-1",
+	})
+
+	ctx := &apptheory.Context{
+		RequestID: "r-comm-send-voice",
+		Request: apptheory.Request{
+			Body: body,
+			Headers: map[string][]string{
+				"authorization": {"Bearer k1"},
+			},
+		},
+	}
+
+	resp, err := s.handleSoulCommSend(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !voiceCalled {
+		t.Fatalf("expected telnyx voice call")
+	}
+	assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusAccepted, commDeliveryProviderTelnyx, commChannelVoice, "call-control-1")
+}
+
 func TestHandleSoulCommSend_SMSInsufficientCreditsBlocksSend(t *testing.T) {
 	t.Parallel()
 
@@ -583,15 +697,21 @@ func TestHandleSoulCommStatus_ReturnsStatusRecord(t *testing.T) {
 
 	qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+		confidence := 0.91
 		*dest = models.SoulCommMessageStatus{
-			MessageID:   messageID,
-			AgentID:     agentID,
-			ChannelType: "email",
-			To:          "alice@example.com",
-			Provider:    "migadu",
-			Status:      models.SoulCommMessageStatusSent,
-			CreatedAt:   time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
-			UpdatedAt:   time.Date(2026, 3, 4, 12, 0, 1, 0, time.UTC),
+			MessageID:         messageID,
+			AgentID:           agentID,
+			ChannelType:       "voice",
+			To:                "+15550143",
+			Provider:          "telnyx",
+			ProviderMessageID: "call-1",
+			Status:            models.SoulCommMessageStatusSent,
+			ReplyMessageID:    "comm-msg-test-reply-call-1",
+			ReplyBody:         commVoiceReplyBody,
+			ReplyConfidence:   &confidence,
+			ReplyReceivedAt:   time.Date(2026, 3, 4, 12, 0, 30, 0, time.UTC),
+			CreatedAt:         time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:         time.Date(2026, 3, 4, 12, 0, 31, 0, time.UTC),
 		}
 	}).Once()
 
@@ -639,5 +759,11 @@ func TestHandleSoulCommStatus_ReturnsStatusRecord(t *testing.T) {
 	}
 	if out.MessageID != messageID || out.Status != commMetricSent || out.AgentID != strings.ToLower(agentID) {
 		t.Fatalf("unexpected response: %#v", out)
+	}
+	if out.ReplyBody != commVoiceReplyBody || out.ReplyMessageID != "comm-msg-test-reply-call-1" || out.ReplyReceivedAt == "" {
+		t.Fatalf("expected reply metadata, got %#v", out)
+	}
+	if out.ReplyConfidence == nil || *out.ReplyConfidence != 0.91 {
+		t.Fatalf("expected reply confidence, got %#v", out.ReplyConfidence)
 	}
 }

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -35,6 +35,7 @@ type Server struct {
 	telnyxOrderNumber func(ctx context.Context, phoneNumber string) (string, error)
 	telnyxRelease     func(ctx context.Context, phoneNumber string) error
 	telnyxSendSMS     func(ctx context.Context, from string, to string, text string) (string, error)
+	telnyxCallVoice   func(ctx context.Context, from string, to string, texmlURL string, statusCallbackURL string) (string, error)
 
 	enqueueCommMessage func(ctx context.Context, msg commworker.QueueMessage) error
 }
@@ -63,6 +64,7 @@ func NewServer(cfg config.Config, st *store.Store) *Server {
 		telnyxOrderNumber: defaultTelnyxOrderPhoneNumber,
 		telnyxRelease:     defaultTelnyxReleasePhoneNumber,
 		telnyxSendSMS:     defaultTelnyxSendSMS,
+		telnyxCallVoice:   defaultTelnyxCreateVoiceCall,
 	}
 	srv.enqueueCommMessage = srv.queues.enqueueCommMessage
 	return srv
@@ -168,6 +170,11 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Post("/webhooks/comm/sms/inbound", s.handleCommSMSInboundWebhook)
 	app.Post("/webhooks/comm/voice/inbound", s.handleCommVoiceInboundWebhook)
 	app.Post("/webhooks/comm/voice/status", s.handleCommVoiceStatusWebhook)
+	app.Post("/webhooks/comm/voice/status/{messageId}", s.handleCommVoiceStatusWebhook)
+	app.Get("/webhooks/comm/voice/gather/{messageId}", s.handleCommVoiceGatherWebhook)
+	app.Post("/webhooks/comm/voice/gather/{messageId}", s.handleCommVoiceGatherWebhook)
+	app.Get("/webhooks/comm/voice/texml/{messageId}", s.handleCommVoiceTeXML)
+	app.Post("/webhooks/comm/voice/texml/{messageId}", s.handleCommVoiceTeXML)
 
 	// Instance registry + billing primitives (admin-only).
 	app.Post("/api/v1/instances", s.handleCreateInstance, apptheory.RequireAuth())

--- a/internal/store/models/soul_comm_message_status.go
+++ b/internal/store/models/soul_comm_message_status.go
@@ -35,9 +35,13 @@ type SoulCommMessageStatus struct {
 	Provider          string `theorydb:"attr:provider" json:"provider,omitempty"`
 	ProviderMessageID string `theorydb:"attr:providerMessageId" json:"provider_message_id,omitempty"`
 
-	Status       string `theorydb:"attr:status" json:"status"` // accepted|sent|failed
-	ErrorCode    string `theorydb:"attr:errorCode" json:"error_code,omitempty"`
-	ErrorMessage string `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
+	Status          string    `theorydb:"attr:status" json:"status"` // accepted|sent|failed
+	ErrorCode       string    `theorydb:"attr:errorCode" json:"error_code,omitempty"`
+	ErrorMessage    string    `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
+	ReplyMessageID  string    `theorydb:"attr:replyMessageId" json:"reply_message_id,omitempty"`
+	ReplyBody       string    `theorydb:"attr:replyBody" json:"reply_body,omitempty"`
+	ReplyConfidence *float64  `theorydb:"attr:replyConfidence" json:"reply_confidence,omitempty"`
+	ReplyReceivedAt time.Time `theorydb:"attr:replyReceivedAt" json:"reply_received_at,omitempty"`
 
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
 	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
@@ -105,6 +109,8 @@ func (m *SoulCommMessageStatus) UpdateKeys() error {
 	m.Status = strings.ToLower(strings.TrimSpace(m.Status))
 	m.ErrorCode = strings.TrimSpace(m.ErrorCode)
 	m.ErrorMessage = strings.TrimSpace(m.ErrorMessage)
+	m.ReplyMessageID = strings.TrimSpace(m.ReplyMessageID)
+	m.ReplyBody = strings.TrimSpace(m.ReplyBody)
 
 	m.PK = fmt.Sprintf("COMM#MSG#%s", m.MessageID)
 	m.SK = "STATUS"

--- a/internal/store/models/soul_comm_voice_instruction.go
+++ b/internal/store/models/soul_comm_voice_instruction.go
@@ -1,0 +1,97 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SoulCommVoiceInstruction stores the TeXML payload source for an outbound voice message.
+//
+// Keys:
+//
+//	PK: COMM#MSG#{messageId}
+//	SK: VOICE#INSTRUCTION
+type SoulCommVoiceInstruction struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	MessageID string `theorydb:"attr:messageId" json:"message_id"`
+	AgentID   string `theorydb:"attr:agentId" json:"agent_id"`
+	From      string `theorydb:"attr:from" json:"from"`
+	To        string `theorydb:"attr:to" json:"to"`
+	Body      string `theorydb:"attr:body" json:"body"`
+	Voice     string `theorydb:"attr:voice,omitempty" json:"voice,omitempty"`
+
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
+}
+
+// TableName returns the database table name for SoulCommVoiceInstruction.
+func (SoulCommVoiceInstruction) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating SoulCommVoiceInstruction.
+func (m *SoulCommVoiceInstruction) BeforeCreate() error {
+	now := time.Now().UTC()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	if m.UpdatedAt.IsZero() {
+		m.UpdatedAt = now
+	}
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("from", m.From); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("to", m.To); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("body", m.Body); err != nil {
+		return err
+	}
+	return nil
+}
+
+// BeforeUpdate updates timestamps and keys before updating SoulCommVoiceInstruction.
+func (m *SoulCommVoiceInstruction) BeforeUpdate() error {
+	m.UpdatedAt = time.Now().UTC()
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateKeys updates the database keys for SoulCommVoiceInstruction.
+func (m *SoulCommVoiceInstruction) UpdateKeys() error {
+	m.MessageID = strings.TrimSpace(m.MessageID)
+	m.AgentID = strings.ToLower(strings.TrimSpace(m.AgentID))
+	m.From = strings.TrimSpace(m.From)
+	m.To = strings.TrimSpace(m.To)
+	m.Body = strings.TrimSpace(m.Body)
+	m.Voice = strings.TrimSpace(m.Voice)
+
+	m.PK = fmt.Sprintf("COMM#MSG#%s", m.MessageID)
+	m.SK = "VOICE#INSTRUCTION"
+	m.TTL = m.CreatedAt.UTC().Add(24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for SoulCommVoiceInstruction.
+func (m *SoulCommVoiceInstruction) GetPK() string { return m.PK }
+
+// GetSK returns the sort key for SoulCommVoiceInstruction.
+func (m *SoulCommVoiceInstruction) GetSK() string { return m.SK }

--- a/internal/store/models/soul_comm_voice_instruction_test.go
+++ b/internal/store/models/soul_comm_voice_instruction_test.go
@@ -1,0 +1,48 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSoulCommVoiceInstructionLifecycle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 9, 12, 0, 0, 0, time.UTC)
+	item := SoulCommVoiceInstruction{
+		MessageID: " comm-msg-1 ",
+		AgentID:   " 0xABCD ",
+		From:      " +15550142 ",
+		To:        " +15550143 ",
+		Body:      " hello there ",
+		Voice:     " Polly.Amy-Neural ",
+		CreatedAt: now,
+	}
+
+	require.Equal(t, MainTableName(), item.TableName())
+	require.NoError(t, item.BeforeCreate())
+	require.Equal(t, "COMM#MSG#comm-msg-1", item.GetPK())
+	require.Equal(t, "VOICE#INSTRUCTION", item.GetSK())
+	require.Equal(t, "0xabcd", item.AgentID)
+	require.Equal(t, "+15550142", item.From)
+	require.Equal(t, "+15550143", item.To)
+	require.Equal(t, "hello there", item.Body)
+	require.Equal(t, "Polly.Amy-Neural", item.Voice)
+	require.Equal(t, now.Add(24*time.Hour).Unix(), item.TTL)
+
+	item.Body = " updated body "
+	require.NoError(t, item.BeforeUpdate())
+	require.Equal(t, "updated body", item.Body)
+}
+
+func TestSoulCommVoiceInstructionRequiresFields(t *testing.T) {
+	t.Parallel()
+
+	require.ErrorContains(t, (&SoulCommVoiceInstruction{}).BeforeCreate(), "messageId")
+	require.ErrorContains(t, (&SoulCommVoiceInstruction{MessageID: "comm-msg-1"}).BeforeCreate(), "agentId")
+	require.ErrorContains(t, (&SoulCommVoiceInstruction{MessageID: "comm-msg-1", AgentID: "0xabc"}).BeforeCreate(), "from")
+	require.ErrorContains(t, (&SoulCommVoiceInstruction{MessageID: "comm-msg-1", AgentID: "0xabc", From: "+15550142"}).BeforeCreate(), "to")
+	require.ErrorContains(t, (&SoulCommVoiceInstruction{MessageID: "comm-msg-1", AgentID: "0xabc", From: "+15550142", To: "+15550143"}).BeforeCreate(), "body")
+}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "focus-trap": "^8.0.0",
         "graphql": "^16.12.0",
         "graphql-ws": "^6.0.7",
+        "hast-util-has-property": "^3.0.0",
         "hast-util-sanitize": "^5.0.2",
         "hast-util-to-mdast": "^10.1.2",
         "mdast-util-gfm": "^3.1.0",

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
     "focus-trap": "^8.0.0",
     "graphql": "^16.12.0",
     "graphql-ws": "^6.0.7",
+    "hast-util-has-property": "^3.0.0",
     "hast-util-sanitize": "^5.0.2",
     "hast-util-to-mdast": "^10.1.2",
     "mdast-util-gfm": "^3.1.0",

--- a/web/src/lib/api/soul.ts
+++ b/web/src/lib/api/soul.ts
@@ -1,3 +1,4 @@
+import type { components } from '../greater/adapters/rest/generated/lesser-host-api.js';
 import { fetchJson, jsonRequest } from './http';
 
 // --- Public config + search ---
@@ -471,61 +472,20 @@ export function soulUpdateRegistration(
 
 // --- Communication (portal) ---
 
-export interface SoulAgentCommActivity {
-	agent_id: string;
-	activity_id: string;
-	channel_type: string;
-	direction: string;
-	counterparty?: string;
-	action?: string;
-	message_id?: string;
-	in_reply_to?: string;
-	boundary_check?: string;
-	preference_respected?: boolean;
-	timestamp: string;
-}
+export type SoulAgentCommActivity =
+	components['schemas']['SoulAgentCommActivityItem'];
 
-export interface SoulAgentCommActivityResponse {
-	version: string;
-	activities: SoulAgentCommActivity[];
-	count: number;
-}
+export type SoulAgentCommActivityResponse =
+	components['schemas']['SoulAgentCommActivityResponse'];
 
-export interface SoulAgentCommQueueItem {
-	agent_id: string;
-	message_id: string;
-	channel_type: string;
-	from_address?: string;
-	from_number?: string;
-	from_soul_agent_id?: string;
-	from_display_name?: string;
-	subject?: string;
-	body: string;
-	in_reply_to?: string;
-	received_at: string;
-	scheduled_delivery_time: string;
-	status: string;
-}
+export type SoulAgentCommQueueItem =
+	components['schemas']['SoulAgentCommQueueItem'];
 
-export interface SoulAgentCommQueueResponse {
-	version: string;
-	items: SoulAgentCommQueueItem[];
-	count: number;
-}
+export type SoulAgentCommQueueResponse =
+	components['schemas']['SoulAgentCommQueueResponse'];
 
-export interface SoulCommStatusResponse {
-	messageId: string;
-	status: string;
-	channel: string;
-	agentId: string;
-	to: string;
-	provider?: string;
-	providerMessageId?: string;
-	errorCode?: string;
-	errorMessage?: string;
-	createdAt: string;
-	updatedAt?: string;
-}
+export type SoulCommStatusResponse =
+	components['schemas']['SoulCommStatusResponse'];
 
 export function soulAgentListCommActivity(token: string, agentId: string, limit: number = 50): Promise<SoulAgentCommActivityResponse> {
 	const params = new URLSearchParams();

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -30,7 +30,8 @@ export interface paths {
         };
         /** Get agent contact preferences (v3) */
         get: operations["soulGetAgentChannelPreferences"];
-        put?: never;
+        /** Update agent contact preferences (v3) */
+        put: operations["soulUpdateAgentChannelPreferences"];
         post?: never;
         delete?: never;
         options?: never;
@@ -140,6 +141,57 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/soul/agents/{agentId}/comm/activity": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List communication activity for a soul agent */
+        get: operations["soulAgentCommActivity"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/comm/queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List queued inbound communications for a soul agent */
+        get: operations["soulAgentCommQueue"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/comm/status/{messageId}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get outbound comm delivery status for a soul agent */
+        get: operations["soulAgentCommStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -230,6 +282,7 @@ export interface components {
             updatedAt: string;
         };
         SoulAgentChannelPreferencesResponse: components["schemas"]["soul-agent-channel-preferences.response.schema"];
+        SoulAgentChannelPreferencesRequest: components["schemas"]["soul-agent-channel-preferences.request.schema"];
         SoulAgentIdentity: components["schemas"]["soul-agent-identity.schema"];
         SoulResolveResponse: {
             /** @enum {string} */
@@ -243,6 +296,10 @@ export interface components {
         SoulCommSendErrorEnvelope: components["schemas"]["soul-comm-send.error.schema"];
         SoulCommStatusResponse: components["schemas"]["soul-comm-status.response.schema"];
         SoulCommStatusErrorEnvelope: components["schemas"]["soul-comm-status.error.schema"];
+        SoulAgentCommActivityItem: components["schemas"]["soul-agent-comm-activity-item.schema"];
+        SoulAgentCommActivityResponse: components["schemas"]["soul-agent-comm-activity.response.schema"];
+        SoulAgentCommQueueItem: components["schemas"]["soul-agent-comm-queue-item.schema"];
+        SoulAgentCommQueueResponse: components["schemas"]["soul-agent-comm-queue.response.schema"];
         /** GET /api/v1/soul/agents/{agentId}/channels/preferences response */
         "soul-agent-channel-preferences.response.schema": {
             agentId: string;
@@ -292,6 +349,53 @@ export interface components {
             } | null;
             /** Format: date-time */
             updatedAt: string;
+        };
+        /** PUT /api/v1/soul/agents/{agentId}/channels/preferences request */
+        "soul-agent-channel-preferences.request.schema": {
+            contactPreferences: {
+                /** @enum {string} */
+                preferred: "email" | "sms" | "voice" | "activitypub" | "mcp";
+                /** @enum {string} */
+                fallback?: "email" | "sms" | "voice" | "activitypub" | "mcp";
+                availability: {
+                    /** @enum {string} */
+                    schedule: "always" | "business-hours" | "custom";
+                    timezone?: string;
+                    windows?: {
+                        days: ("mon" | "tue" | "wed" | "thu" | "fri" | "sat" | "sun")[];
+                        startTime: string;
+                        endTime: string;
+                    }[] | null;
+                };
+                responseExpectation: {
+                    target: string;
+                    /** @enum {string} */
+                    guarantee: "guaranteed" | "best-effort";
+                };
+                rateLimits?: {
+                    email?: {
+                        maxInboundPerHour?: number;
+                        maxInboundPerDay?: number;
+                    };
+                    sms?: {
+                        maxInboundPerHour?: number;
+                        maxInboundPerDay?: number;
+                    };
+                    voice?: {
+                        maxConcurrentCalls?: number;
+                        maxCallsPerDay?: number;
+                    };
+                };
+                languages: string[];
+                contentTypes?: string[];
+                firstContact?: {
+                    /** @default false */
+                    requireSoul: boolean;
+                    requireReputation?: number | null;
+                    /** @default false */
+                    introductionExpected: boolean;
+                };
+            };
         };
         /** Soul agent identity */
         "soul-agent-identity.schema": {
@@ -384,6 +488,11 @@ export interface components {
             providerMessageId?: string;
             errorCode?: string;
             errorMessage?: string;
+            replyMessageId?: string;
+            replyBody?: string;
+            replyConfidence?: number;
+            /** Format: date-time */
+            replyReceivedAt?: string;
             /** Format: date-time */
             createdAt: string;
             /** Format: date-time */
@@ -397,6 +506,59 @@ export interface components {
                 message: string;
                 request_id?: string;
             };
+        };
+        /** Soul agent communication activity item */
+        "soul-agent-comm-activity-item.schema": {
+            agent_id: string;
+            activity_id: string;
+            /** @enum {string} */
+            channel_type: "email" | "sms" | "voice";
+            /** @enum {string} */
+            direction: "inbound" | "outbound";
+            counterparty?: string;
+            action?: string;
+            message_id?: string;
+            in_reply_to?: string;
+            /** @enum {string} */
+            boundary_check?: "passed" | "violated" | "skipped";
+            preference_respected?: boolean;
+            /** Format: date-time */
+            timestamp: string;
+        };
+        /** GET /api/v1/soul/agents/{agentId}/comm/activity response */
+        "soul-agent-comm-activity.response.schema": {
+            /** @enum {string} */
+            version: "1";
+            activities: components["schemas"]["soul-agent-comm-activity-item.schema"][];
+            count: number;
+        };
+        /** Soul agent queued communication item */
+        "soul-agent-comm-queue-item.schema": {
+            agent_id: string;
+            message_id: string;
+            /** @enum {string} */
+            channel_type: "email" | "sms" | "voice";
+            /** Format: email */
+            from_address?: string;
+            from_number?: string;
+            from_soul_agent_id?: string;
+            from_display_name?: string;
+            subject?: string;
+            body: string;
+            in_reply_to?: string;
+            /** Format: date-time */
+            received_at: string;
+            /** Format: date-time */
+            scheduled_delivery_time: string;
+            /** @enum {string} */
+            status: "queued" | "delivered" | "expired";
+        };
+        /** GET /api/v1/soul/agents/{agentId}/comm/queue response */
+        "soul-agent-comm-queue.response.schema": {
+            /** @enum {string} */
+            version: "1";
+            items: components["schemas"]["soul-agent-comm-queue-item.schema"][];
+            count: number;
         };
     };
     responses: never;
@@ -478,6 +640,77 @@ export interface operations {
             };
             /** @description Not found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulUpdateAgentChannelPreferences: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["soul-agent-channel-preferences.request.schema"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["soul-agent-channel-preferences.response.schema"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };
@@ -614,6 +847,7 @@ export interface operations {
                 capability?: string;
                 boundary?: string;
                 ens?: string;
+                principal?: string;
                 channel?: "email" | "phone";
                 cursor?: string;
                 limit?: number;
@@ -758,6 +992,185 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["soul-comm-status.error.schema"];
+                };
+            };
+        };
+    };
+    soulAgentCommActivity: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["soul-agent-comm-activity.response.schema"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulAgentCommQueue: {
+        parameters: {
+            query?: {
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["soul-agent-comm-queue.response.schema"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulAgentCommStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+                messageId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["soul-comm-status.response.schema"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
                 };
             };
         };

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -2202,6 +2202,18 @@
 										{#if st.errorMessage}
 											<DefinitionItem label="Error message">{st.errorMessage}</DefinitionItem>
 										{/if}
+										{#if st.replyBody}
+											<DefinitionItem label="Reply transcript">{st.replyBody}</DefinitionItem>
+										{/if}
+										{#if st.replyConfidence != null}
+											<DefinitionItem label="Reply confidence" monospace>{st.replyConfidence}</DefinitionItem>
+										{/if}
+										{#if st.replyMessageId}
+											<DefinitionItem label="Reply msg ID" monospace>{st.replyMessageId}</DefinitionItem>
+										{/if}
+										{#if st.replyReceivedAt}
+											<DefinitionItem label="Reply received" monospace>{st.replyReceivedAt}</DefinitionItem>
+										{/if}
 										<DefinitionItem label="Created" monospace>{st.createdAt}</DefinitionItem>
 										<DefinitionItem label="Updated" monospace>{st.updatedAt || '—'}</DefinitionItem>
 									</DefinitionList>


### PR DESCRIPTION
## Summary
- add real Telnyx-native outbound voice calling for soul comm send, including TeXML speak + short speech reply capture
- persist and surface reply transcript metadata on comm status and in the portal
- add portal comm activity, queue, and agent-scoped status routes to the OpenAPI contract and regenerate the lesser-host API types
- advertise `voice-send` on provisioned phone channels and fix local schema refs so codegen is reproducible

## Validation
- `env GOTOOLCHAIN=go1.26.1 go test ./internal/controlplane ./internal/store/models`
- `env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/controlplane ./internal/store/models`
- `bash gov-infra/verifiers/gov-verify-rubric.sh`
- `cd web && npm run typecheck`
- `cd web && npm run lint`
- `cd web && npm run build`
- `npx -y openapi-typescript docs/contracts/openapi.yaml -o web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts`
