### PR TITLE
fix: allow open-ended soul capabilities

### DIFF
--- a/internal/controlplane/handlers_soul_boundaries.go
+++ b/internal/controlplane/handlers_soul_boundaries.go
@@ -717,10 +717,7 @@ func (s *Server) finalizeSoulBoundaryAppendRegistration(reg map[string]any, base
 	if appErr != nil {
 		return nil, nil, nil, nil, nil, appErr
 	}
-	capsNorm, appErr := normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, extractCapabilityNames(reg))
-	if appErr != nil {
-		return nil, nil, nil, nil, nil, appErr
-	}
+	capsNorm := normalizeSoulCapabilitiesLoose(extractCapabilityNames(reg))
 	return regV2, regV3, digest, capsNorm, extractCapabilityClaimLevels(reg), nil
 }
 

--- a/internal/controlplane/handlers_soul_boundaries_coverage_internal_test.go
+++ b/internal/controlplane/handlers_soul_boundaries_coverage_internal_test.go
@@ -375,9 +375,9 @@ func TestBuildSoulBoundaryAppendRegistration_MoreCoverage(t *testing.T) {
 		t.Parallel()
 		testBoundaryAppendRegistrationSuccessV3MergesMissingBoundaries(t, key, wallet, identity, input)
 	})
-	t.Run("unsupported_capability", func(t *testing.T) {
+	t.Run("unknown_capability_allowed", func(t *testing.T) {
 		t.Parallel()
-		testBoundaryAppendRegistrationUnsupportedCapability(t, key, wallet, identity, input)
+		testBoundaryAppendRegistrationUnknownCapabilityAllowed(t, key, wallet, identity, input)
 	})
 }
 
@@ -493,7 +493,7 @@ func testBoundaryAppendRegistrationSuccessV3MergesMissingBoundaries(t *testing.T
 	}
 }
 
-func testBoundaryAppendRegistrationUnsupportedCapability(t *testing.T, key *ecdsa.PrivateKey, wallet string, identity *models.SoulAgentIdentity, input soulBoundaryAppendBuildInput) {
+func testBoundaryAppendRegistrationUnknownCapabilityAllowed(t *testing.T, key *ecdsa.PrivateKey, wallet string, identity *models.SoulAgentIdentity, input soulBoundaryAppendBuildInput) {
 	t.Helper()
 	tdb := newSoulLifecycleTestDB()
 	s := &Server{
@@ -508,8 +508,12 @@ func testBoundaryAppendRegistrationUnsupportedCapability(t *testing.T, key *ecds
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentBoundary](t, args, 0)
 		*dest = []*models.SoulAgentBoundary{}
 	}).Once()
-	if _, _, _, _, _, _, appErr := s.buildSoulBoundaryAppendRegistration(t.Context(), base, "2", soulLifecycleTestAgentIDHex, identity, input); appErr == nil || appErr.Code != appErrCodeBadRequest {
-		t.Fatalf("expected bad_request, got %#v", appErr)
+	_, _, _, _, capsNorm, _, appErr := s.buildSoulBoundaryAppendRegistration(t.Context(), base, "2", soulLifecycleTestAgentIDHex, identity, input)
+	if appErr != nil {
+		t.Fatalf("unexpected err: %#v", appErr)
+	}
+	if len(capsNorm) != 1 || capsNorm[0] != "text-summarization" {
+		t.Fatalf("expected normalized capabilities, got %#v", capsNorm)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_boundaries_internal_test.go
+++ b/internal/controlplane/handlers_soul_boundaries_internal_test.go
@@ -58,6 +58,7 @@ func newBoundaryAppendPublishFixture(t *testing.T) *boundaryAppendPublishFixture
 			SoulChainID:                 1,
 			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
 			SoulPackBucketName:          "bucket",
+			SoulSupportedCapabilities:   []string{"social"},
 		},
 		soulPacks: packs,
 	}

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -203,10 +203,7 @@ func (s *Server) finalizeSoulProvisionEmailChannel(
 	selfSig string,
 ) (*apptheory.Response, error) {
 	caps := extractCapabilityNames(regMap)
-	capsNorm, appErr := normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, caps)
-	if appErr != nil {
-		return nil, appErr
-	}
+	capsNorm := normalizeSoulCapabilitiesLoose(caps)
 
 	passParamName := s.soulAgentEmailPasswordSSMParam(agentIDHex)
 	password, passErr := s.ensureSoulAgentEmailPassword(ctx.Context(), passParamName)

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -162,6 +162,7 @@ func newProvisionEmailE2EFixture(t *testing.T) *provisionEmailE2EFixture {
 			SoulChainID:                 1,
 			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
 			SoulPackBucketName:          "bucket",
+			SoulSupportedCapabilities:   []string{"social"},
 			Stage:                       "lab",
 		},
 		soulPacks: fixture.packs,

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -230,10 +230,7 @@ func (s *Server) finalizeSoulProvisionPhoneChannel(
 	}
 
 	caps := extractCapabilityNames(regMap)
-	capsNorm, appErr := normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, caps)
-	if appErr != nil {
-		return nil, appErr
-	}
+	capsNorm := normalizeSoulCapabilitiesLoose(caps)
 
 	regBytes, regSHA256, claimLevels, changeSummary, appErr := buildProvisionRegistrationPayload(regMap)
 	if appErr != nil {

--- a/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
@@ -94,6 +94,7 @@ func newProvisionPhoneServer(tdb soulLifecycleTestDB, packs soulPackStore) *Serv
 			SoulChainID:                 1,
 			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
 			SoulPackBucketName:          "bucket",
+			SoulSupportedCapabilities:   []string{"social"},
 			Stage:                       "lab",
 		},
 	}

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -1587,10 +1587,7 @@ func (s *Server) buildMintConversationFinalizeV2Registration(
 
 	// Capability indexing inputs.
 	caps := extractCapabilityNames(reg)
-	capsNorm, appErr = normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, caps)
-	if appErr != nil {
-		return nil, nil, nil, nil, nil, appErr
-	}
+	capsNorm = normalizeSoulCapabilitiesLoose(caps)
 	claimLevels = extractCapabilityClaimLevels(reg)
 
 	return reg, parsed, digest, capsNorm, claimLevels, nil

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -380,7 +380,7 @@ func testMintConversationExtractDeclarationsGuards(t *testing.T, now time.Time) 
 func testMintConversationFinalizeRegistrationHelper(t *testing.T, now time.Time) {
 	t.Helper()
 
-	s := &Server{cfg: config.Config{SoulPackBucketName: "bucket", SoulSupportedCapabilities: []string{"travel_planning"}}}
+	s := &Server{cfg: config.Config{SoulPackBucketName: "bucket", SoulSupportedCapabilities: []string{"social"}}}
 	identity := testMintConversationIdentity()
 	decl := testMintConversationDecl()
 

--- a/internal/controlplane/handlers_soul_registry.go
+++ b/internal/controlplane/handlers_soul_registry.go
@@ -95,29 +95,6 @@ func normalizeSoulCapabilitiesLoose(caps []string) []string {
 	return out
 }
 
-func normalizeSoulCapabilitiesStrict(supported []string, requested []string) ([]string, *apptheory.AppError) {
-	out := normalizeSoulCapabilitiesLoose(requested)
-	if len(out) == 0 {
-		return nil, nil
-	}
-
-	allowed := normalizeSoulCapabilitiesLoose(supported)
-	if len(allowed) == 0 {
-		return out, nil
-	}
-
-	allowedSet := make(map[string]struct{}, len(allowed))
-	for _, c := range allowed {
-		allowedSet[c] = struct{}{}
-	}
-	for _, c := range out {
-		if _, ok := allowedSet[c]; !ok {
-			return nil, &apptheory.AppError{Code: "app.bad_request", Message: "unsupported capability: " + c}
-		}
-	}
-	return out, nil
-}
-
 func parseSoulRegistrationBeginCapabilities(raw []any) ([]string, *apptheory.AppError) {
 	if raw == nil {
 		return nil, nil
@@ -366,10 +343,7 @@ func (s *Server) handleSoulAgentRegistrationBegin(ctx *apptheory.Context) (*appt
 		return nil, appErr
 	}
 
-	caps, appErr := normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, capNames)
-	if appErr != nil {
-		return nil, appErr
-	}
+	caps := normalizeSoulCapabilitiesLoose(capNames)
 
 	agentIDHex, err := soul.DeriveAgentIDHex(domainNormalized, local)
 	if err != nil {

--- a/internal/controlplane/handlers_soul_registry_internal_test.go
+++ b/internal/controlplane/handlers_soul_registry_internal_test.go
@@ -158,6 +158,64 @@ func TestHandleSoulAgentRegistrationBegin_Success(t *testing.T) {
 	assertSoulAgentRegistrationBeginResponse(t, resp.Body)
 }
 
+func TestHandleSoulAgentRegistrationBegin_AllowsUnknownCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulRegistryTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulEnabled:                 true,
+			SoulChainID:                 1,
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
+			SoulTxMode:                  "safe",
+			SoulAdminSafeAddress:        "0x0000000000000000000000000000000000000002",
+			SoulSupportedCapabilities:   []string{"social"},
+		},
+	}
+
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.User](t, args, 0)
+		*dest = models.User{Username: "alice", Role: models.RoleCustomer, ApprovalStatus: models.UserApprovalStatusApproved}
+	}).Once()
+
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}
+	}).Once()
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "inst1", Owner: "alice"}
+	}).Once()
+
+	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	body, _ := json.Marshal(soulAgentRegistrationBeginRequest{
+		Domain:       testDomainExampleCom,
+		LocalID:      "agent-alice",
+		Wallet:       "0x000000000000000000000000000000000000dEaD",
+		Capabilities: []any{"cross_agent_integration"},
+	})
+
+	ctx := &apptheory.Context{RequestID: "r1x", AuthIdentity: "alice", Request: apptheory.Request{Body: body}}
+	resp, err := s.handleSoulAgentRegistrationBegin(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("expected 201, got %d (body=%q)", resp.Status, string(resp.Body))
+	}
+
+	var out soulAgentRegistrationBeginResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Registration.Capabilities) != 1 || out.Registration.Capabilities[0] != "cross_agent_integration" {
+		t.Fatalf("expected unknown capability to persist, got %#v", out.Registration.Capabilities)
+	}
+}
+
 func assertSoulAgentRegistrationBeginResponse(t *testing.T, body []byte) {
 	t.Helper()
 
@@ -508,19 +566,11 @@ func TestHandleSoulAgentRegistrationVerify_UsesExistingProofFlagsAndCreatesOpera
 	}
 }
 
-func TestNormalizeSoulCapabilitiesStrict_EnforcesSupportedList(t *testing.T) {
+func TestNormalizeSoulCapabilitiesLoose_NormalizesWithoutAllowlist(t *testing.T) {
 	t.Parallel()
 
-	got, err := normalizeSoulCapabilitiesStrict([]string{"social"}, []string{" social ", "SOCIAL", "commerce"})
-	if err == nil {
-		t.Fatalf("expected error for unsupported capability, got=%v", got)
-	}
-
-	got, err = normalizeSoulCapabilitiesStrict([]string{"social"}, []string{" social ", "SOCIAL"})
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if len(got) != 1 || got[0] != "social" {
+	got := normalizeSoulCapabilitiesLoose([]string{" social ", "SOCIAL", "commerce", "cross_agent_integration"})
+	if len(got) != 3 || got[0] != "commerce" || got[1] != "cross_agent_integration" || got[2] != "social" {
 		t.Fatalf("unexpected caps: %#v", got)
 	}
 }

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -858,14 +858,11 @@ func (s *Server) validateSoulUpdateRegistrationDocument(
 		return "", nil, "", nil, appErr
 	}
 
-	// Capabilities affect indexing; validate against the allowlist if configured.
+	// Capabilities affect indexing; the host config list is informational only.
 	// v2 uses structured capabilities (array of objects with "capability" field);
 	// v1 uses a flat string array. Extract capability names for both.
 	caps := extractCapabilityNames(reg)
-	capsNorm, appErr = normalizeSoulCapabilitiesStrict(s.cfg.SoulSupportedCapabilities, caps)
-	if appErr != nil {
-		return "", nil, "", nil, appErr
-	}
+	capsNorm = normalizeSoulCapabilitiesLoose(caps)
 
 	return walletNorm, capsNorm, selfSig, digest, nil
 }

--- a/internal/controlplane/handlers_soul_update_registration_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_internal_test.go
@@ -41,6 +41,7 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 			SoulRPCURL:                  "http://rpc.local",
 			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
 			SoulPackBucketName:          "bucket",
+			SoulSupportedCapabilities:   []string{"social"},
 		},
 		soulPacks: packs,
 	}


### PR DESCRIPTION
## Summary
- stop hard-rejecting soul capability strings based on `SOUL_SUPPORTED_CAPABILITIES`
- keep host-supported capabilities informational only while continuing to normalize capability strings for storage and indexing
- add coverage proving unknown capabilities survive registration, update, mint finalize, channel provisioning, and boundary append flows

## Validation
- `env GOTOOLCHAIN=go1.26.1 go test ./...`
- `env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/controlplane ./internal/commworker ./internal/manageddomain`
- `env GOTOOLCHAIN=go1.26.1 bash gov-infra/verifiers/gov-verify-rubric.sh`

Closes #39