### PR TITLE
chore: update theory and greater pins

### DIFF
--- a/app-theory/app.json
+++ b/app-theory/app.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "apptheory": {
       "module": "github.com/theory-cloud/apptheory",
-      "version": "v0.15.1",
+      "version": "v0.19.1",
       "docs": [
         "docs/getting-started.md",
         "docs/migration/from-lift.md"
@@ -11,7 +11,7 @@
     },
     "tabletheory": {
       "module": "github.com/theory-cloud/tabletheory",
-      "version": "v1.4.1",
+      "version": "v1.5.1",
       "docs": [
         "docs/getting-started.md",
         "docs/api-reference.md",

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.26.1
 require (
 	github.com/andybalholm/brotli v1.2.0
 	github.com/anthropics/anthropic-sdk-go v1.26.0
-	github.com/aws/aws-lambda-go v1.53.0
+	github.com/aws/aws-lambda-go v1.54.0
 	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
@@ -31,8 +31,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v79 v79.12.0
-	github.com/theory-cloud/apptheory v0.18.1
-	github.com/theory-cloud/tabletheory v1.4.2
+	github.com/theory-cloud/apptheory v0.19.1
+	github.com/theory-cloud/tabletheory v1.5.1
 	golang.org/x/net v0.52.0
 )
 
@@ -45,14 +45,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.10 // indirect
+	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.11.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sns v1.39.11 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sns v1.39.14 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect
 	github.com/bits-and-blooms/bitset v1.24.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwTo
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAfT7CoSYSac11PY=
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
-github.com/aws/aws-lambda-go v1.53.0 h1:uAMv6W/vCP/L494BAUSxe+8KVBIPK+SGPyapFt3FuMk=
-github.com/aws/aws-lambda-go v1.53.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
+github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
+github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
 github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
 github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.7 h1:3kGOqnh1pPeddVa/E37XNTaWJ8W6vrbYV9lJEkCnhuY=
@@ -30,8 +30,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21 h1:SwGMTMLIlvDNyhMteQ6r8IJSBPlRdXX5d4idhIGbkXA=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.21/go.mod h1:UUxgWxofmOdAMuqEsSppbDtGKLfR04HGsD0HXzvhI1k=
-github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.10 h1:2kw0xNqhIdrtLVvUfCqpvj/4Pa+XHAqTTPGk6AZjNB4=
-github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.10/go.mod h1:rj15EWI0r5cmVDHEIXpS2FDUjo5uQk1I51o7eFNGOXw=
+github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13 h1:357Yo8n9E3WKIpei+mWQYVsIXMUM+c81J0LMYWjIGVc=
+github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13/go.mod h1:u566wm1nu9AsBqipqf9R1Cseeoouj1t2LVwn5/cEJ+4=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12 h1:lQTVEv/YAk8Rw1Yf4XZS/jNNxF9klCN10WcSR3xlMtU=
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12/go.mod h1:yoa0R6Xku788EmJYkFiARzJBxt4A3hgFjQPRmMAttr0=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20 h1:AFxiBqfeAwybIkTFP2cVYjPpEeo9jvYR5qaJ+664mLI=
@@ -62,8 +62,8 @@ github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4 h1:9aZbO86sraeCIHHCp
 github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.41.4/go.mod h1:cxiXDhEzIq7Xx1BtmC4lGBK3SwAZ79+EUWiKawYHo14=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 h1:0GFOLzEbOyZABS3PhYfBIx2rNBACYcKty+XGkTgw1ow=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.8/go.mod h1:LXypKvk85AROkKhOG6/YEcHFPoX+prKTowKnVdcaIxE=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.11 h1:Ke7RS0NuP9Xwk31prXYcFGA1Qfn8QmNWcxyjKPcXZdc=
-github.com/aws/aws-sdk-go-v2/service/sns v1.39.11/go.mod h1:hdZDKzao0PBfJJygT7T92x2uVcWc/htqlhrjFIjnHDM=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.14 h1:p8WdWDh5AwSZdp19Haa3XMyPCICi9Z375a/Nu3IIEZY=
+github.com/aws/aws-sdk-go-v2/service/sns v1.39.14/go.mod h1:NKVY7DER6VXHkt2I/ycmHakALNboi3Rqwt4eEf/1Cnk=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24 h1:JP2wjWGmUp8lTCZb13Dv0Eciyc1jbO8pd0HZVMHFlrc=
 github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24/go.mod h1:Ql9ziDutk8ERAN9HMaYANCW3lop451ppebkxEJMLCTM=
 github.com/aws/aws-sdk-go-v2/service/ssm v1.68.3 h1:bBoWhx8lsFLTXintRX64ZBXcmFZbGqUmaPUrjXECqIc=
@@ -273,10 +273,10 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theory-cloud/apptheory v0.18.1 h1:Dzx3gGn67elumKcqcnuisyQFwyhN5hF28Kr26FurmDM=
-github.com/theory-cloud/apptheory v0.18.1/go.mod h1:Qsn3OrjFjaJB9Z5sGx38BSGe+k59UJfamn5vmqnknQ8=
-github.com/theory-cloud/tabletheory v1.4.2 h1:ytFmtGEZwbt9QAmQdtUgsRCug2DvWZoPFufqg96NABU=
-github.com/theory-cloud/tabletheory v1.4.2/go.mod h1:L/ofefJDQQRU6ZMv57KfCoIlmB0Q5uZYUXLXrtYs+BE=
+github.com/theory-cloud/apptheory v0.19.1 h1:R8PVbgTMJ5IcRxhKwBDGss0hQnnASkPdnwErp/0qoAw=
+github.com/theory-cloud/apptheory v0.19.1/go.mod h1:VMmZLk5YSHB7NWj7OL8FgrWeI6+idTJGqYjaosn5nQc=
+github.com/theory-cloud/tabletheory v1.5.1 h1:2AQpln+cKQ8XCawL3cRsF4lDGkBkTEzEM18Nxbcv6r8=
+github.com/theory-cloud/tabletheory v1.5.1/go.mod h1:SvW/SkYjgmUFp051IrtKmp5T9KTyHfKJIYCtSgzSLEo=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/web/README.md
+++ b/web/README.md
@@ -5,7 +5,7 @@ This is the frontend for `lesser.host` (repo: `lesser-host`).
 ## Stack
 
 - Vite + Svelte 5 + TypeScript
-- `greater-components` (vendored via `greater` CLI, pinned to `greater-v0.4.2`)
+- `greater-components` (vendored via `greater` CLI, pinned to `greater-v0.6.0`)
 
 ## Local dev
 

--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://greater.components.dev/schema.json",
   "version": "1.0.0",
-  "ref": "greater-v0.4.4",
+  "ref": "greater-v0.6.0",
   "installMode": "vendored",
   "style": "default",
   "rsc": false,
@@ -24,57 +24,57 @@
   "installed": [
     {
       "name": "button",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:00.907Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.457Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "icons",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:00.982Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.562Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "utils",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:00.988Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.572Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "tokens",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:00.992Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.576Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "primitives",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:01.053Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.666Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "content",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:01.056Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:23.671Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "adapters",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:03.537Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:26.243Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "headless",
-      "version": "greater-v0.4.4",
-      "installedAt": "2026-03-16T14:36:03.545Z",
+      "version": "greater-v0.6.0",
+      "installedAt": "2026-03-28T22:18:26.267Z",
       "modified": false,
       "checksums": []
     }

--- a/web/src/lib/greater/adapters/graphql/LesserGraphQLAdapter.ts
+++ b/web/src/lib/greater/adapters/graphql/LesserGraphQLAdapter.ts
@@ -56,7 +56,6 @@ import type {
 	RevokeAgentAccessLeaseMutationVariables,
 	CreateAgentAccessLeaseSessionKeyChallengeMutationVariables,
 	AuthorizeAgentAccessLeaseSessionKeyMutationVariables,
-	CreateAgentAccessLeaseRenewChallengeMutationVariables,
 	ExchangeAgentAccessLeaseTokenMutationVariables,
 	UpdateAdminAgentPolicyMutationVariables,
 	AdminVerifyAgentMutationVariables,

--- a/web/src/lib/greater/adapters/graphql/generated/types.ts
+++ b/web/src/lib/greater/adapters/graphql/generated/types.ts
@@ -696,6 +696,8 @@ export type Agent = {
   readonly delegatedScopes: ReadonlyArray<Scalars['String']['output']>;
   readonly displayName: Scalars['String']['output'];
   readonly id: Scalars['ID']['output'];
+  readonly identitySemantics: AgentIdentitySemantics;
+  readonly mcpAccess: AgentMcpAccess;
   /** @deprecated Use ownerActor / agentOwner */
   readonly owner?: Maybe<Actor>;
   readonly ownerActor?: Maybe<Actor>;
@@ -706,6 +708,7 @@ export type Agent = {
   readonly verifiedAt?: Maybe<Scalars['Time']['output']>;
   /** @deprecated Use agentVersion */
   readonly version: Scalars['String']['output'];
+  readonly workflow?: Maybe<AgentWorkflowSurface>;
 };
 
 export type AgentAccessLease = {
@@ -842,15 +845,69 @@ export type AgentEdge = {
   readonly node: Agent;
 };
 
+export type AgentIdentityCard = {
+  readonly __typename: 'AgentIdentityCard';
+  readonly currentPhase: Scalars['String']['output'];
+  readonly currentState?: Maybe<Scalars['String']['output']>;
+  readonly handle?: Maybe<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly metrics?: Maybe<ReadonlyArray<AgentSurfaceMetric>>;
+  readonly name: Scalars['String']['output'];
+  readonly steward?: Maybe<AgentSurfaceActor>;
+  readonly summary: Scalars['String']['output'];
+  readonly tags?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+};
+
+export type AgentIdentitySemantics = {
+  readonly __typename: 'AgentIdentitySemantics';
+  readonly attributionLabel: Scalars['String']['output'];
+  readonly bodyIdentityPreserved: Scalars['Boolean']['output'];
+  readonly continuityState: Scalars['String']['output'];
+  readonly continuitySummary: Scalars['String']['output'];
+  readonly identityLabel: Scalars['String']['output'];
+  readonly identityState: Scalars['String']['output'];
+  readonly lifecycleState: Scalars['String']['output'];
+  readonly memoryReferencesPreserved: Scalars['Boolean']['output'];
+  readonly moderationLabel: Scalars['String']['output'];
+  readonly soulAgentId?: Maybe<Scalars['String']['output']>;
+  readonly soulBindingState: SoulBindingState;
+  readonly timelinePresencePreserved: Scalars['Boolean']['output'];
+};
+
+export type AgentLifecycleStep = {
+  readonly __typename: 'AgentLifecycleStep';
+  readonly phase: Scalars['String']['output'];
+  readonly state?: Maybe<Scalars['String']['output']>;
+  readonly status: Scalars['String']['output'];
+  readonly summary?: Maybe<Scalars['String']['output']>;
+  readonly title?: Maybe<Scalars['String']['output']>;
+};
+
+export type AgentMcpAccess = {
+  readonly __typename: 'AgentMCPAccess';
+  readonly authorizationServerURL: Scalars['String']['output'];
+  readonly guidance: ReadonlyArray<Scalars['String']['output']>;
+  readonly mcpURL: Scalars['String']['output'];
+  readonly protectedResourceURL: Scalars['String']['output'];
+  readonly registrationURL: Scalars['String']['output'];
+  readonly scopes: ReadonlyArray<Scalars['String']['output']>;
+};
+
 export type AgentPostAttribution = {
   readonly __typename: 'AgentPostAttribution';
   readonly constraints?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly continuityState?: Maybe<Scalars['String']['output']>;
+  readonly continuitySummary?: Maybe<Scalars['String']['output']>;
   readonly delegatedBy?: Maybe<Scalars['String']['output']>;
   readonly delegatedByDid?: Maybe<Scalars['String']['output']>;
+  readonly identityLabel?: Maybe<Scalars['String']['output']>;
+  readonly identityState?: Maybe<Scalars['String']['output']>;
   readonly memoryCitations?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
   readonly modelId?: Maybe<Scalars['String']['output']>;
+  readonly moderationLabel?: Maybe<Scalars['String']['output']>;
   readonly schemaVersion?: Maybe<Scalars['String']['output']>;
   readonly scopes?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly soulAgentId?: Maybe<Scalars['String']['output']>;
   readonly triggerDetails?: Maybe<Scalars['String']['output']>;
   readonly triggerType?: Maybe<Scalars['String']['output']>;
 };
@@ -867,6 +924,70 @@ export type AgentPostAttributionInput = {
   readonly triggerType?: InputMaybe<Scalars['String']['input']>;
 };
 
+export type AgentRuntimeSession = {
+  readonly __typename: 'AgentRuntimeSession';
+  readonly absoluteExpiresAt: Scalars['Time']['output'];
+  readonly authDiagnostic: AgentRuntimeSessionAuthDiagnostic;
+  readonly clientID: Scalars['String']['output'];
+  readonly createdAt: Scalars['Time']['output'];
+  readonly deviceLabel: Scalars['String']['output'];
+  readonly idleExpiresAt: Scalars['Time']['output'];
+  readonly lastUsedAt: Scalars['Time']['output'];
+  readonly revoked: Scalars['Boolean']['output'];
+  readonly revokedAt?: Maybe<Scalars['Time']['output']>;
+  readonly revokedReason?: Maybe<Scalars['String']['output']>;
+  readonly scope: Scalars['String']['output'];
+  readonly sessionID: Scalars['ID']['output'];
+};
+
+export type AgentRuntimeSessionAuthDiagnostic = {
+  readonly __typename: 'AgentRuntimeSessionAuthDiagnostic';
+  readonly failureAt?: Maybe<Scalars['Time']['output']>;
+  readonly failureCode?: Maybe<Scalars['String']['output']>;
+  readonly failureMessage?: Maybe<Scalars['String']['output']>;
+  readonly lastSuccessAt?: Maybe<Scalars['Time']['output']>;
+  readonly status: AgentRuntimeSessionAuthStatus;
+};
+
+export type AgentRuntimeSessionAuthStatus =
+  | 'EXPIRED'
+  | 'FAILED'
+  | 'HEALTHY'
+  | 'REVOKED';
+
+export type AgentSurfaceActor = {
+  readonly __typename: 'AgentSurfaceActor';
+  readonly avatarLabel?: Maybe<Scalars['String']['output']>;
+  readonly handle?: Maybe<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly name: Scalars['String']['output'];
+  readonly role: Scalars['String']['output'];
+  readonly statusLabel?: Maybe<Scalars['String']['output']>;
+};
+
+export type AgentSurfaceArtifact = {
+  readonly __typename: 'AgentSurfaceArtifact';
+  readonly description?: Maybe<Scalars['String']['output']>;
+  readonly emphasis?: Maybe<Scalars['String']['output']>;
+  readonly href?: Maybe<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly title: Scalars['String']['output'];
+};
+
+export type AgentSurfaceArtifactInput = {
+  readonly description?: InputMaybe<Scalars['String']['input']>;
+  readonly emphasis?: InputMaybe<Scalars['String']['input']>;
+  readonly href?: InputMaybe<Scalars['String']['input']>;
+  readonly title: Scalars['String']['input'];
+};
+
+export type AgentSurfaceMetric = {
+  readonly __typename: 'AgentSurfaceMetric';
+  readonly detail?: Maybe<Scalars['String']['output']>;
+  readonly label: Scalars['String']['output'];
+  readonly value: Scalars['String']['output'];
+};
+
 export type AgentType =
   | 'ASSISTANT'
   | 'BRIDGE'
@@ -874,6 +995,36 @@ export type AgentType =
   | 'CUSTOM'
   | 'MODERATOR'
   | 'RESEARCHER';
+
+export type AgentWorkflowConversationState = {
+  readonly __typename: 'AgentWorkflowConversationState';
+  readonly acceptedAt?: Maybe<Scalars['Time']['output']>;
+  readonly conversationId: Scalars['ID']['output'];
+  readonly declinedAt?: Maybe<Scalars['Time']['output']>;
+  readonly folder: Scalars['String']['output'];
+  readonly previewStatusId?: Maybe<Scalars['String']['output']>;
+  readonly requestState?: Maybe<Scalars['String']['output']>;
+  readonly requestedAt?: Maybe<Scalars['Time']['output']>;
+  readonly unread: Scalars['Boolean']['output'];
+  readonly updatedAt: Scalars['Time']['output'];
+};
+
+export type AgentWorkflowSurface = {
+  readonly __typename: 'AgentWorkflowSurface';
+  readonly checkpoint?: Maybe<SignatureCheckpointCard>;
+  readonly continuity?: Maybe<ContinuityPanel>;
+  readonly conversation?: Maybe<AgentWorkflowConversationState>;
+  readonly currentPhase: Scalars['String']['output'];
+  readonly currentState: Scalars['String']['output'];
+  readonly declaration?: Maybe<DeclarationPreviewCard>;
+  readonly graduation?: Maybe<GraduationSummaryCard>;
+  readonly identity: AgentIdentityCard;
+  readonly identitySemantics: AgentIdentitySemantics;
+  readonly lifecycle: ReadonlyArray<AgentLifecycleStep>;
+  readonly request?: Maybe<SoulRequestCard>;
+  readonly review?: Maybe<ReviewDecisionCard>;
+  readonly username: Scalars['String']['output'];
+};
 
 export type AlertLevel =
   | 'CRITICAL'
@@ -1132,6 +1283,26 @@ export type ContentMap = {
 export type ContentMapInput = {
   readonly content: Scalars['String']['input'];
   readonly language: Scalars['String']['input'];
+};
+
+export type ContinuityFollowUp = {
+  readonly __typename: 'ContinuityFollowUp';
+  readonly cadence?: Maybe<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly owner: AgentSurfaceActor;
+  readonly summary: Scalars['String']['output'];
+  readonly title: Scalars['String']['output'];
+};
+
+export type ContinuityPanel = {
+  readonly __typename: 'ContinuityPanel';
+  readonly feedbackLoop: Scalars['String']['output'];
+  readonly followUps?: Maybe<ReadonlyArray<ContinuityFollowUp>>;
+  readonly id: Scalars['ID']['output'];
+  readonly metrics?: Maybe<ReadonlyArray<AgentSurfaceMetric>>;
+  readonly objective: Scalars['String']['output'];
+  readonly owner: AgentSurfaceActor;
+  readonly title: Scalars['String']['output'];
 };
 
 export type Conversation = {
@@ -1401,6 +1572,18 @@ export type DateRangeInput = {
   readonly start: Scalars['Time']['input'];
 };
 
+export type DeclarationPreviewCard = {
+  readonly __typename: 'DeclarationPreviewCard';
+  readonly confidence: Scalars['String']['output'];
+  readonly declaredScope: ReadonlyArray<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly owner?: Maybe<AgentSurfaceActor>;
+  readonly risks?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly statement: Scalars['String']['output'];
+  readonly supportingArtifacts?: Maybe<ReadonlyArray<AgentSurfaceArtifact>>;
+  readonly title: Scalars['String']['output'];
+};
+
 export type DelegateToAgentInput = {
   readonly agentType: AgentType;
   readonly agentUsername: Scalars['String']['input'];
@@ -1508,6 +1691,12 @@ export type Driver = {
   readonly percentOfTotal: Scalars['Float']['output'];
   readonly trend: Trend;
   readonly type: Scalars['String']['output'];
+};
+
+export type DroneWorkflowMutationPayload = {
+  readonly __typename: 'DroneWorkflowMutationPayload';
+  readonly agent: Agent;
+  readonly workflow: AgentWorkflowSurface;
 };
 
 export type Entity = {
@@ -1757,6 +1946,25 @@ export type FilterTestResult = {
   readonly severity: Scalars['String']['output'];
 };
 
+export type FinalizeSoulPromotionInput = {
+  readonly completedMilestones?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+  readonly continuityFeedbackLoop?: InputMaybe<Scalars['String']['input']>;
+  readonly continuityObjective?: InputMaybe<Scalars['String']['input']>;
+  readonly conversationId?: InputMaybe<Scalars['ID']['input']>;
+  readonly declarationConfidence: Scalars['String']['input'];
+  readonly declarationRisks?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+  readonly declarationStatement: Scalars['String']['input'];
+  readonly declarationTitle?: InputMaybe<Scalars['String']['input']>;
+  readonly declaredScope: ReadonlyArray<Scalars['String']['input']>;
+  readonly exitCriteria?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+  readonly nextStep?: InputMaybe<Scalars['String']['input']>;
+  readonly readiness: Scalars['String']['input'];
+  readonly soulAgentId?: InputMaybe<Scalars['ID']['input']>;
+  readonly summary: Scalars['String']['input'];
+  readonly supportingArtifacts?: InputMaybe<ReadonlyArray<AgentSurfaceArtifactInput>>;
+  readonly username: Scalars['String']['input'];
+};
+
 export type FlagInput = {
   readonly evidence?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
   readonly objectId: Scalars['ID']['input'];
@@ -1781,6 +1989,19 @@ export type FlowNode = {
 export type FocusInput = {
   readonly x: Scalars['Float']['input'];
   readonly y: Scalars['Float']['input'];
+};
+
+export type GraduationSummaryCard = {
+  readonly __typename: 'GraduationSummaryCard';
+  readonly completedMilestones?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly exitCriteria?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly id: Scalars['ID']['output'];
+  readonly launchOwner?: Maybe<AgentSurfaceActor>;
+  readonly metrics?: Maybe<ReadonlyArray<AgentSurfaceMetric>>;
+  readonly nextStep?: Maybe<Scalars['String']['output']>;
+  readonly readiness: Scalars['String']['output'];
+  readonly summary: Scalars['String']['output'];
+  readonly title: Scalars['String']['output'];
 };
 
 export type GroupedNotificationGroup = {
@@ -2671,6 +2892,7 @@ export type Mutation = {
   readonly dismissNotification: Scalars['Boolean']['output'];
   readonly exchangeAgentAccessLeaseToken: AgentAccessLeaseTokenPayload;
   readonly exportReputation: PortableReputation;
+  readonly finalizeSoulPromotion: DroneWorkflowMutationPayload;
   readonly flagObject: FlagPayload;
   readonly followActor: Activity;
   readonly followHashtag: HashtagFollowPayload;
@@ -2701,10 +2923,13 @@ export type Mutation = {
   readonly reorderSeriesArticles: Series;
   readonly reportStreamingQuality: StreamingQualityReport;
   readonly requestAIAnalysis: AiAnalysisRequest;
+  readonly requestSoulPromotion: DroneWorkflowMutationPayload;
   readonly requestStreamingUrl: MediaStream;
   readonly restoreRevision: Article;
   readonly resumeFederation: FederationManagementStatus;
+  readonly reviewSoulPromotion: DroneWorkflowMutationPayload;
   readonly revokeAgentAccessLease: AgentAccessLease;
+  readonly revokeAgentRuntimeSession: AgentRuntimeSession;
   readonly revokeAgentToken: Scalars['Boolean']['output'];
   readonly revokeVouch: Scalars['Boolean']['output'];
   readonly saveMarkers: MarkerSet;
@@ -3187,6 +3412,11 @@ export type MutationExchangeAgentAccessLeaseTokenArgs = {
 };
 
 
+export type MutationFinalizeSoulPromotionArgs = {
+  input: FinalizeSoulPromotionInput;
+};
+
+
 export type MutationFlagObjectArgs = {
   input: FlagInput;
 };
@@ -3354,6 +3584,11 @@ export type MutationRequestAiAnalysisArgs = {
 };
 
 
+export type MutationRequestSoulPromotionArgs = {
+  input: RequestSoulPromotionInput;
+};
+
+
 export type MutationRequestStreamingUrlArgs = {
   mediaId: Scalars['ID']['input'];
   quality?: InputMaybe<StreamQuality>;
@@ -3371,9 +3606,21 @@ export type MutationResumeFederationArgs = {
 };
 
 
+export type MutationReviewSoulPromotionArgs = {
+  input: ReviewSoulPromotionInput;
+};
+
+
 export type MutationRevokeAgentAccessLeaseArgs = {
   input?: InputMaybe<RevokeAgentAccessLeaseInput>;
   leaseID: Scalars['ID']['input'];
+  username: Scalars['String']['input'];
+};
+
+
+export type MutationRevokeAgentRuntimeSessionArgs = {
+  reason?: InputMaybe<Scalars['String']['input']>;
+  sessionID: Scalars['ID']['input'];
   username: Scalars['String']['input'];
 };
 
@@ -3405,16 +3652,26 @@ export type MutationScheduleStatusArgs = {
 
 
 export type MutationSendDirectMessageArgs = {
+  agentAttribution?: InputMaybe<AgentPostAttributionInput>;
   content: Scalars['String']['input'];
+  inReplyToId?: InputMaybe<Scalars['ID']['input']>;
+  language?: InputMaybe<Scalars['String']['input']>;
   mediaIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  sensitive?: InputMaybe<Scalars['Boolean']['input']>;
+  spoilerText?: InputMaybe<Scalars['String']['input']>;
   to: Scalars['ID']['input'];
 };
 
 
 export type MutationSendMessageArgs = {
+  agentAttribution?: InputMaybe<AgentPostAttributionInput>;
   content: Scalars['String']['input'];
   conversationId: Scalars['ID']['input'];
+  inReplyToId?: InputMaybe<Scalars['ID']['input']>;
+  language?: InputMaybe<Scalars['String']['input']>;
   mediaIds?: InputMaybe<ReadonlyArray<Scalars['ID']['input']>>;
+  sensitive?: InputMaybe<Scalars['Boolean']['input']>;
+  spoilerText?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -4091,6 +4348,7 @@ export type Query = {
   readonly agentAccessLeases: ReadonlyArray<AgentAccessLease>;
   readonly agentActivity: AgentActivityConnection;
   readonly agentMemorySearch: ObjectConnection;
+  readonly agentRuntimeSessions: ReadonlyArray<AgentRuntimeSession>;
   readonly agents: AgentConnection;
   readonly aiAnalysis?: Maybe<AiAnalysis>;
   readonly aiCapabilities: AiCapabilities;
@@ -4115,6 +4373,7 @@ export type Query = {
   readonly customEmojis: ReadonlyArray<CustomEmoji>;
   readonly domainBlocks: DomainBlockPage;
   readonly draft?: Maybe<Draft>;
+  readonly droneWorkflow?: Maybe<AgentWorkflowSurface>;
   readonly endorsements: ReadonlyArray<Actor>;
   readonly explainObject: ObjectExplanation;
   readonly export?: Maybe<ExportJob>;
@@ -4166,6 +4425,8 @@ export type Query = {
   readonly mutes: ActorListPage;
   readonly myAgents: ReadonlyArray<Agent>;
   readonly myDrafts: DraftConnection;
+  readonly myDroneRequests: ReadonlyArray<SoulRequestCard>;
+  readonly myDroneReviews: ReadonlyArray<ReviewDecisionCard>;
   readonly myPublications: ReadonlyArray<Publication>;
   readonly mySouls: ReadonlyArray<SoulInventoryItem>;
   readonly notification?: Maybe<Notification>;
@@ -4344,6 +4605,11 @@ export type QueryAgentMemorySearchArgs = {
 };
 
 
+export type QueryAgentRuntimeSessionsArgs = {
+  username: Scalars['String']['input'];
+};
+
+
 export type QueryAgentsArgs = {
   after?: InputMaybe<Scalars['Cursor']['input']>;
   first?: InputMaybe<Scalars['Int']['input']>;
@@ -4466,6 +4732,11 @@ export type QueryDomainBlocksArgs = {
 
 export type QueryDraftArgs = {
   id: Scalars['ID']['input'];
+};
+
+
+export type QueryDroneWorkflowArgs = {
+  username: Scalars['String']['input'];
 };
 
 
@@ -5164,6 +5435,51 @@ export type ReputationVerificationResult = {
   readonly valid: Scalars['Boolean']['output'];
 };
 
+export type RequestSoulPromotionInput = {
+  readonly artifacts?: InputMaybe<ReadonlyArray<AgentSurfaceArtifactInput>>;
+  readonly constraints?: InputMaybe<ReadonlyArray<Scalars['String']['input']>>;
+  readonly conversationId?: InputMaybe<Scalars['ID']['input']>;
+  readonly routeDecision?: InputMaybe<Scalars['String']['input']>;
+  readonly summary: Scalars['String']['input'];
+  readonly title: Scalars['String']['input'];
+  readonly username: Scalars['String']['input'];
+};
+
+export type ReviewDecisionCard = {
+  readonly __typename: 'ReviewDecisionCard';
+  readonly decision: Scalars['String']['output'];
+  readonly decisionSummary: Scalars['String']['output'];
+  readonly evidence?: Maybe<ReadonlyArray<AgentSurfaceArtifact>>;
+  readonly findings?: Maybe<ReadonlyArray<ReviewFinding>>;
+  readonly id: Scalars['ID']['output'];
+  readonly reviewer: AgentSurfaceActor;
+  readonly title: Scalars['String']['output'];
+};
+
+export type ReviewFinding = {
+  readonly __typename: 'ReviewFinding';
+  readonly detail: Scalars['String']['output'];
+  readonly id: Scalars['ID']['output'];
+  readonly severity?: Maybe<Scalars['String']['output']>;
+  readonly title: Scalars['String']['output'];
+};
+
+export type ReviewFindingInput = {
+  readonly detail: Scalars['String']['input'];
+  readonly severity?: InputMaybe<Scalars['String']['input']>;
+  readonly title: Scalars['String']['input'];
+};
+
+export type ReviewSoulPromotionInput = {
+  readonly conversationId?: InputMaybe<Scalars['ID']['input']>;
+  readonly decision: Scalars['String']['input'];
+  readonly decisionSummary: Scalars['String']['input'];
+  readonly evidence?: InputMaybe<ReadonlyArray<AgentSurfaceArtifactInput>>;
+  readonly findings?: InputMaybe<ReadonlyArray<ReviewFindingInput>>;
+  readonly title?: InputMaybe<Scalars['String']['input']>;
+  readonly username: Scalars['String']['input'];
+};
+
 export type Revision = {
   readonly __typename: 'Revision';
   readonly changeSummary?: Maybe<Scalars['String']['output']>;
@@ -5333,6 +5649,25 @@ export type SeveredRelationshipEdge = {
   readonly node: SeveredRelationship;
 };
 
+export type SignatureCheckpointCard = {
+  readonly __typename: 'SignatureCheckpointCard';
+  readonly approvalMemo?: Maybe<Scalars['String']['output']>;
+  readonly dueAt?: Maybe<Scalars['Time']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly readinessLabel: Scalars['String']['output'];
+  readonly signers: ReadonlyArray<SignatureCheckpointSigner>;
+  readonly title: Scalars['String']['output'];
+};
+
+export type SignatureCheckpointSigner = {
+  readonly __typename: 'SignatureCheckpointSigner';
+  readonly id: Scalars['ID']['output'];
+  readonly name: Scalars['String']['output'];
+  readonly note?: Maybe<Scalars['String']['output']>;
+  readonly role: Scalars['String']['output'];
+  readonly status: Scalars['String']['output'];
+};
+
 export type SoulAgentBinding = {
   readonly __typename: 'SoulAgentBinding';
   readonly agentUsername: Scalars['String']['output'];
@@ -5368,6 +5703,19 @@ export type SoulInventoryItem = {
   readonly availableForIncorporation: Scalars['Boolean']['output'];
   readonly binding?: Maybe<SoulAgentBinding>;
   readonly bindingState: SoulBindingState;
+};
+
+export type SoulRequestCard = {
+  readonly __typename: 'SoulRequestCard';
+  readonly artifacts?: Maybe<ReadonlyArray<AgentSurfaceArtifact>>;
+  readonly constraints?: Maybe<ReadonlyArray<Scalars['String']['output']>>;
+  readonly currentState?: Maybe<Scalars['String']['output']>;
+  readonly id: Scalars['ID']['output'];
+  readonly requestedBy: AgentSurfaceActor;
+  readonly routeDecision?: Maybe<Scalars['String']['output']>;
+  readonly submittedAt?: Maybe<Scalars['Time']['output']>;
+  readonly summary: Scalars['String']['output'];
+  readonly title: Scalars['String']['output'];
 };
 
 export type SpamAnalysis = {

--- a/web/src/lib/greater/adapters/index.ts
+++ b/web/src/lib/greater/adapters/index.ts
@@ -108,7 +108,13 @@ export { createLesserMessagesHandlers } from './messaging/index.js';
 export type { LesserMessagesHandlersConfig } from './messaging/index.js';
 
 // Reactive Stores (Svelte 5 Runes)
-export { createTimelineStore, createNotificationStore, createPresenceStore } from './stores';
+export {
+	createTimelineStore,
+	createNotificationStore,
+	createPresenceStore,
+	createBrowserPresenceActivitySource,
+	createBrowserPresenceLocationSource,
+} from './stores';
 
 // Admin Streaming Store
 export { AdminStreamingStore, createAdminStreamingStore } from './stores/adminStreamingStore';
@@ -228,6 +234,10 @@ export type {
 	TimelineStore,
 	NotificationStore,
 	PresenceStore,
+	PresenceActivitySource,
+	PresenceLocationSource,
+	BrowserPresenceActivitySourceOptions,
+	BrowserPresenceLocationSourceOptions,
 	BaseStore,
 	StoreFactory,
 

--- a/web/src/lib/greater/adapters/messaging/createLesserMessagesHandlers.ts
+++ b/web/src/lib/greater/adapters/messaging/createLesserMessagesHandlers.ts
@@ -196,8 +196,13 @@ export function createLesserMessagesHandlers(
 				throw new Error('DM v1 only supports 1:1 conversations');
 			}
 
+			const participantId = participantIds[0];
+			if (participantId === undefined) {
+				throw new Error('participantId is required for DM conversation creation');
+			}
+
 			const data = await adapter.mutate(CreateConversationDocument, {
-				participantId: participantIds[0]!,
+				participantId,
 			});
 
 			return mapConversationToUiConversation(

--- a/web/src/lib/greater/adapters/rest/generated/lesser-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-api.ts
@@ -52,6 +52,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/.well-known/oauth-authorization-server": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_well_known_oauth_authorization_server"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/.well-known/reputation-keys": {
         parameters: {
             query?: never;
@@ -1316,6 +1332,38 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{username}/runtime-sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_api_v1_agents_by_username_runtime_sessions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{username}/runtime-sessions/{sessionID}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["post_api_v1_agents_by_username_runtime_sessions_by_sessionID_revoke"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{username}/suspend": {
         parameters: {
             query?: never;
@@ -1486,6 +1534,22 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["post_api_v1_apps"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/apps/{id}/rotate_secret": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["post_api_v1_apps_by_id_rotate_secret"];
         delete?: never;
         options?: never;
         head?: never;
@@ -3748,6 +3812,22 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/device": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_auth_device"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/wallet/challenge": {
         parameters: {
             query?: never;
@@ -4014,6 +4094,22 @@ export interface paths {
         get?: never;
         put?: never;
         post: operations["post_oauth_device_verify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/oauth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["post_oauth_register"];
         delete?: never;
         options?: never;
         head?: never;
@@ -4553,6 +4649,8 @@ export interface components {
             created_at?: components["schemas"]["RFC3339DateTime"] | null;
             delegated_scopes?: string[];
             display_name: string;
+            identity_semantics: components["schemas"]["AgentIdentitySemantics"];
+            mcp_access: components["schemas"]["AgentMCPAccess"];
             username: string;
             verified: boolean;
             verified_at?: components["schemas"]["RFC3339DateTime"] | null;
@@ -4645,6 +4743,7 @@ export interface components {
             agent_info?: unknown;
             agent_username: string;
             bio?: string;
+            device_label?: string;
             display_name: string;
             expires_in?: number;
             scopes: string[];
@@ -4652,6 +4751,20 @@ export interface components {
         AgentDelegationResponse: {
             account: components["schemas"]["Account"];
             token: components["schemas"]["OAuthTokenResponse"];
+        };
+        AgentIdentitySemantics: {
+            attribution_label: string;
+            body_identity_preserved: boolean;
+            continuity_state: string;
+            continuity_summary: string;
+            identity_label: string;
+            identity_state: string;
+            lifecycle_state: string;
+            memory_references_preserved: boolean;
+            moderation_label: string;
+            soul_agent_id?: string;
+            soul_binding_state: string;
+            timeline_presence_preserved: boolean;
         };
         AgentKeyChallengeRequest: {
             username: string;
@@ -4665,6 +4778,14 @@ export interface components {
             username: string;
         };
         AgentList: components["schemas"]["Agent"][];
+        AgentMCPAccess: {
+            authorization_server_url: string;
+            guidance: string[];
+            mcp_url: string;
+            protected_resource_url: string;
+            registration_url: string;
+            scopes: string[];
+        };
         AgentMemoryEventRequest: {
             event_type?: string;
             original_id?: string;
@@ -4702,12 +4823,18 @@ export interface components {
         };
         AgentPostAttribution: {
             constraints?: string[];
+            continuity_state?: string;
+            continuity_summary?: string;
             delegated_by?: string;
             delegated_by_did?: string;
+            identity_label?: string;
+            identity_state?: string;
             memory_citations?: string[];
             model_id?: string;
+            moderation_label?: string;
             schema_version?: string;
             scopes?: string[];
+            soul_agent_id?: string;
             trigger_details?: string;
             trigger_type?: string;
         };
@@ -4717,8 +4844,23 @@ export interface components {
             public_key: string;
             signature: string;
         };
+        AgentRuntimeSession: {
+            absolute_expires_at: components["schemas"]["RFC3339DateTime"];
+            client_id: string;
+            created_at: components["schemas"]["RFC3339DateTime"];
+            device_label: string;
+            idle_expires_at: components["schemas"]["RFC3339DateTime"];
+            last_used_at: components["schemas"]["RFC3339DateTime"];
+            revoked: boolean;
+            revoked_at?: components["schemas"]["RFC3339DateTime"] | null;
+            revoked_reason?: string;
+            scope: string;
+            session_id: string;
+        };
+        AgentRuntimeSessionList: components["schemas"]["AgentRuntimeSession"][];
         AgentSelfAuthTokenRequest: {
             challenge_id: string;
+            device_label?: string;
             signature: string;
             username: string;
         };
@@ -4726,6 +4868,7 @@ export interface components {
             agent_info?: unknown;
             bio?: string;
             challenge_id: string;
+            device_label?: string;
             display_name: string;
             key_type: string;
             public_key: string;
@@ -4780,20 +4923,38 @@ export interface components {
             [key: string]: unknown;
         };
         AppRegistrationRequest: {
+            /** @description Optional Lesser client classification. Public registration accepts `cli` and `web`; `agent` is not accepted on public registration surfaces. */
             client_class?: string;
             client_name: string;
+            grant_types?: string;
             redirect_uris: string;
             scopes: string;
+            token_endpoint_auth_method?: string;
             website?: string;
         };
         AppRegistrationResponse: {
             client_id: string;
             client_secret?: string;
+            grant_types?: string[];
             id: string;
             name: string;
             redirect_uri: string;
+            token_endpoint_auth_method?: string;
             vapid_key?: string;
             website?: string;
+        };
+        AppSecretRotationRequest: {
+            force_invalidate?: boolean;
+            grace_period_seconds?: number;
+        };
+        AppSecretRotationResponse: {
+            client_id: string;
+            client_secret: string;
+            forced_invalidation?: boolean;
+            grace_period_seconds?: number;
+            previous_secret_valid_until?: string;
+            rotated_at?: string;
+            token_endpoint_auth_method?: string;
         };
         AuthAuthResponse: {
             access_token: string;
@@ -5514,11 +5675,13 @@ export interface components {
         NotificationDeliveryFrom: {
             address: string;
             displayName: string;
+            number?: string;
             soulAgentId?: string | null;
         };
         NotificationDeliveryRequest: {
             attachments?: components["schemas"]["NotificationDeliveryAttachment"][];
             body: string;
+            bodyMimeType?: string;
             channel: string;
             from: components["schemas"]["NotificationDeliveryFrom"];
             inReplyTo?: string | null;
@@ -5530,6 +5693,7 @@ export interface components {
         };
         NotificationDeliveryTo: {
             address: string;
+            number?: string;
         };
         NotificationFilter: {
             AccountID: string;
@@ -5585,6 +5749,45 @@ export interface components {
             status: string;
             user_code: string;
         };
+        OAuthDynamicClientRegistrationRequest: {
+            /** @description Optional Lesser client classification. Public registration accepts `cli` and `web`; `agent` is not accepted on public registration surfaces. */
+            client_class?: string;
+            client_name?: string;
+            client_uri?: string;
+            contacts?: string[];
+            grant_types?: string[];
+            logo_uri?: string;
+            policy_uri?: string;
+            redirect_uris?: string[];
+            response_types?: string[];
+            scope?: string;
+            software_id?: string;
+            software_version?: string;
+            token_endpoint_auth_method?: string;
+            tos_uri?: string;
+        };
+        OAuthDynamicClientRegistrationResponse: {
+            /** @description Lesser client classification persisted for the registered public client. */
+            client_class?: string;
+            client_id: string;
+            client_id_issued_at: number;
+            client_name?: string;
+            client_secret?: string;
+            client_secret_expires_at: number;
+            client_uri?: string;
+            contacts?: string[];
+            grant_types?: string[];
+            logo_uri?: string;
+            policy_uri?: string;
+            redirect_uris?: string[];
+            registration_source?: string;
+            response_types?: string[];
+            scope?: string;
+            software_id?: string;
+            software_version?: string;
+            token_endpoint_auth_method?: string;
+            tos_uri?: string;
+        };
         OAuthErrorResponse: {
             error: string;
             error_description?: string;
@@ -5605,6 +5808,8 @@ export interface components {
             grant_type: string;
             redirect_uri?: string;
             refresh_token?: string;
+            /** @description Canonical target resource URI. For remote MCP authorization, this must match the actor-scoped MCP URL used during the authorize request. */
+            resource?: string;
             scope?: string;
         };
         OAuthTokenResponse: {
@@ -5892,6 +6097,9 @@ export interface components {
             severity: number;
         };
         RevokeAgentAccessLeaseRequest: {
+            reason?: string;
+        };
+        RevokeAgentRuntimeSessionRequest: {
             reason?: string;
         };
         Role: {
@@ -6465,12 +6673,18 @@ export interface components {
                 };
                 agentAttribution?: {
                     constraints?: string[];
+                    continuity_state?: string;
+                    continuity_summary?: string;
                     delegated_by?: string;
                     delegated_by_did?: string;
+                    identity_label?: string;
+                    identity_state?: string;
                     memory_citations?: string[];
                     model_id?: string;
+                    moderation_label?: string;
                     schema_version?: string;
                     scopes?: string[];
+                    soul_agent_id?: string;
                     trigger_details?: string;
                     trigger_type?: string;
                 } | null;
@@ -6623,6 +6837,7 @@ export interface components {
             issued_at: components["schemas"]["RFC3339DateTime"];
             message: string;
             nonce: string;
+            registration_completed?: boolean;
             spent: boolean;
             used: boolean;
             username: string;
@@ -7111,6 +7326,28 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["NodeInfoWellKnown"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    get_well_known_oauth_authorization_server: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Map7d31df2b"];
                 };
             };
             400: components["responses"]["BadRequest"];
@@ -9791,6 +10028,62 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    get_api_v1_agents_by_username_runtime_sessions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRuntimeSessionList"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    post_api_v1_agents_by_username_runtime_sessions_by_sessionID_revoke: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                sessionID: string;
+                username: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": components["schemas"]["RevokeAgentRuntimeSessionRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRuntimeSession"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            404: components["responses"]["NotFound"];
+            422: components["responses"]["UnprocessableEntity"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
     post_api_v1_agents_by_username_suspend: {
         parameters: {
             query?: never;
@@ -10145,6 +10438,34 @@ export interface operations {
             400: components["responses"]["BadRequest"];
             401: components["responses"]["Unauthorized"];
             403: components["responses"]["Forbidden"];
+            422: components["responses"]["UnprocessableEntity"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    post_api_v1_apps_by_id_rotate_secret: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AppSecretRotationResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            404: components["responses"]["NotFound"];
             422: components["responses"]["UnprocessableEntity"];
             500: components["responses"]["InternalServerError"];
         };
@@ -12593,6 +12914,8 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
             500: components["responses"]["InternalServerError"];
         };
     };
@@ -14983,6 +15306,26 @@ export interface operations {
             500: components["responses"]["InternalServerError"];
         };
     };
+    get_auth_device: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            400: components["responses"]["BadRequest"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
     post_auth_wallet_challenge: {
         parameters: {
             query?: never;
@@ -15307,6 +15650,8 @@ export interface operations {
                 mode?: string;
                 /** @description OAuth redirect URI (must match registered redirect URI). */
                 redirect_uri: string;
+                /** @description Canonical target resource URI. Required for remote MCP authorization; must be the actor-scoped MCP URL served by this Lesser instance. */
+                resource?: string;
                 /** @description OAuth response type (must be `code`). */
                 response_type: string;
                 /** @description Space-delimited OAuth scope list. */
@@ -15482,6 +15827,49 @@ export interface operations {
                 };
             };
             400: components["responses"]["BadRequest"];
+            422: components["responses"]["UnprocessableEntity"];
+            429: components["responses"]["TooManyRequests"];
+            500: components["responses"]["InternalServerError"];
+        };
+    };
+    post_oauth_register: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["OAuthDynamicClientRegistrationRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    /** @description Request limit per window. */
+                    "X-RateLimit-Limit"?: number;
+                    /** @description Requests remaining in the current window. */
+                    "X-RateLimit-Remaining"?: number;
+                    /** @description Unix timestamp (seconds) when the current window resets. */
+                    "X-RateLimit-Reset"?: number;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OAuthDynamicClientRegistrationResponse"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
+            401: components["responses"]["Unauthorized"];
+            403: components["responses"]["Forbidden"];
+            /** @description Unsupported media type */
+            415: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             422: components["responses"]["UnprocessableEntity"];
             429: components["responses"]["TooManyRequests"];
             500: components["responses"]["InternalServerError"];

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -107,6 +107,193 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/soul/agents/register/begin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Begin a soul promotion request */
+        post: operations["soulRegisterBegin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/register/{id}/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Verify proofs and principal approval for a soul promotion request */
+        post: operations["soulRegisterVerify"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/register/{id}/mint-conversation/{conversationId}/finalize/preflight": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Build finalize preflight data for a completed mint conversation */
+        post: operations["soulMintConversationFinalizePreflight"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/register/{id}/mint-conversation/{conversationId}/finalize/begin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Compatibility alias for finalize preflight */
+        post: operations["soulMintConversationFinalizeBegin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/mint-conversation/{conversationId}/finalize/preflight": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Build finalize preflight data using the stable agentId handle */
+        post: operations["soulAgentMintConversationFinalizePreflight"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/mint-conversation/{conversationId}/finalize/begin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Compatibility alias for finalize preflight via the stable agentId handle */
+        post: operations["soulAgentMintConversationFinalizeBegin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/promotions/mine": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List durable promotion workflows for the authenticated requester */
+        get: operations["soulListMyPromotions"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/promotions/mine/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List structured promotion lifecycle events for the authenticated requester */
+        get: operations["soulListMyPromotionLifecycleEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/promotion": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get the durable, agent-centered promotion state */
+        get: operations["soulGetPromotion"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/promotion/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Verify a soul promotion request using the stable agentId handle */
+        post: operations["soulVerifyPromotion"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/soul/agents/{agentId}/promotion/events": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List structured lifecycle events for a single agent promotion workflow */
+        get: operations["soulListAgentPromotionLifecycleEvents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/soul/comm/send": {
         parameters: {
             query?: never;
@@ -300,6 +487,270 @@ export interface components {
         SoulAgentCommActivityResponse: components["schemas"]["soul-agent-comm-activity.response.schema"];
         SoulAgentCommQueueItem: components["schemas"]["soul-agent-comm-queue-item.schema"];
         SoulAgentCommQueueResponse: components["schemas"]["soul-agent-comm-queue.response.schema"];
+        SafeTxPayload: {
+            safe_address: string;
+            to: string;
+            value: string;
+            data: string;
+        };
+        SoulOperation: {
+            operation_id: string;
+            kind: string;
+            agent_id?: string;
+            /** @enum {string} */
+            status: "pending" | "proposed" | "executed" | "failed";
+            safe_payload?: string;
+            exec_tx_hash?: string;
+            exec_block_number?: number;
+            exec_success?: boolean;
+            receipt_json?: string;
+            snapshot_json?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: date-time */
+            executed_at?: string;
+        };
+        WalletChallengeResponse: {
+            id: string;
+            username?: string;
+            address: string;
+            chainId: number;
+            nonce: string;
+            message: string;
+            /** Format: date-time */
+            issuedAt: string;
+            /** Format: date-time */
+            expiresAt: string;
+        };
+        SoulRegistryProofInstructions: {
+            /** @enum {string} */
+            method: "dns_txt" | "https_well_known";
+            dns_name?: string;
+            dns_value?: string;
+            /** Format: uri */
+            https_url?: string;
+            https_body?: string;
+        };
+        SoulAgentRegistration: {
+            id: string;
+            username?: string;
+            domain_raw?: string;
+            domain_normalized: string;
+            local_id_raw?: string;
+            local_id: string;
+            agent_id: string;
+            wallet_address: string;
+            capabilities?: string[];
+            wallet_nonce?: string;
+            wallet_message?: string;
+            proof_token?: string;
+            dns_verified?: boolean;
+            https_verified?: boolean;
+            wallet_verified?: boolean;
+            /** Format: date-time */
+            verified_at?: string;
+            /** @enum {string} */
+            status: "pending" | "completed";
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            /** Format: date-time */
+            expires_at?: string;
+            /** Format: date-time */
+            completed_at?: string;
+        };
+        SoulAgentPromotionPrerequisites: {
+            principal_declaration_recorded: boolean;
+            mint_operation_created: boolean;
+            mint_executed: boolean;
+            conversation_started: boolean;
+            conversation_completed: boolean;
+            review_draft_ready: boolean;
+            ready_for_finalize: boolean;
+            graduated: boolean;
+        };
+        SoulAgentPromotion: {
+            agent_id: string;
+            registration_id?: string;
+            requested_by?: string;
+            domain: string;
+            local_id: string;
+            wallet: string;
+            /** @enum {string} */
+            stage: "requested" | "approved" | "minted" | "reviewing" | "ready_to_finalize" | "graduated";
+            /** @enum {string} */
+            request_status: "requested" | "verified" | "minted" | "graduated";
+            /** @enum {string} */
+            review_status: "not_started" | "conversation_in_progress" | "draft_ready" | "published";
+            /** @enum {string} */
+            approval_status: "pending" | "approved";
+            /** @enum {string} */
+            readiness_status: "awaiting_verification" | "awaiting_mint" | "ready_for_conversation" | "ready_for_finalize" | "graduated";
+            mint_operation_id?: string;
+            /** @enum {string} */
+            mint_operation_status?: "pending" | "proposed" | "executed" | "failed";
+            principal_address?: string;
+            latest_conversation_id?: string;
+            /** @enum {string} */
+            latest_conversation_status?: "in_progress" | "completed" | "failed";
+            latest_review_sha256?: string;
+            latest_boundary_count?: number;
+            latest_capability_count?: number;
+            published_version?: number;
+            /** Format: date-time */
+            requested_at?: string;
+            /** Format: date-time */
+            verified_at?: string;
+            /** Format: date-time */
+            approved_at?: string;
+            /** Format: date-time */
+            minted_at?: string;
+            /** Format: date-time */
+            review_started_at?: string;
+            /** Format: date-time */
+            review_ready_at?: string;
+            /** Format: date-time */
+            graduated_at?: string;
+            /** Format: date-time */
+            created_at: string;
+            /** Format: date-time */
+            updated_at: string;
+            prerequisites: components["schemas"]["SoulAgentPromotionPrerequisites"];
+            next_actions?: ("verify_request" | "record_mint_execution" | "start_review_conversation" | "complete_review_conversation" | "begin_finalize")[];
+        };
+        SoulAgentPromotionResponse: {
+            /** @enum {string} */
+            version: "1";
+            promotion: components["schemas"]["SoulAgentPromotion"];
+        };
+        SoulAgentPromotionListResponse: {
+            /** @enum {string} */
+            version: "1";
+            promotions: components["schemas"]["SoulAgentPromotion"][];
+            count: number;
+            has_more: boolean;
+            next_cursor?: string;
+        };
+        SoulAgentPromotionLifecycleEvent: {
+            event_id: string;
+            /** @enum {string} */
+            event_type: "request_created" | "request_approved" | "mint_executed" | "review_started" | "finalize_ready" | "graduated";
+            summary?: string;
+            /** Format: date-time */
+            occurred_at: string;
+            request_id?: string;
+            operation_id?: string;
+            conversation_id?: string;
+            promotion: components["schemas"]["SoulAgentPromotion"];
+        };
+        SoulAgentPromotionLifecycleEventListResponse: {
+            /** @enum {string} */
+            version: "1";
+            events: components["schemas"]["SoulAgentPromotionLifecycleEvent"][];
+            count: number;
+            has_more: boolean;
+            next_cursor?: string;
+        };
+        SoulAgentRegistrationBeginRequest: {
+            domain: string;
+            local_id: string;
+            wallet_address: string;
+            capabilities?: (string | {
+                [key: string]: unknown;
+            })[];
+        };
+        SoulAgentRegistrationBeginResponse: {
+            registration: components["schemas"]["SoulAgentRegistration"];
+            wallet: components["schemas"]["WalletChallengeResponse"];
+            proofs: components["schemas"]["SoulRegistryProofInstructions"][];
+            promotion?: components["schemas"]["SoulAgentPromotion"];
+        };
+        SoulAgentRegistrationVerifyRequest: {
+            signature: string;
+            principal_address: string;
+            principal_declaration: string;
+            principal_signature: string;
+            /** Format: date-time */
+            declared_at: string;
+        };
+        SoulAgentRegistrationVerifyResponse: {
+            registration: components["schemas"]["SoulAgentRegistration"];
+            operation: components["schemas"]["SoulOperation"];
+            safe_tx?: components["schemas"]["SafeTxPayload"];
+            promotion?: components["schemas"]["SoulAgentPromotion"];
+        };
+        SoulMintConversationFinalizeBeginRequest: {
+            boundary_signatures: {
+                [key: string]: string;
+            };
+        };
+        SoulMintConversationDeclarationPreview: {
+            selfDescription: {
+                [key: string]: unknown;
+            };
+            capabilities: {
+                [key: string]: unknown;
+            }[];
+            boundaries: {
+                [key: string]: unknown;
+            }[];
+            transparency: {
+                [key: string]: unknown;
+            };
+        };
+        SoulMintConversationFinalizeBoundaryRequirement: {
+            boundary_id: string;
+            category: string;
+            statement: string;
+            rationale?: string;
+            supersedes?: string;
+            signature_hex?: string;
+            signer_wallet: string;
+            /** @enum {string} */
+            signing_method: "eip191_personal_sign";
+            /** @enum {string} */
+            message_encoding: "utf8";
+            message: string;
+            digest_hex: string;
+        };
+        SoulMintConversationFinalizeSigningInput: {
+            signer_wallet: string;
+            /** @enum {string} */
+            signing_method: "eip191_personal_sign";
+            /** @enum {string} */
+            message_encoding: "hex_bytes";
+            message_hex: string;
+            digest_hex: string;
+            canonical_json: string;
+        };
+        SoulMintConversationFinalizeRequestTemplate: {
+            boundary_signatures: {
+                [key: string]: string;
+            };
+            /** Format: date-time */
+            issued_at: string;
+            expected_version: number;
+            self_attestation: string;
+        };
+        SoulMintConversationFinalizePreflightResponse: {
+            /** @enum {string} */
+            version: "1";
+            digest_hex: string;
+            /** Format: date-time */
+            issued_at: string;
+            expected_version: number;
+            next_version: number;
+            declarations_preview: components["schemas"]["SoulMintConversationDeclarationPreview"];
+            boundary_requirements: components["schemas"]["SoulMintConversationFinalizeBoundaryRequirement"][];
+            self_attestation_signing: components["schemas"]["SoulMintConversationFinalizeSigningInput"];
+            finalize_request_template: components["schemas"]["SoulMintConversationFinalizeRequestTemplate"];
+            registration_preview?: {
+                [key: string]: unknown;
+            };
+        };
         /** GET /api/v1/soul/agents/{agentId}/channels/preferences response */
         "soul-agent-channel-preferences.response.schema": {
             agentId: string;
@@ -451,6 +902,7 @@ export interface components {
             subject?: string;
             body: string;
             inReplyTo?: string | null;
+            idempotencyKey?: string;
         } & (unknown & unknown & unknown);
         /** POST /api/v1/soul/comm/send response */
         "soul-comm-send.response.schema": {
@@ -869,6 +1321,715 @@ export interface operations {
             };
             /** @description Invalid request */
             400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulRegisterBegin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulAgentRegistrationBeginRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentRegistrationBeginResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulRegisterVerify: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulAgentRegistrationVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentRegistrationVerifyResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulMintConversationFinalizePreflight: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                conversationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulMintConversationFinalizeBeginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulMintConversationFinalizePreflightResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulMintConversationFinalizeBegin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                id: string;
+                conversationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulMintConversationFinalizeBeginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulMintConversationFinalizePreflightResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulAgentMintConversationFinalizePreflight: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+                conversationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulMintConversationFinalizeBeginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulMintConversationFinalizePreflightResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulAgentMintConversationFinalizeBegin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+                conversationId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulMintConversationFinalizeBeginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulMintConversationFinalizePreflightResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulListMyPromotions: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentPromotionListResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulListMyPromotionLifecycleEvents: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentPromotionLifecycleEventListResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulGetPromotion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentPromotionResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulVerifyPromotion: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["SoulAgentRegistrationVerifyRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentRegistrationVerifyResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    soulListAgentPromotionLifecycleEvents: {
+        parameters: {
+            query?: {
+                cursor?: string;
+                limit?: number;
+            };
+            header?: never;
+            path: {
+                agentId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SoulAgentPromotionLifecycleEventListResponse"];
+                };
+            };
+            /** @description Invalid request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/web/src/lib/greater/adapters/stores/index.ts
+++ b/web/src/lib/greater/adapters/stores/index.ts
@@ -4,6 +4,10 @@
 
 export { createTimelineStore } from './timelineStore';
 export { createNotificationStore } from './notificationStore';
-export { createPresenceStore } from './presenceStore';
+export {
+	createPresenceStore,
+	createBrowserPresenceActivitySource,
+	createBrowserPresenceLocationSource,
+} from './presenceStore';
 
 export type * from './types';

--- a/web/src/lib/greater/adapters/stores/presenceStore.ts
+++ b/web/src/lib/greater/adapters/stores/presenceStore.ts
@@ -9,6 +9,10 @@ import type {
 	UserPresence,
 	SessionInfo,
 	PresenceConfig,
+	PresenceActivitySource,
+	PresenceLocationSource,
+	BrowserPresenceActivitySourceOptions,
+	BrowserPresenceLocationSourceOptions,
 } from './types';
 import { mapLesserAccount } from '../mappers/lesser/mappers.js';
 import type { LesserAccountFragment } from '../mappers/lesser/types.js';
@@ -334,10 +338,7 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 			isOnline: true,
 			lastSeen: Date.now(),
 			status: 'active',
-			location:
-				config.enableLocationTracking && typeof window !== 'undefined'
-					? { page: window.location.pathname }
-					: undefined,
+			location: config.initialLocation,
 			connection: {
 				sessionId: generateSessionId(),
 				transportType: 'unknown',
@@ -362,9 +363,7 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 
 	// Connection health monitoring
 	let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-	let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
 	let updateDebounceTimer: ReturnType<typeof setTimeout> | null = null;
-	let lastActivity = Date.now();
 
 	// Transport event handlers
 	let streamingUnsubscribers: (() => void)[] = [];
@@ -714,20 +713,18 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 		}
 	}
 
-	function startInactivityMonitoring(): void {
+	function attachActivitySource(source: PresenceActivitySource): () => void {
 		const threshold = config.inactivityThreshold || 300000; // 5 minutes
+		let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
 
 		function resetInactivityTimer(): void {
-			const now = Date.now();
-			lastActivity = now;
-
 			if (inactivityTimer) {
 				clearTimeout(inactivityTimer);
 			}
 
 			// Update last activity in presence
 			if (state.value.currentUser) {
-				updatePresence({ lastSeen: lastActivity });
+				updatePresence({ lastSeen: Date.now() });
 			}
 
 			// Set user to active if currently idle
@@ -742,51 +739,42 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 			}, threshold);
 		}
 
-		// Listen for user activity
-		if (typeof window !== 'undefined') {
-			const activityEvents = ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart'];
-
-			const handleActivity = () => resetInactivityTimer();
-
-			activityEvents.forEach((event) => {
-				window.addEventListener(event, handleActivity, { passive: true });
-			});
-
-			// Store cleanup function
-			const cleanup = () => {
-				activityEvents.forEach((event) => {
-					window.removeEventListener(event, handleActivity);
-				});
-			};
-
-			streamingUnsubscribers.push(cleanup);
-		}
+		const unsubscribe = source.subscribe(() => resetInactivityTimer());
 
 		// Initialize timer
 		resetInactivityTimer();
-	}
 
-	function trackLocationChanges(): void {
-		if (!config.enableLocationTracking || typeof window === 'undefined') return;
-
-		// Listen for navigation changes
-		const handleLocationChange = () => {
-			if (state.value.currentUser) {
-				updateLocation({
-					page: window.location.pathname,
-					section: window.location.hash ? window.location.hash.slice(1) : undefined,
-				});
+		return () => {
+			unsubscribe();
+			if (inactivityTimer) {
+				clearTimeout(inactivityTimer);
+				inactivityTimer = null;
 			}
 		};
+	}
 
-		window.addEventListener('popstate', handleLocationChange);
-		window.addEventListener('hashchange', handleLocationChange);
+	function attachLocationSource(source: PresenceLocationSource): () => void {
+		updateLocation(source.getLocation());
 
-		// Store cleanup function
-		streamingUnsubscribers.push(() => {
-			window.removeEventListener('popstate', handleLocationChange);
-			window.removeEventListener('hashchange', handleLocationChange);
+		if (!source.subscribe) {
+			return () => {};
+		}
+
+		return source.subscribe((location) => {
+			updateLocation(location);
 		});
+	}
+
+	function getLocationSourceForMonitoring(): PresenceLocationSource | null {
+		if (config.locationSource) {
+			return config.locationSource;
+		}
+
+		if (config.enableLocationTracking) {
+			return createBrowserPresenceLocationSource();
+		}
+
+		return null;
 	}
 
 	// Store methods
@@ -955,8 +943,16 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 
 		// Start monitoring systems
 		startHeartbeat();
-		startInactivityMonitoring();
-		trackLocationChanges();
+
+		if (config.activitySource) {
+			streamingUnsubscribers.push(attachActivitySource(config.activitySource));
+		}
+
+		const locationSource = getLocationSourceForMonitoring();
+
+		if (locationSource) {
+			streamingUnsubscribers.push(attachLocationSource(locationSource));
+		}
 
 		// Start the transport connection
 		try {
@@ -981,11 +977,6 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 		// Stop monitoring systems
 		stopHeartbeat();
 
-		if (inactivityTimer) {
-			clearTimeout(inactivityTimer);
-			inactivityTimer = null;
-		}
-
 		if (updateDebounceTimer) {
 			clearTimeout(updateDebounceTimer);
 			updateDebounceTimer = null;
@@ -997,6 +988,12 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 
 		// Clear pending updates
 		pendingPresenceUpdates.clear();
+
+		try {
+			config.transportManager.disconnect();
+		} catch (error) {
+			console.warn('[PresenceStore] Failed to disconnect transport manager', error);
+		}
 	}
 
 	function subscribe(callback: (value: PresenceState) => void): () => void {
@@ -1061,5 +1058,84 @@ export function createPresenceStore(config: PresenceConfig): PresenceStore {
 		getActiveSessions,
 		startMonitoring,
 		stopMonitoring,
+	};
+}
+
+const DEFAULT_BROWSER_ACTIVITY_EVENTS = [
+	'mousedown',
+	'mousemove',
+	'keypress',
+	'scroll',
+	'touchstart',
+];
+
+export function createBrowserPresenceActivitySource(
+	options: BrowserPresenceActivitySourceOptions = {}
+): PresenceActivitySource {
+	const target = options.target ?? (typeof window !== 'undefined' ? window : null);
+	const events = options.events ?? DEFAULT_BROWSER_ACTIVITY_EVENTS;
+	const listenerOptions = options.listenerOptions ?? { passive: true };
+
+	return {
+		subscribe(onActivity) {
+			if (!target) {
+				return () => {};
+			}
+
+			events.forEach((eventName) => {
+				target.addEventListener(eventName, onActivity, listenerOptions);
+			});
+
+			return () => {
+				events.forEach((eventName) => {
+					target.removeEventListener(eventName, onActivity, listenerOptions);
+				});
+			};
+		},
+	};
+}
+
+export function createBrowserPresenceLocationSource(
+	options: BrowserPresenceLocationSourceOptions = {}
+): PresenceLocationSource {
+	const target = options.target ?? (typeof window !== 'undefined' ? window : null);
+
+	const getLocation = (): UserPresence['location'] => {
+		if (!target) {
+			return undefined;
+		}
+
+		const page = target.location.pathname || undefined;
+		const section = target.location.hash ? target.location.hash.slice(1) : undefined;
+
+		if (!page && !section) {
+			return undefined;
+		}
+
+		return {
+			page,
+			section,
+		};
+	};
+
+	return {
+		getLocation,
+		subscribe(onLocationChange) {
+			if (!target) {
+				return () => {};
+			}
+
+			const handleLocationChange = () => {
+				onLocationChange(getLocation());
+			};
+
+			target.addEventListener('popstate', handleLocationChange);
+			target.addEventListener('hashchange', handleLocationChange);
+
+			return () => {
+				target.removeEventListener('popstate', handleLocationChange);
+				target.removeEventListener('hashchange', handleLocationChange);
+			};
+		},
 	};
 }

--- a/web/src/lib/greater/adapters/stores/types.ts
+++ b/web/src/lib/greater/adapters/stores/types.ts
@@ -421,12 +421,48 @@ export interface PresenceConfig {
 	};
 	/** Heartbeat interval in ms */
 	heartbeatInterval?: number;
-	/** User inactivity threshold in ms */
+	/** Initial location supplied by the host during SSR or bootstrapping */
+	initialLocation?: UserPresence['location'];
+	/** Explicit activity source for client-side status tracking */
+	activitySource?: PresenceActivitySource;
+	/** Explicit location source for host-provided route tracking */
+	locationSource?: PresenceLocationSource;
+	/** User inactivity threshold in ms when an activity source is attached */
 	inactivityThreshold?: number;
 	/** Presence update debounce time in ms */
 	updateDebounceMs?: number;
-	/** Enable location tracking */
+	/** @deprecated Use locationSource with createBrowserPresenceLocationSource() instead. */
 	enableLocationTracking?: boolean;
+}
+
+export interface PresenceActivitySource {
+	/** Subscribe to user activity events */
+	subscribe(onActivity: () => void): () => void;
+}
+
+export interface PresenceLocationSource {
+	/** Read the host's current location snapshot */
+	getLocation(): UserPresence['location'];
+	/** Subscribe to location changes emitted by the host */
+	subscribe?(onLocationChange: (location: UserPresence['location']) => void): () => void;
+}
+
+export interface BrowserPresenceActivitySourceOptions {
+	/** Event target, defaults to window when available */
+	target?: Pick<Window, 'addEventListener' | 'removeEventListener'> | null;
+	/** Activity event names to watch */
+	events?: string[];
+	/** Listener options applied to each activity subscription */
+	listenerOptions?: AddEventListenerOptions | boolean;
+}
+
+export interface BrowserPresenceLocationSourceOptions {
+	/** Event target, defaults to window when available */
+	target?:
+		| (Pick<Window, 'addEventListener' | 'removeEventListener'> & {
+				location: Pick<Location, 'pathname' | 'hash'>;
+		  })
+		| null;
 }
 
 // Store factory types

--- a/web/src/lib/greater/headless/types/common.ts
+++ b/web/src/lib/greater/headless/types/common.ts
@@ -27,7 +27,7 @@ export interface BaseBuilderConfig {
 /**
  * Action return type for Svelte use:action directive
  */
-export interface ActionReturn<P = any> {
+export interface ActionReturn<P = unknown> {
 	update?: (parameters: P) => void;
 	destroy?: () => void;
 }
@@ -36,7 +36,7 @@ export interface ActionReturn<P = any> {
  * Svelte action type
  * A function that receives a DOM node and returns an action object
  */
-export type Action<T extends HTMLElement = HTMLElement, P = any> = (
+export type Action<T extends HTMLElement = HTMLElement, P = unknown> = (
 	node: T,
 	parameters?: P
 ) => ActionReturn<P> | void;

--- a/web/src/lib/greater/primitives/index.d.ts
+++ b/web/src/lib/greater/primitives/index.d.ts
@@ -195,7 +195,19 @@ export interface SelectOption {
 	label: string;
 	disabled?: boolean;
 }
-export { preferencesStore, getPreferences, getPreferenceState } from './stores/preferences';
+export {
+	preferencesStore,
+	getPreferences,
+	getPreferenceState,
+	parsePreferencesCookie,
+	createThemeBootstrapSnapshot,
+	getThemeBootstrapState,
+	getThemeDocumentAttributes,
+	applyThemeDocumentAttributes,
+	readThemeBootstrapSnapshotFromDocument,
+	PREFERENCES_KEY,
+	PREFERENCES_COOKIE,
+} from './stores/preferences';
 export type {
 	ColorScheme,
 	Density,
@@ -204,6 +216,9 @@ export type {
 	ThemeColors,
 	UserPreferences,
 	PreferencesState,
+	ThemeBootstrapSnapshot,
+	ThemeBootstrapOptions,
+	ThemeDocumentAttributes,
 } from './stores/preferences';
 export {
 	fadeUp,

--- a/web/src/lib/greater/primitives/index.ts
+++ b/web/src/lib/greater/primitives/index.ts
@@ -23,7 +23,7 @@ export type {
 	ColorScale,
 	ColorShade,
 	FontPreset,
-} from '@equaltoai/greater-components-tokens';
+} from 'src/lib/greater/tokens';
 
 // Preset types for strict-CSP-safe APIs
 export type { WidthPreset, HeightPreset } from './components/Skeleton.svelte';
@@ -214,7 +214,19 @@ export interface SelectOption {
 }
 
 // Store exports
-export { preferencesStore, getPreferences, getPreferenceState } from './stores/preferences';
+export {
+	preferencesStore,
+	getPreferences,
+	getPreferenceState,
+	parsePreferencesCookie,
+	createThemeBootstrapSnapshot,
+	getThemeBootstrapState,
+	getThemeDocumentAttributes,
+	applyThemeDocumentAttributes,
+	readThemeBootstrapSnapshotFromDocument,
+	PREFERENCES_KEY,
+	PREFERENCES_COOKIE,
+} from './stores/preferences';
 export type {
 	ColorScheme,
 	Density,
@@ -223,6 +235,9 @@ export type {
 	ThemeColors,
 	UserPreferences,
 	PreferencesState,
+	ThemeBootstrapSnapshot,
+	ThemeBootstrapOptions,
+	ThemeDocumentAttributes,
 } from './stores/preferences';
 
 // Transition exports

--- a/web/src/lib/greater/primitives/stores/preferences.d.ts
+++ b/web/src/lib/greater/primitives/stores/preferences.d.ts
@@ -22,19 +22,75 @@ export interface PreferencesState extends UserPreferences {
 	systemHighContrast: boolean;
 	resolvedColorScheme: 'light' | 'dark' | 'high-contrast';
 }
+export interface ThemeBootstrapSnapshot {
+	preferences: UserPreferences;
+	systemColorScheme: 'light' | 'dark';
+	systemMotion: MotionPreference;
+	systemHighContrast: boolean;
+}
+export interface ThemeBootstrapOptions {
+	defaults?: Partial<UserPreferences>;
+	stored?: Partial<UserPreferences>;
+	cookie?: string | Record<string, string | undefined>;
+	cookieName?: string;
+	system?: Partial<{
+		colorScheme: 'light' | 'dark';
+		motion: MotionPreference;
+		highContrast: boolean;
+	}>;
+}
+export interface ThemeDocumentAttributes {
+	'data-theme': string;
+	'data-density': Density;
+	'data-font-size': FontSize;
+	'data-motion': MotionPreference;
+	'data-gr-font-scale': string;
+	'data-gr-custom-primary'?: string;
+	'data-gr-custom-secondary'?: string;
+	'data-gr-custom-accent'?: string;
+}
+export declare const PREFERENCES_KEY = 'gr-preferences-v1';
+export declare const PREFERENCES_COOKIE = 'gr-preferences';
+export declare function parsePreferencesCookie(
+	input: string | Record<string, string | undefined> | undefined,
+	cookieName?: string
+): Partial<UserPreferences> | null;
+export declare function createThemeBootstrapSnapshot(
+	options?: ThemeBootstrapOptions
+): ThemeBootstrapSnapshot;
+export declare function getThemeBootstrapState(snapshot: ThemeBootstrapSnapshot): PreferencesState;
+export declare function getThemeDocumentAttributes(
+	snapshot: ThemeBootstrapSnapshot
+): ThemeDocumentAttributes;
+export declare function applyThemeDocumentAttributes(
+	snapshot: ThemeBootstrapSnapshot,
+	root?: HTMLElement | null
+): void;
+export declare function readThemeBootstrapSnapshotFromDocument(
+	root?: HTMLElement | null
+): ThemeBootstrapSnapshot | null;
 declare class PreferencesStore {
 	private _preferences;
 	private _systemColorScheme;
 	private _systemMotion;
 	private _systemHighContrast;
+	private _initialized;
+	private _systemPreferenceDetectionReady;
 	private darkModeQuery?;
 	private reducedMotionQuery?;
 	private highContrastQuery?;
-	constructor();
+	private ensureInitialized;
+	private applySnapshot;
 	get preferences(): UserPreferences;
 	get state(): PreferencesState;
 	get resolvedColorScheme(): 'light' | 'dark' | 'high-contrast';
 	get resolvedMotion(): MotionPreference;
+	hydrate(
+		snapshot: ThemeBootstrapSnapshot,
+		options?: {
+			persist?: boolean;
+		}
+	): void;
 	setColorScheme(scheme: ColorScheme): void;
 	setDensity(density: Density): void;
 	setFontSize(size: FontSize): void;
@@ -49,10 +105,8 @@ declare class PreferencesStore {
 	private loadPreferences;
 	private savePreferences;
 	private saveAndApply;
-	private validatePreferences;
 	private setupSystemPreferenceDetection;
 	private applyTheme;
-	private applyCustomAttributes;
 	destroy(): void;
 }
 export declare const preferencesStore: PreferencesStore;

--- a/web/src/lib/greater/primitives/stores/preferences.ts
+++ b/web/src/lib/greater/primitives/stores/preferences.ts
@@ -1,4 +1,3 @@
-// Type definitions for preferences
 export type ColorScheme = 'light' | 'dark' | 'high-contrast' | 'auto';
 export type Density = 'compact' | 'comfortable' | 'spacious';
 export type FontSize = 'small' | 'medium' | 'large';
@@ -17,7 +16,7 @@ export interface UserPreferences {
 	motion: MotionPreference;
 	customColors: ThemeColors;
 	highContrastMode: boolean;
-	fontScale: number; // 0.85 to 1.5 multiplier
+	fontScale: number;
 }
 
 export interface PreferencesState extends UserPreferences {
@@ -27,10 +26,39 @@ export interface PreferencesState extends UserPreferences {
 	resolvedColorScheme: 'light' | 'dark' | 'high-contrast';
 }
 
-// Local storage key
-const PREFERENCES_KEY = 'gr-preferences-v1';
+export interface ThemeBootstrapSnapshot {
+	preferences: UserPreferences;
+	systemColorScheme: 'light' | 'dark';
+	systemMotion: MotionPreference;
+	systemHighContrast: boolean;
+}
 
-// Default preferences
+export interface ThemeBootstrapOptions {
+	defaults?: Partial<UserPreferences>;
+	stored?: Partial<UserPreferences>;
+	cookie?: string | Record<string, string | undefined>;
+	cookieName?: string;
+	system?: Partial<{
+		colorScheme: 'light' | 'dark';
+		motion: MotionPreference;
+		highContrast: boolean;
+	}>;
+}
+
+export interface ThemeDocumentAttributes {
+	'data-theme': string;
+	'data-density': Density;
+	'data-font-size': FontSize;
+	'data-motion': MotionPreference;
+	'data-gr-font-scale': string;
+	'data-gr-custom-primary'?: string;
+	'data-gr-custom-secondary'?: string;
+	'data-gr-custom-accent'?: string;
+}
+
+export const PREFERENCES_KEY = 'gr-preferences-v1';
+export const PREFERENCES_COOKIE = 'gr-preferences';
+
 const DEFAULT_PREFERENCES: UserPreferences = {
 	colorScheme: 'auto',
 	density: 'comfortable',
@@ -44,6 +72,11 @@ const DEFAULT_PREFERENCES: UserPreferences = {
 	highContrastMode: false,
 	fontScale: 1,
 };
+
+const VALID_COLOR_SCHEMES: ColorScheme[] = ['light', 'dark', 'high-contrast', 'auto'];
+const VALID_DENSITIES: Density[] = ['compact', 'comfortable', 'spacious'];
+const VALID_FONT_SIZES: FontSize[] = ['small', 'medium', 'large'];
+const VALID_MOTION_PREFERENCES: MotionPreference[] = ['normal', 'reduced'];
 
 function clonePreferences(preferences: UserPreferences): UserPreferences {
 	return {
@@ -71,104 +104,408 @@ function mergePreferences(
 	return clonePreferences(next);
 }
 
-// Create the preferences store class
+function isColorScheme(value: unknown): value is ColorScheme {
+	return typeof value === 'string' && VALID_COLOR_SCHEMES.includes(value as ColorScheme);
+}
+
+function isDensity(value: unknown): value is Density {
+	return typeof value === 'string' && VALID_DENSITIES.includes(value as Density);
+}
+
+function isFontSize(value: unknown): value is FontSize {
+	return typeof value === 'string' && VALID_FONT_SIZES.includes(value as FontSize);
+}
+
+function isMotionPreference(value: unknown): value is MotionPreference {
+	return typeof value === 'string' && VALID_MOTION_PREFERENCES.includes(value as MotionPreference);
+}
+
+function validatePreferences(prefs: Partial<UserPreferences>): boolean {
+	if (typeof prefs !== 'object' || prefs === null) {
+		return false;
+	}
+
+	if (typeof prefs.colorScheme !== 'undefined' && !isColorScheme(prefs.colorScheme)) {
+		return false;
+	}
+
+	if (typeof prefs.density !== 'undefined' && !isDensity(prefs.density)) {
+		return false;
+	}
+
+	if (typeof prefs.fontSize !== 'undefined' && !isFontSize(prefs.fontSize)) {
+		return false;
+	}
+
+	if (typeof prefs.motion !== 'undefined' && !isMotionPreference(prefs.motion)) {
+		return false;
+	}
+
+	if (
+		typeof prefs.highContrastMode !== 'undefined' &&
+		typeof prefs.highContrastMode !== 'boolean'
+	) {
+		return false;
+	}
+
+	if (typeof prefs.fontScale !== 'undefined' && typeof prefs.fontScale !== 'number') {
+		return false;
+	}
+
+	return true;
+}
+
+function resolveColorScheme(
+	preferences: UserPreferences,
+	systemColorScheme: 'light' | 'dark',
+	systemHighContrast: boolean
+): 'light' | 'dark' | 'high-contrast' {
+	if (preferences.highContrastMode || systemHighContrast) {
+		return 'high-contrast';
+	}
+
+	if (preferences.colorScheme === 'auto') {
+		return systemColorScheme;
+	}
+
+	if (preferences.colorScheme === 'high-contrast') {
+		return 'high-contrast';
+	}
+
+	return preferences.colorScheme as 'light' | 'dark';
+}
+
+function resolveMotion(
+	preferences: UserPreferences,
+	systemMotion: MotionPreference
+): MotionPreference {
+	if (systemMotion === 'reduced') {
+		return 'reduced';
+	}
+
+	return preferences.motion;
+}
+
+function parseCookieHeader(header: string): Record<string, string> {
+	return header
+		.split(';')
+		.map((part) => part.trim())
+		.filter(Boolean)
+		.reduce<Record<string, string>>((cookies, part) => {
+			const separatorIndex = part.indexOf('=');
+			if (separatorIndex === -1) {
+				return cookies;
+			}
+
+			const name = part.slice(0, separatorIndex).trim();
+			const value = part.slice(separatorIndex + 1).trim();
+			if (name) {
+				cookies[name] = value;
+			}
+
+			return cookies;
+		}, {});
+}
+
+export function parsePreferencesCookie(
+	input: string | Record<string, string | undefined> | undefined,
+	cookieName = PREFERENCES_COOKIE
+): Partial<UserPreferences> | null {
+	if (!input) {
+		return null;
+	}
+
+	const cookies = typeof input === 'string' ? parseCookieHeader(input) : input;
+	const rawValue = cookies[cookieName];
+	if (!rawValue) {
+		return null;
+	}
+
+	try {
+		const parsed = JSON.parse(decodeURIComponent(rawValue)) as Partial<UserPreferences>;
+		return validatePreferences(parsed) ? parsed : null;
+	} catch {
+		return null;
+	}
+}
+
+export function createThemeBootstrapSnapshot(
+	options: ThemeBootstrapOptions = {}
+): ThemeBootstrapSnapshot {
+	const basePreferences = mergePreferences(DEFAULT_PREFERENCES, options.defaults ?? {});
+	const cookiePreferences = parsePreferencesCookie(options.cookie, options.cookieName) ?? {};
+	const storedPreferences = validatePreferences(options.stored ?? {}) ? (options.stored ?? {}) : {};
+	const preferences = mergePreferences(
+		mergePreferences(basePreferences, cookiePreferences),
+		storedPreferences
+	);
+
+	return {
+		preferences,
+		systemColorScheme: options.system?.colorScheme ?? 'light',
+		systemMotion: options.system?.motion ?? 'normal',
+		systemHighContrast: options.system?.highContrast ?? false,
+	};
+}
+
+export function getThemeBootstrapState(snapshot: ThemeBootstrapSnapshot): PreferencesState {
+	return {
+		...clonePreferences(snapshot.preferences),
+		systemColorScheme: snapshot.systemColorScheme,
+		systemMotion: snapshot.systemMotion,
+		systemHighContrast: snapshot.systemHighContrast,
+		resolvedColorScheme: resolveColorScheme(
+			snapshot.preferences,
+			snapshot.systemColorScheme,
+			snapshot.systemHighContrast
+		),
+	};
+}
+
+export function getThemeDocumentAttributes(
+	snapshot: ThemeBootstrapSnapshot
+): ThemeDocumentAttributes {
+	const state = getThemeBootstrapState(snapshot);
+	const attributes: ThemeDocumentAttributes = {
+		'data-theme': state.resolvedColorScheme,
+		'data-density': state.density,
+		'data-font-size': state.fontSize,
+		'data-motion': resolveMotion(snapshot.preferences, snapshot.systemMotion),
+		'data-gr-font-scale': String(snapshot.preferences.fontScale),
+	};
+
+	if (snapshot.preferences.customColors.primary) {
+		attributes['data-gr-custom-primary'] = snapshot.preferences.customColors.primary;
+	}
+
+	if (snapshot.preferences.customColors.secondary) {
+		attributes['data-gr-custom-secondary'] = snapshot.preferences.customColors.secondary;
+	}
+
+	if (snapshot.preferences.customColors.accent) {
+		attributes['data-gr-custom-accent'] = snapshot.preferences.customColors.accent;
+	}
+
+	return attributes;
+}
+
+export function applyThemeDocumentAttributes(
+	snapshot: ThemeBootstrapSnapshot,
+	root: HTMLElement | null = typeof document !== 'undefined' ? document.documentElement : null
+): void {
+	if (!root) {
+		return;
+	}
+
+	const attributes = getThemeDocumentAttributes(snapshot);
+	const attributeNames: Array<keyof ThemeDocumentAttributes> = [
+		'data-theme',
+		'data-density',
+		'data-font-size',
+		'data-motion',
+		'data-gr-font-scale',
+		'data-gr-custom-primary',
+		'data-gr-custom-secondary',
+		'data-gr-custom-accent',
+	];
+
+	attributeNames.forEach((attributeName) => {
+		const value = attributes[attributeName];
+		if (value) {
+			root.setAttribute(attributeName, value);
+		} else {
+			root.removeAttribute(attributeName);
+		}
+	});
+}
+
+export function readThemeBootstrapSnapshotFromDocument(
+	root: HTMLElement | null = typeof document !== 'undefined' ? document.documentElement : null
+): ThemeBootstrapSnapshot | null {
+	if (!root) {
+		return null;
+	}
+
+	const theme = root.getAttribute('data-theme');
+	const density = root.getAttribute('data-density');
+	const fontSize = root.getAttribute('data-font-size');
+	const motion = root.getAttribute('data-motion');
+	const fontScale = root.getAttribute('data-gr-font-scale');
+	const customPrimary = root.getAttribute('data-gr-custom-primary');
+	const customSecondary = root.getAttribute('data-gr-custom-secondary');
+	const customAccent = root.getAttribute('data-gr-custom-accent');
+
+	if (!theme && !density && !fontSize && !motion && !fontScale) {
+		return null;
+	}
+
+	const preferences = clonePreferences(DEFAULT_PREFERENCES);
+
+	if (theme === 'high-contrast') {
+		preferences.colorScheme = 'high-contrast';
+		preferences.highContrastMode = true;
+	} else if (theme === 'dark' || theme === 'light') {
+		preferences.colorScheme = theme;
+	}
+
+	if (density && isDensity(density)) {
+		preferences.density = density;
+	}
+
+	if (fontSize && isFontSize(fontSize)) {
+		preferences.fontSize = fontSize;
+	}
+
+	if (motion && isMotionPreference(motion)) {
+		preferences.motion = motion;
+	}
+
+	if (fontScale) {
+		const parsedFontScale = Number(fontScale);
+		if (Number.isFinite(parsedFontScale)) {
+			preferences.fontScale = parsedFontScale;
+		}
+	}
+
+	if (customPrimary) {
+		preferences.customColors.primary = customPrimary;
+	}
+
+	if (customSecondary) {
+		preferences.customColors.secondary = customSecondary;
+	}
+
+	if (customAccent) {
+		preferences.customColors.accent = customAccent;
+	}
+
+	return {
+		preferences,
+		systemColorScheme: theme === 'dark' ? 'dark' : 'light',
+		systemMotion: motion === 'reduced' ? 'reduced' : 'normal',
+		// `data-theme` captures the resolved theme, not whether the OS is actively forcing high contrast.
+		// Treating a resolved high-contrast document as a live system preference locks the user into that
+		// mode until a matchMedia change event fires.
+		systemHighContrast: false,
+	};
+}
+
 class PreferencesStore {
-	// Internal state
 	private _preferences: UserPreferences = clonePreferences(DEFAULT_PREFERENCES);
 	private _systemColorScheme: 'light' | 'dark' = 'light';
 	private _systemMotion: MotionPreference = 'normal';
 	private _systemHighContrast = false;
-
-	// Media query matchers
+	private _initialized = false;
+	private _systemPreferenceDetectionReady = false;
 	private darkModeQuery?: MediaQueryList;
 	private reducedMotionQuery?: MediaQueryList;
 	private highContrastQuery?: MediaQueryList;
 
-	constructor() {
-		// Initialize from localStorage
-		this.loadPreferences();
+	private ensureInitialized() {
+		if (this._initialized) {
+			return;
+		}
 
-		// Set up system preference detection
-		this.setupSystemPreferenceDetection();
+		const documentSnapshot = readThemeBootstrapSnapshotFromDocument();
+		if (documentSnapshot) {
+			this.applySnapshot(documentSnapshot, { apply: false, persist: false });
+			this.setupSystemPreferenceDetection({ preserveInitialValues: true });
+		} else {
+			this.loadPreferences();
+			this.setupSystemPreferenceDetection();
+		}
 
-		// Apply initial theme
-		this.applyTheme();
+		if (typeof window !== 'undefined') {
+			this.applyTheme();
+		}
+
+		this._initialized = true;
 	}
 
-	// Getters using $derived for computed values
+	private applySnapshot(
+		snapshot: ThemeBootstrapSnapshot,
+		options: { apply: boolean; persist: boolean }
+	) {
+		this._preferences = clonePreferences(snapshot.preferences);
+		this._systemColorScheme = snapshot.systemColorScheme;
+		this._systemMotion = snapshot.systemMotion;
+		this._systemHighContrast = snapshot.systemHighContrast;
+
+		if (options.persist) {
+			this.savePreferences();
+		}
+
+		if (options.apply) {
+			this.applyTheme();
+		}
+	}
+
 	get preferences(): UserPreferences {
+		this.ensureInitialized();
 		return clonePreferences(this._preferences);
 	}
 
 	get state(): PreferencesState {
-		const { customColors, ...rest } = this._preferences;
-		return {
-			...rest,
-			customColors: {
-				...customColors,
-			},
+		this.ensureInitialized();
+		return getThemeBootstrapState({
+			preferences: this._preferences,
 			systemColorScheme: this._systemColorScheme,
 			systemMotion: this._systemMotion,
 			systemHighContrast: this._systemHighContrast,
-			resolvedColorScheme: this.resolvedColorScheme,
-		};
+		});
 	}
 
 	get resolvedColorScheme(): 'light' | 'dark' | 'high-contrast' {
-		// High contrast overrides everything
-		if (this._preferences.highContrastMode || this._systemHighContrast) {
-			return 'high-contrast';
-		}
-
-		// Handle auto color scheme
-		if (this._preferences.colorScheme === 'auto') {
-			return this._systemColorScheme;
-		}
-
-		// Use explicit user preference
-		if (this._preferences.colorScheme === 'high-contrast') {
-			return 'high-contrast';
-		}
-
-		return this._preferences.colorScheme as 'light' | 'dark';
+		this.ensureInitialized();
+		return resolveColorScheme(this._preferences, this._systemColorScheme, this._systemHighContrast);
 	}
 
 	get resolvedMotion(): MotionPreference {
-		// System preference for reduced motion always wins
-		if (this._systemMotion === 'reduced') {
-			return 'reduced';
-		}
-		return this._preferences.motion;
+		this.ensureInitialized();
+		return resolveMotion(this._preferences, this._systemMotion);
 	}
 
-	// Methods to update preferences
+	hydrate(snapshot: ThemeBootstrapSnapshot, options: { persist?: boolean } = {}) {
+		this.applySnapshot(snapshot, {
+			apply: typeof window !== 'undefined',
+			persist: options.persist ?? false,
+		});
+		this.setupSystemPreferenceDetection({ preserveInitialValues: true });
+		this._initialized = true;
+	}
+
 	setColorScheme(scheme: ColorScheme) {
+		this.ensureInitialized();
 		this._preferences.colorScheme = scheme;
 		this.saveAndApply();
 	}
 
 	setDensity(density: Density) {
+		this.ensureInitialized();
 		this._preferences.density = density;
 		this.saveAndApply();
 	}
 
 	setFontSize(size: FontSize) {
+		this.ensureInitialized();
 		this._preferences.fontSize = size;
 		this.saveAndApply();
 	}
 
 	setFontScale(scale: number) {
-		// Clamp between 0.85 and 1.5
+		this.ensureInitialized();
 		this._preferences.fontScale = Math.max(0.85, Math.min(1.5, scale));
 		this.saveAndApply();
 	}
 
 	setMotion(motion: MotionPreference) {
+		this.ensureInitialized();
 		this._preferences.motion = motion;
 		this.saveAndApply();
 	}
 
 	setCustomColors(colors: Partial<ThemeColors>) {
+		this.ensureInitialized();
 		this._preferences.customColors = {
 			...this._preferences.customColors,
 			...colors,
@@ -177,33 +514,34 @@ class PreferencesStore {
 	}
 
 	setHighContrastMode(enabled: boolean) {
+		this.ensureInitialized();
 		this._preferences.highContrastMode = enabled;
 		this.saveAndApply();
 	}
 
 	updatePreferences(updates: Partial<UserPreferences>) {
+		this.ensureInitialized();
 		this._preferences = mergePreferences(this._preferences, updates);
 		this.saveAndApply();
 	}
 
-	// Reset to defaults
 	reset() {
+		this.ensureInitialized();
 		this._preferences = clonePreferences(DEFAULT_PREFERENCES);
 		this.saveAndApply();
 	}
 
-	// Export current preferences as JSON
 	export(): string {
+		this.ensureInitialized();
 		return JSON.stringify(this._preferences, null, 2);
 	}
 
-	// Import preferences from JSON
 	import(json: string): boolean {
+		this.ensureInitialized();
+
 		try {
 			const imported = JSON.parse(json) as Partial<UserPreferences>;
-
-			// Validate imported data
-			if (this.validatePreferences(imported)) {
+			if (validatePreferences(imported)) {
 				this._preferences = mergePreferences(DEFAULT_PREFERENCES, imported);
 				this.saveAndApply();
 				return true;
@@ -214,17 +552,20 @@ class PreferencesStore {
 		}
 	}
 
-	// Private methods
 	private loadPreferences() {
-		if (typeof window === 'undefined') return;
+		if (typeof window === 'undefined') {
+			return;
+		}
 
 		try {
 			const stored = localStorage.getItem(PREFERENCES_KEY);
-			if (stored) {
-				const parsed = JSON.parse(stored) as Partial<UserPreferences>;
-				if (this.validatePreferences(parsed)) {
-					this._preferences = mergePreferences(DEFAULT_PREFERENCES, parsed);
-				}
+			if (!stored) {
+				return;
+			}
+
+			const parsed = JSON.parse(stored) as Partial<UserPreferences>;
+			if (validatePreferences(parsed)) {
+				this._preferences = mergePreferences(DEFAULT_PREFERENCES, parsed);
 			}
 		} catch (error) {
 			console.warn('Failed to load preferences from localStorage:', error);
@@ -232,7 +573,9 @@ class PreferencesStore {
 	}
 
 	private savePreferences() {
-		if (typeof window === 'undefined') return;
+		if (typeof window === 'undefined') {
+			return;
+		}
 
 		try {
 			localStorage.setItem(PREFERENCES_KEY, JSON.stringify(this._preferences));
@@ -246,128 +589,70 @@ class PreferencesStore {
 		this.applyTheme();
 	}
 
-	private validatePreferences(prefs: Partial<UserPreferences>): boolean {
-		// Basic validation of preference values
-		const validColorSchemes = ['light', 'dark', 'high-contrast', 'auto'];
-		const validDensities = ['compact', 'comfortable', 'spacious'];
-		const validFontSizes = ['small', 'medium', 'large'];
-		const validMotion = ['normal', 'reduced'];
-
-		if (prefs.colorScheme && !validColorSchemes.includes(prefs.colorScheme)) {
-			return false;
-		}
-		if (prefs.density && !validDensities.includes(prefs.density)) {
-			return false;
-		}
-		if (prefs.fontSize && !validFontSizes.includes(prefs.fontSize)) {
-			return false;
-		}
-		if (prefs.motion && !validMotion.includes(prefs.motion)) {
-			return false;
+	private setupSystemPreferenceDetection(options: { preserveInitialValues?: boolean } = {}) {
+		if (typeof window === 'undefined' || this._systemPreferenceDetectionReady) {
+			return;
 		}
 
-		return true;
-	}
+		const preserveInitialValues = options.preserveInitialValues ?? false;
 
-	private setupSystemPreferenceDetection() {
-		if (typeof window === 'undefined') return;
-
-		// Dark mode detection
 		this.darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)');
-		this._systemColorScheme = this.darkModeQuery.matches ? 'dark' : 'light';
-
-		this.darkModeQuery.addEventListener('change', (e) => {
-			this._systemColorScheme = e.matches ? 'dark' : 'light';
+		if (!preserveInitialValues) {
+			this._systemColorScheme = this.darkModeQuery.matches ? 'dark' : 'light';
+		}
+		this.darkModeQuery.addEventListener('change', (event) => {
+			this._systemColorScheme = event.matches ? 'dark' : 'light';
 			if (this._preferences.colorScheme === 'auto') {
 				this.applyTheme();
 			}
 		});
 
-		// Reduced motion detection
 		this.reducedMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-		this._systemMotion = this.reducedMotionQuery.matches ? 'reduced' : 'normal';
-
-		this.reducedMotionQuery.addEventListener('change', (e) => {
-			this._systemMotion = e.matches ? 'reduced' : 'normal';
+		if (!preserveInitialValues) {
+			this._systemMotion = this.reducedMotionQuery.matches ? 'reduced' : 'normal';
+		}
+		this.reducedMotionQuery.addEventListener('change', (event) => {
+			this._systemMotion = event.matches ? 'reduced' : 'normal';
 			this.applyTheme();
 		});
 
-		// High contrast detection
 		this.highContrastQuery = window.matchMedia('(prefers-contrast: high)');
-		this._systemHighContrast = this.highContrastQuery.matches;
-
-		this.highContrastQuery.addEventListener('change', (e) => {
-			this._systemHighContrast = e.matches;
+		if (!preserveInitialValues) {
+			this._systemHighContrast = this.highContrastQuery.matches;
+		}
+		this.highContrastQuery.addEventListener('change', (event) => {
+			this._systemHighContrast = event.matches;
 			this.applyTheme();
 		});
+
+		this._systemPreferenceDetectionReady = true;
 	}
 
 	private applyTheme() {
-		if (typeof window === 'undefined') return;
+		if (typeof window === 'undefined') {
+			return;
+		}
 
-		const root = document.documentElement;
-
-		// Apply color scheme
-		root.setAttribute('data-theme', this.resolvedColorScheme);
-
-		// Apply density
-		root.setAttribute('data-density', this._preferences.density);
-
-		// Apply font size
-		root.setAttribute('data-font-size', this._preferences.fontSize);
-
-		// Apply motion preference
-		root.setAttribute('data-motion', this.resolvedMotion);
-
-		// Strict-CSP safe: expose custom theme values via data attributes only.
-		// Consumers that require arbitrary values must apply them via external CSS.
-		this.applyCustomAttributes();
+		applyThemeDocumentAttributes(
+			{
+				preferences: this._preferences,
+				systemColorScheme: this._systemColorScheme,
+				systemMotion: this._systemMotion,
+				systemHighContrast: this._systemHighContrast,
+			},
+			document.documentElement
+		);
 	}
 
-	private applyCustomAttributes() {
-		if (typeof window === 'undefined') return;
-
-		const root = document.documentElement;
-
-		const primary = this._preferences.customColors.primary;
-		const secondary = this._preferences.customColors.secondary;
-		const accent = this._preferences.customColors.accent;
-
-		if (primary) {
-			root.setAttribute('data-gr-custom-primary', primary);
-		} else {
-			root.removeAttribute('data-gr-custom-primary');
-		}
-
-		if (secondary) {
-			root.setAttribute('data-gr-custom-secondary', secondary);
-		} else {
-			root.removeAttribute('data-gr-custom-secondary');
-		}
-
-		if (accent) {
-			root.setAttribute('data-gr-custom-accent', accent);
-		} else {
-			root.removeAttribute('data-gr-custom-accent');
-		}
-
-		root.setAttribute('data-gr-font-scale', String(this._preferences.fontScale));
-	}
-
-	// Cleanup method
 	destroy() {
-		// Remove event listeners if they exist
 		if (this.darkModeQuery) {
-			// Note: We stored the handlers inline, so we can't remove them
-			// In a production app, we'd store references to the handlers
+			// Event listener references are attached inline and intentionally left in place.
 		}
 	}
 }
 
-// Export singleton instance
 export const preferencesStore = new PreferencesStore();
 
-// Export convenience functions for use in components
 export function getPreferences() {
 	return preferencesStore.preferences;
 }


### PR DESCRIPTION
## Summary
- bump `github.com/theory-cloud/apptheory` to `v0.19.1` and `github.com/theory-cloud/tabletheory` to `v1.5.1`
- update `app-theory/app.json` to match the latest framework pins
- re-vendor the web UI to `greater-v0.6.0` with the `greater` CLI and refresh the pinned version docs

## Verification
- `GOTOOLCHAIN=auto go test ./...`
- `cd web && greater doctor`
- `cd web && npm run typecheck`
- `cd web && npm test`
- `cd web && npm run build`
- `cd web && node ./node_modules/eslint/bin/eslint.js .`
- `bash gov-infra/verifiers/gov-verify-rubric.sh`