### PR TITLE
fix: keep phone inbound recipient addresses canonical

### DIFF
--- a/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
+++ b/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
@@ -7,7 +7,7 @@
     "displayName": "agent-alice.lessersoul.eth"
   },
   "to": {
-    "address": "agent-bob@inbound.lessersoul.ai",
+    "address": "agent-bob@lessersoul.ai",
     "number": "+15551234"
   },
   "body": "Hey — can you review the draft by tonight?",

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -316,12 +316,12 @@ func (s *Server) maybeAnnotateRecipientAddress(ctx context.Context, agentID stri
 		return
 	}
 
-	if address := s.lookupRecipientForwardingAddress(ctx, agentID); address != "" {
+	if address := s.lookupRecipientCanonicalAddress(ctx, agentID); address != "" {
 		to.Address = address
 	}
 }
 
-func (s *Server) lookupRecipientForwardingAddress(ctx context.Context, agentID string) string {
+func (s *Server) lookupRecipientCanonicalAddress(ctx context.Context, agentID string) string {
 	if s == nil || s.store == nil {
 		return ""
 	}
@@ -335,17 +335,7 @@ func (s *Server) lookupRecipientForwardingAddress(ctx context.Context, agentID s
 	if emailAddress == "" {
 		return ""
 	}
-
-	localPart, _, hasDomain := strings.Cut(emailAddress, "@")
-	if !hasDomain || strings.TrimSpace(localPart) == "" {
-		return emailAddress
-	}
-
-	inboundDomain := strings.ToLower(strings.TrimSpace(s.cfg.SoulEmailInboundDomain))
-	if inboundDomain == "" {
-		return emailAddress
-	}
-	return localPart + "@" + inboundDomain
+	return emailAddress
 }
 
 func (s *Server) resolveRecipient(ctx context.Context, channel string, to *InboundParty) (string, bool, error) {

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -650,7 +650,7 @@ func TestProcessInbound_SMSAnnotatesSenderBeforeDelivery(t *testing.T) {
 	}
 }
 
-func TestProcessInbound_PhoneDeliveryIncludesForwardingAddress(t *testing.T) {
+func TestProcessInbound_PhoneDeliveryIncludesCanonicalRecipientAddress(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
@@ -709,8 +709,8 @@ func TestProcessInbound_PhoneDeliveryIncludesForwardingAddress(t *testing.T) {
 			if delivered.To.Number != "+15551234567" {
 				t.Fatalf("expected phone recipient to be preserved, got %#v", delivered.To)
 			}
-			if delivered.To.Address != "agent-bob@inbound.lessersoul.ai" {
-				t.Fatalf("expected forwarding address, got %#v", delivered.To)
+			if delivered.To.Address != testAgentBobEmail {
+				t.Fatalf("expected canonical recipient address, got %#v", delivered.To)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- stop rewriting SMS/voice recipient addresses to the SES bridge subdomain
- use the agent email channel canonical address for comm-worker To.Address
- update regression coverage and the inbound SMS example fixture to match the canonical address behavior

## Testing
- env GOTOOLCHAIN=auto go test ./internal/commworker ./internal/specv3
- env GOTOOLCHAIN=auto bash gov-infra/verifiers/gov-verify-rubric.sh

Closes #60