### PR TITLE
fix: route phone inbound notifications by address

### DIFF
--- a/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
+++ b/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
@@ -7,6 +7,7 @@
     "displayName": "agent-alice.lessersoul.eth"
   },
   "to": {
+    "address": "agent-bob@inbound.lessersoul.ai",
     "number": "+15551234"
   },
   "body": "Hey — can you review the draft by tonight?",
@@ -14,4 +15,3 @@
   "messageId": "comm-sms-001",
   "inReplyTo": null
 }
-

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -274,6 +274,7 @@ func (s *Server) handleRateLimitedInbound(ctx context.Context, agentID string, c
 func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity) error {
 	// Best-effort: annotate soul-to-soul sender identity.
 	s.maybeAnnotateSenderSoul(ctx, &notif)
+	s.maybeAnnotateRecipientAddress(ctx, agentID, channel, notif.To)
 
 	inst, ok, err := s.resolveAgentInstance(ctx, identity)
 	if err != nil {
@@ -300,6 +301,51 @@ func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, cha
 
 	_ = s.recordInboundActivity(ctx, agentID, channel, notif, "receive", true)
 	return nil
+}
+
+func (s *Server) maybeAnnotateRecipientAddress(ctx context.Context, agentID string, channel string, to *InboundParty) {
+	if s == nil || s.store == nil || to == nil {
+		return
+	}
+	if strings.TrimSpace(to.Address) != "" {
+		return
+	}
+	switch strings.ToLower(strings.TrimSpace(channel)) {
+	case inboundChannelSMS, inboundChannelVoice:
+	default:
+		return
+	}
+
+	if address := s.lookupRecipientForwardingAddress(ctx, agentID); address != "" {
+		to.Address = address
+	}
+}
+
+func (s *Server) lookupRecipientForwardingAddress(ctx context.Context, agentID string) string {
+	if s == nil || s.store == nil {
+		return ""
+	}
+
+	ch, ok, err := s.store.GetSoulAgentChannel(ctx, agentID, models.SoulChannelTypeEmail)
+	if err != nil || !ok || ch == nil {
+		return ""
+	}
+
+	emailAddress := strings.ToLower(strings.TrimSpace(ch.Identifier))
+	if emailAddress == "" {
+		return ""
+	}
+
+	localPart, _, hasDomain := strings.Cut(emailAddress, "@")
+	if !hasDomain || strings.TrimSpace(localPart) == "" {
+		return emailAddress
+	}
+
+	inboundDomain := strings.ToLower(strings.TrimSpace(s.cfg.SoulEmailInboundDomain))
+	if inboundDomain == "" {
+		return emailAddress
+	}
+	return localPart + "@" + inboundDomain
 }
 
 func (s *Server) resolveRecipient(ctx context.Context, channel string, to *InboundParty) (string, bool, error) {

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -163,6 +163,21 @@ func newInboundSMSMessage(now time.Time, to string, from string) QueueMessage {
 	}
 }
 
+func newInboundVoiceMessage(now time.Time, to string, from string) QueueMessage {
+	return QueueMessage{
+		Kind: QueueMessageKindInbound,
+		Notification: InboundNotification{
+			Type:       "communication:inbound",
+			Channel:    "voice",
+			From:       InboundParty{Number: from},
+			To:         &InboundParty{Number: to},
+			Body:       "Voice transcript",
+			ReceivedAt: now.Format(time.RFC3339Nano),
+			MessageID:  "msg-voice-1",
+		},
+	}
+}
+
 func newActiveInboundStore(now time.Time, agentID string, channel string, identifier string) *fakeStore {
 	channelType := channelRecordType(channel)
 	fs := &fakeStore{
@@ -632,6 +647,72 @@ func TestProcessInbound_SMSAnnotatesSenderBeforeDelivery(t *testing.T) {
 	}
 	if len(fs.activities[agentID]) != 1 || fs.activities[agentID][0].Action != "receive" {
 		t.Fatalf("expected recorded receive activity, got %#v", fs.activities[agentID])
+	}
+}
+
+func TestProcessInbound_PhoneDeliveryIncludesForwardingAddress(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	agentID := commStoreTestAgentID
+
+	tests := []struct {
+		name    string
+		channel string
+		build   func(time.Time, string, string) QueueMessage
+	}{
+		{
+			name:    "sms",
+			channel: inboundChannelSMS,
+			build:   newInboundSMSMessage,
+		},
+		{
+			name:    "voice",
+			channel: inboundChannelVoice,
+			build:   newInboundVoiceMessage,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fs := newActiveInboundStore(now, agentID, tc.channel, "+15551234567")
+			fs.channels[agentID+"#"+models.SoulChannelTypeEmail] = &models.SoulAgentChannel{
+				AgentID:       agentID,
+				ChannelType:   models.SoulChannelTypeEmail,
+				Identifier:    testAgentBobEmail,
+				Status:        models.SoulChannelStatusActive,
+				Verified:      true,
+				ProvisionedAt: now.Add(-time.Hour),
+			}
+
+			var delivered InboundNotification
+			s := NewServer(config.Config{Stage: "lab", SoulEmailInboundDomain: "inbound.lessersoul.ai"}, fs, nil, nil)
+			s.now = func() time.Time { return now }
+			s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) { return testInstanceAPIKey, nil }
+			s.deliverNotification = func(_ context.Context, _ string, apiKey string, notif InboundNotification) error {
+				if apiKey != testInstanceAPIKey {
+					t.Fatalf("unexpected api key: %q", apiKey)
+				}
+				delivered = notif
+				return nil
+			}
+
+			if err := s.processInbound(context.Background(), "req-phone", tc.build(now, "+15551234567", "+15557654321")); err != nil {
+				t.Fatalf("unexpected err: %v", err)
+			}
+			if delivered.To == nil {
+				t.Fatal("expected recipient payload")
+			}
+			if delivered.To.Number != "+15551234567" {
+				t.Fatalf("expected phone recipient to be preserved, got %#v", delivered.To)
+			}
+			if delivered.To.Address != "agent-bob@inbound.lessersoul.ai" {
+				t.Fatalf("expected forwarding address, got %#v", delivered.To)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- hydrate `To.Address` for inbound SMS/voice deliveries using the agent email channel and inbound domain
- keep `To.Number` intact so phone channel routing data is preserved alongside the address
- update the SMS communication fixture to show the delivery payload shape now sent to lesser

## Testing
- `env GOTOOLCHAIN=auto go test ./internal/commworker ./internal/specv3`
- `env GOTOOLCHAIN=auto bash gov-infra/verifiers/gov-verify-rubric.sh`

Closes #60