### PR TITLE
fix: repair lesser runner release archive command

### DIFF
--- a/cdk/lib/provision-runner-buildspec.ts
+++ b/cdk/lib/provision-runner-buildspec.ts
@@ -170,7 +170,7 @@ export function renderProvisionRunnerBuildCommands(): string {
 		'echo "Using Lesser release: $TAG"',
 		'LESSER_RELEASE_DIR="$(pwd)/lesser-release"',
 		'prepare_lesser_release_dir "$LESSER_RELEASE_DIR"',
-		'download_github_tag_archive "$OWNER" "$REPO" "$TAG" lesser-src.tgz"',
+		'download_github_tag_archive "$OWNER" "$REPO" "$TAG" lesser-src.tgz',
 		'rm -rf lesser-src && mkdir -p lesser-src && tar -xzf lesser-src.tgz --strip-components=1 -C lesser-src',
 		'ARCH=$(uname -m)',
 		'if [ "$ARCH" = "x86_64" ] || [ "$ARCH" = "amd64" ]; then BIN_NAME="lesser-linux-amd64"; fi',


### PR DESCRIPTION
## Summary
- fix the malformed Lesser release archive download command in the provision runner buildspec
- restore a parseable `RUN_MODE=lesser` runner script for managed updates
- note that lab was redeployed with this hotfix and the stale failed `simulacrum` update job was reconciled out of `running`

## Verification
- `cd cdk && npm test`
- render provision runner build script and run `bash -n`
- `GOTOOLCHAIN=auto theory app up --aws-profile Lesser --stage lab --execute`
- verified DynamoDB job + instance markers for `wfULrxrcNsHVPqI33Ap4CQ`
