### PR TITLE
Fix soul wallet rotation execution recovery

### DIFF
--- a/internal/controlplane/handlers_soul_agent_rotation_operation.go
+++ b/internal/controlplane/handlers_soul_agent_rotation_operation.go
@@ -1,0 +1,132 @@
+package controlplane
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type soulAgentRotationOperationResponse struct {
+	Operation models.SoulOperation `json:"operation"`
+	SafeTx    *safeTxPayload       `json:"safe_tx,omitempty"`
+}
+
+func (s *Server) handleSoulAgentGetRotationOperation(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if appErr := s.requireSoulRegistryConfigured(); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.requireSoulPortalPrereqs(ctx); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+
+	agentIDHex, _, appErr := parseSoulAgentIDHex(ctx.Param("agentId"))
+	if appErr != nil {
+		return nil, appErr
+	}
+	identity, appErr := s.requireSoulAgentWithDomainAccess(ctx, agentIDHex)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	op, appErr := s.loadSoulRotationOperationForIdentity(ctx.Context(), identity, strings.TrimSpace(ctx.AuthIdentity))
+	if appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(http.StatusOK, buildSoulAgentRotationOperationResponse(op))
+}
+
+func (s *Server) handleSoulAgentRecordRotationOperationExecution(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if appErr := s.requireSoulRegistryConfigured(); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.requireSoulPortalPrereqs(ctx); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.requireSoulRPCConfigured(); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+
+	agentIDHex, _, appErr := parseSoulAgentIDHex(ctx.Param("agentId"))
+	if appErr != nil {
+		return nil, appErr
+	}
+	identity, appErr := s.requireSoulAgentWithDomainAccess(ctx, agentIDHex)
+	if appErr != nil {
+		return nil, appErr
+	}
+	txHash, appErr := parseSoulOperationExecutionTxHash(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	op, appErr := s.loadSoulRotationOperationForIdentity(ctx.Context(), identity, strings.TrimSpace(ctx.AuthIdentity))
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	updated, appErr := s.recordSoulOperationExecution(ctx.Context(), strings.TrimSpace(ctx.AuthIdentity), ctx.RequestID, op, txHash)
+	if appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(http.StatusOK, buildSoulAgentRotationOperationResponse(updated))
+}
+
+func (s *Server) loadSoulRotationOperationForIdentity(
+	ctx context.Context,
+	identity *models.SoulAgentIdentity,
+	username string,
+) (*models.SoulOperation, *apptheory.AppError) {
+	if s == nil || identity == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if strings.TrimSpace(username) == "" {
+		return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+
+	rot, err := s.getSoulWalletRotationRequest(ctx, identity.AgentID, username)
+	if theoryErrors.IsNotFound(err) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "rotation operation not found"}
+	}
+	if err != nil || rot == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	_, txTo, appErr := s.soulRegistryContractAddress()
+	if appErr != nil {
+		return nil, appErr
+	}
+	opID := soulRotationOpID(s.cfg.SoulChainID, txTo, identity.AgentID, rot.CurrentWallet, rot.NewWallet, rot.Nonce, rot.Deadline)
+
+	op, err := s.getSoulOperation(ctx, opID)
+	if theoryErrors.IsNotFound(err) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "rotation operation not found"}
+	}
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if strings.ToLower(strings.TrimSpace(op.Kind)) != models.SoulOperationKindRotateWallet {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "rotation operation not found"}
+	}
+	return op, nil
+}
+
+func buildSoulAgentRotationOperationResponse(op *models.SoulOperation) soulAgentRotationOperationResponse {
+	if op == nil {
+		return soulAgentRotationOperationResponse{}
+	}
+	return soulAgentRotationOperationResponse{
+		Operation: *op,
+		SafeTx:    parseSafeTxPayload(op.SafePayloadJSON),
+	}
+}

--- a/internal/controlplane/handlers_soul_agent_rotation_operation_internal_test.go
+++ b/internal/controlplane/handlers_soul_agent_rotation_operation_internal_test.go
@@ -1,0 +1,127 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+func TestHandleSoulAgentGetRotationOperation_Success(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulCommPortalTestDB()
+	s := newSoulPortalServer(tdb)
+	agentID := soulLifecycleTestAgentIDHex
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+
+	tdb.base.qRotation.On("First", mock.AnythingOfType("*models.SoulWalletRotationRequest")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulWalletRotationRequest](t, args, 0)
+		*dest = models.SoulWalletRotationRequest{
+			AgentID:       agentID,
+			Username:      "admin",
+			CurrentWallet: "0x00000000000000000000000000000000000000aa",
+			NewWallet:     "0x00000000000000000000000000000000000000bb",
+			Nonce:         "7",
+			Deadline:      1700000000,
+		}
+	}).Once()
+
+	opID := soulRotationOpID(s.cfg.SoulChainID, "0x0000000000000000000000000000000000000001", agentID, "0x00000000000000000000000000000000000000aa", "0x00000000000000000000000000000000000000bb", "7", 1700000000)
+	tdb.base.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
+		*dest = models.SoulOperation{
+			OperationID:     opID,
+			Kind:            models.SoulOperationKindRotateWallet,
+			AgentID:         agentID,
+			Status:          models.SoulOperationStatusPending,
+			SafePayloadJSON: `{"safe_address":"0x00000000000000000000000000000000000000cc","to":"0x0000000000000000000000000000000000000001","value":"0","data":"0x1234"}`,
+			CreatedAt:       time.Now().Add(-time.Minute).UTC(),
+			UpdatedAt:       time.Now().UTC(),
+		}
+	}).Once()
+
+	ctx := adminCtx()
+	ctx.Params = map[string]string{"agentId": agentID}
+
+	resp, err := s.handleSoulAgentGetRotationOperation(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var out soulAgentRotationOperationResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Equal(t, opID, out.Operation.OperationID)
+	require.NotNil(t, out.SafeTx)
+	require.Equal(t, "0x00000000000000000000000000000000000000cc", out.SafeTx.SafeAddress)
+}
+
+func TestHandleSoulAgentRecordRotationOperationExecution_Success(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulCommPortalTestDB()
+	s := newSoulPortalServer(tdb)
+	agentID := soulLifecycleTestAgentIDHex
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+
+	tdb.base.qRotation.On("First", mock.AnythingOfType("*models.SoulWalletRotationRequest")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulWalletRotationRequest](t, args, 0)
+		*dest = models.SoulWalletRotationRequest{
+			AgentID:       agentID,
+			Username:      "admin",
+			CurrentWallet: "0x00000000000000000000000000000000000000aa",
+			NewWallet:     "0x00000000000000000000000000000000000000bb",
+			Nonce:         "7",
+			Deadline:      1700000000,
+		}
+	}).Once()
+
+	opID := soulRotationOpID(s.cfg.SoulChainID, "0x0000000000000000000000000000000000000001", agentID, "0x00000000000000000000000000000000000000aa", "0x00000000000000000000000000000000000000bb", "7", 1700000000)
+	tdb.base.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
+		*dest = models.SoulOperation{
+			OperationID:     opID,
+			Kind:            models.SoulOperationKindRotateWallet,
+			AgentID:         agentID,
+			Status:          models.SoulOperationStatusPending,
+			SafePayloadJSON: `{"to":"0x0000000000000000000000000000000000000001","value":"0","data":"0x1234"}`,
+			CreatedAt:       time.Now().Add(-time.Minute).UTC(),
+			UpdatedAt:       time.Now().UTC(),
+		}
+	}).Once()
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeEthClient{
+			receipt: &types.Receipt{
+				Status:      0,
+				BlockNumber: big.NewInt(42),
+				GasUsed:     100,
+				Logs:        []*types.Log{},
+			},
+		}, nil
+	}
+
+	txHash := "0x" + strings.Repeat("ab", 32)
+	body, _ := json.Marshal(recordSoulExecutionRequest{ExecTxHash: txHash})
+	ctx := adminCtx()
+	ctx.Params = map[string]string{"agentId": agentID}
+	ctx.Request.Body = body
+
+	resp, err := s.handleSoulAgentRecordRotationOperationExecution(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var out soulAgentRotationOperationResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Equal(t, models.SoulOperationStatusFailed, out.Operation.Status)
+	require.Equal(t, strings.ToLower(txHash), out.Operation.ExecTxHash)
+}

--- a/internal/controlplane/handlers_soul_operations.go
+++ b/internal/controlplane/handlers_soul_operations.go
@@ -445,6 +445,41 @@ func (s *Server) applySoulOperationRotateWalletSideEffects(ctx context.Context, 
 		_ = wi.UpdateKeys()
 		_ = s.store.DB.WithContext(ctx).Model(wi).CreateOrUpdate()
 	}
+
+	ensChannel, err := getSoulAgentItemBySK[models.SoulAgentChannel](s, ctx, agentID, "CHANNEL#ens")
+	if err != nil || ensChannel == nil || strings.TrimSpace(ensChannel.Identifier) == "" {
+		return
+	}
+
+	resolution := &models.SoulAgentENSResolution{
+		ENSName:   ensChannel.Identifier,
+		AgentID:   agentID,
+		Wallet:    newWallet,
+		LocalID:   identity.LocalID,
+		Domain:    identity.Domain,
+		Status:    identity.Status,
+		UpdatedAt: now,
+	}
+	_ = resolution.UpdateKeys()
+
+	var existing models.SoulAgentENSResolution
+	err = s.store.DB.WithContext(ctx).
+		Model(&models.SoulAgentENSResolution{}).
+		Where("PK", "=", resolution.GetPK()).
+		Where("SK", "=", resolution.GetSK()).
+		First(&existing)
+	if err == nil {
+		if !strings.EqualFold(strings.TrimSpace(existing.AgentID), agentID) {
+			return
+		}
+		existing.Wallet = newWallet
+		existing.UpdatedAt = now
+		_ = existing.UpdateKeys()
+		_ = s.store.DB.WithContext(ctx).Model(&existing).Update("Wallet", "UpdatedAt")
+		return
+	}
+
+	_ = s.store.DB.WithContext(ctx).Model(resolution).CreateOrUpdate()
 }
 
 func (s *Server) applySoulOperationBurnSideEffects(ctx context.Context, agentID string) {

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -52,6 +52,8 @@ type soulOperationsTestDB struct {
 	qOp          *ttmocks.MockQuery
 	qID          *ttmocks.MockQuery
 	qWalletAgent *ttmocks.MockQuery
+	qChannel     *ttmocks.MockQuery
+	qENS         *ttmocks.MockQuery
 	qAudit       *ttmocks.MockQuery
 }
 
@@ -60,25 +62,38 @@ func newSoulOperationsTestDB() soulOperationsTestDB {
 	qOp := new(ttmocks.MockQuery)
 	qID := new(ttmocks.MockQuery)
 	qWalletAgent := new(ttmocks.MockQuery)
+	qChannel := new(ttmocks.MockQuery)
+	qENS := new(ttmocks.MockQuery)
 	qAudit := new(ttmocks.MockQuery)
 
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulOperation")).Return(qOp).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qID).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulWalletAgentIndex")).Return(qWalletAgent).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(qENS).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qOp, qID, qWalletAgent, qAudit} {
+	for _, q := range []*ttmocks.MockQuery{qOp, qID, qWalletAgent, qChannel, qENS, qAudit} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Index", mock.Anything).Return(q).Maybe()
 		q.On("IfExists").Return(q).Maybe()
 		q.On("Update", mock.Anything).Return(nil).Maybe()
+		q.On("Update", mock.Anything, mock.Anything).Return(nil).Maybe()
 		q.On("Create").Return(nil).Maybe()
 		q.On("CreateOrUpdate").Return(nil).Maybe()
 		q.On("Delete").Return(nil).Maybe()
 	}
 
-	return soulOperationsTestDB{db: db, qOp: qOp, qID: qID, qWalletAgent: qWalletAgent, qAudit: qAudit}
+	return soulOperationsTestDB{
+		db:           db,
+		qOp:          qOp,
+		qID:          qID,
+		qWalletAgent: qWalletAgent,
+		qChannel:     qChannel,
+		qENS:         qENS,
+		qAudit:       qAudit,
+	}
 }
 
 func opCtx() *apptheory.Context {
@@ -316,11 +331,36 @@ func TestApplySoulOperationSideEffects_RotateWallet(t *testing.T) {
 	agentID := "0x" + strings.Repeat("11", 32)
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{AgentID: agentID, Wallet: oldWallet, Status: models.SoulAgentStatusActive}
+		*dest = models.SoulAgentIdentity{
+			AgentID: agentID,
+			Wallet:  oldWallet,
+			LocalID: "ops",
+			Domain:  "dev.simulacrum.greater.website",
+			Status:  models.SoulAgentStatusActive,
+		}
+	}).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:     agentID,
+			ChannelType: models.SoulChannelTypeENS,
+			Identifier:  "ops.lessersoul.eth",
+			Status:      models.SoulChannelStatusActive,
+			UpdatedAt:   time.Now().UTC(),
+		}
+	}).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
+		*dest = models.SoulAgentENSResolution{
+			ENSName: "ops.lessersoul.eth",
+			AgentID: agentID,
+			Wallet:  oldWallet,
+		}
 	}).Once()
 
 	tdb.qWalletAgent.On("Delete").Return(nil).Once()
 	tdb.qWalletAgent.On("CreateOrUpdate").Return(nil).Once()
+	tdb.qENS.On("Update", "Wallet", "UpdatedAt").Return(nil).Once()
 
 	op := &models.SoulOperation{
 		Kind:    models.SoulOperationKindRotateWallet,

--- a/internal/controlplane/handlers_soul_rotation.go
+++ b/internal/controlplane/handlers_soul_rotation.go
@@ -586,10 +586,13 @@ func (s *Server) createSoulWalletRotationConfirmResponse(
 
 	opID := soulRotationOpID(s.cfg.SoulChainID, txTo, agentIDHex, rot.CurrentWallet, rot.NewWallet, rot.Nonce, rot.Deadline)
 	payload := &safeTxPayload{
-		SafeAddress: safeAddr,
+		SafeAddress: "",
 		To:          txTo,
 		Value:       "0",
 		Data:        "0x" + hex.EncodeToString(data),
+	}
+	if strings.ToLower(strings.TrimSpace(s.cfg.SoulTxMode)) == tipTxModeSafe {
+		payload.SafeAddress = safeAddr
 	}
 	payloadJSON, _ := json.Marshal(payload)
 

--- a/internal/controlplane/handlers_soul_rotation_internal_test.go
+++ b/internal/controlplane/handlers_soul_rotation_internal_test.go
@@ -508,3 +508,62 @@ func TestCreateSoulWalletRotationConfirmResponse_CreateErrorFails(t *testing.T) 
 	require.Nil(t, appResp)
 	require.Equal(t, "app.internal", appErr.Code)
 }
+
+func TestCreateSoulWalletRotationConfirmResponse_DirectModeOmitsSafeAddress(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qOp := new(ttmocks.MockQuery)
+	qRot := new(ttmocks.MockQuery)
+	qAudit := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulOperation")).Return(qOp).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulWalletRotationRequest")).Return(qRot).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
+
+	qOp.On("IfNotExists").Return(qOp).Maybe()
+	qOp.On("Create").Return(nil).Once()
+	qRot.On("IfExists").Return(qRot).Maybe()
+	qRot.On("Update", mock.Anything).Return(nil).Maybe()
+	qAudit.On("Create").Return(nil).Maybe()
+
+	s := &Server{
+		store: store.New(db),
+		cfg: config.Config{
+			SoulChainID: 1,
+			SoulTxMode:  "direct",
+		},
+	}
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "r1"}
+	rot := &models.SoulWalletRotationRequest{
+		AgentID:       "0x" + strings.Repeat("11", 32),
+		Username:      "alice",
+		CurrentWallet: "0x00000000000000000000000000000000000000aa",
+		NewWallet:     "0x00000000000000000000000000000000000000bb",
+		Nonce:         "7",
+		Deadline:      1700000000,
+	}
+	_ = rot.UpdateKeys()
+
+	resp, appErr := s.createSoulWalletRotationConfirmResponse(
+		ctx,
+		rot.AgentID,
+		big.NewInt(1),
+		"0x0000000000000000000000000000000000000001",
+		rot,
+		big.NewInt(7),
+		big.NewInt(1700000000),
+		make([]byte, 65),
+		make([]byte, 65),
+		time.Now().UTC(),
+	)
+	require.Nil(t, appErr)
+	require.NotNil(t, resp)
+
+	var out soulRotateWalletConfirmResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.NotNil(t, out.SafeTx)
+	require.Empty(t, out.SafeTx.SafeAddress)
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -229,6 +229,8 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Post("/api/v1/soul/agents/register/{id}/verify", s.handleSoulAgentRegistrationVerify, apptheory.RequireAuth())
 	app.Post("/api/v1/soul/agents/{agentId}/rotate-wallet/begin", s.handleSoulAgentRotateWalletBegin, apptheory.RequireAuth())
 	app.Post("/api/v1/soul/agents/{agentId}/rotate-wallet/confirm", s.handleSoulAgentRotateWalletConfirm, apptheory.RequireAuth())
+	app.Get("/api/v1/soul/agents/{agentId}/rotate-wallet/operation", s.handleSoulAgentGetRotationOperation, apptheory.RequireAuth())
+	app.Post("/api/v1/soul/agents/{agentId}/rotate-wallet/operation/record-execution", s.handleSoulAgentRecordRotationOperationExecution, apptheory.RequireAuth())
 	app.Post("/api/v1/soul/agents/{agentId}/update-registration", s.handleSoulAgentUpdateRegistration, apptheory.RequireAuth())
 	app.Get("/api/v1/soul/agents/{agentId}/mint-operation", s.handleSoulAgentGetMintOperation, apptheory.RequireAuth())
 	app.Post("/api/v1/soul/agents/{agentId}/mint-operation/record-execution", s.handleSoulAgentRecordMintOperationExecution, apptheory.RequireAuth())

--- a/web/src/lib/api/soul.ts
+++ b/web/src/lib/api/soul.ts
@@ -434,6 +434,11 @@ export interface SoulRotateWalletConfirmResponse {
 	safe_tx?: SafeTxPayload;
 }
 
+export interface SoulAgentRotationOperationResponse {
+	operation: SoulOperation;
+	safe_tx?: SafeTxPayload;
+}
+
 export function soulAgentRotateWalletConfirm(
 	token: string,
 	agentId: string,
@@ -449,6 +454,33 @@ export function soulAgentRotateWalletConfirm(
 		},
 		body: req.body,
 	});
+}
+
+export function soulGetAgentRotationOperation(token: string, agentId: string): Promise<SoulAgentRotationOperationResponse> {
+	return fetchJson<SoulAgentRotationOperationResponse>(`/api/v1/soul/agents/${encodeURIComponent(agentId)}/rotate-wallet/operation`, {
+		headers: {
+			authorization: `Bearer ${token}`,
+		},
+	});
+}
+
+export function soulRecordAgentRotationExecution(
+	token: string,
+	agentId: string,
+	execTxHash: string,
+): Promise<SoulAgentRotationOperationResponse> {
+	const req = jsonRequest({ exec_tx_hash: execTxHash });
+	return fetchJson<SoulAgentRotationOperationResponse>(
+		`/api/v1/soul/agents/${encodeURIComponent(agentId)}/rotate-wallet/operation/record-execution`,
+		{
+			method: 'POST',
+			headers: {
+				authorization: `Bearer ${token}`,
+				...req.headers,
+			},
+			body: req.body,
+		},
+	);
 }
 
 export interface SoulUpdateRegistrationResponse {

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -5,6 +5,7 @@
 	import type {
 		SoulMineAgentItem,
 		SoulAgentMintOperationResponse,
+		SoulAgentRotationOperationResponse,
 		SoulPublicAgentResponse,
 		SoulPublicAgentChannelsResponse,
 		SoulConfigResponse,
@@ -29,6 +30,7 @@
 	import {
 		soulAgentRotateWalletBegin,
 		soulAgentRotateWalletConfirm,
+		soulGetAgentRotationOperation,
 		soulGetAgentMintOperation,
 		soulAppendContinuity,
 		soulCreateRelationship,
@@ -49,6 +51,7 @@
 		soulProvisionEmailConfirm,
 		soulProvisionPhoneBegin,
 		soulProvisionPhoneConfirm,
+		soulRecordAgentRotationExecution,
 		soulRecordAgentMintExecution,
 		soulDeprovisionPhone,
 		soulAgentListCommActivity,
@@ -183,6 +186,17 @@
 	let rotationConfirmLoading = $state(false);
 	let rotationConfirmError = $state<string | null>(null);
 	let rotationConfirmResult = $state<SoulRotateWalletConfirmResponse | null>(null);
+	let rotationOperation = $state<SoulAgentRotationOperationResponse | null>(null);
+	let rotationOperationLoading = $state(false);
+	let rotationOperationError = $state<string | null>(null);
+	let rotationExecTxHash = $state('');
+	let rotationRecordLoading = $state(false);
+	let rotationRecordError = $state<string | null>(null);
+	let showRotationSafePayload = $state(false);
+	let rotationDirectLoading = $state(false);
+	let rotationDirectError = $state<string | null>(null);
+	let rotationDirectNotice = $state<string | null>(null);
+	let rotationDirectTxHash = $state('');
 
 	// Sovereignty state
 	let sovereigntyLoading = $state(false);
@@ -1217,9 +1231,33 @@
 		}
 	}
 
+	async function loadRotationOperation() {
+		rotationOperation = null;
+		rotationOperationError = null;
+		showRotationSafePayload = false;
+
+		rotationOperationLoading = true;
+		try {
+			rotationOperation = await soulGetAgentRotationOperation(token, agentId);
+		} catch (err) {
+			if (await handleAuthError(err)) return;
+			if ((err as Partial<ApiError>).status !== 404) {
+				rotationOperationError = formatError(err);
+			}
+		} finally {
+			rotationOperationLoading = false;
+		}
+	}
+
 	async function recordMintExecutionHash(txHash: string): Promise<void> {
 		mintOperation = await soulRecordAgentMintExecution(token, agentId, txHash);
 		mintExecTxHash = '';
+		await load();
+	}
+
+	async function recordRotationExecutionHash(txHash: string): Promise<void> {
+		rotationOperation = await soulRecordAgentRotationExecution(token, agentId, txHash);
+		rotationExecTxHash = '';
 		await load();
 	}
 
@@ -1239,6 +1277,25 @@
 			mintRecordError = formatError(err);
 		} finally {
 			mintRecordLoading = false;
+		}
+	}
+
+	async function recordRotationExecution() {
+		rotationRecordError = null;
+		const txHash = rotationExecTxHash.trim();
+		if (!txHash) {
+			rotationRecordError = 'Execution tx hash is required.';
+			return;
+		}
+
+		rotationRecordLoading = true;
+		try {
+			await recordRotationExecutionHash(txHash);
+		} catch (err) {
+			if (await handleAuthError(err)) return;
+			rotationRecordError = formatError(err);
+		} finally {
+			rotationRecordLoading = false;
 		}
 	}
 
@@ -1323,6 +1380,73 @@
 		}
 	}
 
+	async function executeDirectRotation() {
+		rotationDirectError = null;
+		rotationDirectNotice = null;
+
+		const payload = rotationOperation?.safe_tx;
+		if (!payload) {
+			rotationDirectError = 'No wallet rotation transaction payload is available.';
+			return;
+		}
+		if (payload.safe_address?.trim()) {
+			rotationDirectError = 'This wallet rotation still requires Safe execution.';
+			return;
+		}
+
+		const provider = getEthereumProvider();
+		if (!provider) {
+			rotationDirectError = 'No wallet detected.';
+			return;
+		}
+
+		rotationDirectLoading = true;
+		rotationRecordError = null;
+		let txHash = '';
+		try {
+			const accounts = await ensureAccounts(provider);
+			const from = accounts[0]?.trim();
+			if (!from) {
+				rotationDirectError = 'Connect a wallet to send the rotation transaction.';
+				return;
+			}
+
+			const expectedChainId = soulConfig?.chain_id;
+			if (expectedChainId) {
+				const currentChainId = await getChainId(provider);
+				if (currentChainId !== expectedChainId) {
+					rotationDirectNotice = `Switching wallet to chain ${expectedChainId}…`;
+					await switchEthereumChain(provider, expectedChainId);
+				}
+			}
+
+			rotationDirectNotice = 'Sending wallet rotation transaction from the connected wallet…';
+			txHash = await sendEthereumTransaction(provider, {
+				from,
+				to: payload.to,
+				value: payload.value,
+				data: payload.data,
+			});
+			rotationDirectTxHash = txHash;
+			rotationExecTxHash = txHash;
+
+			rotationDirectNotice = 'Transaction submitted. Waiting for Sepolia confirmation…';
+			await waitForEthereumTransactionReceipt(provider, txHash, 10 * 60 * 1000, 3000);
+
+			rotationDirectNotice = 'Transaction confirmed. Recording execution in lesser-host…';
+			await recordRotationExecutionHash(txHash);
+			rotationDirectNotice = 'Wallet rotation confirmed onchain and recorded.';
+		} catch (err) {
+			if (await handleAuthError(err)) return;
+			const base = formatError(err);
+			rotationDirectError = txHash
+				? `${base}. Transaction sent as ${txHash}. You can still record it manually below if needed.`
+				: base;
+		} finally {
+			rotationDirectLoading = false;
+		}
+	}
+
 	async function handleAuthError(err: unknown): Promise<boolean> {
 		if ((err as Partial<ApiError>).status === 401) {
 			await logout();
@@ -1349,6 +1473,10 @@
 		mintOperationError = null;
 		mintRecordError = null;
 		showMintSafePayload = false;
+		rotationOperation = null;
+		rotationOperationError = null;
+		rotationRecordError = null;
+		showRotationSafePayload = false;
 		commActivity = null;
 		commQueue = null;
 		commError = null;
@@ -1397,6 +1525,7 @@
 				prefsDraft = prettyJSON(channels.contactPreferences);
 			}
 			await loadMintOperation();
+			await loadRotationOperation();
 		} catch (err) {
 			errorMessage = formatError(err);
 		} finally {
@@ -1700,6 +1829,8 @@
 	let publicOrigin = $derived(typeof window !== 'undefined' ? window.location.origin : '');
 	let needsMintRecovery = $derived(lifecycleStatus === 'pending' && !agent?.agent?.mint_tx_hash);
 	let mintUsesSafe = $derived(Boolean(mintOperation?.safe_tx?.safe_address?.trim()));
+	let pendingRotationOperation = $derived(rotationOperation && !rotationOperation.operation.exec_tx_hash ? rotationOperation : null);
+	let rotationUsesSafe = $derived(Boolean(rotationOperation?.safe_tx?.safe_address?.trim()));
 
 	onMount(() => {
 		void load();
@@ -2855,6 +2986,9 @@
 				{#if rotationConfirmError}
 					<Alert variant="error" title="Confirm rotation failed">{rotationConfirmError}</Alert>
 				{/if}
+				{#if rotationOperationError}
+					<Alert variant="error" title="Pending rotation">{rotationOperationError}</Alert>
+				{/if}
 
 				<div class="soul-agent__form">
 					<TextField label="New wallet" bind:value={rotationNewWallet} placeholder="0x…" />
@@ -2913,23 +3047,124 @@
 									<Heading level={5} size="lg">Operation</Heading>
 								{/snippet}
 								<Text size="sm" color="secondary">
-									Operation <span class="soul-agent__mono">{rotationConfirmResult.operation.operation_id}</span>
+									Operation <span class="soul-agent__mono">{rotationConfirmResult.operation.operation_id}</span> was created.
+									Use the recovery panel below to execute it and record the final tx hash back into lesser-host.
 								</Text>
 								<div class="soul-agent__row">
 									<CopyButton size="sm" text={rotationConfirmResult.operation.operation_id} />
 								</div>
-
-								{#if rotationConfirmResult.safe_tx}
-									<DefinitionList>
-										<DefinitionItem label="Safe" monospace>{rotationConfirmResult.safe_tx.safe_address}</DefinitionItem>
-										<DefinitionItem label="To" monospace>{rotationConfirmResult.safe_tx.to}</DefinitionItem>
-										<DefinitionItem label="Value" monospace>{rotationConfirmResult.safe_tx.value}</DefinitionItem>
-										<DefinitionItem label="Data" monospace>{rotationConfirmResult.safe_tx.data}</DefinitionItem>
-									</DefinitionList>
-								{/if}
 							</Card>
 						{/if}
 					</Card>
+				{/if}
+
+				{#if rotationOperationLoading}
+					<div class="soul-agent__loading-inline">
+						<Spinner size="sm" />
+						<Text size="sm">Loading wallet rotation operation…</Text>
+					</div>
+				{/if}
+
+				{#if pendingRotationOperation}
+					<Alert variant="warning" title={rotationUsesSafe ? 'Wallet rotation still needs execution' : 'Wallet rotation still needs wallet confirmation'}>
+						<Text size="sm">
+							{#if rotationUsesSafe}
+								The signatures are complete, but the wallet change will not appear here until the Safe transaction is
+								executed onchain and its execution tx hash is recorded below.
+							{:else}
+								The signatures are complete, but the wallet change will not appear here until the connected wallet
+								submits the rotation transaction and lesser-host records the confirmed execution.
+							{/if}
+						</Text>
+
+						<DefinitionList>
+							<DefinitionItem label="Operation" monospace>{pendingRotationOperation.operation.operation_id}</DefinitionItem>
+							<DefinitionItem label="Status" monospace>{pendingRotationOperation.operation.status}</DefinitionItem>
+						</DefinitionList>
+
+						{#if rotationUsesSafe}
+							<div class="soul-agent__steps">
+								<Text size="sm">1. Execute the Safe transaction below in your Safe workflow.</Text>
+								<Text size="sm">2. Wait for the transaction to mine on Sepolia.</Text>
+								<Text size="sm">3. Paste the execution tx hash here to reconcile the new wallet.</Text>
+							</div>
+						{:else}
+							<div class="soul-agent__steps">
+								<Text size="sm">1. Submit the rotation transaction from any connected wallet.</Text>
+								<Text size="sm">2. Keep this page open while lesser-host waits for Sepolia confirmation.</Text>
+								<Text size="sm">3. Use the manual tx hash field only if automatic recording does not finish.</Text>
+							</div>
+						{/if}
+
+						{#if rotationDirectNotice}
+							<Alert variant="info" title="Direct rotation">{rotationDirectNotice}</Alert>
+						{/if}
+						{#if rotationDirectError}
+							<Alert variant="error" title="Direct rotation">{rotationDirectError}</Alert>
+						{/if}
+
+						<div class="soul-agent__row">
+							{#if !rotationUsesSafe && rotationOperation?.safe_tx}
+								<Button
+									variant="solid"
+									onclick={() => void executeDirectRotation()}
+									disabled={rotationDirectLoading || rotationRecordLoading}
+								>
+									{rotationDirectLoading ? 'Rotating…' : 'Rotate now with connected wallet'}
+								</Button>
+							{/if}
+							{#if rotationOperation?.safe_tx}
+								<Button variant="outline" onclick={() => (showRotationSafePayload = !showRotationSafePayload)}>
+									{showRotationSafePayload ? 'Hide transaction data' : 'Show transaction data'}
+								</Button>
+								<CopyButton size="sm" text={prettyJSON(rotationOperation.safe_tx)} />
+							{/if}
+							<CopyButton size="sm" text={pendingRotationOperation.operation.operation_id} />
+						</div>
+
+						{#if rotationDirectLoading}
+							<div class="soul-agent__loading-inline">
+								<Spinner size="sm" />
+								<Text size="sm">Waiting for wallet confirmation and chain settlement…</Text>
+							</div>
+						{/if}
+						{#if rotationDirectTxHash}
+							<div class="soul-agent__row">
+								<Text size="sm" color="secondary">
+									Execution tx <span class="soul-agent__mono">{rotationDirectTxHash}</span>
+								</Text>
+								<CopyButton size="sm" text={rotationDirectTxHash} />
+							</div>
+						{/if}
+
+						{#if rotationOperation?.safe_tx && showRotationSafePayload}
+							<DefinitionList>
+								<DefinitionItem label="To" monospace>{rotationOperation.safe_tx.to}</DefinitionItem>
+								<DefinitionItem label="Value" monospace>{rotationOperation.safe_tx.value}</DefinitionItem>
+								{#if rotationOperation.safe_tx.safe_address}
+									<DefinitionItem label="Safe" monospace>{rotationOperation.safe_tx.safe_address}</DefinitionItem>
+								{/if}
+							</DefinitionList>
+							<TextArea readonly rows={6} label="Transaction data" value={rotationOperation.safe_tx.data} />
+						{/if}
+
+						<div class="soul-agent__form">
+							<TextField label="Execution tx hash" bind:value={rotationExecTxHash} placeholder="0x…" />
+							<Button variant="solid" onclick={() => void recordRotationExecution()} disabled={rotationRecordLoading}>
+								Record execution
+							</Button>
+						</div>
+
+						{#if rotationRecordLoading}
+							<div class="soul-agent__loading-inline">
+								<Spinner size="sm" />
+								<Text size="sm">Recording execution…</Text>
+							</div>
+						{/if}
+						{#if rotationRecordError}
+							<Alert variant="error" title="Record execution">{rotationRecordError}</Alert>
+						{/if}
+					</Alert>
 				{/if}
 			</Card>
 		{/if}


### PR DESCRIPTION
## Summary\n- add portal recovery APIs for agent wallet rotation operations\n- support direct wallet rotation execution and manual execution recording in the soul portal\n- keep ENS resolution in sync when a wallet rotation is reconciled\n\n## Validation\n- env GOTOOLCHAIN=go1.26.1 go test ./...\n- env GOTOOLCHAIN=go1.26.1 golangci-lint run --timeout=5m ./internal/controlplane ./internal/store/models\n- cd web && npm run typecheck\n- cd web && npm run lint\n- cd web && npm run build\n- env GOTOOLCHAIN=go1.26.1 bash gov-infra/verifiers/gov-verify-rubric.sh\n- cd cdk && env GOTOOLCHAIN=go1.26.1 npm run synth -- -c stage=lab\n\nCloses #43