### PR TITLE
Add body-only lesser-body instance updates

### DIFF
--- a/internal/controlplane/handlers_portal_updates.go
+++ b/internal/controlplane/handlers_portal_updates.go
@@ -21,6 +21,7 @@ type createUpdateJobRequest struct {
 	LesserVersion     string `json:"lesser_version,omitempty"`
 	LesserBodyVersion string `json:"lesser_body_version,omitempty"`
 	RotateInstanceKey bool   `json:"rotate_instance_key,omitempty"`
+	BodyOnly          bool   `json:"body_only,omitempty"`
 }
 
 type updateJobResponse struct {
@@ -40,6 +41,7 @@ type updateJobResponse struct {
 
 	LesserVersion     string `json:"lesser_version,omitempty"`
 	LesserBodyVersion string `json:"lesser_body_version,omitempty"`
+	BodyOnly          bool   `json:"body_only,omitempty"`
 
 	LesserHostBaseURL              string `json:"lesser_host_base_url,omitempty"`
 	LesserHostAttestationsURL      string `json:"lesser_host_attestations_url,omitempty"`
@@ -100,6 +102,7 @@ func updateJobResponseFromModel(j *models.UpdateJob) updateJobResponse {
 		BaseDomain:                     strings.TrimSpace(j.BaseDomain),
 		LesserVersion:                  strings.TrimSpace(j.LesserVersion),
 		LesserBodyVersion:              strings.TrimSpace(j.LesserBodyVersion),
+		BodyOnly:                       j.BodyOnly,
 		LesserHostBaseURL:              strings.TrimSpace(j.LesserHostBaseURL),
 		LesserHostAttestationsURL:      strings.TrimSpace(j.LesserHostAttestationsURL),
 		LesserHostInstanceKeySecretARN: strings.TrimSpace(j.LesserHostInstanceKeySecretARN),
@@ -208,6 +211,9 @@ func (s *Server) handlePortalCreateInstanceUpdateJob(ctx *apptheory.Context) (*a
 	if err != nil {
 		return nil, err
 	}
+	if req.BodyOnly && req.RotateInstanceKey {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "body_only updates cannot rotate the instance key"}
+	}
 	lesserVersion, lesserBodyVersion, appErr := s.resolveManagedUpdateVersions(ctx.Context(), inst, req)
 	if appErr != nil {
 		return nil, appErr
@@ -313,6 +319,14 @@ func (s *Server) resolveManagedUpdateVersions(ctx context.Context, inst *models.
 	if lesserBodyVersion == "" && effectiveBodyEnabled(inst.BodyEnabled) {
 		lesserBodyVersion = strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
 	}
+	if req.BodyOnly {
+		if !effectiveBodyEnabled(inst.BodyEnabled) {
+			return "", "", &apptheory.AppError{Code: "app.conflict", Message: "lesser-body updates are disabled for this instance"}
+		}
+		if lesserBodyVersion == "" {
+			return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "lesser_body_version is required for body_only updates when no default lesser-body version is configured"}
+		}
+	}
 
 	return lesserVersion, lesserBodyVersion, nil
 }
@@ -352,6 +366,7 @@ func (s *Server) buildManagedUpdateJob(
 		BaseDomain:                     strings.TrimSpace(inst.HostedBaseDomain),
 		LesserVersion:                  strings.TrimSpace(lesserVersion),
 		LesserBodyVersion:              strings.TrimSpace(lesserBodyVersion),
+		BodyOnly:                       req.BodyOnly,
 		LesserHostBaseURL:              baseURL,
 		LesserHostAttestationsURL:      attestationsURL,
 		LesserHostInstanceKeySecretARN: strings.TrimSpace(inst.LesserHostInstanceKeySecretARN),

--- a/internal/controlplane/handlers_portal_updates_internal_test.go
+++ b/internal/controlplane/handlers_portal_updates_internal_test.go
@@ -164,6 +164,116 @@ func TestHandlePortalCreateInstanceUpdateJob_DefaultsLesserBodyVersion(t *testin
 	require.Equal(t, "v.0.1.3", parsed.LesserBodyVersion)
 }
 
+func TestHandlePortalCreateInstanceUpdateJob_BodyOnlyUsesBodyVersion(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+
+	s := &Server{
+		cfg: config.Config{
+			Stage:                   "lab",
+			WebAuthnRPID:            "example.com",
+			ManagedInstanceRoleName: "role",
+		},
+		store: store.New(tdb.db),
+	}
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
+	ctx.Params = map[string]string{"slug": testPortalInstanceSlugDemo}
+	body, _ := json.Marshal(createUpdateJobRequest{LesserBodyVersion: "v0.2.0", BodyOnly: true})
+	ctx.Request.Body = body
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             testPortalInstanceSlugDemo,
+			Owner:            "alice",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "demo.example.com",
+			LesserVersion:    "v1.2.3",
+			UpdateStatus:     models.UpdateJobStatusOK,
+			UpdateJobID:      "",
+			BodyEnabled:      nil,
+		}
+	}).Once()
+
+	resp, err := s.handlePortalCreateInstanceUpdateJob(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 202, resp.Status)
+
+	var parsed updateJobResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &parsed))
+	require.Equal(t, "v1.2.3", parsed.LesserVersion)
+	require.Equal(t, "v0.2.0", parsed.LesserBodyVersion)
+	require.True(t, parsed.BodyOnly)
+}
+
+func TestHandlePortalCreateInstanceUpdateJob_BodyOnlyRejectsRotateInstanceKey(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
+	ctx.Params = map[string]string{"slug": testPortalInstanceSlugDemo}
+	body, _ := json.Marshal(createUpdateJobRequest{LesserBodyVersion: "v0.2.0", BodyOnly: true, RotateInstanceKey: true})
+	ctx.Request.Body = body
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             testPortalInstanceSlugDemo,
+			Owner:            "alice",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "demo.example.com",
+			LesserVersion:    "v1.2.3",
+			BodyEnabled:      nil,
+		}
+	}).Once()
+
+	_, err := s.handlePortalCreateInstanceUpdateJob(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.bad_request", appErr.Code)
+}
+
+func TestHandlePortalCreateInstanceUpdateJob_BodyOnlyRequiresBodyVersionWhenNoDefault(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
+	ctx.Params = map[string]string{"slug": testPortalInstanceSlugDemo}
+	body, _ := json.Marshal(createUpdateJobRequest{BodyOnly: true})
+	ctx.Request.Body = body
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             testPortalInstanceSlugDemo,
+			Owner:            "alice",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "demo.example.com",
+			LesserVersion:    "v1.2.3",
+			BodyEnabled:      nil,
+		}
+	}).Once()
+
+	_, err := s.handlePortalCreateInstanceUpdateJob(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.bad_request", appErr.Code)
+}
+
 func TestHandlePortalCreateInstanceUpdateJob_TransactWriteFailureReturnsInternalError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -228,7 +228,11 @@ func (s *Server) startManagedUpdateJobIfQueued(ctx context.Context, job *models.
 	}
 
 	job.Status = models.UpdateJobStatusRunning
-	job.Note = "starting update"
+	if job.BodyOnly {
+		job.Note = "starting lesser-body update"
+	} else {
+		job.Note = "starting update"
+	}
 	if strings.TrimSpace(job.Step) == "" {
 		job.Step = updateStepQueued
 	}
@@ -461,8 +465,13 @@ func (s *Server) advanceUpdateInstanceConfig(ctx context.Context, job *models.Up
 	job.AISpamDetectionEnabled = effectiveLesserAISpamDetectionEnabled(inst.LesserAISpamDetectionEnabled)
 	job.AIPiiDetectionEnabled = effectiveLesserAIPiiDetectionEnabled(inst.LesserAIPiiDetectionEnabled)
 	job.AIContentDetectionEnabled = effectiveLesserAIContentDetectionEnabled(inst.LesserAIContentDetectionEnabled)
-	job.Step = updateStepDeployStart
-	job.Note = "starting update deploy runner"
+	if job.BodyOnly {
+		job.Step = updateStepBodyDeployStart
+		job.Note = noteStartingLesserBodyDeployRunner
+	} else {
+		job.Step = updateStepDeployStart
+		job.Note = "starting update deploy runner"
+	}
 
 	if err := s.persistUpdateJobAndInstance(ctx, job, requestID, now, updateInstanceConfigInstanceUpdate(publicBaseURL, attestationsURL, secretArn, job)); err != nil {
 		return 0, false, err

--- a/internal/provisionworker/update_jobs_flow_internal_test.go
+++ b/internal/provisionworker/update_jobs_flow_internal_test.go
@@ -29,6 +29,11 @@ import (
 	"github.com/equaltoai/lesser-host/internal/testutil"
 )
 
+const (
+	testManagedUpdateTrustBaseURL = "https://example.test"
+	testManagedUpdateReceiptJSON  = `{"app":"x","base_domain":"d"}`
+)
+
 func TestRunManagedUpdateStateMachine_HappyPath(t *testing.T) {
 	t.Parallel()
 
@@ -37,7 +42,7 @@ func TestRunManagedUpdateStateMachine_HappyPath(t *testing.T) {
 	handler.HandleFunc("/api/v2/instance", func(w http.ResponseWriter, _ *http.Request) {
 		baseURL := trustBaseURL
 		if strings.TrimSpace(baseURL) == "" {
-			baseURL = "https://example.test"
+			baseURL = testManagedUpdateTrustBaseURL
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -132,9 +137,8 @@ func TestRunManagedUpdateStateMachine_HappyPath(t *testing.T) {
 		},
 	}
 
-	receiptJSON := `{"app":"x","base_domain":"d"}`
 	s3Client := &fakeS3{
-		out: &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(receiptJSON))},
+		out: &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(testManagedUpdateReceiptJSON))},
 	}
 
 	cfg := config.Config{
@@ -207,7 +211,7 @@ func TestRunManagedUpdateStateMachine_DeploysLesserBodyWithDefaultVersion(t *tes
 	handler.HandleFunc("/api/v2/instance", func(w http.ResponseWriter, _ *http.Request) {
 		baseURL := trustBaseURL
 		if strings.TrimSpace(baseURL) == "" {
-			baseURL = "https://example.test"
+			baseURL = testManagedUpdateTrustBaseURL
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
@@ -303,9 +307,8 @@ func TestRunManagedUpdateStateMachine_DeploysLesserBodyWithDefaultVersion(t *tes
 		},
 	}
 
-	receiptJSON := `{"app":"x","base_domain":"d"}`
 	s3Client := &fakeS3{
-		out: &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(receiptJSON))},
+		out: &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(testManagedUpdateReceiptJSON))},
 	}
 
 	cfg := config.Config{
@@ -399,6 +402,197 @@ func TestRunManagedUpdateStateMachine_DeploysLesserBodyWithDefaultVersion(t *tes
 	require.Equal(t, "lesser-mcp", envValue(cb.startInputs[2], "RUN_MODE"))
 	require.Equal(t, "v.0.1.3", envValue(cb.startInputs[1], "LESSER_BODY_VERSION"))
 	require.Equal(t, "v.0.1.3", envValue(cb.startInputs[2], "LESSER_BODY_VERSION"))
+}
+
+func TestRunManagedUpdateStateMachine_BodyOnlySkipsLesserDeploy(t *testing.T) {
+	t.Parallel()
+
+	trustBaseURL := ""
+	handler := http.NewServeMux()
+	handler.HandleFunc("/api/v2/instance", func(w http.ResponseWriter, _ *http.Request) {
+		baseURL := trustBaseURL
+		if strings.TrimSpace(baseURL) == "" {
+			baseURL = testManagedUpdateTrustBaseURL
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"configuration": map[string]any{
+				"translation": map[string]any{"enabled": true},
+				"trust": map[string]any{
+					"enabled":  true,
+					"base_url": baseURL,
+				},
+				"tips": map[string]any{
+					"enabled":          true,
+					"chain_id":         8453,
+					"contract_address": "0xabc",
+				},
+			},
+		})
+	})
+	handler.HandleFunc("/api/v1/instance/translation_languages", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.HandleFunc("/api/v1/trust/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.HandleFunc("/api/v1/ai/jobs/", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+	ts := httptest.NewTLSServer(handler)
+	t.Cleanup(ts.Close)
+	trustBaseURL = ts.URL
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancel)
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+	qKey := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
+
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+
+	translationEnabled := true
+	tipEnabled := true
+	aiEnabled := true
+	aiModerationEnabled := true
+	aiNsfwEnabled := true
+	aiSpamEnabled := true
+	aiPiiEnabled := false
+	aiContentEnabled := false
+
+	instValue := models.Instance{
+		Slug:                            "slug",
+		Owner:                           "wallet-deadbeef",
+		HostedAccountID:                 "123",
+		HostedRegion:                    "us-east-1",
+		HostedBaseDomain:                ts.URL,
+		LesserHostInstanceKeySecretARN:  "",
+		LesserVersion:                   "v1.2.3",
+		TranslationEnabled:              &translationEnabled,
+		TipEnabled:                      &tipEnabled,
+		TipChainID:                      8453,
+		TipContractAddress:              "0xabc",
+		LesserAIEnabled:                 &aiEnabled,
+		LesserAIModerationEnabled:       &aiModerationEnabled,
+		LesserAINsfwDetectionEnabled:    &aiNsfwEnabled,
+		LesserAISpamDetectionEnabled:    &aiSpamEnabled,
+		LesserAIPiiDetectionEnabled:     &aiPiiEnabled,
+		LesserAIContentDetectionEnabled: &aiContentEnabled,
+		BodyEnabled:                     nil,
+	}
+
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = instValue
+	}).Maybe()
+
+	qKey.On("IfNotExists").Return(qKey).Maybe()
+	qKey.On("Create").Return(nil).Maybe()
+
+	cb := &fakeCodebuild{
+		startOut: &codebuild.StartBuildOutput{
+			Build: &cbtypes.Build{Id: aws.String("build1")},
+		},
+		batchOut: &codebuild.BatchGetBuildsOutput{
+			Builds: []cbtypes.Build{
+				{
+					BuildStatus: cbtypes.StatusTypeSucceeded,
+					Logs:        &cbtypes.LogsLocation{DeepLink: aws.String("https://logs.example")},
+				},
+			},
+		},
+	}
+
+	s3Client := &fakeS3{
+		out: &s3.GetObjectOutput{Body: io.NopCloser(strings.NewReader(testManagedUpdateReceiptJSON))},
+	}
+
+	cfg := config.Config{
+		Stage:                             "live",
+		ManagedProvisioningEnabled:        true,
+		ManagedInstanceRoleName:           "role",
+		ManagedProvisionRunnerProjectName: "project",
+		ArtifactBucketName:                "artifact-bucket",
+		ProvisionQueueURL:                 "https://example.com/queue",
+		ManagedOrgVendingRoleARN:          "arn:aws:iam::123:role/vending",
+		ManagedLesserBodyDefaultVersion:   "v.0.1.3",
+		ManagedLesserBodyGitHubOwner:      "equaltoai",
+		ManagedLesserBodyGitHubRepo:       "lesser-body",
+	}
+
+	st := store.New(db)
+	sqsClient := &fakeSQS{}
+	srv := NewServer(cfg, st, nil, nil, nil, sqsClient, cb, s3Client)
+	srv.httpClient = ts.Client()
+
+	fsm := &fakeSecretsManager{
+		describeErr: &smtypes.ResourceNotFoundException{},
+		createOut: &secretsmanager.CreateSecretOutput{
+			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:lesser-host/live/instances/slug/instance-key"),
+		},
+		getOut: &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String(`{"secret":"lhk_test"}`),
+		},
+	}
+	srv.smFactory = func(_ context.Context, _ string, _ string, _ string, _ string, _ string) (secretsManagerAPI, error) {
+		return fsm, nil
+	}
+
+	job := &models.UpdateJob{
+		ID:                        "job1",
+		InstanceSlug:              "slug",
+		Status:                    models.UpdateJobStatusQueued,
+		LesserVersion:             "v1.2.3",
+		LesserBodyVersion:         "v.0.1.3",
+		BodyOnly:                  true,
+		LesserHostBaseURL:         ts.URL,
+		LesserHostAttestationsURL: ts.URL,
+		TranslationEnabled:        true,
+		MaxAttempts:               3,
+	}
+
+	now := time.Unix(100, 0).UTC()
+
+	envValue := func(in *codebuild.StartBuildInput, name string) string {
+		if in == nil {
+			return ""
+		}
+		for _, v := range in.EnvironmentVariablesOverride {
+			if aws.ToString(v.Name) == name {
+				return aws.ToString(v.Value)
+			}
+		}
+		return ""
+	}
+
+	require.NoError(t, srv.runManagedUpdateStateMachine(ctx, job, "req", now))
+	require.Equal(t, updateStepBodyDeployWait, job.Step)
+	require.Equal(t, models.UpdateJobStatusRunning, job.Status)
+	require.NotEmpty(t, job.RunID)
+	require.Len(t, sqsClient.inputs, 1)
+
+	require.NoError(t, srv.runManagedUpdateStateMachine(ctx, job, "req", now.Add(1*time.Minute)))
+	require.Equal(t, updateStepDeployMcpWait, job.Step)
+	require.Equal(t, models.UpdateJobStatusRunning, job.Status)
+	require.NotEmpty(t, job.RunID)
+	require.Len(t, sqsClient.inputs, 2)
+
+	require.NoError(t, srv.runManagedUpdateStateMachine(ctx, job, "req", now.Add(2*time.Minute)))
+	require.Equal(t, updateStepDone, job.Step)
+	require.Equal(t, models.UpdateJobStatusOK, job.Status)
+	require.NotEmpty(t, job.RunURL)
+
+	require.Len(t, cb.startInputs, 2)
+	require.Equal(t, "lesser-body", envValue(cb.startInputs[0], "RUN_MODE"))
+	require.Equal(t, "lesser-mcp", envValue(cb.startInputs[1], "RUN_MODE"))
+	require.Equal(t, "v.0.1.3", envValue(cb.startInputs[0], "LESSER_BODY_VERSION"))
+	require.Equal(t, "v.0.1.3", envValue(cb.startInputs[1], "LESSER_BODY_VERSION"))
 }
 
 func TestUpdateJob_ProcessableAndMissingConfig(t *testing.T) {

--- a/internal/store/models/update_job.go
+++ b/internal/store/models/update_job.go
@@ -43,6 +43,7 @@ type UpdateJob struct {
 	// When empty, the deploy runner falls back to MANAGED_LESSER_BODY_DEFAULT_VERSION (if configured)
 	// or resolves releases/latest.
 	LesserBodyVersion string `theorydb:"attr:lesserBodyVersion" json:"lesser_body_version,omitempty"`
+	BodyOnly          bool   `theorydb:"attr:bodyOnly" json:"body_only,omitempty"`
 
 	// Desired configuration snapshot (applied during update).
 	LesserHostBaseURL              string `theorydb:"attr:lesserHostBaseUrl" json:"lesser_host_base_url,omitempty"`

--- a/web/src/lib/api/portalInstances.ts
+++ b/web/src/lib/api/portalInstances.ts
@@ -185,6 +185,8 @@ export interface UpdateJobResponse {
 	region?: string;
 	base_domain?: string;
 	lesser_version?: string;
+	lesser_body_version?: string;
+	body_only?: boolean;
 	lesser_host_base_url?: string;
 	lesser_host_attestations_url?: string;
 	lesser_host_instance_key_secret_arn?: string;
@@ -311,7 +313,9 @@ export function portalCreateUpdateJob(
 	slug: string,
 	input?: {
 		lesser_version?: string;
+		lesser_body_version?: string;
 		rotate_instance_key?: boolean;
+		body_only?: boolean;
 	},
 ): Promise<UpdateJobResponse> {
 	const req = jsonRequest(input ?? {});

--- a/web/src/pages/operator/InstanceSupport.svelte
+++ b/web/src/pages/operator/InstanceSupport.svelte
@@ -35,6 +35,7 @@
 	let updatesPolling = $state(false);
 	let updateCreating = $state(false);
 	let updateLesserVersion = $state('');
+	let updateLesserBodyVersion = $state('');
 
 	let updatesPollController: AbortController | null = null;
 
@@ -171,15 +172,31 @@
 		}
 	}
 
-	async function startUpdateJob(targetSlug: string, lesserVersion?: string, rotateInstanceKey?: boolean) {
+	async function startUpdateJob(
+		targetSlug: string,
+		options?: {
+			lesserVersion?: string;
+			lesserBodyVersion?: string;
+			rotateInstanceKey?: boolean;
+			bodyOnly?: boolean;
+		}
+	) {
 		updatesError = null;
-		const version = (lesserVersion || '').trim();
+		const version = (options?.lesserVersion || '').trim();
+		const bodyVersion = (options?.lesserBodyVersion || '').trim();
 
 		updateCreating = true;
 		try {
-			const input: { lesser_version?: string; rotate_instance_key?: boolean } = {};
+			const input: {
+				lesser_version?: string;
+				lesser_body_version?: string;
+				rotate_instance_key?: boolean;
+				body_only?: boolean;
+			} = {};
 			if (version) input.lesser_version = version;
-			if (rotateInstanceKey) input.rotate_instance_key = true;
+			if (bodyVersion) input.lesser_body_version = bodyVersion;
+			if (options?.rotateInstanceKey) input.rotate_instance_key = true;
+			if (options?.bodyOnly) input.body_only = true;
 			const job = await portalCreateUpdateJob(token, targetSlug, input);
 			updateJobs = [job, ...updateJobs.filter((j) => j.id !== job.id)];
 			void pollUpdateJob(targetSlug, job.id);
@@ -460,7 +477,7 @@
 			<div class="op-support__row">
 				<Button
 					variant="outline"
-					onclick={() => slug && void startUpdateJob(slug, undefined, true)}
+					onclick={() => slug && void startUpdateJob(slug, { rotateInstanceKey: true })}
 					disabled={!slug || updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed()}
 				>
 					Rotate instance key
@@ -477,7 +494,7 @@
 			<div class="op-support__actions">
 				<Button
 					variant="outline"
-					onclick={() => slug && void startUpdateJob(slug, updateLesserVersion)}
+					onclick={() => slug && void startUpdateJob(slug, { lesserVersion: updateLesserVersion })}
 					disabled={
 						!slug ||
 						updateCreating ||
@@ -490,6 +507,30 @@
 				>
 					Start version update
 				</Button>
+				<Text size="sm" color="secondary">
+					Re-runs <span class="op-support__mono">lesser up</span> at the requested Lesser release.
+				</Text>
+			</div>
+
+			<div class="op-support__form">
+				<TextField
+					label="Update Lesser Body version"
+					bind:value={updateLesserBodyVersion}
+					placeholder="vX.Y.Z, latest, or blank for configured default"
+				/>
+			</div>
+
+			<div class="op-support__actions">
+				<Button
+					variant="outline"
+					onclick={() => slug && void startUpdateJob(slug, { lesserBodyVersion: updateLesserBodyVersion, bodyOnly: true })}
+					disabled={!slug || updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed()}
+				>
+					Update lesser-body only
+				</Button>
+				<Text size="sm" color="secondary">
+					Skips <span class="op-support__mono">lesser up</span> and only redeploys <span class="op-support__mono">lesser-body</span> plus MCP wiring.
+				</Text>
 				<Button variant="outline" onclick={() => slug && void loadUpdates(slug)} disabled={!slug || updatesLoading}>
 					Refresh
 				</Button>
@@ -509,6 +550,8 @@
 					<DefinitionItem label="Step" monospace>{formatStep(job?.step)}</DefinitionItem>
 					<DefinitionItem label="Updated" monospace>{job?.updated_at}</DefinitionItem>
 					<DefinitionItem label="Lesser version" monospace>{job?.lesser_version || '—'}</DefinitionItem>
+					<DefinitionItem label="Lesser Body version" monospace>{job?.lesser_body_version || '—'}</DefinitionItem>
+					<DefinitionItem label="Body-only" monospace>{job?.body_only ? 'yes' : 'no'}</DefinitionItem>
 						<DefinitionItem label="Run id" monospace>{job?.run_id || '—'}</DefinitionItem>
 						<DefinitionItem label="Run url" monospace>
 							{@const runUrl = safeHref(job?.run_url)}

--- a/web/src/pages/portal/InstanceDetail.svelte
+++ b/web/src/pages/portal/InstanceDetail.svelte
@@ -49,6 +49,7 @@
 	let updatesPolling = $state(false);
 	let updateCreating = $state(false);
 	let updateLesserVersion = $state('');
+	let updateLesserBodyVersion = $state('');
 
 	let provisionRegion = $state('');
 	let provisionLesserVersion = $state('');
@@ -255,16 +256,29 @@
 		}
 	}
 
-	async function startUpdateJob(lesserVersion?: string, rotateInstanceKey?: boolean) {
+	async function startUpdateJob(options?: {
+		lesserVersion?: string;
+		lesserBodyVersion?: string;
+		rotateInstanceKey?: boolean;
+		bodyOnly?: boolean;
+	}) {
 		updatesError = null;
 
-		const version = (lesserVersion || '').trim();
+		const version = (options?.lesserVersion || '').trim();
+		const bodyVersion = (options?.lesserBodyVersion || '').trim();
 
 		updateCreating = true;
 		try {
-			const input: { lesser_version?: string; rotate_instance_key?: boolean } = {};
+			const input: {
+				lesser_version?: string;
+				lesser_body_version?: string;
+				rotate_instance_key?: boolean;
+				body_only?: boolean;
+			} = {};
 			if (version) input.lesser_version = version;
-			if (rotateInstanceKey) input.rotate_instance_key = true;
+			if (bodyVersion) input.lesser_body_version = bodyVersion;
+			if (options?.rotateInstanceKey) input.rotate_instance_key = true;
+			if (options?.bodyOnly) input.body_only = true;
 
 			const job = await portalCreateUpdateJob(token, slug, input);
 			updateJobs = [job, ...updateJobs.filter((j) => j.id !== job.id)];
@@ -679,7 +693,7 @@
 			<div class="instance-detail__row">
 				<Button
 					variant="outline"
-					onclick={() => void startUpdateJob(undefined, true)}
+					onclick={() => void startUpdateJob({ rotateInstanceKey: true })}
 					disabled={updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed}
 				>
 					Rotate instance key
@@ -696,7 +710,7 @@
 			<div class="instance-detail__row">
 				<Button
 					variant="outline"
-					onclick={() => void startUpdateJob(updateLesserVersion)}
+					onclick={() => void startUpdateJob({ lesserVersion: updateLesserVersion })}
 					disabled={
 						updateCreating ||
 						updatesPolling ||
@@ -708,6 +722,29 @@
 				>
 					Start version update
 				</Button>
+				<Text size="sm" color="secondary">
+					Re-runs <span class="instance-detail__mono">lesser up</span> at the requested Lesser release.
+				</Text>
+			</div>
+
+			<div class="instance-detail__form">
+				<TextField
+					label="Update Lesser Body version"
+					bind:value={updateLesserBodyVersion}
+					placeholder="vX.Y.Z, latest, or blank for configured default"
+				/>
+			</div>
+			<div class="instance-detail__row">
+				<Button
+					variant="outline"
+					onclick={() => void startUpdateJob({ lesserBodyVersion: updateLesserBodyVersion, bodyOnly: true })}
+					disabled={updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed}
+				>
+					Update lesser-body only
+				</Button>
+				<Text size="sm" color="secondary">
+					Skips <span class="instance-detail__mono">lesser up</span> and only redeploys <span class="instance-detail__mono">lesser-body</span> plus MCP wiring.
+				</Text>
 			</div>
 
 			{#if updatesPolling && updateInProgress()}
@@ -724,6 +761,8 @@
 					<DefinitionItem label="Step" monospace>{formatStep(job?.step)}</DefinitionItem>
 					<DefinitionItem label="Updated" monospace>{job?.updated_at}</DefinitionItem>
 					<DefinitionItem label="Lesser version" monospace>{job?.lesser_version || '—'}</DefinitionItem>
+					<DefinitionItem label="Lesser Body version" monospace>{job?.lesser_body_version || '—'}</DefinitionItem>
+					<DefinitionItem label="Body-only" monospace>{job?.body_only ? 'yes' : 'no'}</DefinitionItem>
 						<DefinitionItem label="Run id" monospace>{job?.run_id || '—'}</DefinitionItem>
 						<DefinitionItem label="Run url" monospace>
 							{@const runUrl = safeHref(job?.run_url)}


### PR DESCRIPTION
## Summary
- add a  managed update mode for instance updates
- skip the long  runner and go straight to  plus MCP when requested
- expose the new body-only update action in both portal and operator instance pages

## Validation
- env GOTOOLCHAIN=go1.26.1 go test ./internal/controlplane ./internal/provisionworker ./internal/store/models
- env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/controlplane ./internal/provisionworker ./internal/store/models
- cd web && npm ci --include=dev && npm run typecheck && npm run lint && npm run build
- cd web && npm ci --include=dev && cd .. && env GOTOOLCHAIN=go1.26.1 bash gov-infra/verifiers/gov-verify-rubric.sh