### PR TITLE
fix: reject malformed managed release tags

### DIFF
--- a/internal/controlplane/handlers_portal_updates.go
+++ b/internal/controlplane/handlers_portal_updates.go
@@ -728,7 +728,7 @@ func (s *Server) resolveManagedLesserUpdateVersion(ctx context.Context, inst *mo
 	if lesserVersion == "" {
 		return "", &apptheory.AppError{Code: "app.bad_request", Message: "lesser_version is required"}
 	}
-	return s.resolveManagedReleaseVersion(ctx, lesserVersion, s.cfg.ManagedLesserGitHubOwner, s.cfg.ManagedLesserGitHubRepo, "failed to resolve latest Lesser release")
+	return s.resolveManagedReleaseVersion(ctx, lesserVersion, "lesser_version", s.cfg.ManagedLesserGitHubOwner, s.cfg.ManagedLesserGitHubRepo, "failed to resolve latest Lesser release")
 }
 
 func (s *Server) resolveManagedBodyUpdateVersion(ctx context.Context, inst *models.Instance, req createUpdateJobRequest) (string, *apptheory.AppError) {
@@ -755,7 +755,7 @@ func (s *Server) resolveManagedBodyUpdateVersion(ctx context.Context, inst *mode
 	if lesserBodyVersion == "" {
 		return "", nil
 	}
-	return s.resolveManagedReleaseVersion(ctx, lesserBodyVersion, s.cfg.ManagedLesserBodyGitHubOwner, s.cfg.ManagedLesserBodyGitHubRepo, "failed to resolve latest lesser-body release")
+	return s.resolveManagedReleaseVersion(ctx, lesserBodyVersion, "lesser_body_version", s.cfg.ManagedLesserBodyGitHubOwner, s.cfg.ManagedLesserBodyGitHubRepo, "failed to resolve latest lesser-body release")
 }
 
 func (s *Server) resolveManagedUpdateVersions(ctx context.Context, inst *models.Instance, req createUpdateJobRequest) (string, string, *apptheory.AppError) {
@@ -770,8 +770,11 @@ func (s *Server) resolveManagedUpdateVersions(ctx context.Context, inst *models.
 	return lesserVersion, lesserBodyVersion, nil
 }
 
-func (s *Server) resolveManagedReleaseVersion(ctx context.Context, version string, owner string, repo string, failureMessage string) (string, *apptheory.AppError) {
+func (s *Server) resolveManagedReleaseVersion(ctx context.Context, version string, field string, owner string, repo string, failureMessage string) (string, *apptheory.AppError) {
 	version = strings.TrimSpace(version)
+	if appErr := validateManagedReleaseVersion(version, field); appErr != nil {
+		return "", appErr
+	}
 	if !strings.EqualFold(version, "latest") {
 		return version, nil
 	}

--- a/internal/controlplane/handlers_portal_updates_internal_test.go
+++ b/internal/controlplane/handlers_portal_updates_internal_test.go
@@ -188,7 +188,7 @@ func TestHandlePortalCreateInstanceUpdateJob_DoesNotDefaultLesserBodyVersionForL
 			Stage:                           "lab",
 			WebAuthnRPID:                    "example.com",
 			ManagedInstanceRoleName:         "role",
-			ManagedLesserBodyDefaultVersion: "v.0.1.3",
+			ManagedLesserBodyDefaultVersion: "v0.1.3",
 		},
 		store: store.New(tdb.db),
 	}
@@ -221,6 +221,62 @@ func TestHandlePortalCreateInstanceUpdateJob_DoesNotDefaultLesserBodyVersionForL
 	var parsed updateJobResponse
 	require.NoError(t, json.Unmarshal(resp.Body, &parsed))
 	require.Equal(t, "", parsed.LesserBodyVersion)
+}
+
+func TestHandlePortalCreateInstanceUpdateJob_RejectsMalformedReleaseTags(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "lesser version", body: `{"lesser_version":"v.1.2.3"}`},
+		{name: "lesser body version", body: `{"body_only":true,"lesser_body_version":"v.0.1.3"}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tdb := newPortalTestDB()
+			qUpdate := new(ttmocks.MockQuery)
+			tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+			addStandardMockQueryStubs(qUpdate)
+
+			s := &Server{
+				cfg: config.Config{
+					Stage:                   "lab",
+					WebAuthnRPID:            "example.com",
+					ManagedInstanceRoleName: "role",
+				},
+				store: store.New(tdb.db),
+			}
+
+			ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
+			ctx.Params = map[string]string{"slug": testPortalInstanceSlugDemo}
+			ctx.Request.Body = []byte(tt.body)
+
+			tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+				*dest = models.Instance{
+					Slug:              testPortalInstanceSlugDemo,
+					Owner:             "alice",
+					HostedAccountID:   "123",
+					HostedRegion:      "us-east-1",
+					HostedBaseDomain:  "demo.example.com",
+					LesserVersion:     "v1.2.3",
+					LesserBodyVersion: "v0.1.15",
+					UpdateStatus:      models.UpdateJobStatusOK,
+				}
+			}).Once()
+			expectEmptyUpdateJobHistory(t, qUpdate)
+
+			_, err := s.handlePortalCreateInstanceUpdateJob(ctx)
+			require.Error(t, err)
+			appErr, ok := err.(*apptheory.AppError)
+			require.True(t, ok)
+			require.Equal(t, "app.bad_request", appErr.Code)
+			require.Contains(t, appErr.Message, "must be \"latest\" or a tag like v1.2.3")
+		})
+	}
 }
 
 func TestHandlePortalCreateInstanceUpdateJob_BodyOnlyDefaultsLesserBodyVersion(t *testing.T) {
@@ -536,7 +592,7 @@ func TestHandlePortalCreateInstanceUpdateJob_TransactWriteFailureReturnsInternal
 	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
 	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
 	ctx.Params = map[string]string{"slug": testPortalInstanceSlugDemo}
-	ctx.Request.Body = []byte(`{"lesser_version":"v1"}`)
+	ctx.Request.Body = []byte(`{"lesser_version":"v1.0.0"}`)
 
 	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
@@ -546,7 +602,7 @@ func TestHandlePortalCreateInstanceUpdateJob_TransactWriteFailureReturnsInternal
 			HostedAccountID:  "123",
 			HostedRegion:     "us-east-1",
 			HostedBaseDomain: "demo.example.com",
-			LesserVersion:    "v1",
+			LesserVersion:    "v1.0.0",
 		}
 	}).Once()
 	expectEmptyUpdateJobHistory(t, qUpdate)

--- a/internal/controlplane/handlers_provisioning.go
+++ b/internal/controlplane/handlers_provisioning.go
@@ -258,6 +258,9 @@ func (s *Server) buildManagedProvisionJob(slug string, req startInstanceProvisio
 	if lesserVersion == "" {
 		lesserVersion = strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
 	}
+	if appErr := validateManagedReleaseVersion(lesserVersion, "lesser_version"); appErr != nil {
+		return nil, "", "", appErr
+	}
 
 	accountEmail := strings.TrimSpace(expandManagedAccountEmailTemplate(s.cfg.ManagedAccountEmailTemplate, slug))
 

--- a/internal/controlplane/handlers_provisioning_internal_test.go
+++ b/internal/controlplane/handlers_provisioning_internal_test.go
@@ -10,6 +10,7 @@ import (
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
@@ -81,7 +82,7 @@ func TestStartAndGetInstanceProvisioning(t *testing.T) {
 
 	body, _ := json.Marshal(startInstanceProvisionRequest{
 		Region:             "us-west-2",
-		LesserVersion:      "v1",
+		LesserVersion:      "v1.0.0",
 		AdminWalletType:    "ethereum",
 		AdminWalletAddress: "0x0000000000000000000000000000000000000003",
 		AdminWalletChainID: 1,
@@ -166,4 +167,41 @@ func TestStartAndGetInstanceProvisioning(t *testing.T) {
 	if _, err := s.handleGetInstanceProvisioning(ctxMissing); err == nil {
 		t.Fatalf("expected not found for missing job")
 	}
+}
+
+func TestHandleStartInstanceProvisioning_RejectsMalformedReleaseTag(t *testing.T) {
+	t.Parallel()
+
+	tdb := newProvisioningTestDB()
+	s := &Server{
+		cfg: config.Config{
+			ManagedParentDomain:         "lesser.host",
+			ManagedDefaultRegion:        "us-east-1",
+			ManagedLesserDefaultVersion: "v0.0.0",
+		},
+		store: store.New(tdb.db),
+	}
+
+	tdb.qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Status: models.InstanceStatusActive}
+		_ = dest.UpdateKeys()
+	}).Once()
+
+	body, _ := json.Marshal(startInstanceProvisionRequest{
+		LesserVersion:      "v.1.2.3",
+		AdminWalletType:    "ethereum",
+		AdminWalletAddress: "0x0000000000000000000000000000000000000003",
+		AdminWalletChainID: 1,
+	})
+	ctx := adminCtx()
+	ctx.Params = map[string]string{"slug": "demo"}
+	ctx.Request.Body = body
+
+	_, err := s.handleStartInstanceProvisioning(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.bad_request", appErr.Code)
+	require.Contains(t, appErr.Message, "lesser_version must be \"latest\" or a tag like v1.2.3")
 }

--- a/internal/controlplane/lesser_releases.go
+++ b/internal/controlplane/lesser_releases.go
@@ -6,13 +6,18 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
 )
 
 type githubLatestRelease struct {
 	TagName string `json:"tag_name"`
 }
+
+var managedReleaseTagRE = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 
 func resolveLatestGitHubReleaseTag(ctx context.Context, owner string, repo string) (string, error) {
 	owner = strings.TrimSpace(owner)
@@ -75,4 +80,23 @@ func isValidGitHubRepoSegment(s string) bool {
 		}
 	}
 	return true
+}
+
+func validateManagedReleaseVersion(version string, field string) *apptheory.AppError {
+	version = strings.TrimSpace(version)
+	field = strings.TrimSpace(field)
+	if version == "" {
+		return nil
+	}
+	if strings.EqualFold(version, "latest") {
+		return nil
+	}
+	if managedReleaseTagRE.MatchString(version) {
+		return nil
+	}
+	message := "release version must be \"latest\" or a tag like v1.2.3"
+	if field != "" {
+		message = field + " must be \"latest\" or a tag like v1.2.3"
+	}
+	return &apptheory.AppError{Code: "app.bad_request", Message: message}
 }

--- a/internal/controlplane/lesser_releases_internal_test.go
+++ b/internal/controlplane/lesser_releases_internal_test.go
@@ -108,3 +108,35 @@ func TestResolveLatestGitHubReleaseTag_SuccessTrimsTagAndSetsHeaders(t *testing.
 	require.NotNil(t, gotReq.URL)
 	require.True(t, strings.Contains(gotReq.URL.Path, "/repos/owner/repo/releases/latest"))
 }
+
+func TestValidateManagedReleaseVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		wantErr bool
+	}{
+		{name: "empty", version: "", wantErr: false},
+		{name: "latest", version: "latest", wantErr: false},
+		{name: "plain semver tag", version: "v1.2.3", wantErr: false},
+		{name: "prerelease tag", version: "v1.2.3-rc.1", wantErr: false},
+		{name: "build metadata tag", version: "v1.2.3+build.5", wantErr: false},
+		{name: "leading typo", version: "v.1.2.3", wantErr: true},
+		{name: "missing v", version: "1.2.3", wantErr: true},
+		{name: "short tag", version: "v1.2", wantErr: true},
+		{name: "spaces", version: "v1.2.3 beta", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			appErr := validateManagedReleaseVersion(tt.version, "lesser_version")
+			if tt.wantErr {
+				require.NotNil(t, appErr)
+				require.Equal(t, "app.bad_request", appErr.Code)
+				return
+			}
+			require.Nil(t, appErr)
+		})
+	}
+}

--- a/web/src/lib/utils/versionTags.test.ts
+++ b/web/src/lib/utils/versionTags.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { validateManagedReleaseTag } from './versionTags';
+
+describe('validateManagedReleaseTag', () => {
+	it('accepts latest and semver-style tags', () => {
+		expect(validateManagedReleaseTag('latest')).toBeNull();
+		expect(validateManagedReleaseTag('v1.2.3')).toBeNull();
+		expect(validateManagedReleaseTag('v1.2.3-rc.1')).toBeNull();
+		expect(validateManagedReleaseTag('v1.2.3+build.5')).toBeNull();
+	});
+
+	it('allows blank input when requested', () => {
+		expect(validateManagedReleaseTag('', { allowBlank: true })).toBeNull();
+	});
+
+	it('rejects malformed tags', () => {
+		expect(validateManagedReleaseTag('v.1.2.3')).toContain('must be "latest" or a tag like v1.2.3');
+		expect(validateManagedReleaseTag('1.2.3')).toContain('must be "latest" or a tag like v1.2.3');
+		expect(validateManagedReleaseTag('v1.2')).toContain('must be "latest" or a tag like v1.2.3');
+	});
+});

--- a/web/src/lib/utils/versionTags.ts
+++ b/web/src/lib/utils/versionTags.ts
@@ -1,0 +1,24 @@
+const managedReleaseTagRE = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+
+export function validateManagedReleaseTag(
+	value: string,
+	options?: {
+		allowBlank?: boolean;
+		label?: string;
+	}
+): string | null {
+	const trimmed = value.trim();
+	const allowBlank = options?.allowBlank ?? false;
+	const label = options?.label ?? 'Release version';
+
+	if (!trimmed) {
+		return allowBlank ? null : `${label} is required.`;
+	}
+	if (trimmed.toLowerCase() === 'latest') {
+		return null;
+	}
+	if (managedReleaseTagRE.test(trimmed)) {
+		return null;
+	}
+	return `${label} must be "latest" or a tag like v1.2.3.`;
+}

--- a/web/src/pages/operator/InstanceSupport.svelte
+++ b/web/src/pages/operator/InstanceSupport.svelte
@@ -15,6 +15,7 @@
 	import { logout } from 'src/lib/auth/logout';
 	import { pollUntil } from 'src/lib/polling';
 	import { navigate } from 'src/lib/router';
+	import { validateManagedReleaseTag } from 'src/lib/utils/versionTags';
 	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token, slug } = $props<{ token: string; slug?: string }>();
@@ -214,6 +215,17 @@
 		updatesError = null;
 		const version = (options?.lesserVersion || '').trim();
 		const bodyVersion = (options?.lesserBodyVersion || '').trim();
+		const versionErr =
+			!options?.bodyOnly && !options?.mcpOnly
+				? validateManagedReleaseTag(version, { label: 'Lesser version' })
+				: null;
+		const bodyVersionErr = options?.bodyOnly
+			? validateManagedReleaseTag(bodyVersion, { allowBlank: true, label: 'lesser-body version' })
+			: null;
+		if (versionErr || bodyVersionErr) {
+			updatesError = versionErr || bodyVersionErr;
+			return;
+		}
 
 		updateCreating = true;
 		try {
@@ -534,7 +546,7 @@
 			</div>
 
 			<div class="op-support__form">
-				<TextField label="Update Lesser version" bind:value={updateLesserVersion} placeholder="vX.Y.Z or latest" />
+				<TextField label="Update Lesser version" bind:value={updateLesserVersion} placeholder="v1.2.3 or latest" />
 			</div>
 
 			<div class="op-support__actions">
@@ -562,7 +574,7 @@
 				<TextField
 					label="Update Lesser Body version"
 					bind:value={updateLesserBodyVersion}
-					placeholder="vX.Y.Z, latest, or blank for configured default"
+					placeholder="v1.2.3, latest, or blank for configured default"
 				/>
 			</div>
 

--- a/web/src/pages/portal/InstanceDetail.svelte
+++ b/web/src/pages/portal/InstanceDetail.svelte
@@ -15,6 +15,7 @@
 	import { logout } from 'src/lib/auth/logout';
 	import { pollUntil } from 'src/lib/polling';
 	import { navigate } from 'src/lib/router';
+	import { validateManagedReleaseTag } from 'src/lib/utils/versionTags';
 	import { getEthereumProvider, personalSign, requestAccounts } from 'src/lib/wallet/ethereum';
 	import {
 		Alert,
@@ -302,6 +303,17 @@
 
 		const version = (options?.lesserVersion || '').trim();
 		const bodyVersion = (options?.lesserBodyVersion || '').trim();
+		const versionErr =
+			!options?.bodyOnly && !options?.mcpOnly
+				? validateManagedReleaseTag(version, { label: 'Lesser version' })
+				: null;
+		const bodyVersionErr = options?.bodyOnly
+			? validateManagedReleaseTag(bodyVersion, { allowBlank: true, label: 'lesser-body version' })
+			: null;
+		if (versionErr || bodyVersionErr) {
+			updatesError = versionErr || bodyVersionErr;
+			return;
+		}
 
 		updateCreating = true;
 		try {
@@ -419,6 +431,14 @@
 
 		const region = provisionRegion.trim();
 		const lesserVersion = provisionLesserVersion.trim();
+		const lesserVersionErr = validateManagedReleaseTag(lesserVersion, {
+			allowBlank: true,
+			label: 'Lesser version',
+		});
+		if (lesserVersionErr) {
+			provisioningError = lesserVersionErr;
+			return;
+		}
 		const adminUsernameRaw = provisionAdminUsername.trim().toLowerCase();
 		const adminUsername = adminUsernameRaw || slug.trim().toLowerCase();
 		if (!slugRE.test(adminUsername)) {
@@ -657,7 +677,7 @@
 
 					<div class="instance-detail__form">
 						<TextField label="Region (optional)" bind:value={provisionRegion} placeholder="us-east-1" />
-						<TextField label="Lesser version (optional)" bind:value={provisionLesserVersion} placeholder="vX.Y.Z" />
+						<TextField label="Lesser version (optional)" bind:value={provisionLesserVersion} placeholder="v1.2.3 or latest" />
 					</div>
 
 					<div class="instance-detail__row">
@@ -694,7 +714,7 @@
 				<div class="instance-detail__form">
 					<TextField label="Admin username" bind:value={provisionAdminUsername} placeholder={slug} />
 					<TextField label="Region (optional)" bind:value={provisionRegion} placeholder="us-east-1" />
-					<TextField label="Lesser version (optional)" bind:value={provisionLesserVersion} placeholder="vX.Y.Z" />
+					<TextField label="Lesser version (optional)" bind:value={provisionLesserVersion} placeholder="v1.2.3 or latest" />
 				</div>
 
 				<div class="instance-detail__row">
@@ -755,7 +775,7 @@
 			</div>
 
 			<div class="instance-detail__form">
-				<TextField label="Update Lesser version" bind:value={updateLesserVersion} placeholder="vX.Y.Z or latest" />
+				<TextField label="Update Lesser version" bind:value={updateLesserVersion} placeholder="v1.2.3 or latest" />
 			</div>
 			<div class="instance-detail__row">
 				<Button
@@ -781,7 +801,7 @@
 				<TextField
 					label="Update Lesser Body version"
 					bind:value={updateLesserBodyVersion}
-					placeholder="vX.Y.Z, latest, or blank for configured default"
+					placeholder="v1.2.3, latest, or blank for configured default"
 				/>
 			</div>
 			<div class="instance-detail__row">


### PR DESCRIPTION
## Summary
- reject malformed Lesser and lesser-body release tags in the control plane before CodeBuild starts
- surface the same validation in portal and operator UI flows for provisioning and managed updates
- add focused Go and web tests for the new validation paths

## Verification
- GOTOOLCHAIN=auto go test ./internal/controlplane
- GOTOOLCHAIN=auto golangci-lint run --timeout=5m ./internal/controlplane
- cd web && npm run lint
- cd web && npm run typecheck
- cd web && npm test -- versionTags
- GOTOOLCHAIN=auto theory app up --stage lab --aws-profile Lesser --execute

## Deploy
- deployed to lab from commit `39f3ebb`
- CloudFormation stack `lesser-host-lab` reached `UPDATE_COMPLETE`
- public URL: https://lab.lesser.host