### PR TITLE
fix: address open dependabot npm alerts

### DIFF
--- a/contracts/package-lock.json
+++ b/contracts/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "devDependencies": {
-        "@nomicfoundation/hardhat-ethers": "^4.0.4",
-        "@nomicfoundation/hardhat-network-helpers": "^3.0.3",
+        "@nomicfoundation/hardhat-ethers": "^4.0.6",
+        "@nomicfoundation/hardhat-network-helpers": "^3.0.4",
         "@openzeppelin/contracts": "5.4.0",
         "dotenv": "^17.3.1",
         "ethers": "^6.16.0",
-        "hardhat": "^3.1.9",
+        "hardhat": "^3.1.12",
         "solhint": "^6.0.3"
       },
       "engines": {
@@ -532,28 +532,28 @@
       }
     },
     "node_modules/@nomicfoundation/edr": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.24.tgz",
-      "integrity": "sha512-/NwB9yX7uBs/FIJKHBZo2hVhP7g3v6LbE21JvTLvshgb+XscyaRRUmzB//ankxLGJ1TehtXAf/Qh/a19vgpiig==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr/-/edr-0.12.0-next.28.tgz",
+      "integrity": "sha512-DOW5VFGIZWpuB6Llx+5ewn9HingN7uV/6nI3ecB3pZ4qc5OnwxnfG/KatYS6Fq3J55SuWMSxgDMHHA0kAVTFHQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.24",
-        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.24",
-        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.24",
-        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.24",
-        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.24",
-        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.24",
-        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.24"
+        "@nomicfoundation/edr-darwin-arm64": "0.12.0-next.28",
+        "@nomicfoundation/edr-darwin-x64": "0.12.0-next.28",
+        "@nomicfoundation/edr-linux-arm64-gnu": "0.12.0-next.28",
+        "@nomicfoundation/edr-linux-arm64-musl": "0.12.0-next.28",
+        "@nomicfoundation/edr-linux-x64-gnu": "0.12.0-next.28",
+        "@nomicfoundation/edr-linux-x64-musl": "0.12.0-next.28",
+        "@nomicfoundation/edr-win32-x64-msvc": "0.12.0-next.28"
       },
       "engines": {
         "node": ">= 20"
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-arm64": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.24.tgz",
-      "integrity": "sha512-lYcD9IM52G0hk/3Sso2Rpdpyfafy3aHH0GsSy/FVog9UrEkmmU14AmccE18/zTL+UyV0yzYMDOmh6y83SD/lbg==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-arm64/-/edr-darwin-arm64-0.12.0-next.28.tgz",
+      "integrity": "sha512-fJsQ8enlgp4Sky98jHcAFXXmb3EYNoYlwtGlmfoYjDsIeL74a2lozNzyo55CtduHD/sugffjtyF0nDyxZEdwMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -561,9 +561,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-darwin-x64": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.24.tgz",
-      "integrity": "sha512-cHDJZlPDpDXJXxQDVM0TGzEuNvV3wW94gipEdjNxZHeC9T2/NU/5GUoQajMJgvCZ6PWDlRMwIBRtM1jC/ny5DA==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-darwin-x64/-/edr-darwin-x64-0.12.0-next.28.tgz",
+      "integrity": "sha512-QST3PPJPejfRJhxThR5CoCxQAfIty0n8k40JtI+wLwKGCDT86JRKkJ3AaXPM1a72nUqMYoQK+gzQyA11zZGd4Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -571,9 +571,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-gnu": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.24.tgz",
-      "integrity": "sha512-G/iln4W79CR9f68+crBZM1kBdmmK3IbQCD4b5u+iqby+H5BOLSPQmjeW9UREK5WSecnv7Oxr/ZTHHRq/w9pUPA==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-gnu/-/edr-linux-arm64-gnu-0.12.0-next.28.tgz",
+      "integrity": "sha512-sj4p6jeQfkiePxn1goZFZzz7V0SVFfZDH6ngPileQcAoFBWHKqi17UOG4IZ4NFpjYmDCcdrUWDNRbxC7OhgEqQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -581,9 +581,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-arm64-musl": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.24.tgz",
-      "integrity": "sha512-wt6UuOutufL3UTSyMiwPOyfRly3uQEFHASXqLsNjgp4qBrm0s+kkyaYpAe8h53lGzZmXIDOAbO0P/fwxnLCnWw==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-arm64-musl/-/edr-linux-arm64-musl-0.12.0-next.28.tgz",
+      "integrity": "sha512-d0hV02jMTozPEqRF3PO65Xi6/RqN5EywU5KaiDMcO+8b0nk+pJZ6VdcugRgv3lMMJbM/sP3LDFQn2eoOhalp7w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -591,9 +591,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-gnu": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.24.tgz",
-      "integrity": "sha512-mHgkUSynINTnnIvZuZymJ4dMqjemGjdrzQ87rP5/SQQGRQVV82uDomSEglp9btSmbBWfPj4r4tWsV+a3844W0w==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-gnu/-/edr-linux-x64-gnu-0.12.0-next.28.tgz",
+      "integrity": "sha512-x3z4xbmCtSyZZg9MOhHcw1DOscngj50KK+6ZG0HKkGEbZ7WvDB9BnmRFEWo1rvIM+gqIcZvUBJbpLIdkA/BQYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-linux-x64-musl": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.24.tgz",
-      "integrity": "sha512-E0XNSlPc8Hx5Nhowe5VIvAqVeT+1VUWSRqG0cZtYcpUgJZxTp8p03ojPtbyfjL4T+78GfnpmzkkLhB6S2jZ1FQ==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-linux-x64-musl/-/edr-linux-x64-musl-0.12.0-next.28.tgz",
+      "integrity": "sha512-CKGcvP7enTo7gTXVxQiR8txPDOTNqS+wPLPkKXFzQBuVJ0FDj8eKIMRlZaw3Wbcd8QObaAKmKH7KzHVO5zzXmQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -611,9 +611,9 @@
       }
     },
     "node_modules/@nomicfoundation/edr-win32-x64-msvc": {
-      "version": "0.12.0-next.24",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.24.tgz",
-      "integrity": "sha512-PbtY2zWc4k8HK4gVnVbPohJnfrICboo6J91vxTlhnPKCWGvfGbsqLfDUAp91ExHHY+80qRfQnwaLbhJiIqLFGw==",
+      "version": "0.12.0-next.28",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/edr-win32-x64-msvc/-/edr-win32-x64-msvc-0.12.0-next.28.tgz",
+      "integrity": "sha512-QAzb9dZGwOU7Ee2N96dvdSLiUMmjlPVxgLqTKsQbkibcBZ9I+Zs8TGisGUZsDccrbUcR4wDv8S9tD1EM9fEs/g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -621,50 +621,50 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-errors": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.6.tgz",
-      "integrity": "sha512-3x+OVdZv7Rgy3z6os9pB6kiHLxs6q0PCXHRu+WLZflr44PG9zW+7V9o+ehrUqmmivlHcIFr3Qh4M2wZVuoCYww==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-errors/-/hardhat-errors-3.0.8.tgz",
+      "integrity": "sha512-gHAZDYb0e5joq+WecgC3ciz5OcgqUBgK2zLQmNoKSn/I52h3SH1stxXsY4dcVsj0OY4ZksqIRhJDKskHC5DvTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-utils": "^3.0.1"
+        "@nomicfoundation/hardhat-utils": "^4.0.1"
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-4.0.4.tgz",
-      "integrity": "sha512-UTw3iM7AMZ1kZlzgJbtAEfWWDYjcnT0EZkRUZd1wIVtMOXIE4nc6Ya4veodAt/KpBhG+6W06g50W+Z/0wTm62g==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-4.0.6.tgz",
+      "integrity": "sha512-ZGQ7UzKs/EAzVgm0OShJP25oAGEqv9YKuRpRSHd1NyxD0bqJj4U3QeFhZ/3sB5CUly+pJlowJn2e8IVqoELxzA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.2",
-        "@nomicfoundation/hardhat-utils": "^3.0.5",
+        "@nomicfoundation/hardhat-errors": "^3.0.7",
+        "@nomicfoundation/hardhat-utils": "^4.0.0",
         "debug": "^4.3.2",
         "ethereum-cryptography": "^2.2.1",
         "ethers": "^6.14.0"
       },
       "peerDependencies": {
-        "hardhat": "^3.0.7"
+        "hardhat": "^3.1.11"
       }
     },
     "node_modules/@nomicfoundation/hardhat-network-helpers": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.3.tgz",
-      "integrity": "sha512-FqXD8CPFNdluEhELqNV/Q0grOQtlwRWr28LW+/NTas3rrDAXpNOIPCCq3RIXJIqsdbNPQsG2FpnfKj9myqIsKQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-network-helpers/-/hardhat-network-helpers-3.0.4.tgz",
+      "integrity": "sha512-WTNISH3/ZkcSDNp//dML18zgV4z3ooeibNcxvv4soCh0AmI8I+2kKaTlKN/Ou1mhKOdiLUbCZCbKNz9LGK3uQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.5",
-        "@nomicfoundation/hardhat-utils": "^3.0.5"
+        "@nomicfoundation/hardhat-errors": "^3.0.7",
+        "@nomicfoundation/hardhat-utils": "^4.0.0"
       },
       "peerDependencies": {
         "hardhat": "^3.0.0"
       }
     },
     "node_modules/@nomicfoundation/hardhat-utils": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-3.0.6.tgz",
-      "integrity": "sha512-AD/LPNdjXNFRrZcaAAewgJpdnHpPppZxo5p+x6wGMm5Hz4B3+oLf/LUzVn8qb4DDy9RE2c24l2F8vmL/w6ZuXg==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-utils/-/hardhat-utils-4.0.1.tgz",
+      "integrity": "sha512-9xxD6WXLn+kopd+hmF+XYcJJ38Gm06QmZxKf/fIJzlzs9FuNI6C7Lvdd4qHv8/3ReegIbpBCrzozaL2GISmNrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -686,14 +686,14 @@
       "license": "MIT"
     },
     "node_modules/@nomicfoundation/hardhat-zod-utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.1.tgz",
-      "integrity": "sha512-I6/pyYiS9p2lLkzQuedr1ScMocH+ew8l233xTi+LP92gjEiviJDxselpkzgU01MUM0t6BPpfP8yMO958LDEJVg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-zod-utils/-/hardhat-zod-utils-3.0.3.tgz",
+      "integrity": "sha512-WER4/UKLpm7/nz1asvNR7EKZKKBW+48Hw7GOdcd3Rhdr3VTNuTaeIxCJpl6YxTTg+Eq/sPAWX0mr25+USs6KWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@nomicfoundation/hardhat-errors": "^3.0.0",
-        "@nomicfoundation/hardhat-utils": "^3.0.2"
+        "@nomicfoundation/hardhat-errors": "^3.0.7",
+        "@nomicfoundation/hardhat-utils": "^4.0.0"
       },
       "peerDependencies": {
         "zod": "^3.23.8"
@@ -1649,18 +1649,18 @@
       "license": "ISC"
     },
     "node_modules/hardhat": {
-      "version": "3.1.9",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.1.9.tgz",
-      "integrity": "sha512-LCThGBbROzRiI0RwD85i61bYM380ZWwVZ5XRHsY/ADUWnoMKIRYN835f4rQxT2qkVvDnZB0jbmU3RRS/MPy7Gw==",
+      "version": "3.1.12",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-3.1.12.tgz",
+      "integrity": "sha512-/3TrZV4ViCIKgy2K5XwPS5xla2v4xjxYA2Ms1pi/0t+1GQQ1dWQpKJhDjKBc02UWYiWihIZFAv9RS30anyhqpQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@nomicfoundation/edr": "0.12.0-next.24",
-        "@nomicfoundation/hardhat-errors": "^3.0.6",
-        "@nomicfoundation/hardhat-utils": "^3.0.6",
+        "@nomicfoundation/edr": "0.12.0-next.28",
+        "@nomicfoundation/hardhat-errors": "^3.0.8",
+        "@nomicfoundation/hardhat-utils": "^4.0.1",
         "@nomicfoundation/hardhat-vendored": "^3.0.1",
-        "@nomicfoundation/hardhat-zod-utils": "^3.0.1",
+        "@nomicfoundation/hardhat-zod-utils": "^3.0.3",
         "@nomicfoundation/solidity-analyzer": "^0.1.1",
         "@sentry/core": "^9.4.0",
         "adm-zip": "^0.4.16",
@@ -2553,9 +2553,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
+      "integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -18,15 +18,16 @@
     "test": "hardhat compile && node --test test/*.test.js"
   },
   "devDependencies": {
-    "@nomicfoundation/hardhat-ethers": "^4.0.4",
-    "@nomicfoundation/hardhat-network-helpers": "^3.0.3",
+    "@nomicfoundation/hardhat-ethers": "^4.0.6",
+    "@nomicfoundation/hardhat-network-helpers": "^3.0.4",
     "@openzeppelin/contracts": "5.4.0",
     "dotenv": "^17.3.1",
     "ethers": "^6.16.0",
-    "hardhat": "^3.1.9",
+    "hardhat": "^3.1.12",
     "solhint": "^6.0.3"
   },
   "overrides": {
-    "minimatch": "10.2.4"
+    "minimatch": "10.2.4",
+    "undici": "6.24.0"
   }
 }

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -42,7 +42,7 @@
         "eslint-plugin-svelte": "^3.12.2",
         "globals": "^17.3.0",
         "jsdom": "^28.1.0",
-        "svelte": "^5.53.7",
+        "svelte": "^5.53.12",
         "svelte-check": "^4.4.3",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.23.0",
@@ -2516,9 +2516,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
-      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
       "dev": true,
       "license": "MIT"
     },
@@ -3002,9 +3002,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -5270,9 +5270,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.53.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.7.tgz",
-      "integrity": "sha512-uxck1KI7JWtlfP3H6HOWi/94soAl23jsGJkBzN2BAWcQng0+lTrRNhxActFqORgnO9BHVd1hKJhG+ljRuIUWfQ==",
+      "version": "5.53.12",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.53.12.tgz",
+      "integrity": "sha512-4x/uk4rQe/d7RhfvS8wemTfNjQ0bJbKvamIzRBfTe2eHHjzBZ7PZicUQrC2ryj83xxEacfA1zHKd1ephD1tAxA==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5286,7 +5286,7 @@
         "aria-query": "5.3.1",
         "axobject-query": "^4.1.0",
         "clsx": "^2.1.1",
-        "devalue": "^5.6.3",
+        "devalue": "^5.6.4",
         "esm-env": "^1.2.1",
         "esrap": "^2.2.2",
         "is-reference": "^3.0.3",
@@ -5557,9 +5557,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/web/package.json
+++ b/web/package.json
@@ -25,7 +25,7 @@
     "eslint-plugin-svelte": "^3.12.2",
     "globals": "^17.3.0",
     "jsdom": "^28.1.0",
-    "svelte": "^5.53.7",
+    "svelte": "^5.53.12",
     "svelte-check": "^4.4.3",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.23.0",
@@ -58,8 +58,11 @@
     "viem": "^2.47.0"
   },
   "overrides": {
+    "devalue": "5.6.4",
+    "flatted": "3.4.1",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
+    "undici": "7.24.3",
     "@typescript-eslint/typescript-estree": {
       "minimatch": "10.2.4"
     }


### PR DESCRIPTION
## Summary
- refresh `web` dependency resolutions to patched `svelte`, `devalue`, `undici`, and `flatted`
- refresh `contracts` dependency resolutions to patched Hardhat-related packages and `undici`
- clear the 8 open Dependabot npm alerts on `web/package-lock.json` and `contracts/package-lock.json`

## Validation
- `cd web && npm audit`
- `cd web && npm run typecheck`
- `cd web && npm run lint`
- `cd web && npm test`
- `cd web && npm run build`
- `cd contracts && npm audit`
- `cd contracts && npm run build`
- `cd contracts && npm run lint`
- `cd contracts && npm test`
