### PR TITLE
fix: enforce soul comm preferences and managed stage aliases

### DIFF
--- a/docs/spec/v3/fixtures/soul-comm-send.error.boundary-violation.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.error.boundary-violation.example.json
@@ -1,8 +1,0 @@
-{
-  "error": {
-    "code": "comm.boundary_violation",
-    "message": "Outbound email blocked: unsolicited outbound communication is not allowed by this agent's declared boundaries.",
-    "request_id": "req_123"
-  }
-}
-

--- a/docs/spec/v3/fixtures/soul-comm-send.error.preference-violation.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.error.preference-violation.example.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "comm.preference_violation",
+    "message": "Outbound communication blocked: recipient first-contact policy requires soul reputation >= 0.90.",
+    "request_id": "req_123"
+  }
+}

--- a/docs/spec/v3/schemas/soul-comm-send.error.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.error.schema.json
@@ -20,7 +20,7 @@
             "comm.channel_not_provisioned",
             "comm.channel_unverified",
             "comm.rate_limited",
-            "comm.boundary_violation",
+            "comm.preference_violation",
             "comm.insufficient_credits",
             "comm.provider_unavailable",
             "comm.provider_rejected",

--- a/internal/commworker/helpers_internal_test.go
+++ b/internal/commworker/helpers_internal_test.go
@@ -267,6 +267,27 @@ func testResolveAgentInstanceAndInboundCounts(t *testing.T, s *Server, now time.
 	if err != nil || !ok || inst == nil || inst.Slug != "inst-1" {
 		t.Fatalf("unexpected instance resolution: %#v %v %v", inst, ok, err)
 	}
+	aliasServer := &Server{
+		cfg: config.Config{Stage: "lab"},
+		store: &fakeStore{
+			domains: map[string]*models.Domain{
+				"simulacrum.greater.website": {
+					Domain:             "simulacrum.greater.website",
+					InstanceSlug:       "simulacrum",
+					Status:             models.DomainStatusVerified,
+					Type:               models.DomainTypePrimary,
+					VerificationMethod: "managed",
+				},
+			},
+			instances: map[string]*models.Instance{
+				"simulacrum": {Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"},
+			},
+		},
+	}
+	aliasInst, aliasOK, aliasErr := aliasServer.resolveAgentInstance(context.Background(), &models.SoulAgentIdentity{Domain: "dev.simulacrum.greater.website"})
+	if aliasErr != nil || !aliasOK || aliasInst == nil || aliasInst.Slug != "simulacrum" {
+		t.Fatalf("unexpected managed alias resolution: %#v %v %v", aliasInst, aliasOK, aliasErr)
+	}
 	if _, instanceOK, instanceErr := s.resolveAgentInstance(context.Background(), &models.SoulAgentIdentity{}); instanceErr != nil || instanceOK {
 		t.Fatalf("expected empty domain to miss")
 	}

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"net/smtp"
@@ -269,6 +270,8 @@ func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, cha
 		return err
 	}
 	if !ok || inst == nil {
+		log.Printf("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(strings.TrimSpace(agentID)), strings.ToLower(strings.TrimSpace(identity.Domain)), strings.ToLower(strings.TrimSpace(channel)), strings.TrimSpace(notif.MessageID))
+		_ = s.recordInboundActivity(ctx, agentID, channel, notif, "drop", false)
 		return nil
 	}
 

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -841,3 +841,60 @@ func TestDefaultMigaduSendSMTPWithAddr_SMTPFlow(t *testing.T) {
 		}
 	})
 }
+
+func TestProcessInbound_RecordsDropWhenInstanceResolutionMisses(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 12, 0, 5, 0, 0, time.UTC)
+	agentID := commStoreTestAgentID
+	to := "+19347321081"
+
+	fs := &fakeStore{
+		phoneIndex: map[string]string{normalizePhone(to): agentID},
+		identities: map[string]*models.SoulAgentIdentity{
+			agentID: {
+				AgentID:         agentID,
+				Domain:          "dev.simulacrum.greater.website",
+				LifecycleStatus: models.SoulAgentStatusActive,
+				Status:          models.SoulAgentStatusActive,
+			},
+		},
+		channels: map[string]*models.SoulAgentChannel{
+			agentID + "#phone": {
+				AgentID:       agentID,
+				ChannelType:   models.SoulChannelTypePhone,
+				Identifier:    to,
+				Status:        models.SoulChannelStatusActive,
+				Verified:      true,
+				ProvisionedAt: now.Add(-time.Hour),
+			},
+		},
+		activities: map[string][]*models.SoulAgentCommActivity{},
+	}
+
+	s := NewServer(config.Config{Stage: "lab"}, fs, nil, nil)
+	s.now = func() time.Time { return now }
+	s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) {
+		t.Fatal("instance key fetch should not be called when resolution misses")
+		return "", nil
+	}
+	s.deliverNotification = func(context.Context, string, string, InboundNotification) error {
+		t.Fatal("delivery should not be called when resolution misses")
+		return nil
+	}
+
+	if err := s.processInbound(context.Background(), "req-drop", newInboundSMSMessage(now, to, "+15551234567")); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	acts := fs.activities[agentID]
+	if len(acts) != 1 {
+		t.Fatalf("expected 1 recorded activity, got %#v", acts)
+	}
+	if acts[0].Action != "drop" || acts[0].ChannelType != inboundChannelSMS || acts[0].Direction != models.SoulCommDirectionInbound {
+		t.Fatalf("unexpected drop activity: %#v", acts[0])
+	}
+	if acts[0].PreferenceRespected == nil || *acts[0].PreferenceRespected {
+		t.Fatalf("expected preference respected=false on drop, got %#v", acts[0].PreferenceRespected)
+	}
+}

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -41,6 +41,7 @@ const (
 	commMetricProviderUnavailable = "provider_unavailable"
 	commMetricProviderRejected    = "provider_rejected"
 	commMetricInsufficientCredits = "insufficient_credits"
+	commMetricPreferenceViolation = "preference_violation"
 	commMetricSent                = "sent"
 
 	commCodeInvalidRequest      = "comm.invalid_request"
@@ -48,6 +49,7 @@ const (
 	commCodeInternal            = "comm.internal"
 	commCodeProviderUnavailable = "comm.provider_unavailable"
 	commCodeInsufficientCredits = "comm.insufficient_credits"
+	commCodePreferenceViolation = "comm.preference_violation"
 )
 
 type soulCommSendRequest struct {
@@ -120,6 +122,10 @@ type soulCommSendDelivery struct {
 	provider          string
 	providerMessageID string
 	initialStatus     string
+}
+
+type soulCommSendGuardDecision struct {
+	preferenceRespected *bool
 }
 
 func newSoulCommSendMetrics(stage string, instance string) *soulCommSendMetrics {
@@ -197,7 +203,7 @@ func (s *Server) handleSoulCommSend(ctx *apptheory.Context) (*apptheory.Response
 	}
 
 	now := time.Now().UTC()
-	guardErr := s.enforceSoulCommSendGuards(ctx, req, now, metrics)
+	guardDecision, guardErr := s.enforceSoulCommSendGuards(ctx, route.identity, req, now, metrics)
 	if guardErr != nil {
 		return nil, guardErr
 	}
@@ -212,7 +218,7 @@ func (s *Server) handleSoulCommSend(ctx *apptheory.Context) (*apptheory.Response
 	if appErr != nil {
 		return nil, appErr
 	}
-	recordErr := s.recordSoulCommSend(ctx, key, req, messageID, delivery, now, metrics)
+	recordErr := s.recordSoulCommSend(ctx, key, req, messageID, delivery, guardDecision, now, metrics)
 	if recordErr != nil {
 		return nil, recordErr
 	}
@@ -359,16 +365,16 @@ func (s *Server) loadSoulCommSendChannel(ctx context.Context, req validatedSoulC
 	return channel, nil
 }
 
-func (s *Server) enforceSoulCommSendGuards(ctx *apptheory.Context, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+func (s *Server) enforceSoulCommSendGuards(ctx *apptheory.Context, identity *models.SoulAgentIdentity, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics) (soulCommSendGuardDecision, *apptheory.AppTheoryError) {
 	hourCount, err := s.countSoulOutboundCommSince(ctx.Context(), req.agentIDHex, req.channel, now.Add(-1*time.Hour), 250)
 	if err != nil {
 		metrics.status = commMetricInternalError
-		return apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+		return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 	dayCount, err := s.countSoulOutboundCommSince(ctx.Context(), req.agentIDHex, req.channel, now.Add(-24*time.Hour), 500)
 	if err != nil {
 		metrics.status = commMetricInternalError
-		return apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+		return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 
 	maxHour, maxDay := 50, 500
@@ -377,34 +383,153 @@ func (s *Server) enforceSoulCommSendGuards(ctx *apptheory.Context, req validated
 	}
 	if hourCount >= maxHour || dayCount >= maxDay {
 		metrics.status = "rate_limited"
-		return apptheory.NewAppTheoryError("comm.rate_limited", "rate limited").WithStatusCode(http.StatusTooManyRequests)
+		return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError("comm.rate_limited", "rate limited").WithStatusCode(http.StatusTooManyRequests)
 	}
 	if req.inReplyTo != "" {
-		return nil
+		return soulCommSendGuardDecision{}, nil
+	}
+	return s.enforceSoulCommFirstContactPolicy(ctx, identity, req, now, metrics)
+}
+
+func (s *Server) enforceSoulCommFirstContactPolicy(ctx *apptheory.Context, identity *models.SoulAgentIdentity, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics) (soulCommSendGuardDecision, *apptheory.AppTheoryError) {
+	recipientAgentID, prefs, appErr := s.loadSoulCommFirstContactRecipient(ctx.Context(), req)
+	if appErr != nil {
+		return soulCommSendGuardDecision{}, appErr
+	}
+	if recipientAgentID == "" || prefs == nil {
+		return soulCommSendGuardDecision{}, nil
 	}
 
-	metrics.status = "boundary_violation"
+	enforced := false
+	if prefs.FirstContactRequireSoul {
+		enforced = true
+		if identity == nil || strings.TrimSpace(identity.AgentID) == "" {
+			return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(ctx, req, now, metrics, "recipient first-contact policy requires a soul sender")
+		}
+	}
+
+	if prefs.FirstContactRequireReputation != nil {
+		enforced = true
+		rep, err := s.getSoulAgentReputation(ctx.Context(), req.agentIDHex)
+		if err != nil && !theoryErrors.IsNotFound(err) {
+			metrics.status = commMetricInternalError
+			return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+		}
+		score := 0.0
+		if rep != nil {
+			score = rep.Composite
+		}
+		if rep == nil || score < *prefs.FirstContactRequireReputation {
+			return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(
+				ctx,
+				req,
+				now,
+				metrics,
+				fmt.Sprintf("recipient first-contact policy requires soul reputation >= %.2f", *prefs.FirstContactRequireReputation),
+			)
+		}
+	}
+
+	// `introductionExpected` is currently advisory because the send contract does not yet
+	// include a structured introduction field to validate against.
+	if prefs.FirstContactIntroductionExpected {
+		enforced = true
+	}
+	if enforced {
+		return soulCommSendGuardDecision{preferenceRespected: boolPtr(true)}, nil
+	}
+	return soulCommSendGuardDecision{}, nil
+}
+
+func (s *Server) loadSoulCommFirstContactRecipient(ctx context.Context, req validatedSoulCommSendRequest) (string, *models.SoulAgentContactPreferences, *apptheory.AppTheoryError) {
+	agentID, found, err := s.lookupSoulCommRecipientAgentID(ctx, req.channel, req.to)
+	if err != nil {
+		return "", nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	if !found || agentID == "" {
+		return "", nil, nil
+	}
+
+	prefs, err := getSoulAgentItemBySK[models.SoulAgentContactPreferences](s, ctx, agentID, "CONTACT_PREFERENCES")
+	if theoryErrors.IsNotFound(err) {
+		return agentID, nil, nil
+	}
+	if err != nil {
+		return "", nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	return agentID, prefs, nil
+}
+
+func (s *Server) lookupSoulCommRecipientAgentID(ctx context.Context, channel string, to string) (string, bool, error) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return "", false, errors.New("store not configured")
+	}
+
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case commChannelEmail:
+		idx := &models.SoulEmailAgentIndex{Email: strings.TrimSpace(to)}
+		_ = idx.UpdateKeys()
+		var item models.SoulEmailAgentIndex
+		err := s.store.DB.WithContext(ctx).
+			Model(&models.SoulEmailAgentIndex{}).
+			Where("PK", "=", idx.PK).
+			Where("SK", "=", "AGENT").
+			First(&item)
+		if theoryErrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		agentID := strings.ToLower(strings.TrimSpace(item.AgentID))
+		return agentID, agentID != "", nil
+	case commChannelSMS, commChannelVoice:
+		idx := &models.SoulPhoneAgentIndex{Phone: strings.TrimSpace(to)}
+		_ = idx.UpdateKeys()
+		var item models.SoulPhoneAgentIndex
+		err := s.store.DB.WithContext(ctx).
+			Model(&models.SoulPhoneAgentIndex{}).
+			Where("PK", "=", idx.PK).
+			Where("SK", "=", "AGENT").
+			First(&item)
+		if theoryErrors.IsNotFound(err) {
+			return "", false, nil
+		}
+		if err != nil {
+			return "", false, err
+		}
+		agentID := strings.ToLower(strings.TrimSpace(item.AgentID))
+		return agentID, agentID != "", nil
+	default:
+		return "", false, nil
+	}
+}
+
+func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics, message string) *apptheory.AppTheoryError {
+	metrics.status = commMetricPreferenceViolation
 	violationID := strings.TrimSpace(ctx.RequestID)
 	if violationID == "" {
 		if token, tokenErr := generateRandomSecret(8); tokenErr == nil {
 			violationID = token
 		}
 	}
+	preferenceRespected := false
 	activity := &models.SoulAgentCommActivity{
-		AgentID:       req.agentIDHex,
-		ActivityID:    "comm-violation-" + violationID,
-		ChannelType:   req.channel,
-		Direction:     models.SoulCommDirectionOutbound,
-		Counterparty:  req.to,
-		Action:        "send",
-		MessageID:     "",
-		InReplyTo:     "",
-		BoundaryCheck: models.SoulCommBoundaryCheckViolated,
-		Timestamp:     now,
+		AgentID:             req.agentIDHex,
+		ActivityID:          "comm-pref-deny-" + violationID,
+		ChannelType:         req.channel,
+		Direction:           models.SoulCommDirectionOutbound,
+		Counterparty:        req.to,
+		Action:              "send",
+		MessageID:           "",
+		InReplyTo:           "",
+		BoundaryCheck:       models.SoulCommBoundaryCheckSkipped,
+		PreferenceRespected: &preferenceRespected,
+		Timestamp:           now,
 	}
 	_ = activity.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(activity).Create()
-	return apptheory.NewAppTheoryError("comm.boundary_violation", "unsolicited outbound communication is not allowed; inReplyTo is required").WithStatusCode(http.StatusForbidden)
+	return apptheory.NewAppTheoryError(commCodePreferenceViolation, message).WithStatusCode(http.StatusForbidden)
 }
 
 func newSoulCommSendMessageID() (string, *apptheory.AppTheoryError) {
@@ -661,7 +786,7 @@ func (s *Server) debitSoulSMSCredits(ctx context.Context, instanceSlug string, a
 	return nil
 }
 
-func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, delivery soulCommSendDelivery, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, delivery soulCommSendDelivery, decision soulCommSendGuardDecision, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
 	statusValue := strings.TrimSpace(delivery.initialStatus)
 	if statusValue == "" {
 		statusValue = models.SoulCommMessageStatusSent
@@ -685,16 +810,17 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 	}
 
 	activity := &models.SoulAgentCommActivity{
-		AgentID:       req.agentIDHex,
-		ActivityID:    messageID,
-		ChannelType:   req.channel,
-		Direction:     models.SoulCommDirectionOutbound,
-		Counterparty:  req.to,
-		Action:        "send",
-		MessageID:     messageID,
-		InReplyTo:     req.inReplyTo,
-		BoundaryCheck: models.SoulCommBoundaryCheckPassed,
-		Timestamp:     now,
+		AgentID:             req.agentIDHex,
+		ActivityID:          messageID,
+		ChannelType:         req.channel,
+		Direction:           models.SoulCommDirectionOutbound,
+		Counterparty:        req.to,
+		Action:              "send",
+		MessageID:           messageID,
+		InReplyTo:           req.inReplyTo,
+		BoundaryCheck:       models.SoulCommBoundaryCheckPassed,
+		PreferenceRespected: decision.preferenceRespected,
+		Timestamp:           now,
 	}
 	_ = activity.UpdateKeys()
 	createActivityErr := s.store.DB.WithContext(ctx.Context()).Model(activity).Create()
@@ -1065,3 +1191,5 @@ func isCommProviderUnavailable(err error) bool {
 	var netErr net.Error
 	return errors.As(err, &netErr)
 }
+
+func boolPtr(v bool) *bool { return &v }

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/stretchr/testify/mock"
@@ -81,7 +82,7 @@ func TestHandleSoulCommSend_UnauthorizedWithoutBearer(t *testing.T) {
 	}
 }
 
-func TestHandleSoulCommSend_BoundaryViolationRequiresInReplyTo(t *testing.T) {
+func TestEnforceSoulCommSendGuards_AllowsFirstContactToExternalRecipient(t *testing.T) {
 	t.Parallel()
 
 	db := ttmocks.NewMockExtendedDB()
@@ -90,18 +91,16 @@ func TestHandleSoulCommSend_BoundaryViolationRequiresInReplyTo(t *testing.T) {
 	qIdentity := new(ttmocks.MockQuery)
 	qChannel := new(ttmocks.MockQuery)
 	qCommActivity := new(ttmocks.MockQuery)
+	qEmailIdx := new(ttmocks.MockQuery)
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qIdentity).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qCommActivity).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(qEmailIdx).Maybe()
 
-	allowCommQueryOps(qKey, qDomain, qIdentity, qChannel, qCommActivity)
-	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(nil).Run(func(args mock.Arguments) {
-		dest := testutil.RequireMockArg[*models.InstanceKey](t, args, 0)
-		*dest = models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()}
-	}).Once()
+	allowCommQueryOps(qKey, qDomain, qIdentity, qChannel, qCommActivity, qEmailIdx)
 
 	agentID := soulLifecycleTestAgentIDHex
 
@@ -139,41 +138,28 @@ func TestHandleSoulCommSend_BoundaryViolationRequiresInReplyTo(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	s := &Server{
 		store: store.New(db),
 		cfg:   config.Config{SoulEnabled: true},
 	}
 
-	body, _ := json.Marshal(map[string]any{
-		"channel": "email",
-		"agentId": agentID,
-		"to":      "alice@example.com",
-		"subject": "Hello",
-		"body":    "Test",
-	})
-
-	ctx := &apptheory.Context{
-		RequestID:    "r-comm-boundary",
-		AuthIdentity: "",
-		Request: apptheory.Request{
-			Body: body,
-			Headers: map[string][]string{
-				"authorization": {"Bearer k1"},
-			},
-		},
+	decision, err := s.enforceSoulCommSendGuards(&apptheory.Context{RequestID: "r-comm-first-contact"}, &models.SoulAgentIdentity{
+		AgentID: agentID,
+		Domain:  "example.com",
+	}, validatedSoulCommSendRequest{
+		channel:    commChannelEmail,
+		agentIDHex: agentID,
+		to:         commSendTestEmailRecipient,
+		subject:    "Hello",
+		body:       "Test",
+	}, time.Now().UTC(), newSoulCommSendMetrics("lab", "inst1"))
+	if err != nil {
+		t.Fatalf("expected unsolicited external first contact to be allowed, got %v", err)
 	}
-
-	_, err := s.handleSoulCommSend(ctx)
-	if err == nil {
-		t.Fatalf("expected error")
-	}
-	appErr, ok := err.(*apptheory.AppTheoryError)
-	if !ok {
-		t.Fatalf("expected AppTheoryError, got %T", err)
-	}
-	if appErr.Code != "comm.boundary_violation" || appErr.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected comm.boundary_violation/403, got %q/%d", appErr.Code, appErr.StatusCode)
+	if decision.preferenceRespected != nil {
+		t.Fatalf("expected nil preferenceRespected for external recipient, got %#v", decision.preferenceRespected)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -28,6 +28,10 @@ type soulCommSendMoreTestDB struct {
 	qDomain       *ttmocks.MockQuery
 	qIdentity     *ttmocks.MockQuery
 	qChannel      *ttmocks.MockQuery
+	qEmailIdx     *ttmocks.MockQuery
+	qPhoneIdx     *ttmocks.MockQuery
+	qPrefs        *ttmocks.MockQuery
+	qReputation   *ttmocks.MockQuery
 	qCommActivity *ttmocks.MockQuery
 	qStatus       *ttmocks.MockQuery
 	qInstance     *ttmocks.MockQuery
@@ -41,6 +45,10 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 	qDomain := new(ttmocks.MockQuery)
 	qIdentity := new(ttmocks.MockQuery)
 	qChannel := new(ttmocks.MockQuery)
+	qEmailIdx := new(ttmocks.MockQuery)
+	qPhoneIdx := new(ttmocks.MockQuery)
+	qPrefs := new(ttmocks.MockQuery)
+	qReputation := new(ttmocks.MockQuery)
 	qCommActivity := new(ttmocks.MockQuery)
 	qStatus := new(ttmocks.MockQuery)
 	qInstance := new(ttmocks.MockQuery)
@@ -52,13 +60,17 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qIdentity).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(qEmailIdx).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(qPhoneIdx).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentContactPreferences")).Return(qPrefs).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentReputation")).Return(qReputation).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qCommActivity).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(qBudget).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qKey, qDomain, qIdentity, qChannel, qCommActivity, qStatus, qInstance, qBudget, qAudit} {
+	for _, q := range []*ttmocks.MockQuery{qKey, qDomain, qIdentity, qChannel, qEmailIdx, qPhoneIdx, qPrefs, qReputation, qCommActivity, qStatus, qInstance, qBudget, qAudit} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
@@ -74,6 +86,10 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 		qDomain:       qDomain,
 		qIdentity:     qIdentity,
 		qChannel:      qChannel,
+		qEmailIdx:     qEmailIdx,
+		qPhoneIdx:     qPhoneIdx,
+		qPrefs:        qPrefs,
+		qReputation:   qReputation,
 		qCommActivity: qCommActivity,
 		qStatus:       qStatus,
 		qInstance:     qInstance,
@@ -423,7 +439,7 @@ func TestRequireCommInstanceKey_FallbackAndErrors(t *testing.T) {
 	t.Run("falls back to raw token when hash miss", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		tdb.qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(theoryErrors.ErrItemNotFound).Once()
-		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "plain-token", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
+		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "plain-token", InstanceSlug: commWebhookTestInstanceSlug, CreatedAt: time.Now().Add(-time.Hour).UTC()})
 		s := &Server{store: store.New(tdb.db)}
 
 		key, err := s.requireCommInstanceKey(&apptheory.Context{
@@ -432,7 +448,7 @@ func TestRequireCommInstanceKey_FallbackAndErrors(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		if key == nil || key.ID != "plain-token" || strings.TrimSpace(key.InstanceSlug) != "inst1" {
+		if key == nil || key.ID != "plain-token" || strings.TrimSpace(key.InstanceSlug) != commWebhookTestInstanceSlug {
 			t.Fatalf("unexpected key: %#v", key)
 		}
 		if key.LastUsedAt.IsZero() {
@@ -447,7 +463,7 @@ func TestRequireCommInstanceKey_FallbackAndErrors(t *testing.T) {
 			dest := testutil.RequireMockArg[*models.InstanceKey](t, args, 0)
 			*dest = models.InstanceKey{
 				ID:           "plain-token",
-				InstanceSlug: "inst1",
+				InstanceSlug: commWebhookTestInstanceSlug,
 				CreatedAt:    time.Now().Add(-time.Hour).UTC(),
 				RevokedAt:    time.Now().UTC(),
 			}
@@ -537,6 +553,128 @@ func TestRequireCommAgentInstanceAccess_ErrorsAndSuccess(t *testing.T) {
 			t.Fatalf("expected success, got %v", appErr)
 		}
 	})
+
+	t.Run("managed stage alias resolves through base domain", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+		expectCommDomain(t, tdb.qDomain, models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "inst1",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		})
+		tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+			*dest = models.Instance{Slug: "inst1", HostedBaseDomain: "simulacrum.greater.website"}
+		}).Once()
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{Stage: "lab"}}
+		if appErr := s.requireCommAgentInstanceAccess(context.Background(), key, &models.SoulAgentIdentity{Domain: "dev.simulacrum.greater.website"}); appErr != nil {
+			t.Fatalf("expected managed alias success, got %v", appErr)
+		}
+	})
+}
+
+func TestEnforceSoulCommSendGuards_RecipientFirstContactPreferences(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+
+	t.Run("recipient reputation requirement blocks first contact", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{}
+		}).Twice()
+		expectCommEmailIdx(t, tdb.qEmailIdx, "recipient@lessersoul.ai", "0xrecipient")
+		minRep := 0.9
+		expectCommPrefs(t, tdb.qPrefs, models.SoulAgentContactPreferences{
+			AgentID:                       "0xrecipient",
+			FirstContactRequireReputation: &minRep,
+			UpdatedAt:                     time.Now().UTC(),
+		})
+		tdb.qReputation.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		decision, appErr := s.enforceSoulCommSendGuards(
+			&apptheory.Context{RequestID: "req-pref-deny"},
+			&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+			validatedSoulCommSendRequest{
+				channel:    commChannelEmail,
+				agentIDHex: agentID,
+				to:         "recipient@lessersoul.ai",
+				subject:    "Hello",
+				body:       "First contact",
+			},
+			time.Now().UTC(),
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr == nil {
+			t.Fatalf("expected preference violation")
+		}
+		if appErr.Code != commCodePreferenceViolation || appErr.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected %s/403, got %q/%d", commCodePreferenceViolation, appErr.Code, appErr.StatusCode)
+		}
+		if decision.preferenceRespected == nil || *decision.preferenceRespected {
+			t.Fatalf("expected preferenceRespected=false, got %#v", decision.preferenceRespected)
+		}
+	})
+
+	t.Run("recipient requireSoul is satisfied for a soul sender", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{}
+		}).Twice()
+		expectCommEmailIdx(t, tdb.qEmailIdx, "recipient@lessersoul.ai", "0xrecipient")
+		expectCommPrefs(t, tdb.qPrefs, models.SoulAgentContactPreferences{
+			AgentID:                 "0xrecipient",
+			FirstContactRequireSoul: true,
+			UpdatedAt:               time.Now().UTC(),
+		})
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		decision, appErr := s.enforceSoulCommSendGuards(
+			&apptheory.Context{RequestID: "req-pref-allow"},
+			&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+			validatedSoulCommSendRequest{
+				channel:    commChannelEmail,
+				agentIDHex: agentID,
+				to:         "recipient@lessersoul.ai",
+				subject:    "Hello",
+				body:       "First contact",
+			},
+			time.Now().UTC(),
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr != nil {
+			t.Fatalf("expected allowed first contact, got %v", appErr)
+		}
+		if decision.preferenceRespected == nil || !*decision.preferenceRespected {
+			t.Fatalf("expected preferenceRespected=true, got %#v", decision.preferenceRespected)
+		}
+	})
+}
+
+func TestLookupSoulCommRecipientAgentID_PhoneAndUnsupported(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulCommSendMoreTestDB()
+	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulPhoneAgentIndex](t, args, 0)
+		*dest = models.SoulPhoneAgentIndex{Phone: "+15551234567", AgentID: "0xphone"}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+	agentID, found, err := s.lookupSoulCommRecipientAgentID(context.Background(), commChannelSMS, "+15551234567")
+	if err != nil || !found || agentID != "0xphone" {
+		t.Fatalf("expected phone lookup hit, got agent=%q found=%v err=%v", agentID, found, err)
+	}
+
+	agentID, found, err = s.lookupSoulCommRecipientAgentID(context.Background(), "pager", "whatever")
+	if err != nil || found || agentID != "" {
+		t.Fatalf("expected unsupported channel miss, got agent=%q found=%v err=%v", agentID, found, err)
+	}
 }
 
 func TestRequireCommAgentInstanceAccess_ManagedStageDomain(t *testing.T) {
@@ -780,6 +918,22 @@ func expectCommChannel(t *testing.T, q *ttmocks.MockQuery, ch models.SoulAgentCh
 	q.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
 		*dest = ch
+	}).Once()
+}
+
+func expectCommEmailIdx(t *testing.T, q *ttmocks.MockQuery, email string, agentID string) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{Email: email, AgentID: agentID}
+	}).Once()
+}
+
+func expectCommPrefs(t *testing.T, q *ttmocks.MockQuery, prefs models.SoulAgentContactPreferences) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.SoulAgentContactPreferences")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentContactPreferences](t, args, 0)
+		*dest = prefs
 	}).Once()
 }
 

--- a/internal/controlplane/handlers_tip_registry_internal_test.go
+++ b/internal/controlplane/handlers_tip_registry_internal_test.go
@@ -108,7 +108,7 @@ func TestHandleTipHostRegistrationBegin_Success(t *testing.T) {
 	if out.Registration.ID == "" || out.Wallet.Message == "" || out.Wallet.Nonce == "" {
 		t.Fatalf("unexpected response: %#v", out)
 	}
-	if out.Registration.DomainNormalized != "example.com" {
+	if out.Registration.DomainNormalized != testDomainExampleCom {
 		t.Fatalf("expected normalized domain, got %#v", out.Registration.DomainNormalized)
 	}
 	if out.Wallet.Address != strings.ToLower("0x000000000000000000000000000000000000dEaD") {

--- a/internal/controlplane/managed_domain_resolution_internal_test.go
+++ b/internal/controlplane/managed_domain_resolution_internal_test.go
@@ -1,0 +1,217 @@
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+func TestLoadManagedStageAwareDomain_ManagedAlias(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	d, err := s.loadManagedStageAwareDomain(context.Background(), "dev.simulacrum.greater.website")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d == nil || d.Domain != "simulacrum.greater.website" || d.InstanceSlug != "simulacrum" {
+		t.Fatalf("unexpected managed alias resolution: %#v", d)
+	}
+}
+
+func TestLoadManagedStageAwareDomain_ExactDomain(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	_ = queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:       "example.com",
+			InstanceSlug: "inst1",
+			Status:       models.DomainStatusVerified,
+		}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	d, err := s.loadManagedStageAwareDomain(context.Background(), "example.com")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d == nil || d.Domain != "example.com" || d.InstanceSlug != "inst1" {
+		t.Fatalf("unexpected exact domain resolution: %#v", d)
+	}
+}
+
+func TestLoadManagedStageAwareDomain_ManagedAliasRejectsMismatchedHostedBaseDomain(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "other.greater.website"}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	if _, err := s.loadManagedStageAwareDomain(context.Background(), "dev.simulacrum.greater.website"); !theoryErrors.IsNotFound(err) {
+		t.Fatalf("expected not found for mismatched hosted base domain, got %v", err)
+	}
+}
+
+func TestLoadManagedStageAwareDomain_ManagedAliasRejectsUnverifiedDomain(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	_ = queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusPending,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	if _, err := s.loadManagedStageAwareDomain(context.Background(), "dev.simulacrum.greater.website"); !theoryErrors.IsNotFound(err) {
+		t.Fatalf("expected not found for unverified alias domain, got %v", err)
+	}
+}
+
+func TestRequireSoulAgentInstanceAccess_ManagedStageAlias(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	if appErr := s.requireSoulAgentInstanceAccess(context.Background(), "simulacrum", &models.SoulAgentIdentity{Domain: "dev.simulacrum.greater.website"}); appErr != nil {
+		t.Fatalf("expected managed alias access, got %#v", appErr)
+	}
+}
+
+func TestLoadTelnyxVoiceInstanceSlug_ManagedStageAlias(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	slug, err := s.loadTelnyxVoiceInstanceSlug(&apptheory.Context{RequestID: "req"}, &models.SoulAgentIdentity{Domain: "dev.simulacrum.greater.website"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if slug != "simulacrum" {
+		t.Fatalf("expected simulacrum slug, got %q", slug)
+	}
+}
+
+func TestLoadMetadata_BlankAndNotFound(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	if d, err := s.loadDomainMetadata(context.Background(), " "); !theoryErrors.IsNotFound(err) || d != nil {
+		t.Fatalf("expected blank domain to miss, got domain=%#v err=%v", d, err)
+	}
+	if inst, err := s.loadInstanceMetadata(context.Background(), " "); !theoryErrors.IsNotFound(err) || inst != nil {
+		t.Fatalf("expected blank instance slug to miss, got inst=%#v err=%v", inst, err)
+	}
+
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	if d, err := s.loadDomainMetadata(context.Background(), "missing.example"); !theoryErrors.IsNotFound(err) || d != nil {
+		t.Fatalf("expected missing domain to miss, got domain=%#v err=%v", d, err)
+	}
+
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+	if inst, err := s.loadInstanceMetadata(context.Background(), "missing"); !theoryErrors.IsNotFound(err) || inst != nil {
+		t.Fatalf("expected missing instance slug to miss, got inst=%#v err=%v", inst, err)
+	}
+}

--- a/internal/manageddomain/stage_test.go
+++ b/internal/manageddomain/stage_test.go
@@ -22,11 +22,11 @@ func TestStageHelpers(t *testing.T) {
 		t.Fatalf("unexpected dev domain: %q", got)
 	}
 
-	if base, ok := BaseDomainFromStageDomain("lab", "DEV.Example.com."); !ok || base != "example.com" {
-		t.Fatalf("expected dev alias to resolve, got %q %v", base, ok)
-	}
 	if _, ok := BaseDomainFromStageDomain("prod", "example.com"); ok {
 		t.Fatal("expected live domain not to be treated as alias")
+	}
+	if base, ok := BaseDomainFromStageDomain("lab", "dev.simulacrum.greater.website"); !ok || base != "simulacrum.greater.website" {
+		t.Fatalf("expected managed alias to resolve, got %q %v", base, ok)
 	}
 	if _, ok := BaseDomainFromStageDomain("lab", "example.com"); ok {
 		t.Fatal("expected base domain not to be treated as alias")

--- a/internal/specv3/contracts_test.go
+++ b/internal/specv3/contracts_test.go
@@ -47,7 +47,7 @@ func TestV3ContractFixturesValidate(t *testing.T) {
 		{
 			name:     "soul_comm_send_error",
 			schema:   filepath.Join(schemasDir, "soul-comm-send.error.schema.json"),
-			fixtures: []string{filepath.Join(fixturesDir, "soul-comm-send.error.boundary-violation.example.json")},
+			fixtures: []string{filepath.Join(fixturesDir, "soul-comm-send.error.preference-violation.example.json")},
 		},
 		{
 			name:     "soul_agent_channels_response",

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -470,7 +470,7 @@ export interface components {
         "soul-comm-send.error.schema": {
             error: {
                 /** @enum {string} */
-                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.boundary_violation" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.internal";
+                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.preference_violation" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.internal";
                 message: string;
                 request_id?: string;
             };


### PR DESCRIPTION
## Summary
- allow first-contact outbound comm by default and enforce recipient soul contact preferences instead of treating everything as a boundary violation
- resolve managed stage-domain aliases like \ consistently across comm auth, registration access, webhooks, and commworker delivery
- update the comm send error contract and add coverage for the shared alias-resolution helpers and inbound drop handling

## Validation
- env GOTOOLCHAIN=go1.26.1 go test ./...
- env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/manageddomain ./internal/controlplane ./internal/commworker
- env GOTOOLCHAIN=go1.26.1 bash gov-infra/verifiers/gov-verify-rubric.sh
- cd web && npm run typecheck
- cd web && npm run lint
- cd web && npm run build
- cd cdk && env GOTOOLCHAIN=go1.26.1 npm run synth -- -c stage=lab