### PR TITLE
Filter Telnyx SMS webhooks to inbound events

### DIFF
--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -153,6 +153,10 @@ func (s *Server) handleCommSMSInboundWebhook(ctx *apptheory.Context) (*apptheory
 	if err := json.Unmarshal(ctx.Request.Body, &tel); err != nil {
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
 	}
+	eventType := strings.TrimSpace(tel.Data.EventType)
+	if eventType != "message.received" {
+		return apptheory.JSON(http.StatusOK, map[string]any{"ok": true, "skipped": eventType})
+	}
 
 	from := strings.TrimSpace(tel.Data.Payload.From.PhoneNumber)
 	to := ""

--- a/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
@@ -188,6 +188,37 @@ func TestHandleCommSMSInboundWebhook_EnqueueFailureReturnsInternal(t *testing.T)
 	requireWebhookAppError(t, err, appErrCodeInternal, commWebhookFailedToEnqueue)
 }
 
+func TestHandleCommSMSInboundWebhook_SkipsNonInboundTelnyxEvents(t *testing.T) {
+	t.Parallel()
+
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		t.Fatalf("enqueue should not be called for non-inbound Telnyx events: %#v", msg)
+		return nil
+	})
+	body := marshalCommWebhookBody(t, map[string]any{
+		"data": map[string]any{
+			"event_type": "message.sent",
+			"payload": map[string]any{
+				"id":   "telnyx-msg-2",
+				"text": "Hello",
+				"from": map[string]any{"phone_number": "+15550142"},
+				"to":   []map[string]any{{"phone_number": "+15550143"}},
+			},
+		},
+	})
+
+	resp, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	requireCommWebhookOK(t, resp, err)
+
+	var got map[string]any
+	if err := json.Unmarshal(resp.Body, &got); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if got["skipped"] != "message.sent" {
+		t.Fatalf("expected skipped event type, got %#v", got)
+	}
+}
+
 func TestHandleCommVoiceInboundWebhook_NormalizesPayload(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- filter raw Telnyx SMS webhooks to only process message.received
- acknowledge other Telnyx SMS event types without enqueuing duplicate inbound notifications
- add regression coverage for skipped non-inbound Telnyx events

## Testing
- GOTOOLCHAIN=auto go test ./internal/controlplane -run 'TestHandleCommSMSInboundWebhook'
- GOTOOLCHAIN=auto go test ./internal/controlplane
- GOTOOLCHAIN=auto bash gov-infra/verifiers/gov-verify-rubric.sh

Closes #66