### PR TITLE
Add comm/send idempotency deduplication

### DIFF
--- a/docs/spec/v3/fixtures/soul-comm-send.request.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.request.example.json
@@ -4,6 +4,6 @@
   "to": "alice@example.com",
   "subject": "Re: Project collaboration",
   "body": "Hi Alice,\\n\\nYes — happy to collaborate.\\n",
-  "inReplyTo": "comm-msg-001"
+  "inReplyTo": "comm-msg-001",
+  "idempotencyKey": "mcp-email-send-6a4b7a70-0c4d-4b1d-8e18-7b6f55f3f3e5"
 }
-

--- a/docs/spec/v3/schemas/soul-comm-send.request.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.request.schema.json
@@ -20,7 +20,8 @@
     "replyTo": { "type": "string", "format": "email" },
     "subject": { "type": "string", "minLength": 1, "maxLength": 998 },
     "body": { "type": "string", "minLength": 1 },
-    "inReplyTo": { "type": ["string", "null"], "minLength": 1, "maxLength": 128 }
+    "inReplyTo": { "type": ["string", "null"], "minLength": 1, "maxLength": 128 },
+    "idempotencyKey": { "type": "string", "minLength": 1, "maxLength": 256 }
   },
   "allOf": [
     {
@@ -44,4 +45,3 @@
     }
   ]
 }
-

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -2,7 +2,9 @@ package controlplane
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -50,18 +52,20 @@ const (
 	commCodeProviderUnavailable = "comm.provider_unavailable"
 	commCodeInsufficientCredits = "comm.insufficient_credits"
 	commCodePreferenceViolation = "comm.preference_violation"
+	commCodeIdempotencyConflict = "comm.idempotency_conflict"
 )
 
 type soulCommSendRequest struct {
-	Channel   string   `json:"channel"`
-	AgentID   string   `json:"agentId"`
-	To        string   `json:"to"`
-	CC        []string `json:"cc,omitempty"`
-	BCC       []string `json:"bcc,omitempty"`
-	ReplyTo   string   `json:"replyTo,omitempty"`
-	Subject   string   `json:"subject,omitempty"`
-	Body      string   `json:"body"`
-	InReplyTo *string  `json:"inReplyTo,omitempty"`
+	Channel        string   `json:"channel"`
+	AgentID        string   `json:"agentId"`
+	To             string   `json:"to"`
+	CC             []string `json:"cc,omitempty"`
+	BCC            []string `json:"bcc,omitempty"`
+	ReplyTo        string   `json:"replyTo,omitempty"`
+	Subject        string   `json:"subject,omitempty"`
+	Body           string   `json:"body"`
+	InReplyTo      *string  `json:"inReplyTo,omitempty"`
+	IdempotencyKey string   `json:"idempotencyKey,omitempty"`
 }
 
 type soulCommSendResponse struct {
@@ -102,15 +106,16 @@ type soulCommSendMetrics struct {
 }
 
 type validatedSoulCommSendRequest struct {
-	channel    string
-	agentIDHex string
-	to         string
-	cc         []string
-	bcc        []string
-	replyTo    string
-	subject    string
-	body       string
-	inReplyTo  string
+	channel        string
+	agentIDHex     string
+	to             string
+	cc             []string
+	bcc            []string
+	replyTo        string
+	subject        string
+	body           string
+	inReplyTo      string
+	idempotencyKey string
 }
 
 type soulCommSendRoute struct {
@@ -214,7 +219,16 @@ func (s *Server) handleSoulCommSend(ctx *apptheory.Context) (*apptheory.Response
 		return nil, appErr
 	}
 
+	idem, existingResp, appErr := s.prepareSoulCommSendIdempotency(ctx, key, req, messageID, now, metrics)
+	if appErr != nil {
+		return nil, appErr
+	}
+	if existingResp != nil {
+		return existingResp, nil
+	}
+
 	delivery, appErr := s.dispatchSoulCommSend(ctx, key, req, route.channel, now, messageID, metrics)
+	s.finalizeSoulCommSendIdempotency(ctx.Context(), idem, delivery, appErr)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -287,17 +301,23 @@ func parseSoulCommSendRequest(ctx *apptheory.Context, metrics *soulCommSendMetri
 	if req.InReplyTo != nil {
 		inReplyTo = strings.TrimSpace(*req.InReplyTo)
 	}
+	idempotencyKey := strings.TrimSpace(req.IdempotencyKey)
+	if len(idempotencyKey) > 256 {
+		metrics.status = commMetricInvalidRequest
+		return validatedSoulCommSendRequest{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "idempotencyKey is invalid").WithStatusCode(http.StatusBadRequest)
+	}
 
 	return validatedSoulCommSendRequest{
-		channel:    channel,
-		agentIDHex: agentIDHex,
-		to:         to,
-		cc:         req.CC,
-		bcc:        req.BCC,
-		replyTo:    strings.TrimSpace(req.ReplyTo),
-		subject:    subject,
-		body:       body,
-		inReplyTo:  inReplyTo,
+		channel:        channel,
+		agentIDHex:     agentIDHex,
+		to:             to,
+		cc:             req.CC,
+		bcc:            req.BCC,
+		replyTo:        strings.TrimSpace(req.ReplyTo),
+		subject:        subject,
+		body:           body,
+		inReplyTo:      inReplyTo,
+		idempotencyKey: idempotencyKey,
 	}, nil
 }
 
@@ -538,6 +558,244 @@ func newSoulCommSendMessageID() (string, *apptheory.AppTheoryError) {
 		return "", apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 	return "comm-msg-" + messageIDToken, nil
+}
+
+func normalizeCommIdempotencyEmail(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeCommIdempotencyEmails(items []string) []string {
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		item = normalizeCommIdempotencyEmail(item)
+		if item != "" {
+			out = append(out, item)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func soulCommSendRequestHash(instanceSlug string, req validatedSoulCommSendRequest) string {
+	payload := struct {
+		InstanceSlug string   `json:"instanceSlug"`
+		Channel      string   `json:"channel"`
+		AgentID      string   `json:"agentId"`
+		To           string   `json:"to"`
+		CC           []string `json:"cc,omitempty"`
+		BCC          []string `json:"bcc,omitempty"`
+		ReplyTo      string   `json:"replyTo,omitempty"`
+		Subject      string   `json:"subject,omitempty"`
+		Body         string   `json:"body"`
+		InReplyTo    string   `json:"inReplyTo,omitempty"`
+	}{
+		InstanceSlug: strings.ToLower(strings.TrimSpace(instanceSlug)),
+		Channel:      strings.ToLower(strings.TrimSpace(req.channel)),
+		AgentID:      strings.ToLower(strings.TrimSpace(req.agentIDHex)),
+		To:           strings.TrimSpace(req.to),
+		CC:           normalizeCommIdempotencyEmails(req.cc),
+		BCC:          normalizeCommIdempotencyEmails(req.bcc),
+		ReplyTo:      normalizeCommIdempotencyEmail(req.replyTo),
+		Subject:      strings.TrimSpace(req.subject),
+		Body:         strings.TrimSpace(req.body),
+		InReplyTo:    strings.TrimSpace(req.inReplyTo),
+	}
+	if payload.Channel == commChannelEmail {
+		payload.To = normalizeCommIdempotencyEmail(payload.To)
+	}
+	raw, _ := json.Marshal(payload)
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+func (s *Server) claimSoulCommSendIdempotency(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, now time.Time, metrics *soulCommSendMetrics) (*models.SoulCommSendIdempotency, *apptheory.Response, *apptheory.AppTheoryError) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		metrics.status = commMetricInternalError
+		return nil, nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	instanceSlug := strings.ToLower(strings.TrimSpace(key.InstanceSlug))
+	if instanceSlug == "" {
+		metrics.status = commMetricUnauthorized
+		return nil, nil, apptheory.NewAppTheoryError(commCodeUnauthorized, "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+
+	item := &models.SoulCommSendIdempotency{
+		InstanceSlug:   instanceSlug,
+		AgentID:        req.agentIDHex,
+		IdempotencyKey: req.idempotencyKey,
+		RequestHash:    soulCommSendRequestHash(instanceSlug, req),
+		MessageID:      messageID,
+		ChannelType:    req.channel,
+		To:             req.to,
+		Status:         models.SoulCommSendIdempotencyStatusProcessing,
+		ResponseStatus: models.SoulCommMessageStatusAccepted,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_ = item.UpdateKeys()
+	if err := s.store.DB.WithContext(ctx.Context()).Model(item).IfNotExists().Create(); err == nil {
+		return item, nil, nil
+	} else if !theoryErrors.IsConditionFailed(err) {
+		metrics.status = commMetricInternalError
+		return nil, nil, apptheory.NewAppTheoryError(commCodeInternal, "failed to reserve idempotency key").WithStatusCode(http.StatusInternalServerError)
+	}
+
+	existing, err := s.getSoulCommSendIdempotency(ctx.Context(), instanceSlug, req.agentIDHex, req.idempotencyKey)
+	if err != nil {
+		if status, statusErr := s.lookupSoulCommStatusByIdempotencyKey(ctx.Context(), instanceSlug, req.agentIDHex, req.idempotencyKey); statusErr == nil && status != nil {
+			metrics.provider = strings.TrimSpace(status.Provider)
+			metrics.status = commMetricSent
+			resp, appErr := soulCommSendJSONFromStatusItem(*status)
+			return nil, resp, appErr
+		}
+		metrics.status = commMetricInternalError
+		return nil, nil, apptheory.NewAppTheoryError(commCodeInternal, "failed to load idempotent response").WithStatusCode(http.StatusInternalServerError)
+	}
+	if strings.TrimSpace(existing.RequestHash) != strings.TrimSpace(item.RequestHash) {
+		metrics.status = commMetricInvalidRequest
+		return nil, nil, apptheory.NewAppTheoryError(commCodeIdempotencyConflict, "idempotency key already used for a different request").WithStatusCode(http.StatusConflict)
+	}
+	resp, appErr := s.respondFromSoulCommSendIdempotency(ctx.Context(), existing, metrics)
+	return existing, resp, appErr
+}
+
+func (s *Server) prepareSoulCommSendIdempotency(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, now time.Time, metrics *soulCommSendMetrics) (*models.SoulCommSendIdempotency, *apptheory.Response, *apptheory.AppTheoryError) {
+	if req.idempotencyKey == "" {
+		return nil, nil, nil
+	}
+	return s.claimSoulCommSendIdempotency(ctx, key, req, messageID, now, metrics)
+}
+
+func (s *Server) getSoulCommSendIdempotency(ctx context.Context, instanceSlug string, agentIDHex string, idempotencyKey string) (*models.SoulCommSendIdempotency, error) {
+	rec := &models.SoulCommSendIdempotency{
+		InstanceSlug:   instanceSlug,
+		AgentID:        agentIDHex,
+		IdempotencyKey: idempotencyKey,
+	}
+	_ = rec.UpdateKeys()
+	var item models.SoulCommSendIdempotency
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulCommSendIdempotency{}).
+		Where("PK", "=", rec.PK).
+		Where("SK", "=", rec.SK).
+		First(&item)
+	if err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func (s *Server) lookupSoulCommStatusByIdempotencyKey(ctx context.Context, instanceSlug string, agentIDHex string, idempotencyKey string) (*models.SoulCommMessageStatus, error) {
+	var items []*models.SoulCommMessageStatus
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulCommMessageStatus{}).
+		Index("gsi1").
+		Where("gsi1PK", "=", models.SoulCommMessageStatusIdempotencyIndexPK(instanceSlug, agentIDHex, idempotencyKey)).
+		OrderBy("gsi1SK", "DESC").
+		Limit(1).
+		All(&items)
+	if err != nil {
+		return nil, err
+	}
+	for _, item := range items {
+		if item != nil {
+			return item, nil
+		}
+	}
+	return nil, theoryErrors.ErrItemNotFound
+}
+
+func (s *Server) respondFromSoulCommSendIdempotency(ctx context.Context, item *models.SoulCommSendIdempotency, metrics *soulCommSendMetrics) (*apptheory.Response, *apptheory.AppTheoryError) {
+	if item == nil {
+		metrics.status = commMetricInternalError
+		return nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	if status, err := s.lookupSoulCommStatusByIdempotencyKey(ctx, item.InstanceSlug, item.AgentID, item.IdempotencyKey); err == nil && status != nil {
+		metrics.provider = strings.TrimSpace(status.Provider)
+		metrics.status = commMetricSent
+		return soulCommSendJSONFromStatusItem(*status)
+	}
+
+	switch strings.TrimSpace(item.Status) {
+	case models.SoulCommSendIdempotencyStatusFailed:
+		metrics.provider = strings.TrimSpace(item.Provider)
+		metrics.status = commMetricProviderRejected
+		statusCode := item.ErrorStatusCode
+		if statusCode == 0 {
+			statusCode = http.StatusInternalServerError
+		}
+		code := strings.TrimSpace(item.ErrorCode)
+		if code == "" {
+			code = commCodeInternal
+		}
+		message := strings.TrimSpace(item.ErrorMessage)
+		if message == "" {
+			message = "internal error"
+		}
+		return nil, apptheory.NewAppTheoryError(code, message).WithStatusCode(statusCode)
+	default:
+		metrics.provider = strings.TrimSpace(item.Provider)
+		metrics.status = commMetricSent
+		return soulCommSendJSONFromIdempotencyItem(*item)
+	}
+}
+
+func (s *Server) completeSoulCommSendIdempotencySuccess(ctx context.Context, item *models.SoulCommSendIdempotency, delivery soulCommSendDelivery) error {
+	if s == nil || s.store == nil || s.store.DB == nil || item == nil {
+		return nil
+	}
+	update := &models.SoulCommSendIdempotency{
+		InstanceSlug:      item.InstanceSlug,
+		AgentID:           item.AgentID,
+		IdempotencyKey:    item.IdempotencyKey,
+		RequestHash:       item.RequestHash,
+		MessageID:         item.MessageID,
+		ChannelType:       item.ChannelType,
+		To:                item.To,
+		Status:            models.SoulCommSendIdempotencyStatusSucceeded,
+		ResponseStatus:    soulCommSendResultStatus(delivery.initialStatus),
+		Provider:          delivery.provider,
+		ProviderMessageID: delivery.providerMessageID,
+		CreatedAt:         item.CreatedAt,
+		UpdatedAt:         time.Now().UTC(),
+	}
+	_ = update.UpdateKeys()
+	return s.store.DB.WithContext(ctx).Model(update).IfExists().Update("Status", "ResponseStatus", "Provider", "ProviderMessageID", "UpdatedAt")
+}
+
+func (s *Server) completeSoulCommSendIdempotencyFailure(ctx context.Context, item *models.SoulCommSendIdempotency, appErr *apptheory.AppTheoryError) error {
+	if s == nil || s.store == nil || s.store.DB == nil || item == nil || appErr == nil {
+		return nil
+	}
+	update := &models.SoulCommSendIdempotency{
+		InstanceSlug:    item.InstanceSlug,
+		AgentID:         item.AgentID,
+		IdempotencyKey:  item.IdempotencyKey,
+		RequestHash:     item.RequestHash,
+		MessageID:       item.MessageID,
+		ChannelType:     item.ChannelType,
+		To:              item.To,
+		Status:          models.SoulCommSendIdempotencyStatusFailed,
+		ResponseStatus:  models.SoulCommMessageStatusFailed,
+		ErrorCode:       appErr.Code,
+		ErrorMessage:    appErr.Message,
+		ErrorStatusCode: appErr.StatusCode,
+		CreatedAt:       item.CreatedAt,
+		UpdatedAt:       time.Now().UTC(),
+	}
+	_ = update.UpdateKeys()
+	return s.store.DB.WithContext(ctx).Model(update).IfExists().Update("Status", "ResponseStatus", "ErrorCode", "ErrorMessage", "ErrorStatusCode", "UpdatedAt")
+}
+
+func (s *Server) finalizeSoulCommSendIdempotency(ctx context.Context, item *models.SoulCommSendIdempotency, delivery soulCommSendDelivery, appErr *apptheory.AppTheoryError) {
+	if item == nil {
+		return
+	}
+	if appErr != nil {
+		_ = s.completeSoulCommSendIdempotencyFailure(ctx, item, appErr)
+		return
+	}
+	_ = s.completeSoulCommSendIdempotencySuccess(ctx, item, delivery)
 }
 
 func (s *Server) dispatchSoulCommSend(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, channel *models.SoulAgentChannel, now time.Time, messageID string, metrics *soulCommSendMetrics) (soulCommSendDelivery, *apptheory.AppTheoryError) {
@@ -787,13 +1045,12 @@ func (s *Server) debitSoulSMSCredits(ctx context.Context, instanceSlug string, a
 }
 
 func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, delivery soulCommSendDelivery, decision soulCommSendGuardDecision, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
-	statusValue := strings.TrimSpace(delivery.initialStatus)
-	if statusValue == "" {
-		statusValue = models.SoulCommMessageStatusSent
-	}
+	statusValue := soulCommSendResultStatus(delivery.initialStatus)
 	status := &models.SoulCommMessageStatus{
 		MessageID:         messageID,
+		InstanceSlug:      strings.TrimSpace(key.InstanceSlug),
 		AgentID:           req.agentIDHex,
+		IdempotencyKey:    req.idempotencyKey,
 		ChannelType:       req.channel,
 		To:                req.to,
 		Provider:          delivery.provider,
@@ -839,24 +1096,40 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 }
 
 func soulCommSendJSON(messageID string, req validatedSoulCommSendRequest, delivery soulCommSendDelivery, now time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
-	statusValue := strings.TrimSpace(delivery.initialStatus)
+	return soulCommSendJSONFields(messageID, soulCommSendResultStatus(delivery.initialStatus), req.channel, req.agentIDHex, req.to, delivery.provider, delivery.providerMessageID, now)
+}
+
+func soulCommSendResultStatus(initialStatus string) string {
+	statusValue := strings.TrimSpace(initialStatus)
 	if statusValue == "" {
 		statusValue = models.SoulCommMessageStatusSent
 	}
+	return statusValue
+}
+
+func soulCommSendJSONFields(messageID string, status string, channel string, agentID string, to string, provider string, providerMessageID string, createdAt time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
 	resp, err := apptheory.JSON(http.StatusOK, soulCommSendResponse{
-		MessageID:         messageID,
-		Status:            statusValue,
-		Channel:           req.channel,
-		AgentID:           req.agentIDHex,
-		To:                req.to,
-		Provider:          delivery.provider,
-		ProviderMessageID: delivery.providerMessageID,
-		CreatedAt:         now.Format(time.RFC3339Nano),
+		MessageID:         strings.TrimSpace(messageID),
+		Status:            strings.TrimSpace(status),
+		Channel:           strings.TrimSpace(channel),
+		AgentID:           strings.ToLower(strings.TrimSpace(agentID)),
+		To:                strings.TrimSpace(to),
+		Provider:          strings.TrimSpace(provider),
+		ProviderMessageID: strings.TrimSpace(providerMessageID),
+		CreatedAt:         createdAt.UTC().Format(time.RFC3339Nano),
 	})
 	if err != nil {
 		return nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 	return resp, nil
+}
+
+func soulCommSendJSONFromStatusItem(item models.SoulCommMessageStatus) (*apptheory.Response, *apptheory.AppTheoryError) {
+	return soulCommSendJSONFields(item.MessageID, item.Status, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.CreatedAt)
+}
+
+func soulCommSendJSONFromIdempotencyItem(item models.SoulCommSendIdempotency) (*apptheory.Response, *apptheory.AppTheoryError) {
+	return soulCommSendJSONFields(item.MessageID, item.ResponseStatus, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.CreatedAt)
 }
 
 func soulCommStatusJSON(item models.SoulCommMessageStatus) soulCommStatusResponse {

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -28,8 +28,10 @@ const (
 func allowCommQueryOps(queries ...*ttmocks.MockQuery) {
 	for _, q := range queries {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("Index", mock.Anything).Return(q).Maybe()
 		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("IfExists").Return(q).Maybe()
+		q.On("IfNotExists").Return(q).Maybe()
 		q.On("Update", mock.Anything).Return(nil).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -33,6 +33,7 @@ type soulCommSendMoreTestDB struct {
 	qPrefs        *ttmocks.MockQuery
 	qReputation   *ttmocks.MockQuery
 	qCommActivity *ttmocks.MockQuery
+	qIdem         *ttmocks.MockQuery
 	qStatus       *ttmocks.MockQuery
 	qInstance     *ttmocks.MockQuery
 	qBudget       *ttmocks.MockQuery
@@ -50,6 +51,7 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 	qPrefs := new(ttmocks.MockQuery)
 	qReputation := new(ttmocks.MockQuery)
 	qCommActivity := new(ttmocks.MockQuery)
+	qIdem := new(ttmocks.MockQuery)
 	qStatus := new(ttmocks.MockQuery)
 	qInstance := new(ttmocks.MockQuery)
 	qBudget := new(ttmocks.MockQuery)
@@ -65,16 +67,19 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentContactPreferences")).Return(qPrefs).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentReputation")).Return(qReputation).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qCommActivity).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommSendIdempotency")).Return(qIdem).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(qBudget).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qKey, qDomain, qIdentity, qChannel, qEmailIdx, qPhoneIdx, qPrefs, qReputation, qCommActivity, qStatus, qInstance, qBudget, qAudit} {
+	for _, q := range []*ttmocks.MockQuery{qKey, qDomain, qIdentity, qChannel, qEmailIdx, qPhoneIdx, qPrefs, qReputation, qCommActivity, qIdem, qStatus, qInstance, qBudget, qAudit} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("Index", mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
 		q.On("IfExists").Return(q).Maybe()
+		q.On("IfNotExists").Return(q).Maybe()
 		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("Update", mock.Anything).Return(nil).Maybe()
 		q.On("Create").Return(nil).Maybe()
@@ -91,6 +96,7 @@ func newSoulCommSendMoreTestDB() soulCommSendMoreTestDB {
 		qPrefs:        qPrefs,
 		qReputation:   qReputation,
 		qCommActivity: qCommActivity,
+		qIdem:         qIdem,
 		qStatus:       qStatus,
 		qInstance:     qInstance,
 		qBudget:       qBudget,
@@ -366,6 +372,367 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 		})
 		_, err := s.handleSoulCommSend(newCommSendCtx(body, strPtr("comm-msg-prev")))
 		assertCommTheoryErrorCode(t, err, commCodeProviderUnavailable, http.StatusServiceUnavailable)
+	})
+}
+
+func TestHandleSoulCommSend_IdempotencyBehavior(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+	body := map[string]any{
+		"channel":        "email",
+		"agentId":        agentID,
+		"to":             "alice@example.com",
+		"subject":        "Hello",
+		"body":           "hello",
+		"idempotencyKey": "dup-key",
+	}
+	expectedHash := soulCommSendRequestHash("inst1", validatedSoulCommSendRequest{
+		channel:        commChannelEmail,
+		agentIDHex:     agentID,
+		to:             "alice@example.com",
+		subject:        "Hello",
+		body:           "hello",
+		idempotencyKey: "dup-key",
+	})
+
+	t.Run("returns original success without redispatch", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
+		expectActiveCommRoute(t, tdb, agentID, "email")
+		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+		resetCommMockQueryChain(tdb.qIdem)
+		resetCommMockQueryChain(tdb.qStatus)
+		tdb.qIdem.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
+		tdb.qIdem.On("First", mock.AnythingOfType("*models.SoulCommSendIdempotency")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulCommSendIdempotency](t, args, 0)
+			*dest = models.SoulCommSendIdempotency{
+				InstanceSlug:   "inst1",
+				AgentID:        agentID,
+				IdempotencyKey: "dup-key",
+				RequestHash:    expectedHash,
+				MessageID:      "comm-msg-existing",
+				ChannelType:    commChannelEmail,
+				To:             "alice@example.com",
+				Status:         models.SoulCommSendIdempotencyStatusSucceeded,
+				ResponseStatus: models.SoulCommMessageStatusSent,
+				CreatedAt:      time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+			}
+		}).Once()
+		tdb.qStatus.On("All", mock.AnythingOfType("*[]*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMessageStatus](t, args, 0)
+			*dest = []*models.SoulCommMessageStatus{{
+				MessageID:         "comm-msg-existing",
+				InstanceSlug:      "inst1",
+				AgentID:           agentID,
+				IdempotencyKey:    "dup-key",
+				ChannelType:       commChannelEmail,
+				To:                "alice@example.com",
+				Provider:          commDeliveryProviderMigadu,
+				ProviderMessageID: "<comm-msg-existing@lessersoul.ai>",
+				Status:            models.SoulCommMessageStatusSent,
+				CreatedAt:         time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+			}}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		resp, err := s.handleSoulCommSend(newCommSendCtx(mustMarshalCommSendBody(t, body), nil))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusSent, commDeliveryProviderMigadu, commChannelEmail, "<comm-msg-existing@lessersoul.ai>")
+
+		var out soulCommSendResponse
+		if err := json.Unmarshal(resp.Body, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if out.MessageID != "comm-msg-existing" {
+			t.Fatalf("expected existing message id, got %#v", out)
+		}
+	})
+
+	t.Run("returns accepted while original request is still processing", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
+		expectActiveCommRoute(t, tdb, agentID, "email")
+		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+		resetCommMockQueryChain(tdb.qIdem)
+		resetCommMockQueryChain(tdb.qStatus)
+		tdb.qIdem.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
+		tdb.qIdem.On("First", mock.AnythingOfType("*models.SoulCommSendIdempotency")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulCommSendIdempotency](t, args, 0)
+			*dest = models.SoulCommSendIdempotency{
+				InstanceSlug:   "inst1",
+				AgentID:        agentID,
+				IdempotencyKey: "dup-key",
+				RequestHash:    expectedHash,
+				MessageID:      "comm-msg-existing",
+				ChannelType:    commChannelEmail,
+				To:             "alice@example.com",
+				Status:         models.SoulCommSendIdempotencyStatusProcessing,
+				ResponseStatus: models.SoulCommMessageStatusAccepted,
+				CreatedAt:      time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+			}
+		}).Once()
+		tdb.qStatus.On("All", mock.AnythingOfType("*[]*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMessageStatus](t, args, 0)
+			*dest = []*models.SoulCommMessageStatus{}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		resp, err := s.handleSoulCommSend(newCommSendCtx(mustMarshalCommSendBody(t, body), nil))
+		if err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+		assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusAccepted, "", commChannelEmail, "")
+
+		var out soulCommSendResponse
+		if err := json.Unmarshal(resp.Body, &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if out.MessageID != "comm-msg-existing" {
+			t.Fatalf("expected in-flight message id, got %#v", out)
+		}
+	})
+
+	t.Run("rejects same key for different payload", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
+		expectActiveCommRoute(t, tdb, agentID, "email")
+		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+		resetCommMockQueryChain(tdb.qIdem)
+		tdb.qIdem.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
+		tdb.qIdem.On("First", mock.AnythingOfType("*models.SoulCommSendIdempotency")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulCommSendIdempotency](t, args, 0)
+			*dest = models.SoulCommSendIdempotency{
+				InstanceSlug:   "inst1",
+				AgentID:        agentID,
+				IdempotencyKey: "dup-key",
+				RequestHash:    "different-hash",
+				MessageID:      "comm-msg-existing",
+				ChannelType:    commChannelEmail,
+				To:             "alice@example.com",
+				Status:         models.SoulCommSendIdempotencyStatusSucceeded,
+				ResponseStatus: models.SoulCommMessageStatusSent,
+				CreatedAt:      time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+			}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		_, err := s.handleSoulCommSend(newCommSendCtx(mustMarshalCommSendBody(t, body), nil))
+		assertCommTheoryErrorCode(t, err, commCodeIdempotencyConflict, http.StatusConflict)
+	})
+}
+
+func testSoulCommSendBaseIdempotencyItem() *models.SoulCommSendIdempotency {
+	return &models.SoulCommSendIdempotency{
+		InstanceSlug:   "inst1",
+		AgentID:        soulLifecycleTestAgentIDHex,
+		IdempotencyKey: "dup-key",
+		RequestHash:    "hash-1",
+		MessageID:      "comm-msg-1",
+		ChannelType:    commChannelEmail,
+		To:             "alice@example.com",
+		CreatedAt:      time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC),
+	}
+}
+
+func TestSoulCommSendIdempotencyCompleteHelpers(t *testing.T) {
+	t.Parallel()
+
+	baseItem := testSoulCommSendBaseIdempotencyItem()
+
+	t.Run("success updates provider fields", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qIdem)
+		tdb.qIdem.On("Update", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			got := testutil.RequireMockArg[[]string](t, args, 0)
+			if strings.Join(got, ",") != "Status,ResponseStatus,Provider,ProviderMessageID,UpdatedAt" {
+				t.Fatalf("unexpected update fields: %#v", got)
+			}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db)}
+		if err := s.completeSoulCommSendIdempotencySuccess(context.Background(), baseItem, soulCommSendDelivery{
+			provider:          commDeliveryProviderMigadu,
+			providerMessageID: "<comm-msg-1@lessersoul.ai>",
+			initialStatus:     models.SoulCommMessageStatusSent,
+		}); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+
+	t.Run("failure stores original error", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qIdem)
+		tdb.qIdem.On("Update", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			got := testutil.RequireMockArg[[]string](t, args, 0)
+			if strings.Join(got, ",") != "Status,ResponseStatus,ErrorCode,ErrorMessage,ErrorStatusCode,UpdatedAt" {
+				t.Fatalf("unexpected update fields: %#v", got)
+			}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db)}
+		appErr := apptheory.NewAppTheoryError(commCodeProviderUnavailable, "provider unavailable").WithStatusCode(http.StatusServiceUnavailable)
+		if err := s.completeSoulCommSendIdempotencyFailure(context.Background(), baseItem, appErr); err != nil {
+			t.Fatalf("unexpected err: %v", err)
+		}
+	})
+}
+
+func TestFinalizeSoulCommSendIdempotency(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulCommSendMoreTestDB()
+	resetCommMockQueryChain(tdb.qIdem)
+	tdb.qIdem.On("Update", mock.Anything).Return(nil).Once()
+	tdb.qIdem.On("Update", mock.Anything).Return(nil).Once()
+
+	s := &Server{store: store.New(tdb.db)}
+	baseItem := testSoulCommSendBaseIdempotencyItem()
+	s.finalizeSoulCommSendIdempotency(context.Background(), baseItem, soulCommSendDelivery{
+		provider:          commDeliveryProviderMigadu,
+		providerMessageID: "<comm-msg-1@lessersoul.ai>",
+		initialStatus:     models.SoulCommMessageStatusSent,
+	}, nil)
+	s.finalizeSoulCommSendIdempotency(context.Background(), baseItem, soulCommSendDelivery{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError))
+	s.finalizeSoulCommSendIdempotency(context.Background(), nil, soulCommSendDelivery{}, nil)
+}
+
+func TestRespondFromSoulCommSendIdempotency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil item returns internal", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		s := &Server{store: store.New(tdb.db)}
+		_, appErr := s.respondFromSoulCommSendIdempotency(context.Background(), nil, newSoulCommSendMetrics("lab", "inst1"))
+		if appErr == nil || appErr.Code != commCodeInternal || appErr.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected internal error, got %#v", appErr)
+		}
+	})
+
+	t.Run("failed item returns original error", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qStatus)
+		tdb.qStatus.On("All", mock.AnythingOfType("*[]*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMessageStatus](t, args, 0)
+			*dest = []*models.SoulCommMessageStatus{}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db)}
+		_, appErr := s.respondFromSoulCommSendIdempotency(context.Background(), &models.SoulCommSendIdempotency{
+			InstanceSlug:    "inst1",
+			AgentID:         soulLifecycleTestAgentIDHex,
+			IdempotencyKey:  "dup-key",
+			MessageID:       "comm-msg-1",
+			ChannelType:     commChannelEmail,
+			To:              "alice@example.com",
+			Status:          models.SoulCommSendIdempotencyStatusFailed,
+			ResponseStatus:  models.SoulCommMessageStatusFailed,
+			ErrorCode:       commCodeProviderUnavailable,
+			ErrorMessage:    "provider unavailable",
+			ErrorStatusCode: http.StatusServiceUnavailable,
+			CreatedAt:       testSoulCommSendBaseIdempotencyItem().CreatedAt,
+		}, newSoulCommSendMetrics("lab", "inst1"))
+		if appErr == nil || appErr.Code != commCodeProviderUnavailable || appErr.StatusCode != http.StatusServiceUnavailable {
+			t.Fatalf("expected provider unavailable, got %#v", appErr)
+		}
+	})
+
+	t.Run("processing item returns accepted response", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qStatus)
+		tdb.qStatus.On("All", mock.AnythingOfType("*[]*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMessageStatus](t, args, 0)
+			*dest = []*models.SoulCommMessageStatus{}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db)}
+		resp, appErr := s.respondFromSoulCommSendIdempotency(context.Background(), &models.SoulCommSendIdempotency{
+			InstanceSlug:   "inst1",
+			AgentID:        soulLifecycleTestAgentIDHex,
+			IdempotencyKey: "dup-key",
+			MessageID:      "comm-msg-1",
+			ChannelType:    commChannelEmail,
+			To:             "alice@example.com",
+			Status:         models.SoulCommSendIdempotencyStatusProcessing,
+			ResponseStatus: models.SoulCommMessageStatusAccepted,
+			CreatedAt:      testSoulCommSendBaseIdempotencyItem().CreatedAt,
+		}, newSoulCommSendMetrics("lab", "inst1"))
+		if appErr != nil {
+			t.Fatalf("unexpected appErr: %v", appErr)
+		}
+		assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusAccepted, "", commChannelEmail, "")
+	})
+}
+
+func TestClaimSoulCommSendIdempotency_Branches(t *testing.T) {
+	t.Parallel()
+
+	req := validatedSoulCommSendRequest{
+		channel:        commChannelEmail,
+		agentIDHex:     soulLifecycleTestAgentIDHex,
+		to:             "alice@example.com",
+		subject:        "Hello",
+		body:           "hello",
+		idempotencyKey: "dup-key",
+	}
+	createdAt := testSoulCommSendBaseIdempotencyItem().CreatedAt
+
+	t.Run("non-condition create error returns internal", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qIdem)
+		tdb.qIdem.On("Create").Return(errors.New("boom")).Once()
+		s := &Server{store: store.New(tdb.db)}
+
+		_, _, appErr := s.claimSoulCommSendIdempotency(
+			&apptheory.Context{Request: apptheory.Request{}},
+			&models.InstanceKey{InstanceSlug: "inst1"},
+			req,
+			"comm-msg-1",
+			createdAt,
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr == nil || appErr.Code != commCodeInternal || appErr.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("expected internal error, got %#v", appErr)
+		}
+	})
+
+	t.Run("status fallback returns original response", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		resetCommMockQueryChain(tdb.qIdem)
+		resetCommMockQueryChain(tdb.qStatus)
+		tdb.qIdem.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
+		tdb.qIdem.On("First", mock.AnythingOfType("*models.SoulCommSendIdempotency")).Return(errors.New("boom")).Once()
+		tdb.qStatus.On("All", mock.AnythingOfType("*[]*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMessageStatus](t, args, 0)
+			*dest = []*models.SoulCommMessageStatus{{
+				MessageID:         "comm-msg-existing",
+				InstanceSlug:      "inst1",
+				AgentID:           soulLifecycleTestAgentIDHex,
+				IdempotencyKey:    "dup-key",
+				ChannelType:       commChannelEmail,
+				To:                "alice@example.com",
+				Provider:          commDeliveryProviderMigadu,
+				ProviderMessageID: "<comm-msg-existing@lessersoul.ai>",
+				Status:            models.SoulCommMessageStatusSent,
+				CreatedAt:         createdAt,
+			}}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db)}
+		_, resp, appErr := s.claimSoulCommSendIdempotency(
+			&apptheory.Context{Request: apptheory.Request{}},
+			&models.InstanceKey{InstanceSlug: "inst1"},
+			req,
+			"comm-msg-1",
+			createdAt,
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr != nil {
+			t.Fatalf("unexpected appErr: %v", appErr)
+		}
+		assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusSent, commDeliveryProviderMigadu, commChannelEmail, "<comm-msg-existing@lessersoul.ai>")
 	})
 }
 
@@ -967,6 +1334,18 @@ func expectActiveCommRoute(t *testing.T, tdb soulCommSendMoreTestDB, agentID str
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+}
+
+func resetCommMockQueryChain(q *ttmocks.MockQuery) {
+	q.ExpectedCalls = nil
+	q.Calls = nil
+	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("Index", mock.Anything).Return(q).Maybe()
+	q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("Limit", mock.Anything).Return(q).Maybe()
+	q.On("IfExists").Return(q).Maybe()
+	q.On("IfNotExists").Return(q).Maybe()
+	q.On("ConsistentRead").Return(q).Maybe()
 }
 
 func requireCommTheoryError(t *testing.T, err error) *apptheory.AppTheoryError {

--- a/internal/store/models/contracts_more_test.go
+++ b/internal/store/models/contracts_more_test.go
@@ -44,6 +44,7 @@ func TestModelContracts_TableNameAndKeyAccessors(t *testing.T) {
 		ProvisionJob{},
 		RenderArtifact{},
 		SetupSession{},
+		SoulCommSendIdempotency{},
 		TipHostRegistration{},
 		TipHostState{},
 		TipRegistryOperation{},
@@ -111,6 +112,19 @@ func TestModelContracts_TableNameAndKeyAccessors(t *testing.T) {
 	require.NoError(t, th.BeforeCreate())
 	require.NotEmpty(t, th.GetPK())
 	require.NotEmpty(t, th.GetSK())
+
+	idem := &SoulCommSendIdempotency{
+		InstanceSlug:   "slug",
+		AgentID:        "0xabc",
+		IdempotencyKey: "retry-1",
+		RequestHash:    "hash-1",
+		MessageID:      "comm-msg-1",
+		ChannelType:    "email",
+		To:             "alice@example.com",
+	}
+	require.NoError(t, idem.BeforeCreate())
+	require.NotEmpty(t, idem.GetPK())
+	require.NotEmpty(t, idem.GetSK())
 }
 
 func TestModelContracts_BeforeUpdate_MaintainsKeys(t *testing.T) {

--- a/internal/store/models/soul_comm_message_status.go
+++ b/internal/store/models/soul_comm_message_status.go
@@ -26,8 +26,13 @@ type SoulCommMessageStatus struct {
 	SK  string `theorydb:"sk,attr:SK" json:"-"`
 	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
 
-	MessageID string `theorydb:"attr:messageId" json:"message_id"`
-	AgentID   string `theorydb:"attr:agentId" json:"agent_id"`
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+
+	MessageID      string `theorydb:"attr:messageId" json:"message_id"`
+	InstanceSlug   string `theorydb:"attr:instanceSlug" json:"instance_slug,omitempty"`
+	AgentID        string `theorydb:"attr:agentId" json:"agent_id"`
+	IdempotencyKey string `theorydb:"attr:idempotencyKey" json:"idempotency_key,omitempty"`
 
 	ChannelType string `theorydb:"attr:channelType" json:"channel_type"` // email|sms|voice
 	To          string `theorydb:"attr:to" json:"to"`
@@ -68,6 +73,11 @@ func (m *SoulCommMessageStatus) BeforeCreate() error {
 	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
 		return err
 	}
+	if strings.TrimSpace(m.IdempotencyKey) != "" {
+		if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+			return err
+		}
+	}
 	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
 		return err
 	}
@@ -101,7 +111,9 @@ func (m *SoulCommMessageStatus) BeforeUpdate() error {
 // UpdateKeys updates the database keys for SoulCommMessageStatus.
 func (m *SoulCommMessageStatus) UpdateKeys() error {
 	m.MessageID = strings.TrimSpace(m.MessageID)
+	m.InstanceSlug = strings.ToLower(strings.TrimSpace(m.InstanceSlug))
 	m.AgentID = strings.ToLower(strings.TrimSpace(m.AgentID))
+	m.IdempotencyKey = strings.TrimSpace(m.IdempotencyKey)
 	m.ChannelType = strings.ToLower(strings.TrimSpace(m.ChannelType))
 	m.To = strings.TrimSpace(m.To)
 	m.Provider = strings.ToLower(strings.TrimSpace(m.Provider))
@@ -114,6 +126,13 @@ func (m *SoulCommMessageStatus) UpdateKeys() error {
 
 	m.PK = fmt.Sprintf("COMM#MSG#%s", m.MessageID)
 	m.SK = "STATUS"
+	if m.InstanceSlug != "" && m.IdempotencyKey != "" && m.AgentID != "" {
+		m.GSI1PK = SoulCommMessageStatusIdempotencyIndexPK(m.InstanceSlug, m.AgentID, m.IdempotencyKey)
+		m.GSI1SK = fmt.Sprintf("%s#%s", m.CreatedAt.UTC().Format(time.RFC3339Nano), m.MessageID)
+	} else {
+		m.GSI1PK = ""
+		m.GSI1SK = ""
+	}
 	m.TTL = m.CreatedAt.UTC().Add(90 * 24 * time.Hour).Unix()
 	return nil
 }

--- a/internal/store/models/soul_comm_send_idempotency.go
+++ b/internal/store/models/soul_comm_send_idempotency.go
@@ -1,0 +1,171 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	SoulCommSendIdempotencyStatusProcessing = "processing"
+	SoulCommSendIdempotencyStatusSucceeded  = "succeeded"
+	SoulCommSendIdempotencyStatusFailed     = "failed"
+)
+
+// SoulCommSendIdempotency stores the outcome for an outbound comm send request keyed by
+// caller-provided idempotency material so retries can return the original result without
+// re-dispatching the provider call.
+type SoulCommSendIdempotency struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	InstanceSlug   string `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	AgentID        string `theorydb:"attr:agentId" json:"agent_id"`
+	IdempotencyKey string `theorydb:"attr:idempotencyKey" json:"idempotency_key"`
+	RequestHash    string `theorydb:"attr:requestHash" json:"request_hash"`
+
+	MessageID      string `theorydb:"attr:messageId" json:"message_id"`
+	ChannelType    string `theorydb:"attr:channelType" json:"channel_type"`
+	To             string `theorydb:"attr:to" json:"to"`
+	Status         string `theorydb:"attr:status" json:"status"`                  // processing|succeeded|failed
+	ResponseStatus string `theorydb:"attr:responseStatus" json:"response_status"` // accepted|sent|failed
+
+	Provider          string `theorydb:"attr:provider" json:"provider,omitempty"`
+	ProviderMessageID string `theorydb:"attr:providerMessageId" json:"provider_message_id,omitempty"`
+
+	ErrorCode       string `theorydb:"attr:errorCode" json:"error_code,omitempty"`
+	ErrorMessage    string `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
+	ErrorStatusCode int    `theorydb:"attr:errorStatusCode" json:"error_status_code,omitempty"`
+
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
+}
+
+// TableName returns the database table name for SoulCommSendIdempotency.
+func (SoulCommSendIdempotency) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating SoulCommSendIdempotency.
+func (m *SoulCommSendIdempotency) BeforeCreate() error {
+	now := time.Now().UTC()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	if m.UpdatedAt.IsZero() {
+		m.UpdatedAt = now
+	}
+	if strings.TrimSpace(m.Status) == "" {
+		m.Status = SoulCommSendIdempotencyStatusProcessing
+	}
+	if strings.TrimSpace(m.ResponseStatus) == "" {
+		m.ResponseStatus = SoulCommMessageStatusAccepted
+	}
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("idempotencyKey", m.IdempotencyKey); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("requestHash", m.RequestHash); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("channelType", m.ChannelType); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("to", m.To); err != nil {
+		return err
+	}
+	if err := requireOneOf("status", m.Status, SoulCommSendIdempotencyStatusProcessing, SoulCommSendIdempotencyStatusSucceeded, SoulCommSendIdempotencyStatusFailed); err != nil {
+		return err
+	}
+	return requireOneOf("responseStatus", m.ResponseStatus, SoulCommMessageStatusAccepted, SoulCommMessageStatusSent, SoulCommMessageStatusFailed)
+}
+
+// BeforeUpdate updates timestamps and keys before updating SoulCommSendIdempotency.
+func (m *SoulCommSendIdempotency) BeforeUpdate() error {
+	m.UpdatedAt = time.Now().UTC()
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("idempotencyKey", m.IdempotencyKey); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("requestHash", m.RequestHash); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
+		return err
+	}
+	if err := requireOneOf("status", m.Status, SoulCommSendIdempotencyStatusProcessing, SoulCommSendIdempotencyStatusSucceeded, SoulCommSendIdempotencyStatusFailed); err != nil {
+		return err
+	}
+	return requireOneOf("responseStatus", m.ResponseStatus, SoulCommMessageStatusAccepted, SoulCommMessageStatusSent, SoulCommMessageStatusFailed)
+}
+
+// UpdateKeys updates the database keys for SoulCommSendIdempotency.
+func (m *SoulCommSendIdempotency) UpdateKeys() error {
+	m.InstanceSlug = strings.ToLower(strings.TrimSpace(m.InstanceSlug))
+	m.AgentID = strings.ToLower(strings.TrimSpace(m.AgentID))
+	m.IdempotencyKey = strings.TrimSpace(m.IdempotencyKey)
+	m.RequestHash = strings.TrimSpace(m.RequestHash)
+	m.MessageID = strings.TrimSpace(m.MessageID)
+	m.ChannelType = strings.ToLower(strings.TrimSpace(m.ChannelType))
+	m.To = strings.TrimSpace(m.To)
+	m.Status = strings.ToLower(strings.TrimSpace(m.Status))
+	m.ResponseStatus = strings.ToLower(strings.TrimSpace(m.ResponseStatus))
+	m.Provider = strings.ToLower(strings.TrimSpace(m.Provider))
+	m.ProviderMessageID = strings.TrimSpace(m.ProviderMessageID)
+	m.ErrorCode = strings.TrimSpace(m.ErrorCode)
+	m.ErrorMessage = strings.TrimSpace(m.ErrorMessage)
+
+	m.PK = SoulCommSendIdempotencyPK(m.InstanceSlug, m.AgentID, m.IdempotencyKey)
+	m.SK = "STATE"
+	m.TTL = m.CreatedAt.UTC().Add(90 * 24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for SoulCommSendIdempotency.
+func (m *SoulCommSendIdempotency) GetPK() string { return m.PK }
+
+// GetSK returns the sort key for SoulCommSendIdempotency.
+func (m *SoulCommSendIdempotency) GetSK() string { return m.SK }
+
+// SoulCommSendIdempotencyScope returns the canonical scope for outbound comm idempotency.
+func SoulCommSendIdempotencyScope(instanceSlug string, agentID string, idempotencyKey string) string {
+	return fmt.Sprintf("%s#%s#%s",
+		strings.ToLower(strings.TrimSpace(instanceSlug)),
+		strings.ToLower(strings.TrimSpace(agentID)),
+		strings.TrimSpace(idempotencyKey),
+	)
+}
+
+// SoulCommSendIdempotencyPK returns the primary key used to reserve an outbound comm idempotency key.
+func SoulCommSendIdempotencyPK(instanceSlug string, agentID string, idempotencyKey string) string {
+	sum := sha256.Sum256([]byte(SoulCommSendIdempotencyScope(instanceSlug, agentID, idempotencyKey)))
+	return "COMM#IDEMPOTENCY#" + hex.EncodeToString(sum[:])
+}
+
+// SoulCommMessageStatusIdempotencyIndexPK returns the GSI partition key for message status rows
+// that belong to an outbound comm idempotency scope.
+func SoulCommMessageStatusIdempotencyIndexPK(instanceSlug string, agentID string, idempotencyKey string) string {
+	return "COMM#IDEMPOTENCY#" + SoulCommSendIdempotencyScope(instanceSlug, agentID, idempotencyKey)
+}

--- a/internal/store/models/soul_models_v3_test.go
+++ b/internal/store/models/soul_models_v3_test.go
@@ -147,24 +147,65 @@ func TestSoulCommMessageStatus_TTLAndKeys(t *testing.T) {
 
 	created := time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC)
 	m := &SoulCommMessageStatus{
-		MessageID:    " comm-msg-1 ",
-		AgentID:      " 0xABC ",
-		ChannelType:  " Email ",
-		To:           " alice@example.com ",
-		Status:       " SENT ",
-		CreatedAt:    created,
-		Provider:     " Migadu ",
-		ErrorMessage: "  ",
+		MessageID:      " comm-msg-1 ",
+		InstanceSlug:   " Lab-Inst ",
+		AgentID:        " 0xABC ",
+		IdempotencyKey: " retry-1 ",
+		ChannelType:    " Email ",
+		To:             " alice@example.com ",
+		Status:         " SENT ",
+		CreatedAt:      created,
+		Provider:       " Migadu ",
+		ErrorMessage:   "  ",
 	}
 	require.NoError(t, m.BeforeCreate())
 
 	require.Equal(t, "COMM#MSG#comm-msg-1", m.PK)
 	require.Equal(t, "STATUS", m.SK)
+	require.Equal(t, "COMM#IDEMPOTENCY#lab-inst#0xabc#retry-1", m.GSI1PK)
+	require.Equal(t, "2026-03-04T12:00:00Z#comm-msg-1", m.GSI1SK)
 	require.Equal(t, "comm-msg-1", m.MessageID)
+	require.Equal(t, "lab-inst", m.InstanceSlug)
 	require.Equal(t, "0xabc", m.AgentID)
+	require.Equal(t, "retry-1", m.IdempotencyKey)
 	require.Equal(t, "email", m.ChannelType)
 	require.Equal(t, "alice@example.com", m.To)
 	require.Equal(t, "sent", m.Status)
+	require.Equal(t, "migadu", m.Provider)
+	require.Equal(t, created.Add(90*24*time.Hour).Unix(), m.TTL)
+	require.False(t, m.UpdatedAt.IsZero())
+}
+
+func TestSoulCommSendIdempotency_TTLAndKeys(t *testing.T) {
+	t.Parallel()
+
+	created := time.Date(2026, 3, 4, 12, 0, 0, 0, time.UTC)
+	m := &SoulCommSendIdempotency{
+		InstanceSlug:   " Lab-Inst ",
+		AgentID:        " 0xABC ",
+		IdempotencyKey: " retry-1 ",
+		RequestHash:    " hash-1 ",
+		MessageID:      " comm-msg-1 ",
+		ChannelType:    " Email ",
+		To:             " alice@example.com ",
+		Status:         " Succeeded ",
+		ResponseStatus: " SENT ",
+		Provider:       " Migadu ",
+		CreatedAt:      created,
+	}
+	require.NoError(t, m.BeforeCreate())
+
+	require.Equal(t, SoulCommSendIdempotencyPK("lab-inst", "0xabc", "retry-1"), m.PK)
+	require.Equal(t, "STATE", m.SK)
+	require.Equal(t, "lab-inst", m.InstanceSlug)
+	require.Equal(t, "0xabc", m.AgentID)
+	require.Equal(t, "retry-1", m.IdempotencyKey)
+	require.Equal(t, "hash-1", m.RequestHash)
+	require.Equal(t, "comm-msg-1", m.MessageID)
+	require.Equal(t, "email", m.ChannelType)
+	require.Equal(t, "alice@example.com", m.To)
+	require.Equal(t, SoulCommSendIdempotencyStatusSucceeded, m.Status)
+	require.Equal(t, SoulCommMessageStatusSent, m.ResponseStatus)
 	require.Equal(t, "migadu", m.Provider)
 	require.Equal(t, created.Add(90*24*time.Hour).Unix(), m.TTL)
 	require.False(t, m.UpdatedAt.IsZero())


### PR DESCRIPTION
## Summary
- add request-level idempotency support to the comm/send endpoint
- persist idempotency claims and completed outcomes so retries reuse the original result
- cover duplicate success, in-flight retry, and payload-conflict cases in tests

## Verification
- GOTOOLCHAIN=auto bash gov-infra/verifiers/gov-verify-rubric.sh

Fixes #64