### PR TITLE
Use slug-prefixed instance key secret names

### DIFF
--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -1068,15 +1068,11 @@ const (
 )
 
 func managedInstanceKeySecretName(controlPlaneStage, slug string) string {
-	stage := strings.ToLower(strings.TrimSpace(controlPlaneStage))
-	if stage == "" {
-		stage = defaultControlPlaneStage
-	}
 	slug = strings.ToLower(strings.TrimSpace(slug))
 	if slug == "" {
 		return ""
 	}
-	return fmt.Sprintf("lesser-host/%s/instances/%s/instance-key", stage, slug)
+	return fmt.Sprintf("%s/instance-key", slug)
 }
 
 func secretsManagerTagValue(tags []smtypes.Tag, key string) string {

--- a/internal/provisionworker/server_provisioning_branches_internal_test.go
+++ b/internal/provisionworker/server_provisioning_branches_internal_test.go
@@ -124,6 +124,14 @@ func TestInitializeManagedProvisionJob_SetsDefaultsAndPreservesValues(t *testing
 	require.Equal(t, "custom.example.com", job.BaseDomain)
 }
 
+func TestManagedInstanceKeySecretName_UsesSlugPrefix(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "slug/instance-key", managedInstanceKeySecretName("LIVE", " Slug "))
+	require.Equal(t, "slug/instance-key", managedInstanceKeySecretName("", "slug"))
+	require.Equal(t, "", managedInstanceKeySecretName("live", " "))
+}
+
 func TestStartManagedProvisioningJobIfQueued_Branches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provisionworker/update_jobs_flow_internal_test.go
+++ b/internal/provisionworker/update_jobs_flow_internal_test.go
@@ -161,7 +161,7 @@ func TestRunManagedUpdateStateMachine_HappyPath(t *testing.T) {
 	fsm := &fakeSecretsManager{
 		describeErr: &smtypes.ResourceNotFoundException{},
 		createOut: &secretsmanager.CreateSecretOutput{
-			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:lesser-host/live/instances/slug/instance-key"),
+			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:slug/instance-key"),
 		},
 		getOut: &secretsmanager.GetSecretValueOutput{
 			SecretString: aws.String(`{"secret":"lhk_test"}`),
@@ -299,7 +299,7 @@ func TestRunManagedUpdateStateMachine_BodyOnlyCompletesIndependently(t *testing.
 	fsm := &fakeSecretsManager{
 		describeErr: &smtypes.ResourceNotFoundException{},
 		createOut: &secretsmanager.CreateSecretOutput{
-			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:lesser-host/live/instances/slug/instance-key"),
+			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:slug/instance-key"),
 		},
 		getOut: &secretsmanager.GetSecretValueOutput{
 			SecretString: aws.String(`{"secret":"lhk_test"}`),
@@ -451,7 +451,7 @@ func TestRunManagedUpdateStateMachine_MCPOnlySkipsLesserAndBodyDeploy(t *testing
 	fsm := &fakeSecretsManager{
 		describeErr: &smtypes.ResourceNotFoundException{},
 		createOut: &secretsmanager.CreateSecretOutput{
-			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:lesser-host/live/instances/slug/instance-key"),
+			ARN: aws.String("arn:aws:secretsmanager:us-east-1:000000000000:secret:slug/instance-key"),
 		},
 		getOut: &secretsmanager.GetSecretValueOutput{
 			SecretString: aws.String(`{"secret":"lhk_test"}`),


### PR DESCRIPTION
## Summary
- change managed instance key secret naming to use the instance slug prefix (`{slug}/instance-key`)
- update provision worker flow tests to expect the new secret ARN shape
- add a regression test locking the helper output to the slug-prefixed path

## Testing
- GOTOOLCHAIN=auto go test ./internal/provisionworker
- GOTOOLCHAIN=auto bash gov-infra/verifiers/gov-verify-rubric.sh

Closes #68