### PR TITLE
Fix Dependabot alert #25 for flatted

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2967,9 +2967,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/web/package.json
+++ b/web/package.json
@@ -59,7 +59,7 @@
   },
   "overrides": {
     "devalue": "5.6.4",
-    "flatted": "3.4.1",
+    "flatted": "3.4.2",
     "minimatch": "10.2.4",
     "rollup": "4.59.0",
     "undici": "7.24.3",


### PR DESCRIPTION
## Summary
- bump the `web` override for `flatted` from `3.4.1` to `3.4.2`
- update `web/package-lock.json` to resolve the patched transitive version
- address Dependabot alert #25 (`GHSA-rf6f-7fwh-wjgh` / `CVE-2026-33228`)

## Validation
- `cd web && npm audit --json`
- `cd web && npm run lint`
- `cd web && npm run typecheck`
- `cd web && npm test`

Alert: https://github.com/equaltoai/lesser-host/security/dependabot/25