### PR TITLE
Add public soul avatar variants and agent-first portal flow

### DIFF
--- a/docs/portal.md
+++ b/docs/portal.md
@@ -5,6 +5,14 @@ This document describes the **self-serve portal API** for `lesser.host` and the 
 The portal is currently API-first (frontend is tracked separately). All portal endpoints use the same bearer session
 token mechanism as operator auth, but portal wallet login auto-creates a `customer` user on first login.
 
+## Canonical Soul Flow
+
+For soul creation, review, approval, and finalize UX, the canonical user-facing path is now the agent-first
+Simulacrum client served from Lesser at `/l/*`.
+
+Portal soul routes remain supported as secondary, fallback, or operator-guided surfaces. They should not be presented as
+the primary product path once the Simulacrum flow is available.
+
 ## Authentication
 
 ### Portal wallet login (public)

--- a/docs/soul-agent-first-client-contract.md
+++ b/docs/soul-agent-first-client-contract.md
@@ -28,6 +28,27 @@ This contract covers the soul promotion lifecycle introduced for agent-first cli
 
 It does not restate the entire public soul registry surface. For the wider registry API, see `docs/soul-surface.md`.
 
+## Published Identity Payload
+
+When an agent-first client resolves a published soul profile through `GET /api/v1/soul/agents/{agentId}`, it should
+treat the response as machine-readable identity state rather than scraping legacy portal UI behavior.
+
+Important fields include:
+
+- core identity: `agent_id`, `domain`, `local_id`, `ens_name`, `wallet`, `token_id`, `meta_uri`
+- declaration metadata: `principal_address`, `principal_signature`, `principal_declaration`, `principal_declared_at`
+- lifecycle metadata: `status`, `lifecycle_status`, `lifecycle_reason`, `successor_agent_id`, `predecessor_agent_id`
+- publication metadata: `self_description_version`, `mint_tx_hash`, `minted_at`, `updated_at`
+- on-chain avatar metadata under `avatar`
+  - `current_style_id`
+  - `current_style_name`
+  - `current_renderer_address`
+  - `image`
+  - `styles[]` containing the currently configured avatar variants for client display and selection UI
+
+Clients should prefer these structured fields directly. Fetching `meta_uri` for token metadata should be treated as a
+fallback for older records, not the primary integration path.
+
 ## Authentication
 
 All workflow endpoints in this document use the control-plane bearer session token:

--- a/docs/spec/v3/schemas/soul-agent-identity.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-identity.schema.json
@@ -5,13 +5,44 @@
   "type": "object",
   "additionalProperties": false,
   "required": ["agent_id", "domain", "local_id", "wallet", "status"],
+  "$defs": {
+    "avatar_style": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["style_id"],
+      "properties": {
+        "style_id": { "type": "integer", "minimum": 0, "maximum": 255 },
+        "style_name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "renderer_address": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+        "image": { "type": "string", "minLength": 1 }
+      }
+    },
+    "avatar": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "token_uri": { "type": "string", "minLength": 1 },
+        "image": { "type": "string", "minLength": 1 },
+        "current_style_id": { "type": "integer", "minimum": 0, "maximum": 255 },
+        "current_style_name": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "current_renderer_address": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
+        "styles": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/avatar_style" },
+          "maxItems": 16
+        }
+      }
+    }
+  },
   "properties": {
     "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
     "domain": { "type": "string", "minLength": 1, "maxLength": 255 },
     "local_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "ens_name": { "type": "string", "minLength": 1, "maxLength": 255 },
     "wallet": { "type": "string", "pattern": "^0x[0-9a-fA-F]{40}$" },
     "token_id": { "type": "string", "minLength": 1, "maxLength": 256 },
     "meta_uri": { "type": "string", "format": "uri" },
+    "avatar": { "$ref": "#/$defs/avatar" },
     "capabilities": {
       "type": "array",
       "items": { "type": "string", "minLength": 1, "maxLength": 128 }

--- a/internal/controlplane/eth_rpc.go
+++ b/internal/controlplane/eth_rpc.go
@@ -11,6 +11,7 @@ import (
 
 type ethRPCClient interface {
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	Close()
 }

--- a/internal/controlplane/handlers_soul_discovery_v3.go
+++ b/internal/controlplane/handlers_soul_discovery_v3.go
@@ -385,7 +385,7 @@ func (s *Server) handleSoulPublicResolveENSName(ctx *apptheory.Context) (*appthe
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: *identity})
+	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
@@ -440,7 +440,7 @@ func (s *Server) handleSoulPublicResolveEmail(ctx *apptheory.Context) (*apptheor
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: *identity})
+	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
@@ -496,7 +496,7 @@ func (s *Server) handleSoulPublicResolvePhone(ctx *apptheory.Context) (*apptheor
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: *identity})
+	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}

--- a/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
+++ b/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
@@ -498,6 +498,7 @@ func discoverySuccessSetup(setup discoveryResolveSetup, localID string) discover
 			dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 			*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: localID, Status: models.SoulAgentStatusActive}
 		}).Once()
+		tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
 	}
 }
 

--- a/internal/controlplane/handlers_soul_lifecycle_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_internal_test.go
@@ -37,6 +37,7 @@ const soulLifecycleTestAgentIDHex = "0x8db124b1d48e366002db4e61cc1501eeb8561e1ef
 
 type fakeEVMClient struct {
 	callContract func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+	filterLogs   func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 }
 
 func (f *fakeEVMClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
@@ -48,6 +49,13 @@ func (f *fakeEVMClient) CallContract(ctx context.Context, msg ethereum.CallMsg, 
 
 func (f *fakeEVMClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	return nil, ethereum.NotFound
+}
+
+func (f *fakeEVMClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	if f == nil || f.filterLogs == nil {
+		return nil, nil
+	}
+	return f.filterLogs(ctx, q)
 }
 
 func (f *fakeEVMClient) Close() {}

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -32,6 +32,7 @@ type fakeEthClient struct {
 	err     error
 
 	callContract func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+	filterLogs   func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 }
 
 func (f *fakeEthClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
@@ -43,6 +44,13 @@ func (f *fakeEthClient) CallContract(ctx context.Context, msg ethereum.CallMsg, 
 
 func (f *fakeEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	return f.receipt, f.err
+}
+
+func (f *fakeEthClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	if f != nil && f.filterLogs != nil {
+		return f.filterLogs(ctx, q)
+	}
+	return nil, errors.New("not implemented")
 }
 
 func (f *fakeEthClient) Close() {}

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -24,7 +24,7 @@ import (
 
 type soulPublicAgentResponse struct {
 	Version    string                      `json:"version"`
-	Agent      models.SoulAgentIdentity    `json:"agent"`
+	Agent      soulPublicAgentView         `json:"agent"`
 	Reputation *models.SoulAgentReputation `json:"reputation,omitempty"`
 }
 
@@ -56,7 +56,7 @@ func (s *Server) handleSoulPublicGetAgent(ctx *apptheory.Context) (*apptheory.Re
 
 	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{
 		Version:    "1",
-		Agent:      *identity,
+		Agent:      s.buildSoulPublicAgentView(ctx.Context(), identity),
 		Reputation: rep,
 	})
 	if err != nil {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -1,15 +1,22 @@
 package controlplane
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -18,6 +25,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
@@ -40,6 +48,31 @@ func (f *fakeSoulPublicPacks) GetObject(ctx context.Context, key string, maxByte
 	}
 	return f.body, f.contentType, f.etag, nil
 }
+
+type fakeSoulPublicEthClient struct {
+	callContract func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
+	filterLogs   func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+}
+
+func (f *fakeSoulPublicEthClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
+	if f != nil && f.callContract != nil {
+		return f.callContract(ctx, msg)
+	}
+	return nil, errors.New("unexpected CallContract")
+}
+
+func (f *fakeSoulPublicEthClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	if f != nil && f.filterLogs != nil {
+		return f.filterLogs(ctx, q)
+	}
+	return nil, errors.New("unexpected FilterLogs")
+}
+
+func (f *fakeSoulPublicEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
+	return nil, ethereum.NotFound
+}
+
+func (f *fakeSoulPublicEthClient) Close() {}
 
 type soulPublicTestDB struct {
 	db        *ttmocks.MockExtendedDB
@@ -216,6 +249,344 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 	}
 	if out.Version != "1" || out.Agent.AgentID != agentID || out.Reputation == nil || out.Reputation.AgentID != agentID {
 		t.Fatalf("unexpected response: %#v", out)
+	}
+}
+
+func TestHandleSoulPublicGetAgent_IncludesENSAndAvatarStyles(t *testing.T) {
+	t.Parallel()
+
+	s, expected := newSoulPublicAvatarTestServer(t)
+
+	ctx := &apptheory.Context{Params: map[string]string{"agentId": expected.agentID}}
+	resp, err := s.handleSoulPublicGetAgent(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	var out soulPublicAgentResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	assertSoulPublicAvatarResponse(t, out, expected)
+}
+
+type soulPublicAvatarExpectations struct {
+	agentID          string
+	ensName          string
+	registryAddr     common.Address
+	renderers        [3]common.Address
+	images           [3]string
+	currentStyleID   int
+	currentStyleName string
+}
+
+type soulPublicAvatarRPCFixture struct {
+	tokenURI         string
+	tokenURICall     []byte
+	styleNameCall    []byte
+	renderAvatarCall []byte
+	styleNames       [3]string
+	styleSVGs        [3]string
+}
+
+func newSoulPublicAvatarTestServer(t *testing.T) (*Server, soulPublicAvatarExpectations) {
+	t.Helper()
+
+	tdb := newSoulPublicTestDB()
+	expected := soulPublicAvatarExpectations{
+		agentID:          "0x" + strings.Repeat("12", 32),
+		ensName:          "agent-bot.lessersoul.eth",
+		registryAddr:     common.HexToAddress("0x0000000000000000000000000000000000000abc"),
+		renderers:        [3]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000100"), common.HexToAddress("0x0000000000000000000000000000000000000101"), common.HexToAddress("0x0000000000000000000000000000000000000102")},
+		images:           [3]string{encodeSoulPublicAvatarSVG("<svg>blob</svg>"), encodeSoulPublicAvatarSVG("<svg>geometry</svg>"), encodeSoulPublicAvatarSVG("<svg>sigil</svg>")},
+		currentStyleID:   1,
+		currentStyleName: "Sacred Geometry",
+	}
+
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulEnabled:                 true,
+			SoulRPCURL:                  "http://rpc",
+			SoulRegistryContractAddress: expected.registryAddr.Hex(),
+		},
+	}
+
+	expectSoulPublicAvatarIdentity(t, tdb, expected.agentID)
+	expectSoulPublicAvatarENSChannel(t, tdb, expected.agentID, expected.ensName)
+	configureSoulPublicAvatarRPC(t, s, expected)
+
+	return s, expected
+}
+
+func expectSoulPublicAvatarIdentity(t *testing.T, tdb soulPublicTestDB, agentID string) {
+	t.Helper()
+
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{
+			AgentID:                agentID,
+			Domain:                 "example.com",
+			LocalID:                "agent-bot",
+			Wallet:                 "0x00000000000000000000000000000000000000aa",
+			TokenID:                agentID,
+			MetaURI:                "https://example.com/metadata.json",
+			PrincipalAddress:       "0x00000000000000000000000000000000000000bb",
+			PrincipalSignature:     "0xdeadbeef",
+			PrincipalDeclaration:   "I accept responsibility for this agent's behavior.",
+			PrincipalDeclaredAt:    "2026-04-01T12:00:00Z",
+			SelfDescriptionVersion: 3,
+			Status:                 models.SoulAgentStatusActive,
+			LifecycleStatus:        models.SoulAgentStatusActive,
+			MintTxHash:             "0x" + strings.Repeat("ab", 32),
+			MintedAt:               time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:              time.Date(2026, 4, 2, 8, 30, 0, 0, time.UTC),
+		}
+	}).Once()
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+}
+
+func expectSoulPublicAvatarENSChannel(t *testing.T, tdb soulPublicTestDB, agentID string, ensName string) {
+	t.Helper()
+
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:     agentID,
+			ChannelType: models.SoulChannelTypeENS,
+			Identifier:  ensName,
+			Status:      models.SoulChannelStatusActive,
+		}
+	}).Once()
+}
+
+func configureSoulPublicAvatarRPC(t *testing.T, s *Server, expected soulPublicAvatarExpectations) {
+	t.Helper()
+
+	fixture := newSoulPublicAvatarRPCFixture(t, expected)
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeSoulPublicEthClient{
+			callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+				if response, ok := soulPublicAvatarCallResult(t, msg, expected, fixture); ok {
+					return response, nil
+				}
+				t.Fatalf("unexpected CallContract to=%v data=%x", msg.To, msg.Data)
+				return nil, errors.New("unexpected call")
+			},
+			filterLogs: func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+				return []types.Log{
+					rendererUpdatedLog(0, expected.renderers[0]),
+					rendererUpdatedLog(1, expected.renderers[1]),
+					rendererUpdatedLog(2, expected.renderers[2]),
+				}, nil
+			},
+		}, nil
+	}
+}
+
+func newSoulPublicAvatarRPCFixture(t *testing.T, expected soulPublicAvatarExpectations) soulPublicAvatarRPCFixture {
+	t.Helper()
+
+	tokenID, ok := new(big.Int).SetString(strings.TrimPrefix(expected.agentID, "0x"), 16)
+	if !ok {
+		t.Fatalf("failed to parse token id")
+	}
+
+	styleNameCall, err := soul.EncodeRendererStyleNameCall()
+	if err != nil {
+		t.Fatalf("encode styleName: %v", err)
+	}
+	renderAvatarCall, err := soul.EncodeRendererRenderAvatarCall(tokenID)
+	if err != nil {
+		t.Fatalf("encode renderAvatar: %v", err)
+	}
+	tokenURICall, err := soul.EncodeTokenURICall(tokenID)
+	if err != nil {
+		t.Fatalf("encode tokenURI: %v", err)
+	}
+
+	tokenMetadataJSON, err := json.Marshal(soulAvatarTokenMetadata{
+		Image: expected.images[expected.currentStyleID],
+		Attributes: []soulAvatarTokenMetadataAttribute{
+			{TraitType: "Style", Value: expected.currentStyleName},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	return soulPublicAvatarRPCFixture{
+		tokenURI:         "data:application/json;base64," + base64.StdEncoding.EncodeToString(tokenMetadataJSON),
+		tokenURICall:     tokenURICall,
+		styleNameCall:    styleNameCall,
+		renderAvatarCall: renderAvatarCall,
+		styleNames:       [3]string{"Ethereal Blob", "Sacred Geometry", "Sigil"},
+		styleSVGs:        [3]string{"<svg>blob</svg>", "<svg>geometry</svg>", "<svg>sigil</svg>"},
+	}
+}
+
+func soulPublicAvatarCallResult(t *testing.T, msg ethereum.CallMsg, expected soulPublicAvatarExpectations, fixture soulPublicAvatarRPCFixture) ([]byte, bool) {
+	t.Helper()
+
+	if msg.To != nil && *msg.To == expected.registryAddr && bytes.Equal(msg.Data, fixture.tokenURICall) {
+		return packSingleStringResult(t, fixture.tokenURI), true
+	}
+	return soulPublicAvatarRendererCallResult(t, msg, expected, fixture)
+}
+
+func soulPublicAvatarRendererCallResult(t *testing.T, msg ethereum.CallMsg, expected soulPublicAvatarExpectations, fixture soulPublicAvatarRPCFixture) ([]byte, bool) {
+	t.Helper()
+
+	for idx, renderer := range expected.renderers {
+		if msg.To == nil || *msg.To != renderer {
+			continue
+		}
+		if bytes.Equal(msg.Data, fixture.styleNameCall) {
+			return packSingleStringResult(t, fixture.styleNames[idx]), true
+		}
+		if bytes.Equal(msg.Data, fixture.renderAvatarCall) {
+			return packSingleStringResult(t, fixture.styleSVGs[idx]), true
+		}
+	}
+	return nil, false
+}
+
+func assertSoulPublicAvatarResponse(t *testing.T, out soulPublicAgentResponse, expected soulPublicAvatarExpectations) {
+	t.Helper()
+
+	if out.Agent.ENSName != expected.ensName {
+		t.Fatalf("expected ens_name, got %#v", out.Agent)
+	}
+	if out.Agent.Avatar == nil {
+		t.Fatalf("expected avatar payload, got %#v", out.Agent)
+	}
+	assertSoulPublicAvatarSelection(t, out.Agent.Avatar, expected)
+	assertSoulPublicAvatarStyles(t, out.Agent.Avatar, expected)
+	assertSoulPublicAgentIdentityDetails(t, out)
+}
+
+func assertSoulPublicAvatarSelection(t *testing.T, avatar *soulPublicAvatarView, expected soulPublicAvatarExpectations) {
+	t.Helper()
+
+	if avatar.CurrentStyleID == nil || *avatar.CurrentStyleID != expected.currentStyleID {
+		t.Fatalf("expected current style id %d, got %#v", expected.currentStyleID, avatar)
+	}
+	if avatar.CurrentStyleName != expected.currentStyleName {
+		t.Fatalf("expected current style name, got %#v", avatar)
+	}
+	if avatar.CurrentRendererAddress != strings.ToLower(expected.renderers[expected.currentStyleID].Hex()) {
+		t.Fatalf("expected current renderer %s, got %#v", expected.renderers[expected.currentStyleID].Hex(), avatar)
+	}
+	if avatar.Image != expected.images[expected.currentStyleID] {
+		t.Fatalf("expected current image %q, got %#v", expected.images[expected.currentStyleID], avatar)
+	}
+	if !avatar.Styles[expected.currentStyleID].Selected {
+		t.Fatalf("expected selected style, got %#v", avatar.Styles)
+	}
+}
+
+func assertSoulPublicAvatarStyles(t *testing.T, avatar *soulPublicAvatarView, expected soulPublicAvatarExpectations) {
+	t.Helper()
+
+	if len(avatar.Styles) != len(expected.images) {
+		t.Fatalf("expected three styles, got %#v", avatar)
+	}
+	for idx, image := range expected.images {
+		if avatar.Styles[idx].Image != image {
+			t.Fatalf("unexpected style images: %#v", avatar.Styles)
+		}
+	}
+}
+
+func assertSoulPublicAgentIdentityDetails(t *testing.T, out soulPublicAgentResponse) {
+	t.Helper()
+
+	if out.Agent.PrincipalSignature == "" || out.Agent.PrincipalDeclaration == "" || out.Agent.PrincipalDeclaredAt == "" || out.Agent.MetaURI == "" {
+		t.Fatalf("expected richer identity details, got %#v", out.Agent)
+	}
+}
+
+func encodeSoulPublicAvatarSVG(svg string) string {
+	return "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(svg))
+}
+
+func TestHandleSoulPublicGetAgent_AvatarLookupFailureIsNonFatal(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulPublicTestDB()
+	agentID := "0x" + strings.Repeat("34", 32)
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulEnabled:                 true,
+			SoulRPCURL:                  "http://rpc",
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000abc",
+		},
+	}
+
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{
+			AgentID:         agentID,
+			Domain:          "example.com",
+			LocalID:         "agent-bot",
+			Wallet:          "0x00000000000000000000000000000000000000aa",
+			Status:          models.SoulAgentStatusActive,
+			LifecycleStatus: models.SoulAgentStatusActive,
+		}
+	}).Once()
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeSoulPublicEthClient{
+			filterLogs: func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+				return nil, errors.New("rpc boom")
+			},
+		}, nil
+	}
+
+	ctx := &apptheory.Context{Params: map[string]string{"agentId": agentID}}
+	resp, err := s.handleSoulPublicGetAgent(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+
+	var out soulPublicAgentResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Agent.Avatar != nil {
+		t.Fatalf("expected avatar enrichment to fail closed, got %#v", out.Agent.Avatar)
+	}
+	if out.Agent.AgentID != agentID {
+		t.Fatalf("expected base identity to survive, got %#v", out.Agent)
+	}
+}
+
+func packSingleStringResult(t *testing.T, value string) []byte {
+	t.Helper()
+
+	stringType, err := abi.NewType("string", "", nil)
+	if err != nil {
+		t.Fatalf("new string type: %v", err)
+	}
+	args := abi.Arguments{{Type: stringType}}
+	out, err := args.Pack(value)
+	if err != nil {
+		t.Fatalf("pack string result: %v", err)
+	}
+	return out
+}
+
+func rendererUpdatedLog(styleID uint8, renderer common.Address) types.Log {
+	return types.Log{
+		Topics: []common.Hash{
+			soulRendererUpdatedTopic,
+			common.BigToHash(big.NewInt(int64(styleID))),
+		},
+		Data: common.LeftPadBytes(renderer.Bytes(), 32),
 	}
 }
 

--- a/internal/controlplane/handlers_soul_rotation_internal_test.go
+++ b/internal/controlplane/handlers_soul_rotation_internal_test.go
@@ -33,6 +33,7 @@ import (
 type stubEthRPCClient struct {
 	t            *testing.T
 	callContract func(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
+	filterLogs   func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
 }
 
 func (c *stubEthRPCClient) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error) {
@@ -45,6 +46,13 @@ func (c *stubEthRPCClient) CallContract(ctx context.Context, msg ethereum.CallMs
 func (c *stubEthRPCClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	c.t.Fatalf("unexpected TransactionReceipt(%s)", txHash.Hex())
 	return nil, nil
+}
+
+func (c *stubEthRPCClient) FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+	if c.filterLogs == nil {
+		c.t.Fatalf("unexpected FilterLogs(%#v)", q)
+	}
+	return c.filterLogs(ctx, q)
 }
 
 func (c *stubEthRPCClient) Close() {}

--- a/internal/controlplane/soul_public_agent_view.go
+++ b/internal/controlplane/soul_public_agent_view.go
@@ -1,0 +1,386 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"math/big"
+	"net/url"
+	"strings"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+var soulRendererUpdatedTopic = crypto.Keccak256Hash([]byte("RendererUpdated(uint8,address)"))
+
+var soulAvatarStyleDefaults = []struct {
+	StyleID   uint8
+	StyleName string
+}{
+	{StyleID: 0, StyleName: "Ethereal Blob"},
+	{StyleID: 1, StyleName: "Sacred Geometry"},
+	{StyleID: 2, StyleName: "Sigil"},
+}
+
+type soulPublicAgentView struct {
+	models.SoulAgentIdentity
+	ENSName string                `json:"ens_name,omitempty"`
+	Avatar  *soulPublicAvatarView `json:"avatar,omitempty"`
+}
+
+type soulPublicAvatarView struct {
+	TokenURI               string                      `json:"token_uri,omitempty"`
+	Image                  string                      `json:"image,omitempty"`
+	CurrentStyleID         *int                        `json:"current_style_id,omitempty"`
+	CurrentStyleName       string                      `json:"current_style_name,omitempty"`
+	CurrentRendererAddress string                      `json:"current_renderer_address,omitempty"`
+	Styles                 []soulPublicAvatarStyleView `json:"styles,omitempty"`
+}
+
+type soulPublicAvatarStyleView struct {
+	StyleID         int    `json:"style_id"`
+	StyleName       string `json:"style_name,omitempty"`
+	RendererAddress string `json:"renderer_address,omitempty"`
+	Image           string `json:"image,omitempty"`
+	Selected        bool   `json:"selected,omitempty"`
+}
+
+type soulAvatarTokenMetadata struct {
+	Image      string                             `json:"image"`
+	Attributes []soulAvatarTokenMetadataAttribute `json:"attributes"`
+}
+
+type soulAvatarTokenMetadataAttribute struct {
+	TraitType string `json:"trait_type"`
+	Value     any    `json:"value"`
+}
+
+func (s *Server) buildSoulPublicAgentView(ctx context.Context, identity *models.SoulAgentIdentity) soulPublicAgentView {
+	view := soulPublicAgentView{}
+	if identity == nil {
+		return view
+	}
+
+	view.SoulAgentIdentity = *identity
+	if strings.TrimSpace(identity.LocalID) != "" {
+		if ensName, err := s.loadSoulPublicAgentENSName(ctx, identity.AgentID); err == nil {
+			view.ENSName = ensName
+		}
+	}
+	if avatar, err := s.loadSoulPublicAgentAvatar(ctx, identity); err == nil {
+		view.Avatar = avatar
+	} else if err != nil && s != nil && s.cfg.SoulV2StrictIntegrity {
+		log.Printf("controlplane: soul_public_avatar_enrichment_failed agent=%s err=%v", strings.TrimSpace(identity.AgentID), err)
+	}
+
+	return view
+}
+
+func (s *Server) loadSoulPublicAgentENSName(ctx context.Context, agentIDHex string) (string, error) {
+	ens, err := getSoulAgentItemBySK[models.SoulAgentChannel](s, ctx, agentIDHex, "CHANNEL#ens")
+	if theoryErrors.IsNotFound(err) || ens == nil {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(ens.Identifier), nil
+}
+
+func (s *Server) loadSoulPublicAgentAvatar(ctx context.Context, identity *models.SoulAgentIdentity) (*soulPublicAvatarView, error) {
+	if s == nil || identity == nil || s.dialEVM == nil {
+		return nil, nil
+	}
+	rpcURL := strings.TrimSpace(s.cfg.SoulRPCURL)
+	if rpcURL == "" {
+		return nil, nil
+	}
+	contractAddrRaw := strings.TrimSpace(s.cfg.SoulRegistryContractAddress)
+	if !common.IsHexAddress(contractAddrRaw) {
+		return nil, nil
+	}
+	agentIDHex := strings.TrimSpace(identity.AgentID)
+	if agentIDHex == "" {
+		return nil, nil
+	}
+
+	tokenID, ok := new(big.Int).SetString(strings.TrimPrefix(strings.ToLower(agentIDHex), "0x"), 16)
+	if !ok {
+		return nil, fmt.Errorf("invalid token id for agent %s", agentIDHex)
+	}
+
+	client, err := s.dialEVM(ctx, rpcURL)
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	contractAddr := common.HexToAddress(contractAddrRaw)
+	view, err := loadSoulPublicAvatarViewFromChain(ctx, client, contractAddr, tokenID)
+	if err != nil {
+		return nil, err
+	}
+	if view == nil {
+		return nil, nil
+	}
+	return view, nil
+}
+
+func loadSoulPublicAvatarViewFromChain(ctx context.Context, client ethRPCClient, contractAddr common.Address, tokenID *big.Int) (*soulPublicAvatarView, error) {
+	if client == nil || tokenID == nil {
+		return nil, nil
+	}
+
+	tokenURI, metadata, err := loadSoulAvatarTokenMetadata(ctx, client, contractAddr, tokenID)
+	if err != nil {
+		return nil, err
+	}
+	renderers, err := loadSoulAvatarRenderers(ctx, client, contractAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	view := newSoulPublicAvatarView(tokenURI, metadata)
+	view.Styles = loadSoulPublicAvatarStyles(ctx, client, tokenID, renderers, view)
+
+	if soulPublicAvatarViewEmpty(view) {
+		return nil, nil
+	}
+	return view, nil
+}
+
+func loadSoulAvatarTokenMetadata(ctx context.Context, client ethRPCClient, contractAddr common.Address, tokenID *big.Int) (string, *soulAvatarTokenMetadata, error) {
+	callData, err := soul.EncodeTokenURICall(tokenID)
+	if err != nil {
+		return "", nil, err
+	}
+	ret, err := client.CallContract(ctx, ethereum.CallMsg{To: &contractAddr, Data: callData}, nil)
+	if err != nil {
+		return "", nil, err
+	}
+	tokenURI, err := soul.DecodeTokenURIResult(ret)
+	if err != nil {
+		return "", nil, err
+	}
+	metadata, err := decodeSoulAvatarTokenMetadata(tokenURI)
+	if err != nil {
+		return tokenURI, nil, nil
+	}
+	return tokenURI, metadata, nil
+}
+
+func loadSoulAvatarRenderers(ctx context.Context, client ethRPCClient, contractAddr common.Address) (map[uint8]common.Address, error) {
+	logs, err := client.FilterLogs(ctx, ethereum.FilterQuery{
+		Addresses: []common.Address{contractAddr},
+		Topics:    [][]common.Hash{{soulRendererUpdatedTopic}},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	renderers := make(map[uint8]common.Address, len(soulAvatarStyleDefaults))
+	for _, entry := range logs {
+		styleID, renderer, ok := decodeSoulRendererUpdatedLog(entry)
+		if !ok {
+			continue
+		}
+		renderers[styleID] = renderer
+	}
+	return renderers, nil
+}
+
+func decodeSoulRendererUpdatedLog(entry types.Log) (uint8, common.Address, bool) {
+	if len(entry.Topics) < 2 || entry.Topics[0] != soulRendererUpdatedTopic || len(entry.Data) < 32 {
+		return 0, common.Address{}, false
+	}
+	styleValue := entry.Topics[1].Big()
+	if !styleValue.IsUint64() {
+		return 0, common.Address{}, false
+	}
+	rawStyleID := styleValue.Uint64()
+	if rawStyleID > 255 {
+		return 0, common.Address{}, false
+	}
+	styleID := uint8(rawStyleID)
+	renderer := common.BytesToAddress(entry.Data[len(entry.Data)-20:])
+	return styleID, renderer, true
+}
+
+func loadRendererStyleName(ctx context.Context, client ethRPCClient, rendererAddr common.Address) (string, error) {
+	callData, err := soul.EncodeRendererStyleNameCall()
+	if err != nil {
+		return "", err
+	}
+	ret, err := client.CallContract(ctx, ethereum.CallMsg{To: &rendererAddr, Data: callData}, nil)
+	if err != nil {
+		return "", err
+	}
+	return soul.DecodeRendererStyleNameResult(ret)
+}
+
+func loadRendererAvatarImage(ctx context.Context, client ethRPCClient, rendererAddr common.Address, tokenID *big.Int) (string, error) {
+	callData, err := soul.EncodeRendererRenderAvatarCall(tokenID)
+	if err != nil {
+		return "", err
+	}
+	ret, err := client.CallContract(ctx, ethereum.CallMsg{To: &rendererAddr, Data: callData}, nil)
+	if err != nil {
+		return "", err
+	}
+	svg, err := soul.DecodeRendererRenderAvatarResult(ret)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(svg) == "" {
+		return "", nil
+	}
+	return "data:image/svg+xml;base64," + base64.StdEncoding.EncodeToString([]byte(svg)), nil
+}
+
+func decodeSoulAvatarTokenMetadata(tokenURI string) (*soulAvatarTokenMetadata, error) {
+	body, contentType, err := decodeDataURI(tokenURI)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(contentType, "application/json") {
+		return nil, fmt.Errorf("unsupported content type %q", contentType)
+	}
+	var metadata soulAvatarTokenMetadata
+	if err := json.Unmarshal(body, &metadata); err != nil {
+		return nil, err
+	}
+	return &metadata, nil
+}
+
+func decodeDataURI(raw string) ([]byte, string, error) {
+	raw = strings.TrimSpace(raw)
+	if !strings.HasPrefix(raw, "data:") {
+		return nil, "", fmt.Errorf("not a data uri")
+	}
+	parts := strings.SplitN(raw, ",", 2)
+	if len(parts) != 2 {
+		return nil, "", fmt.Errorf("invalid data uri")
+	}
+	meta := strings.TrimPrefix(parts[0], "data:")
+	payload := parts[1]
+	segments := strings.Split(meta, ";")
+	contentType := strings.TrimSpace(segments[0])
+	isBase64 := false
+	for _, segment := range segments[1:] {
+		if strings.EqualFold(strings.TrimSpace(segment), "base64") {
+			isBase64 = true
+		}
+	}
+	if isBase64 {
+		body, err := base64.StdEncoding.DecodeString(payload)
+		if err != nil {
+			return nil, "", err
+		}
+		return body, contentType, nil
+	}
+	body, err := url.PathUnescape(payload)
+	if err != nil {
+		return nil, "", err
+	}
+	return []byte(body), contentType, nil
+}
+
+func soulAvatarMetadataStyleName(metadata *soulAvatarTokenMetadata) string {
+	if metadata == nil {
+		return ""
+	}
+	for _, attr := range metadata.Attributes {
+		if !strings.EqualFold(strings.TrimSpace(attr.TraitType), "Style") {
+			continue
+		}
+		value := strings.TrimSpace(fmt.Sprint(attr.Value))
+		if value == "" || strings.EqualFold(value, "<nil>") {
+			return ""
+		}
+		return value
+	}
+	return ""
+}
+
+func currentStyleMatches(currentStyleName string, currentImage string, item soulPublicAvatarStyleView) bool {
+	if currentStyleName != "" && strings.EqualFold(strings.TrimSpace(currentStyleName), strings.TrimSpace(item.StyleName)) {
+		return true
+	}
+	if currentImage != "" && strings.TrimSpace(currentImage) == strings.TrimSpace(item.Image) {
+		return true
+	}
+	return false
+}
+
+func newSoulPublicAvatarView(tokenURI string, metadata *soulAvatarTokenMetadata) *soulPublicAvatarView {
+	view := &soulPublicAvatarView{TokenURI: tokenURI}
+	if metadata == nil {
+		return view
+	}
+	view.Image = strings.TrimSpace(metadata.Image)
+	view.CurrentStyleName = soulAvatarMetadataStyleName(metadata)
+	return view
+}
+
+func loadSoulPublicAvatarStyles(ctx context.Context, client ethRPCClient, tokenID *big.Int, renderers map[uint8]common.Address, view *soulPublicAvatarView) []soulPublicAvatarStyleView {
+	styles := make([]soulPublicAvatarStyleView, 0, len(soulAvatarStyleDefaults))
+	for _, def := range soulAvatarStyleDefaults {
+		item := buildSoulPublicAvatarStyleView(ctx, client, tokenID, def.StyleID, def.StyleName, renderers)
+		selectCurrentSoulAvatarStyle(view, &item)
+		styles = append(styles, item)
+	}
+	return styles
+}
+
+func buildSoulPublicAvatarStyleView(ctx context.Context, client ethRPCClient, tokenID *big.Int, styleID uint8, defaultName string, renderers map[uint8]common.Address) soulPublicAvatarStyleView {
+	item := soulPublicAvatarStyleView{
+		StyleID:   int(styleID),
+		StyleName: defaultName,
+	}
+	rendererAddr, ok := renderers[styleID]
+	if !ok || rendererAddr == (common.Address{}) {
+		return item
+	}
+	item.RendererAddress = strings.ToLower(rendererAddr.Hex())
+
+	if styleName, err := loadRendererStyleName(ctx, client, rendererAddr); err == nil && strings.TrimSpace(styleName) != "" {
+		item.StyleName = strings.TrimSpace(styleName)
+	}
+	if image, err := loadRendererAvatarImage(ctx, client, rendererAddr, tokenID); err == nil {
+		item.Image = image
+	}
+	return item
+}
+
+func selectCurrentSoulAvatarStyle(view *soulPublicAvatarView, item *soulPublicAvatarStyleView) {
+	if view == nil || item == nil || !currentStyleMatches(view.CurrentStyleName, view.Image, *item) {
+		return
+	}
+	item.Selected = true
+	currentStyleID := item.StyleID
+	view.CurrentStyleID = &currentStyleID
+	view.CurrentStyleName = item.StyleName
+	view.CurrentRendererAddress = item.RendererAddress
+	if strings.TrimSpace(view.Image) == "" {
+		view.Image = item.Image
+	}
+}
+
+func soulPublicAvatarViewEmpty(view *soulPublicAvatarView) bool {
+	if view == nil {
+		return true
+	}
+	return view.CurrentStyleID == nil &&
+		strings.TrimSpace(view.CurrentStyleName) == "" &&
+		strings.TrimSpace(view.Image) == "" &&
+		strings.TrimSpace(view.TokenURI) == ""
+}

--- a/internal/controlplane/soul_public_agent_view_internal_test.go
+++ b/internal/controlplane/soul_public_agent_view_internal_test.go
@@ -1,0 +1,450 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestSoulPublicAvatarViewHelpers(t *testing.T) {
+	t.Parallel()
+
+	styleID := 1
+	view := newSoulPublicAvatarView("token-uri", &soulAvatarTokenMetadata{
+		Image: " data:image/svg+xml;base64,abc ",
+		Attributes: []soulAvatarTokenMetadataAttribute{
+			{TraitType: "Style", Value: " Sacred Geometry "},
+		},
+	})
+	if view == nil || view.TokenURI != "token-uri" || view.Image != "data:image/svg+xml;base64,abc" || view.CurrentStyleName != "Sacred Geometry" {
+		t.Fatalf("unexpected view: %#v", view)
+	}
+	if soulPublicAvatarViewEmpty(view) {
+		t.Fatalf("expected populated view to be non-empty")
+	}
+
+	emptyView := &soulPublicAvatarView{}
+	if !soulPublicAvatarViewEmpty(emptyView) {
+		t.Fatalf("expected empty view to be empty")
+	}
+
+	item := soulPublicAvatarStyleView{
+		StyleID:         styleID,
+		StyleName:       "Sacred Geometry",
+		RendererAddress: "0xabc",
+		Image:           "data:image/svg+xml;base64,abc",
+	}
+	selectCurrentSoulAvatarStyle(view, &item)
+	if view.CurrentStyleID == nil || *view.CurrentStyleID != styleID || !item.Selected {
+		t.Fatalf("expected style selection to be recorded: view=%#v item=%#v", view, item)
+	}
+	if !currentStyleMatches("Sacred Geometry", "", item) {
+		t.Fatalf("expected name-based style match")
+	}
+	if !currentStyleMatches("", "data:image/svg+xml;base64,abc", item) {
+		t.Fatalf("expected image-based style match")
+	}
+	if currentStyleMatches("Sigil", "", item) {
+		t.Fatalf("did not expect mismatched style name to match")
+	}
+}
+
+func TestDecodeSoulAvatarMetadataAndDataURIs(t *testing.T) {
+	t.Parallel()
+
+	rawJSON, err := json.Marshal(soulAvatarTokenMetadata{
+		Image: "data:image/svg+xml;base64,xyz",
+		Attributes: []soulAvatarTokenMetadataAttribute{
+			{TraitType: "Style", Value: "Sigil"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal metadata: %v", err)
+	}
+
+	base64URI := "data:application/json;base64," + base64.StdEncoding.EncodeToString(rawJSON)
+	plainURI := "data:text/plain," + url.PathEscape("hello world")
+
+	metadata, err := decodeSoulAvatarTokenMetadata(base64URI)
+	if err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	if metadata == nil || metadata.Image != "data:image/svg+xml;base64,xyz" || soulAvatarMetadataStyleName(metadata) != "Sigil" {
+		t.Fatalf("unexpected metadata: %#v", metadata)
+	}
+	if soulAvatarMetadataStyleName(&soulAvatarTokenMetadata{
+		Attributes: []soulAvatarTokenMetadataAttribute{{TraitType: "Style", Value: "   "}},
+	}) != "" {
+		t.Fatalf("expected blank style metadata to collapse to empty")
+	}
+
+	body, contentType, err := decodeDataURI(plainURI)
+	if err != nil {
+		t.Fatalf("decode plain data uri: %v", err)
+	}
+	if string(body) != "hello world" || contentType != "text/plain" {
+		t.Fatalf("unexpected decoded payload: body=%q contentType=%q", string(body), contentType)
+	}
+	if _, _, err := decodeDataURI("not-a-data-uri"); err == nil {
+		t.Fatalf("expected invalid scheme to fail")
+	}
+	if _, err := decodeSoulAvatarTokenMetadata("data:text/plain,hello"); err == nil {
+		t.Fatalf("expected non-json metadata to fail")
+	}
+}
+
+func TestDecodeSoulRendererUpdatedLog(t *testing.T) {
+	t.Parallel()
+
+	renderer := common.HexToAddress("0x0000000000000000000000000000000000000abc")
+	entry := types.Log{
+		Topics: []common.Hash{
+			soulRendererUpdatedTopic,
+			common.BigToHash(big.NewInt(2)),
+		},
+		Data: common.LeftPadBytes(renderer.Bytes(), 32),
+	}
+	styleID, decodedRenderer, ok := decodeSoulRendererUpdatedLog(entry)
+	if !ok || styleID != 2 || decodedRenderer != renderer {
+		t.Fatalf("expected valid renderer log decode, got styleID=%d renderer=%s ok=%v", styleID, decodedRenderer.Hex(), ok)
+	}
+
+	overflow := types.Log{
+		Topics: []common.Hash{
+			soulRendererUpdatedTopic,
+			common.BigToHash(big.NewInt(256)),
+		},
+		Data: common.LeftPadBytes(renderer.Bytes(), 32),
+	}
+	if _, _, ok := decodeSoulRendererUpdatedLog(overflow); ok {
+		t.Fatalf("expected overflow style id to be rejected")
+	}
+	if _, _, ok := decodeSoulRendererUpdatedLog(types.Log{}); ok {
+		t.Fatalf("expected empty log to be rejected")
+	}
+}
+
+func TestLoadSoulPublicAvatarViewShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	view, err := loadSoulPublicAvatarViewFromChain(context.Background(), nil, common.Address{}, big.NewInt(1))
+	if err != nil || view != nil {
+		t.Fatalf("expected nil client to short-circuit, got view=%#v err=%v", view, err)
+	}
+	view, err = loadSoulPublicAvatarViewFromChain(context.Background(), &fakeSoulPublicEthClient{}, common.Address{}, nil)
+	if err != nil || view != nil {
+		t.Fatalf("expected nil token to short-circuit, got view=%#v err=%v", view, err)
+	}
+}
+
+func TestLoadSoulAvatarRendererHelpers(t *testing.T) {
+	t.Parallel()
+
+	tokenID := big.NewInt(7)
+	contractAddr := common.HexToAddress("0x0000000000000000000000000000000000000def")
+	rendererAddr := common.HexToAddress("0x0000000000000000000000000000000000000abc")
+
+	styleNameCall, err := soul.EncodeRendererStyleNameCall()
+	if err != nil {
+		t.Fatalf("encode styleName: %v", err)
+	}
+	renderAvatarCall, err := soul.EncodeRendererRenderAvatarCall(tokenID)
+	if err != nil {
+		t.Fatalf("encode renderAvatar: %v", err)
+	}
+
+	client := &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			switch {
+			case msg.To != nil && *msg.To == rendererAddr && bytes.Equal(msg.Data, styleNameCall):
+				return packSingleStringResult(t, "Sigil"), nil
+			case msg.To != nil && *msg.To == rendererAddr && bytes.Equal(msg.Data, renderAvatarCall):
+				return packSingleStringResult(t, "<svg>sigil</svg>"), nil
+			default:
+				t.Fatalf("unexpected call contract request: %#v", msg)
+				return nil, nil
+			}
+		},
+		filterLogs: func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+			return []types.Log{
+				{},
+				rendererUpdatedLog(2, rendererAddr),
+			}, nil
+		},
+	}
+
+	renderers, err := loadSoulAvatarRenderers(context.Background(), client, contractAddr)
+	if err != nil {
+		t.Fatalf("load renderers: %v", err)
+	}
+	if renderers[2] != rendererAddr {
+		t.Fatalf("expected renderer map to include style 2, got %#v", renderers)
+	}
+
+	styleName, err := loadRendererStyleName(context.Background(), client, rendererAddr)
+	if err != nil || styleName != "Sigil" {
+		t.Fatalf("expected style name helper to decode, got styleName=%q err=%v", styleName, err)
+	}
+
+	image, err := loadRendererAvatarImage(context.Background(), client, rendererAddr, tokenID)
+	if err != nil || !strings.HasPrefix(image, "data:image/svg+xml;base64,") {
+		t.Fatalf("expected avatar image helper to base64-encode SVG, got image=%q err=%v", image, err)
+	}
+}
+
+func TestLoadSoulAvatarTokenMetadataFallsBackForNonJSON(t *testing.T) {
+	t.Parallel()
+
+	tokenID := big.NewInt(9)
+	contractAddr := common.HexToAddress("0x0000000000000000000000000000000000000aaa")
+	tokenURICall, err := soul.EncodeTokenURICall(tokenID)
+	if err != nil {
+		t.Fatalf("encode tokenURI: %v", err)
+	}
+
+	client := &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			if msg.To == nil || *msg.To != contractAddr || !bytes.Equal(msg.Data, tokenURICall) {
+				t.Fatalf("unexpected tokenURI call: %#v", msg)
+			}
+			return packSingleStringResult(t, "data:text/plain,hello"), nil
+		},
+	}
+
+	tokenURI, metadata, err := loadSoulAvatarTokenMetadata(context.Background(), client, contractAddr, tokenID)
+	if err != nil {
+		t.Fatalf("load token metadata: %v", err)
+	}
+	if tokenURI != "data:text/plain,hello" || metadata != nil {
+		t.Fatalf("expected non-json metadata to fall back cleanly, got tokenURI=%q metadata=%#v", tokenURI, metadata)
+	}
+}
+
+func TestBuildSoulPublicAgentViewHandlesNilAndStrictIntegrity(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	if view := s.buildSoulPublicAgentView(context.Background(), nil); view.AgentID != "" || view.Avatar != nil {
+		t.Fatalf("expected nil identity to return zero view, got %#v", view)
+	}
+
+	s = &Server{
+		cfg: config.Config{
+			SoulV2StrictIntegrity:       true,
+			SoulRPCURL:                  "http://rpc",
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000abc",
+		},
+	}
+	view := s.buildSoulPublicAgentView(context.Background(), &models.SoulAgentIdentity{AgentID: "not-hex"})
+	if view.AgentID != "not-hex" || view.Avatar != nil {
+		t.Fatalf("expected strict-integrity enrichment failure to preserve base identity, got %#v", view)
+	}
+}
+
+func TestLoadSoulPublicAgentAvatarGuardClauses(t *testing.T) {
+	t.Parallel()
+
+	validIdentity := &models.SoulAgentIdentity{AgentID: "0x" + strings.Repeat("12", 32)}
+
+	s := &Server{cfg: config.Config{SoulRegistryContractAddress: "0x0000000000000000000000000000000000000abc"}, dialEVM: func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		t.Fatalf("dialEVM should not be called when rpc url is blank")
+		return nil, nil
+	}}
+	if view, err := s.loadSoulPublicAgentAvatar(context.Background(), validIdentity); err != nil || view != nil {
+		t.Fatalf("expected blank rpc url to short-circuit, got view=%#v err=%v", view, err)
+	}
+
+	s.cfg.SoulRPCURL = "http://rpc"
+	s.cfg.SoulRegistryContractAddress = "not-an-address"
+	if view, err := s.loadSoulPublicAgentAvatar(context.Background(), validIdentity); err != nil || view != nil {
+		t.Fatalf("expected invalid contract to short-circuit, got view=%#v err=%v", view, err)
+	}
+
+	s.cfg.SoulRegistryContractAddress = "0x0000000000000000000000000000000000000abc"
+	if view, err := s.loadSoulPublicAgentAvatar(context.Background(), &models.SoulAgentIdentity{}); err != nil || view != nil {
+		t.Fatalf("expected blank agent id to short-circuit, got view=%#v err=%v", view, err)
+	}
+}
+
+func TestLoadSoulPublicAgentAvatarErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{
+		cfg: config.Config{
+			SoulRPCURL:                  "http://rpc",
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000abc",
+		},
+		dialEVM: func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+			return nil, errors.New("dial failed")
+		},
+	}
+	if _, err := s.loadSoulPublicAgentAvatar(context.Background(), &models.SoulAgentIdentity{AgentID: "0x" + strings.Repeat("13", 32)}); err == nil {
+		t.Fatalf("expected dial error to propagate")
+	}
+
+	tokenID := new(big.Int).SetUint64(14)
+	tokenURICall, err := soul.EncodeTokenURICall(tokenID)
+	if err != nil {
+		t.Fatalf("encode tokenURI: %v", err)
+	}
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeSoulPublicEthClient{
+			callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+				return packSingleStringResult(t, ""), nil
+			},
+			filterLogs: func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+				return nil, nil
+			},
+		}, nil
+	}
+	view, err := s.loadSoulPublicAgentAvatar(context.Background(), &models.SoulAgentIdentity{AgentID: "0x000000000000000000000000000000000000000000000000000000000000000e"})
+	if err != nil {
+		t.Fatalf("expected empty avatar view to be non-fatal, got err=%v", err)
+	}
+	if view != nil {
+		t.Fatalf("expected empty avatar view to collapse to nil, got %#v", view)
+	}
+	_ = tokenURICall
+}
+
+func TestLoadSoulPublicAvatarViewFromChainErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	contractAddr := common.HexToAddress("0x0000000000000000000000000000000000000abc")
+	tokenID := big.NewInt(21)
+	tokenURICall, err := soul.EncodeTokenURICall(tokenID)
+	if err != nil {
+		t.Fatalf("encode tokenURI: %v", err)
+	}
+
+	client := &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			return []byte("bad"), nil
+		},
+	}
+	if _, err := loadSoulPublicAvatarViewFromChain(context.Background(), client, contractAddr, tokenID); err == nil {
+		t.Fatalf("expected invalid tokenURI response to fail")
+	}
+
+	client = &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			if !bytes.Equal(msg.Data, tokenURICall) {
+				t.Fatalf("unexpected call: %#v", msg)
+			}
+			return packSingleStringResult(t, "data:text/plain,hello"), nil
+		},
+		filterLogs: func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error) {
+			return nil, errors.New("filter failed")
+		},
+	}
+	if _, err := loadSoulPublicAvatarViewFromChain(context.Background(), client, contractAddr, tokenID); err == nil {
+		t.Fatalf("expected renderer lookup error to fail")
+	}
+}
+
+func TestLoadRendererHelperErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	rendererAddr := common.HexToAddress("0x0000000000000000000000000000000000000abc")
+	if _, err := loadRendererStyleName(context.Background(), &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			return nil, errors.New("style name failed")
+		},
+	}, rendererAddr); err == nil {
+		t.Fatalf("expected style name call failure")
+	}
+
+	tokenID := big.NewInt(33)
+	if _, err := loadRendererAvatarImage(context.Background(), &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			return nil, errors.New("render failed")
+		},
+	}, rendererAddr, tokenID); err == nil {
+		t.Fatalf("expected render call failure")
+	}
+
+	if _, err := loadRendererAvatarImage(context.Background(), &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			return []byte("bad"), nil
+		},
+	}, rendererAddr, tokenID); err == nil {
+		t.Fatalf("expected decode failure for malformed render result")
+	}
+
+	image, err := loadRendererAvatarImage(context.Background(), &fakeSoulPublicEthClient{
+		callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+			return packSingleStringResult(t, "   "), nil
+		},
+	}, rendererAddr, tokenID)
+	if err != nil || image != "" {
+		t.Fatalf("expected blank svg to produce empty image, got image=%q err=%v", image, err)
+	}
+}
+
+func TestDecodeMetadataHelperErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	if _, err := decodeSoulAvatarTokenMetadata("not-a-data-uri"); err == nil {
+		t.Fatalf("expected invalid metadata uri to fail")
+	}
+	if _, err := decodeSoulAvatarTokenMetadata("data:application/json,{"); err == nil {
+		t.Fatalf("expected malformed json metadata to fail")
+	}
+	if _, _, err := decodeDataURI("data:text/plain"); err == nil {
+		t.Fatalf("expected missing comma to fail")
+	}
+	if _, _, err := decodeDataURI("data:text/plain;base64,@@@"); err == nil {
+		t.Fatalf("expected invalid base64 payload to fail")
+	}
+	if _, _, err := decodeDataURI("data:text/plain,%zz"); err == nil {
+		t.Fatalf("expected invalid percent-encoding to fail")
+	}
+}
+
+func TestAvatarMetadataAndStyleEmptyCases(t *testing.T) {
+	t.Parallel()
+
+	if soulAvatarMetadataStyleName(nil) != "" {
+		t.Fatalf("expected nil metadata to have empty style name")
+	}
+	if soulAvatarMetadataStyleName(&soulAvatarTokenMetadata{
+		Attributes: []soulAvatarTokenMetadataAttribute{{TraitType: "Mood", Value: "calm"}},
+	}) != "" {
+		t.Fatalf("expected non-style attributes to be ignored")
+	}
+
+	view := newSoulPublicAvatarView("token-uri", nil)
+	if view == nil || view.TokenURI != "token-uri" || view.Image != "" {
+		t.Fatalf("expected nil metadata to preserve only token uri, got %#v", view)
+	}
+
+	style := buildSoulPublicAvatarStyleView(context.Background(), &fakeSoulPublicEthClient{}, big.NewInt(1), 9, "Custom", map[uint8]common.Address{})
+	if style.StyleID != 9 || style.StyleName != "Custom" || style.RendererAddress != "" {
+		t.Fatalf("expected missing renderer to keep defaults, got %#v", style)
+	}
+
+	selectView := &soulPublicAvatarView{CurrentStyleName: "Sigil"}
+	selectItem := soulPublicAvatarStyleView{StyleID: 2, StyleName: "Sigil", Image: "data:image/svg+xml;base64,abc"}
+	selectCurrentSoulAvatarStyle(selectView, &selectItem)
+	if selectView.Image != selectItem.Image {
+		t.Fatalf("expected selected style to backfill missing image, got %#v", selectView)
+	}
+
+	if !soulPublicAvatarViewEmpty(nil) {
+		t.Fatalf("expected nil view to be empty")
+	}
+}

--- a/internal/soul/avatar_renderer_abi.go
+++ b/internal/soul/avatar_renderer_abi.go
@@ -1,0 +1,11 @@
+package soul
+
+import "github.com/ethereum/go-ethereum/accounts/abi"
+
+// SoulAvatarRendererABI is the minimal ABI required for public avatar rendering helpers.
+const SoulAvatarRendererABI = `[
+  {"type":"function","name":"renderAvatar","stateMutability":"view","inputs":[{"name":"tokenId","type":"uint256"}],"outputs":[{"name":"","type":"string"}]},
+  {"type":"function","name":"styleName","stateMutability":"pure","inputs":[],"outputs":[{"name":"","type":"string"}]}
+]`
+
+var soulAvatarRendererParsedABI abi.ABI = mustParseABI(SoulAvatarRendererABI)

--- a/internal/soul/avatar_renderer_calls.go
+++ b/internal/soul/avatar_renderer_calls.go
@@ -1,0 +1,51 @@
+package soul
+
+import (
+	"errors"
+	"math/big"
+)
+
+// EncodeRendererRenderAvatarCall returns ABI-encoded call data for ISoulAvatarRenderer.renderAvatar(tokenId).
+func EncodeRendererRenderAvatarCall(tokenID *big.Int) ([]byte, error) {
+	if tokenID == nil {
+		tokenID = new(big.Int)
+	}
+	return soulAvatarRendererParsedABI.Pack("renderAvatar", tokenID)
+}
+
+// DecodeRendererRenderAvatarResult decodes the ABI result for ISoulAvatarRenderer.renderAvatar(tokenId).
+func DecodeRendererRenderAvatarResult(ret []byte) (string, error) {
+	out, err := soulAvatarRendererParsedABI.Unpack("renderAvatar", ret)
+	if err != nil {
+		return "", err
+	}
+	if len(out) != 1 {
+		return "", errors.New("unexpected renderAvatar result shape")
+	}
+	value, ok := out[0].(string)
+	if !ok {
+		return "", errors.New("unexpected renderAvatar result type")
+	}
+	return value, nil
+}
+
+// EncodeRendererStyleNameCall returns ABI-encoded call data for ISoulAvatarRenderer.styleName().
+func EncodeRendererStyleNameCall() ([]byte, error) {
+	return soulAvatarRendererParsedABI.Pack("styleName")
+}
+
+// DecodeRendererStyleNameResult decodes the ABI result for ISoulAvatarRenderer.styleName().
+func DecodeRendererStyleNameResult(ret []byte) (string, error) {
+	out, err := soulAvatarRendererParsedABI.Unpack("styleName", ret)
+	if err != nil {
+		return "", err
+	}
+	if len(out) != 1 {
+		return "", errors.New("unexpected styleName result shape")
+	}
+	value, ok := out[0].(string)
+	if !ok {
+		return "", errors.New("unexpected styleName result type")
+	}
+	return value, nil
+}

--- a/internal/soul/registry_abi.go
+++ b/internal/soul/registry_abi.go
@@ -15,6 +15,7 @@ const SoulRegistryABI = `[
   {"type":"function","name":"rotateWallet","stateMutability":"nonpayable","inputs":[{"name":"agentId","type":"uint256"},{"name":"newWallet","type":"address"},{"name":"nonce","type":"uint256"},{"name":"deadline","type":"uint256"},{"name":"currentSig","type":"bytes"},{"name":"newSig","type":"bytes"}],"outputs":[]},
   {"type":"function","name":"getAgentWallet","stateMutability":"view","inputs":[{"name":"agentId","type":"uint256"}],"outputs":[{"name":"","type":"address"}]},
   {"type":"function","name":"principalOf","stateMutability":"view","inputs":[{"name":"agentId","type":"uint256"}],"outputs":[{"name":"","type":"address"}]},
+  {"type":"function","name":"tokenURI","stateMutability":"view","inputs":[{"name":"tokenId","type":"uint256"}],"outputs":[{"name":"","type":"string"}]},
   {"type":"function","name":"agentNonces","stateMutability":"view","inputs":[{"name":"","type":"uint256"}],"outputs":[{"name":"","type":"uint256"}]},
   {"type":"function","name":"transferCount","stateMutability":"view","inputs":[{"name":"","type":"uint256"}],"outputs":[{"name":"","type":"uint256"}]},
   {"type":"function","name":"lastTransferredAt","stateMutability":"view","inputs":[{"name":"","type":"uint256"}],"outputs":[{"name":"","type":"uint256"}]},

--- a/internal/soul/registry_calls.go
+++ b/internal/soul/registry_calls.go
@@ -107,6 +107,30 @@ func DecodePrincipalOfResult(ret []byte) (common.Address, error) {
 	return addr, nil
 }
 
+// EncodeTokenURICall returns ABI-encoded call data for SoulRegistry.tokenURI(tokenId).
+func EncodeTokenURICall(tokenID *big.Int) ([]byte, error) {
+	if tokenID == nil {
+		tokenID = new(big.Int)
+	}
+	return soulRegistryParsedABI.Pack("tokenURI", tokenID)
+}
+
+// DecodeTokenURIResult decodes the ABI result for SoulRegistry.tokenURI(tokenId).
+func DecodeTokenURIResult(ret []byte) (string, error) {
+	out, err := soulRegistryParsedABI.Unpack("tokenURI", ret)
+	if err != nil {
+		return "", err
+	}
+	if len(out) != 1 {
+		return "", errors.New("unexpected tokenURI result shape")
+	}
+	value, ok := out[0].(string)
+	if !ok {
+		return "", errors.New("unexpected tokenURI result type")
+	}
+	return value, nil
+}
+
 // EncodeAgentNoncesCall returns ABI-encoded call data for SoulRegistry.agentNonces(agentId).
 func EncodeAgentNoncesCall(agentID *big.Int) ([]byte, error) {
 	if agentID == nil {

--- a/web/src/lib/api/soul.ts
+++ b/web/src/lib/api/soul.ts
@@ -215,9 +215,24 @@ export interface SoulAgentIdentity {
 	agent_id: string;
 	domain: string;
 	local_id: string;
+	ens_name?: string;
 	wallet: string;
 	token_id?: string;
 	meta_uri?: string;
+	avatar?: {
+		token_uri?: string;
+		image?: string;
+		current_style_id?: number;
+		current_style_name?: string;
+		current_renderer_address?: string;
+		styles?: Array<{
+			style_id: number;
+			style_name?: string;
+			renderer_address?: string;
+			image?: string;
+			selected?: boolean;
+		}>;
+	};
 	capabilities?: string[];
 	status: string;
 	lifecycle_status?: string;
@@ -225,6 +240,9 @@ export interface SoulAgentIdentity {
 	successor_agent_id?: string;
 	predecessor_agent_id?: string;
 	principal_address?: string;
+	principal_signature?: string;
+	principal_declaration?: string;
+	principal_declared_at?: string;
 	self_description_version?: number;
 	mint_tx_hash?: string;
 	minted_at?: string;

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -1062,15 +1062,31 @@ export interface components {
                 };
             };
         };
+        avatar_style: {
+            style_id: number;
+            style_name?: string;
+            renderer_address?: string;
+            image?: string;
+        };
+        avatar: {
+            token_uri?: string;
+            image?: string;
+            current_style_id?: number;
+            current_style_name?: string;
+            current_renderer_address?: string;
+            styles?: components["schemas"]["avatar_style"][];
+        };
         /** Soul agent identity */
         "soul-agent-identity.schema": {
             agent_id: string;
             domain: string;
             local_id: string;
+            ens_name?: string;
             wallet: string;
             token_id?: string;
             /** Format: uri */
             meta_uri?: string;
+            avatar?: components["schemas"]["avatar"];
             capabilities?: string[];
             principal_address?: string;
             principal_signature?: string;
@@ -1087,6 +1103,22 @@ export interface components {
             minted_at?: string;
             /** Format: date-time */
             updated_at?: string;
+            $defs: {
+                avatar_style: {
+                    style_id: number;
+                    style_name?: string;
+                    renderer_address?: string;
+                    image?: string;
+                };
+                avatar: {
+                    token_uri?: string;
+                    image?: string;
+                    current_style_id?: number;
+                    current_style_name?: string;
+                    current_renderer_address?: string;
+                    styles?: components["schemas"]["avatar_style"][];
+                };
+            };
         };
         /** GET /api/v1/soul/search result entry */
         "soul-search.result.schema": {

--- a/web/src/pages/Portal.svelte
+++ b/web/src/pages/Portal.svelte
@@ -161,6 +161,16 @@
 				</div>
 			</Card>
 
+			{#if portalRoute.kind === 'souls' || portalRoute.kind === 'soulRegister' || portalRoute.kind === 'soulMint' || portalRoute.kind === 'soulAgent'}
+				<Alert variant="warning" title="Secondary soul route">
+					<Text size="sm">
+						The canonical soul creation, review, approval, and finalize flow now lives in the agent-first Simulacrum
+						client served from Lesser at <span class="portal__mono">/l/*</span>. These portal soul routes remain
+						available as fallback and operator-oriented tools.
+					</Text>
+				</Alert>
+			{/if}
+
 			{#if !$session}
 				<Alert variant="warning" title="Signed out">
 					<Text size="sm">Sign in to continue.</Text>

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -1842,7 +1842,7 @@
 <div class="soul-agent">
 	<header class="soul-agent__header">
 		<div class="soul-agent__title">
-			<Heading level={2} size="xl">Agent</Heading>
+			<Heading level={2} size="xl">Legacy Agent Detail</Heading>
 			<Text color="secondary"><span class="soul-agent__mono">{agentId}</span></Text>
 		</div>
 		<div class="soul-agent__actions">
@@ -1850,6 +1850,13 @@
 			<Button variant="ghost" onclick={() => navigate('/portal/souls')}>Back</Button>
 		</div>
 	</header>
+
+	<Alert variant="warning" title="Secondary route">
+		<Text size="sm">
+			Use this portal detail page as a fallback or operator surface. The canonical soul lifecycle, approval, and
+			finalize flow now belongs in the agent-first Simulacrum client on the Lesser instance.
+		</Text>
+	</Alert>
 
 	{#if loading}
 		<div class="soul-agent__loading">
@@ -1885,7 +1892,7 @@
 						<div class="soul-agent__row-right">
 							{#if !current.agent.self_description_version}
 								<Button variant="solid" onclick={() => navigate(`/portal/souls/${current.agent.agent_id}/mint`)}>
-									Complete profile
+									Open legacy profile step
 								</Button>
 							{/if}
 							<CopyButton size="sm" text={current.agent.agent_id} />

--- a/web/src/pages/portal/SoulMintConversation.svelte
+++ b/web/src/pages/portal/SoulMintConversation.svelte
@@ -439,7 +439,7 @@
 <div class="soul-mint">
 	<header class="soul-mint__header">
 		<div class="soul-mint__title">
-			<Heading level={2} size="xl">Complete profile</Heading>
+			<Heading level={2} size="xl">Legacy Profile Completion</Heading>
 			<Text color="secondary"><span class="soul-mint__mono">{agentId}</span></Text>
 		</div>
 		<div class="soul-mint__actions">
@@ -447,6 +447,11 @@
 			<Button variant="ghost" onclick={() => navigate(`/portal/souls/${agentId}`)}>Back to agent</Button>
 		</div>
 	</header>
+
+	<Alert variant="warning" title="Secondary route">
+		Use this portal conversation only when you need the legacy/fallback host flow. The canonical review and finalize
+		experience now belongs in the agent-first Simulacrum client.
+	</Alert>
 
 	{#if loading}
 		<div class="soul-mint__loading">
@@ -475,8 +480,9 @@
 				</Alert>
 			{:else}
 				<Alert variant="info" title="Pick up where you left off">
-					The mint step is already done. This conversation is the follow-up profile step where you draft and publish
-					the self-description, capabilities, boundaries, and transparency record for this agent.
+					The mint step is already done. This legacy portal conversation remains available for drafting and publishing
+					the self-description, capabilities, boundaries, and transparency record when the Simulacrum path is not in
+					use.
 				</Alert>
 			{/if}
 		</Card>

--- a/web/src/pages/portal/SoulRegister.svelte
+++ b/web/src/pages/portal/SoulRegister.svelte
@@ -919,15 +919,22 @@
 <div class="soul-register">
 	<header class="soul-register__header">
 		<div class="soul-register__title">
-			<Heading level={2} size="xl">Register agent</Heading>
+			<Heading level={2} size="xl">Legacy Agent Registration</Heading>
 			<Text color="secondary">
-				Choose your managed instance, confirm the wallet, and prepare the onchain mint from your connected wallet.
+				Fallback portal path for starting a soul registration when you are not using the agent-first Simulacrum flow.
 			</Text>
 		</div>
 		<div class="soul-register__actions">
 			<Button variant="ghost" onclick={() => navigate('/portal/souls')}>Back</Button>
 		</div>
 	</header>
+
+	<Alert variant="warning" title="Secondary route">
+		<Text size="sm">
+			The canonical user-facing soul flow now starts in Simulacrum on the Lesser instance. Use this portal route only
+			for fallback, recovery, or operator-guided registration.
+		</Text>
+	</Alert>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -958,7 +965,7 @@
 			<TextField label="Wallet" bind:value={walletAddress} placeholder="0x…" />
 			<TextField label="Capabilities (comma-separated)" bind:value={capabilities} placeholder="social, commerce" />
 			<div class="soul-register__row">
-				<Button variant="solid" onclick={() => void handleBegin()} disabled={beginLoading || instancesLoading}>Start registration</Button>
+				<Button variant="solid" onclick={() => void handleBegin()} disabled={beginLoading || instancesLoading}>Start legacy registration</Button>
 				<Button variant="outline" onclick={() => void useConnectedWallet()} disabled={beginLoading}>Use connected wallet</Button>
 			</div>
 		</div>

--- a/web/src/pages/portal/Souls.svelte
+++ b/web/src/pages/portal/Souls.svelte
@@ -66,14 +66,21 @@
 <div class="souls">
 	<header class="souls__header">
 		<div class="souls__title">
-			<Heading level={2} size="xl">My Agents</Heading>
-			<Text color="secondary">Manage Lesser Soul identities, reputation, and validation.</Text>
+			<Heading level={2} size="xl">Legacy Soul Tools</Heading>
+			<Text color="secondary">Secondary lesser-host portal surface for soul operations and inspection.</Text>
 		</div>
 		<div class="souls__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="solid" onclick={() => navigate('/portal/souls/register')}>Register agent</Button>
+			<Button variant="solid" onclick={() => navigate('/portal/souls/register')}>Open legacy registration</Button>
 		</div>
 	</header>
+
+	<Alert variant="warning" title="Agent-first flow lives in Simulacrum">
+		<Text size="sm">
+			Use the Simulacrum agent workspace on your Lesser instance for the canonical request, review, approval, and
+			finalize experience. Keep this portal surface for fallback, recovery, or operator-guided work.
+		</Text>
+	</Alert>
 
 	{#if loading}
 		<div class="souls__loading">
@@ -84,9 +91,9 @@
 		<Alert variant="error" title="Failed to load /api/v1/soul/agents/mine">{errorMessage}</Alert>
 	{:else if agents.length === 0}
 		<Alert variant="info" title="No agents">
-			<Text size="sm">Register your first agent to get started.</Text>
+			<Text size="sm">No legacy portal agents found yet.</Text>
 			<div class="souls__actions-inline">
-				<Button variant="solid" onclick={() => navigate('/portal/souls/register')}>Register agent</Button>
+				<Button variant="solid" onclick={() => navigate('/portal/souls/register')}>Open legacy registration</Button>
 			</div>
 		</Alert>
 	{:else}
@@ -126,7 +133,7 @@
 						<div class="souls__item-actions">
 							{#if needsProfile}
 								<Button variant="solid" onclick={() => navigate(`/portal/souls/${item.agent.agent_id}/mint`)}>
-									Complete profile
+									Open legacy profile step
 								</Button>
 							{/if}
 							<Button variant="outline" onclick={() => navigate(`/portal/souls/${item.agent.agent_id}`)}>


### PR DESCRIPTION
## Summary
- enrich the public soul agent payload with ENS data plus on-chain avatar styles, current style, renderer address, and current image
- add the chain-facing renderer helpers and focused control-plane tests needed to keep the public avatar contract stable under rubric verification
- demote the portal-only soul flow in docs and UI in favor of the agent-first client path, including regenerated web API types

## Verification
- `bash gov-infra/verifiers/gov-verify-rubric.sh`

## Notes
- companion API parity branch in `equaltoai/lesser`: `codex/soul-avatar-contract-parity`