### PR TITLE
chore(web): update greater to v0.6.1

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -5,7 +5,7 @@ This is the frontend for `lesser.host` (repo: `lesser-host`).
 ## Stack
 
 - Vite + Svelte 5 + TypeScript
-- `greater-components` (vendored via `greater` CLI, pinned to `greater-v0.6.0`)
+- `greater-components` (vendored via `greater` CLI, pinned to `greater-v0.6.1`)
 
 ## Local dev
 

--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://greater.components.dev/schema.json",
   "version": "1.0.0",
-  "ref": "greater-v0.6.0",
+  "ref": "greater-v0.6.1",
   "installMode": "vendored",
   "style": "default",
   "rsc": false,
@@ -24,57 +24,57 @@
   "installed": [
     {
       "name": "button",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.457Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:04.868Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "icons",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.562Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:04.968Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "utils",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.572Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:04.978Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "tokens",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.576Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:04.983Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "primitives",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.666Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:05.022Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "content",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:23.671Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:05.027Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "adapters",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:26.243Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:05.053Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "headless",
-      "version": "greater-v0.6.0",
-      "installedAt": "2026-03-28T22:18:26.267Z",
+      "version": "greater-v0.6.1",
+      "installedAt": "2026-03-29T13:52:05.068Z",
       "modified": false,
       "checksums": []
     }

--- a/web/src/lib/types/common.ts
+++ b/web/src/lib/types/common.ts
@@ -27,7 +27,7 @@ export interface BaseBuilderConfig {
 /**
  * Action return type for Svelte use:action directive
  */
-export interface ActionReturn<P = any> {
+export interface ActionReturn<P = unknown> {
 	update?: (parameters: P) => void;
 	destroy?: () => void;
 }
@@ -36,7 +36,7 @@ export interface ActionReturn<P = any> {
  * Svelte action type
  * A function that receives a DOM node and returns an action object
  */
-export type Action<T extends HTMLElement = HTMLElement, P = any> = (
+export type Action<T extends HTMLElement = HTMLElement, P = unknown> = (
 	node: T,
 	parameters?: P
 ) => ActionReturn<P> | void;


### PR DESCRIPTION
## Summary
- update the vendored `greater-components` ref from `greater-v0.6.0` to `greater-v0.6.1`
- refresh `web/components.json` to the new ref metadata
- sync the pinned version note in `web/README.md`
- carry forward the upstream `ActionReturn` / `Action` generic default change from `any` to `unknown` in `web/src/lib/types/common.ts`, matching the `greater-v0.6.1` cache

## Verification
- `cd web && greater doctor`
- `cd web && npx -y npm@11.9.0 ci`
- `cd web && npm run typecheck`
- `cd web && npm test`
- `cd web && node ./node_modules/eslint/bin/eslint.js .`
- `cd web && npm run build`

## Notes
- Latest stable `greater-components` tag was verified from the upstream repo on `2026-03-29` as `greater-v0.6.1`.
