### PR TITLE
[codex] resolve soul local-id search semantics

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1243,10 +1243,28 @@ paths:
     get:
       operationId: soulSearch
       summary: Search soul agents (including channel + ens filters)
+      description: |
+        Accepted lookup forms include domain-only queries (`q=example.com`), domain-qualified agent queries
+        (`q=example.com/medic`), explicit domain plus local queries (`q=medic&domain=example.com`), and bare local
+        queries such as `q=medic`, `q=@medic`, or `q=medic/` when the request host maps to a verified instance domain.
+
+        The endpoint stays fail-closed for cross-domain ambiguity: it does not perform an unbounded local-ID scan, and
+        requests where `q` and `domain` specify conflicting domains reject with `400`.
       parameters:
+        - name: q
+          in: query
+          required: false
+          description: |
+            Domain-only, domain-qualified, or local query. Bare local queries require either `domain` or a request
+            host that maps to a verified instance domain.
+          schema:
+            type: string
         - name: domain
           in: query
           required: false
+          description: |
+            Optional domain override for local queries. Managed stage aliases are canonicalized to the indexed primary
+            instance domain before lookup.
           schema:
             type: string
         - name: capability

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -48,6 +48,27 @@ The soul registry is served by `cmd/control-plane-api` through the `lesser.host`
 - `GET /api/v1/soul/agents/{agentId}/validations` (paginated)
 - `GET /api/v1/soul/search?q=...&capability=...`
 
+#### `GET /api/v1/soul/search` query semantics
+
+The soul search endpoint is intentionally fail-closed and does not perform an unbounded cross-domain local-ID scan.
+
+Accepted lookup forms:
+
+- domain-only: `q=example.com`
+- domain-qualified agent: `q=example.com/medic`
+- explicit domain + local query: `q=medic&domain=example.com`
+- current-instance bare local query: `q=medic`, `q=@medic`, or `q=medic/` when the request host maps to a verified
+  instance domain in the control plane
+
+Managed stage aliases are canonicalized before lookup. For example, `domain=dev.simulacrum.greater.website` resolves
+through the managed primary domain index for `simulacrum.greater.website`.
+
+Security boundaries:
+
+- if the request host does not map to a verified instance domain, bare local queries still reject with a bad request
+- if both `q` and `domain=` specify domains and they do not match, the request rejects instead of guessing
+- malformed local IDs and malformed domains reject with bad-request semantics rather than falling back to a wider search
+
 ### Authenticated lifecycle (portal/operator session)
 
 All write endpoints require `Authorization: Bearer <session>`. Sessions are shared with the portal/operator auth system

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -376,6 +376,11 @@ func (s *Server) parseSoulPublicSearchParams(ctx *apptheory.Context) (soulPublic
 }
 
 func (s *Server) resolveSoulSearchDomainAndLocal(ctx *apptheory.Context, q string, domainRaw string) (string, string, bool, *apptheory.AppError) {
+	q, domainRaw, appErr := s.canonicalizeSoulSearchInputDomains(ctx, q, domainRaw)
+	if appErr != nil {
+		return "", "", false, appErr
+	}
+
 	currentDomain, appErr := s.resolveSoulSearchCurrentDomainIfNeeded(ctx, q, domainRaw)
 	if appErr != nil {
 		return "", "", false, appErr
@@ -396,11 +401,82 @@ func (s *Server) resolveSoulSearchDomainAndLocal(ctx *apptheory.Context, q strin
 	return domain, localID, localExact, nil
 }
 
+func (s *Server) canonicalizeSoulSearchInputDomains(ctx *apptheory.Context, q string, domainRaw string) (string, string, *apptheory.AppError) {
+	q = strings.TrimSpace(q)
+	domainRaw = strings.TrimSpace(domainRaw)
+
+	canonicalDomain, appErr := s.canonicalizeSoulSearchRawDomain(ctx, domainRaw)
+	if appErr != nil {
+		return "", "", appErr
+	}
+
+	canonicalQ, appErr := s.canonicalizeSoulSearchQueryDomain(ctx, q)
+	if appErr != nil {
+		return "", "", appErr
+	}
+	return canonicalQ, canonicalDomain, nil
+}
+
+func (s *Server) canonicalizeSoulSearchQueryDomain(ctx *apptheory.Context, q string) (string, *apptheory.AppError) {
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return "", nil
+	}
+
+	if strings.Contains(q, "/") {
+		parts := strings.SplitN(q, "/", 2)
+		head := strings.TrimSpace(parts[0])
+		if _, err := domains.NormalizeDomain(head); err != nil {
+			return q, nil
+		}
+
+		canonicalDomain, appErr := s.canonicalizeSoulSearchRawDomain(ctx, head)
+		if appErr != nil {
+			return "", appErr
+		}
+		return canonicalDomain + "/" + parts[1], nil
+	}
+
+	if _, err := domains.NormalizeDomain(q); err != nil {
+		return q, nil
+	}
+	return s.canonicalizeSoulSearchRawDomain(ctx, q)
+}
+
+func (s *Server) canonicalizeSoulSearchRawDomain(ctx *apptheory.Context, domainRaw string) (string, *apptheory.AppError) {
+	domainRaw = strings.TrimSpace(domainRaw)
+	if domainRaw == "" {
+		return "", nil
+	}
+
+	domain, appErr := normalizeSoulSearchDomainParam(domainRaw)
+	if appErr != nil {
+		return "", appErr
+	}
+	return s.canonicalizeSoulSearchDomain(ctx.Context(), domain)
+}
+
 func (s *Server) resolveSoulSearchCurrentDomainIfNeeded(ctx *apptheory.Context, q string, domainRaw string) (string, *apptheory.AppError) {
-	if strings.TrimSpace(domainRaw) != "" || strings.TrimSpace(q) == "" {
+	if !soulSearchNeedsCurrentDomain(q, domainRaw) {
 		return "", nil
 	}
 	return s.resolveTrustedSoulSearchCurrentDomain(ctx)
+}
+
+func soulSearchNeedsCurrentDomain(q string, domainRaw string) bool {
+	if strings.TrimSpace(domainRaw) != "" {
+		return false
+	}
+
+	q = strings.TrimSpace(q)
+	if q == "" {
+		return false
+	}
+	if strings.Contains(q, "/") && soulSearchQueryLooksDomainQualified(q) {
+		return false
+	}
+	_, err := domains.NormalizeDomain(q)
+	return err != nil
 }
 
 func parseSoulPublicSearchFilterParams(ctx *apptheory.Context) (claimLevel string, ensName string, principal string, boundary string, channels []string, status string, appErr *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"sort"
 	"strconv"
@@ -17,6 +18,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/domains"
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/manageddomain"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/soulsearch"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -289,7 +291,7 @@ func (s *Server) handleSoulPublicSearch(ctx *apptheory.Context) (*apptheory.Resp
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 	}
 
-	params, appErr := parseSoulPublicSearchParams(ctx)
+	params, appErr := s.parseSoulPublicSearchParams(ctx)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -328,7 +330,7 @@ type soulPublicSearchParams struct {
 	Limit      int
 }
 
-func parseSoulPublicSearchParams(ctx *apptheory.Context) (soulPublicSearchParams, *apptheory.AppError) {
+func (s *Server) parseSoulPublicSearchParams(ctx *apptheory.Context) (soulPublicSearchParams, *apptheory.AppError) {
 	if ctx == nil {
 		return soulPublicSearchParams{}, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
@@ -344,7 +346,7 @@ func parseSoulPublicSearchParams(ctx *apptheory.Context) (soulPublicSearchParams
 
 	limit := envIntPositiveClampedFromString(httpx.FirstQueryValue(ctx.Request.Query, "limit"), 50, 100)
 
-	domain, localID, localExact, appErr := parseSoulSearchDomainAndLocal(q, domainRaw)
+	domain, localID, localExact, appErr := s.resolveSoulSearchDomainAndLocal(ctx, q, domainRaw)
 	if appErr != nil {
 		return soulPublicSearchParams{}, appErr
 	}
@@ -371,6 +373,34 @@ func parseSoulPublicSearchParams(ctx *apptheory.Context) (soulPublicSearchParams
 		Cursor:     cursor,
 		Limit:      limit,
 	}, nil
+}
+
+func (s *Server) resolveSoulSearchDomainAndLocal(ctx *apptheory.Context, q string, domainRaw string) (string, string, bool, *apptheory.AppError) {
+	currentDomain, appErr := s.resolveSoulSearchCurrentDomainIfNeeded(ctx, q, domainRaw)
+	if appErr != nil {
+		return "", "", false, appErr
+	}
+
+	domain, localID, localExact, appErr := parseSoulSearchDomainAndLocal(q, domainRaw, currentDomain)
+	if appErr != nil {
+		return "", "", false, appErr
+	}
+	if domain == "" {
+		return "", localID, localExact, nil
+	}
+
+	domain, appErr = s.canonicalizeSoulSearchDomain(ctx.Context(), domain)
+	if appErr != nil {
+		return "", "", false, appErr
+	}
+	return domain, localID, localExact, nil
+}
+
+func (s *Server) resolveSoulSearchCurrentDomainIfNeeded(ctx *apptheory.Context, q string, domainRaw string) (string, *apptheory.AppError) {
+	if strings.TrimSpace(domainRaw) != "" || strings.TrimSpace(q) == "" {
+		return "", nil
+	}
+	return s.resolveTrustedSoulSearchCurrentDomain(ctx)
 }
 
 func parseSoulPublicSearchFilterParams(ctx *apptheory.Context) (claimLevel string, ensName string, principal string, boundary string, channels []string, status string, appErr *apptheory.AppError) {
@@ -1118,54 +1148,179 @@ func parseSoulSearchQuery(q string) (string, string, *apptheory.AppError) {
 	return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "q must include a domain"}
 }
 
-func parseSoulSearchDomainAndLocal(q string, domainRaw string) (domain string, localID string, localExact bool, appErr *apptheory.AppError) {
+func parseSoulSearchDomainAndLocal(q string, domainRaw string, currentDomain string) (domain string, localID string, localExact bool, appErr *apptheory.AppError) {
 	q = strings.TrimSpace(q)
 	domainRaw = strings.TrimSpace(domainRaw)
+	currentDomain = strings.TrimSpace(currentDomain)
 
-	if domainRaw != "" {
-		norm, err := domains.NormalizeDomain(domainRaw)
-		if err != nil {
-			return "", "", false, &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
-		}
-		domain = norm
+	domain, appErr = normalizeSoulSearchDomainParam(domainRaw)
+	if appErr != nil {
+		return "", "", false, appErr
 	}
 
 	if q == "" {
 		return domain, "", false, nil
 	}
 
-	if strings.Contains(q, "/") {
-		dFromQ, localFromQ, parseErr := parseSoulSearchQuery(q)
-		if parseErr != nil {
-			return "", "", false, parseErr
-		}
-		if domain != "" && dFromQ != "" && domain != dFromQ {
-			return "", "", false, &apptheory.AppError{Code: "app.bad_request", Message: "q domain does not match domain parameter"}
-		}
-		return dFromQ, localFromQ, true, nil
+	dFromQ, localFromQ, localExact, handled, appErr := tryParseSoulSearchQualifiedOrDomainQuery(q, domain)
+	if appErr != nil || handled {
+		return dFromQ, localFromQ, localExact, appErr
 	}
 
-	if dFromQ, err := domains.NormalizeDomain(q); err == nil {
-		if domain != "" && domain != dFromQ {
-			return "", "", false, &apptheory.AppError{Code: "app.bad_request", Message: "q domain does not match domain parameter"}
-		}
-		return dFromQ, "", false, nil
-	}
-
+	domain = resolveSoulSearchLocalDomain(domain, currentDomain)
 	if domain == "" {
-		return "", "", false, &apptheory.AppError{Code: "app.bad_request", Message: "q must include a domain (or provide domain=)"}
+		return "", "", false, &apptheory.AppError{Code: "app.bad_request", Message: "q must include a domain unless the request host maps to a verified instance domain (or provide domain=)"}
 	}
 
-	localID = normalizeSoulSearchLocalQuery(q)
+	localID, appErr = normalizeSoulSearchLocalQuery(q)
+	if appErr != nil {
+		return "", "", false, appErr
+	}
 	return domain, localID, false, nil
 }
 
-func normalizeSoulSearchLocalQuery(raw string) string {
+func normalizeSoulSearchDomainParam(domainRaw string) (string, *apptheory.AppError) {
+	domainRaw = strings.TrimSpace(domainRaw)
+	if domainRaw == "" {
+		return "", nil
+	}
+
+	norm, err := domains.NormalizeDomain(domainRaw)
+	if err != nil {
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
+	}
+	return norm, nil
+}
+
+func tryParseSoulSearchQualifiedOrDomainQuery(q string, domain string) (string, string, bool, bool, *apptheory.AppError) {
+	if strings.Contains(q, "/") {
+		dFromQ, localFromQ, parseErr := parseSoulSearchQuery(q)
+		if parseErr == nil {
+			if soulSearchDomainsConflict(domain, dFromQ) {
+				return "", "", false, true, &apptheory.AppError{Code: "app.bad_request", Message: "q domain does not match domain parameter"}
+			}
+			return dFromQ, localFromQ, true, true, nil
+		}
+		if soulSearchQueryLooksDomainQualified(q) {
+			return "", "", false, true, parseErr
+		}
+	}
+
+	dFromQ, err := domains.NormalizeDomain(q)
+	if err != nil {
+		return "", "", false, false, nil
+	}
+	if soulSearchDomainsConflict(domain, dFromQ) {
+		return "", "", false, true, &apptheory.AppError{Code: "app.bad_request", Message: "q domain does not match domain parameter"}
+	}
+	return dFromQ, "", false, true, nil
+}
+
+func soulSearchQueryLooksDomainQualified(q string) bool {
+	qHead := strings.TrimSpace(strings.SplitN(q, "/", 2)[0])
+	_, err := domains.NormalizeDomain(qHead)
+	return err == nil
+}
+
+func soulSearchDomainsConflict(domain string, domainFromQ string) bool {
+	return domain != "" && domainFromQ != "" && domain != domainFromQ
+}
+
+func resolveSoulSearchLocalDomain(domain string, currentDomain string) string {
+	if strings.TrimSpace(domain) != "" {
+		return domain
+	}
+	return strings.TrimSpace(currentDomain)
+}
+
+func normalizeSoulSearchLocalQuery(raw string) (string, *apptheory.AppError) {
+	localID, err := soul.NormalizeLocalAgentID(raw)
+	if err != nil {
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
+	}
+	return localID, nil
+}
+
+func (s *Server) canonicalizeSoulSearchDomain(ctx context.Context, domain string) (string, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	domain = strings.TrimSpace(domain)
+	if domain == "" {
+		return "", nil
+	}
+	if _, ok := manageddomain.BaseDomainFromStageDomain(s.cfg.Stage, domain); !ok {
+		return domain, nil
+	}
+
+	item, err := s.loadManagedStageAwareDomain(ctx, domain)
+	if err != nil {
+		if theoryErrors.IsNotFound(err) {
+			return domain, nil
+		}
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if item == nil || !domainIsVerifiedOrActive(item.Status) {
+		return domain, nil
+	}
+	if canonical := strings.TrimSpace(item.Domain); canonical != "" {
+		return canonical, nil
+	}
+	return domain, nil
+}
+
+func (s *Server) resolveTrustedSoulSearchCurrentDomain(ctx *apptheory.Context) (string, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if ctx == nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	hostDomain := normalizeSoulSearchRequestHost(httpx.FirstHeaderValue(ctx.Request.Headers, "host"))
+	if hostDomain == "" {
+		return "", nil
+	}
+
+	item, err := s.loadManagedStageAwareDomain(ctx.Context(), hostDomain)
+	if err != nil {
+		if theoryErrors.IsNotFound(err) {
+			return "", nil
+		}
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if item == nil || !domainIsVerifiedOrActive(item.Status) {
+		return "", nil
+	}
+	return strings.TrimSpace(item.Domain), nil
+}
+
+func normalizeSoulSearchRequestHost(raw string) string {
 	raw = strings.TrimSpace(raw)
-	raw = strings.TrimPrefix(raw, "@")
-	raw = strings.TrimSuffix(raw, "/")
-	raw = strings.ToLower(raw)
-	return raw
+	if raw == "" {
+		return ""
+	}
+	if strings.ContainsAny(raw, " \t\r\n/\\") || strings.Contains(raw, "@") {
+		return ""
+	}
+
+	host := raw
+	if strings.Contains(host, ":") {
+		if h, _, err := net.SplitHostPort(host); err == nil {
+			host = h
+		}
+	}
+	host = strings.Trim(host, "[]")
+	if host == "" {
+		return ""
+	}
+
+	domain, err := domains.NormalizeDomain(host)
+	if err != nil {
+		return ""
+	}
+	return domain
 }
 
 func envIntPositiveFromString(raw string, fallback int) int {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -79,6 +79,8 @@ type soulPublicTestDB struct {
 	qID       *ttmocks.MockQuery
 	qRep      *ttmocks.MockQuery
 	qVal      *ttmocks.MockQuery
+	qDomain   *ttmocks.MockQuery
+	qInstance *ttmocks.MockQuery
 	qDomIdx   *ttmocks.MockQuery
 	qCapIdx   *ttmocks.MockQuery
 	qBoundIdx *ttmocks.MockQuery
@@ -95,6 +97,8 @@ func newSoulPublicTestDB() soulPublicTestDB {
 	qID := new(ttmocks.MockQuery)
 	qRep := new(ttmocks.MockQuery)
 	qVal := new(ttmocks.MockQuery)
+	qDomain := new(ttmocks.MockQuery)
+	qInstance := new(ttmocks.MockQuery)
 	qDomIdx := new(ttmocks.MockQuery)
 	qCapIdx := new(ttmocks.MockQuery)
 	qBoundIdx := new(ttmocks.MockQuery)
@@ -109,6 +113,8 @@ func newSoulPublicTestDB() soulPublicTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qID).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentReputation")).Return(qRep).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentValidationRecord")).Return(qVal).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulDomainAgentIndex")).Return(qDomIdx).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(qCapIdx).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulBoundaryKeywordAgentIndex")).Return(qBoundIdx).Maybe()
@@ -119,19 +125,20 @@ func newSoulPublicTestDB() soulPublicTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(qENS).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulChannelAgentIndex")).Return(qChanIdx).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qID, qRep, qVal, qDomIdx, qCapIdx, qBoundIdx, qChannel, qPrefs, qEmailIdx, qPhoneIdx, qENS, qChanIdx} {
+	for _, q := range []*ttmocks.MockQuery{qID, qRep, qVal, qDomain, qInstance, qDomIdx, qCapIdx, qBoundIdx, qChannel, qPrefs, qEmailIdx, qPhoneIdx, qENS, qChanIdx} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
 		q.On("Cursor", mock.Anything).Return(q).Maybe()
 		q.On("Index", mock.Anything).Return(q).Maybe()
 	}
-
 	return soulPublicTestDB{
 		db:        db,
 		qID:       qID,
 		qRep:      qRep,
 		qVal:      qVal,
+		qDomain:   qDomain,
+		qInstance: qInstance,
 		qDomIdx:   qDomIdx,
 		qCapIdx:   qCapIdx,
 		qBoundIdx: qBoundIdx,
@@ -193,6 +200,82 @@ func TestParseSoulSearchQuery(t *testing.T) {
 	if _, _, err := parseSoulSearchQuery("agent-only"); err == nil {
 		t.Fatalf("expected local-only query to fail closed")
 	}
+}
+
+func TestHandleSoulPublicSearch_CurrentInstanceBareLocalQuery(t *testing.T) {
+	t.Parallel()
+
+	agentID := "0x" + strings.Repeat("ab", 32)
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
+
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+	}).Once()
+	tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+	}).Once()
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
+	}).Once()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{"host": {"dev.simulacrum.greater.website"}},
+		Query:   map[string][]string{"q": {"medic"}},
+	}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+}
+
+func TestHandleSoulPublicSearch_DomainParamManagedAliasCanonicalizes(t *testing.T) {
+	t.Parallel()
+
+	agentID := "0x" + strings.Repeat("ac", 32)
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
+
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             "simulacrum.greater.website",
+			InstanceSlug:       "simulacrum",
+			Status:             models.DomainStatusVerified,
+			Type:               models.DomainTypePrimary,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+	}).Once()
+	tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+	}).Once()
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
+	}).Once()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
+		"domain": {"dev.simulacrum.greater.website"},
+		"q":      {"medic"},
+	}}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
 }
 
 func TestSetSoulPublicHeaders(t *testing.T) {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -243,7 +243,52 @@ func TestHandleSoulPublicSearch_CurrentInstanceBareLocalQuery(t *testing.T) {
 func TestHandleSoulPublicSearch_DomainParamManagedAliasCanonicalizes(t *testing.T) {
 	t.Parallel()
 
-	agentID := "0x" + strings.Repeat("ac", 32)
+	agentID, s := newManagedAliasSoulSearchTestServer(t, "ac")
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
+		"domain": {"dev.simulacrum.greater.website"},
+		"q":      {"medic"},
+	}}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+}
+
+func TestHandleSoulPublicSearch_QDomainAndDomainParamAliasCanonicalizeTogether(t *testing.T) {
+	t.Parallel()
+
+	agentID, s := newManagedAliasSoulSearchTestServer(t, "ad")
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
+		"domain": {"dev.simulacrum.greater.website"},
+		"q":      {"simulacrum.greater.website/medic"},
+	}}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+}
+
+func TestHandleSoulPublicSearch_QualifiedQuerySkipsCurrentHostResolution(t *testing.T) {
+	t.Parallel()
+
+	agentID := "0x" + strings.Repeat("ae", 32)
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
+
+	tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "example.com", LocalID: "medic"}}
+	}).Once()
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
+	}).Once()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{"host": {"dev.simulacrum.greater.website"}},
+		Query:   map[string][]string{"q": {"example.com/medic"}},
+	}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+}
+
+func newManagedAliasSoulSearchTestServer(t *testing.T, agentHexByte string) (string, *Server) {
+	t.Helper()
+
+	agentID := "0x" + strings.Repeat(agentHexByte, 32)
 	tdb := newSoulPublicTestDB()
 	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
 
@@ -271,11 +316,7 @@ func TestHandleSoulPublicSearch_DomainParamManagedAliasCanonicalizes(t *testing.
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
 	}).Once()
 
-	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
-		"domain": {"dev.simulacrum.greater.website"},
-		"q":      {"medic"},
-	}}}
-	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+	return agentID, s
 }
 
 func TestSetSoulPublicHeaders(t *testing.T) {

--- a/internal/controlplane/handlers_soul_public_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_more_internal_test.go
@@ -509,6 +509,138 @@ func TestParseSoulSearchDomainAndLocal_MismatchErrors(t *testing.T) {
 	}
 }
 
+func TestParseSoulSearchDomainAndLocal_CurrentDomainBareLocalForms(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		q    string
+		want string
+	}{
+		{name: "plain", q: "medic", want: "medic"},
+		{name: "at_prefix", q: "@medic", want: "medic"},
+		{name: "trailing_slash", q: "medic/", want: "medic"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			domain, localID, localExact, appErr := parseSoulSearchDomainAndLocal(tc.q, "", "simulacrum.greater.website")
+			if appErr != nil {
+				t.Fatalf("unexpected appErr: %#v", appErr)
+			}
+			if domain != "simulacrum.greater.website" || localID != tc.want || localExact {
+				t.Fatalf("unexpected resolution for %q: domain=%q local=%q exact=%v", tc.q, domain, localID, localExact)
+			}
+		})
+	}
+}
+
+func TestParseSoulSearchDomainAndLocal_BadRequestShapes(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing current domain fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, _, appErr := parseSoulSearchDomainAndLocal("medic", "", "")
+		if appErr == nil || appErr.Code != appErrCodeBadRequest || appErr.Message != "q must include a domain unless the request host maps to a verified instance domain (or provide domain=)" {
+			t.Fatalf("unexpected appErr: %#v", appErr)
+		}
+	})
+
+	t.Run("malformed local id", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, _, appErr := parseSoulSearchDomainAndLocal("bad/local", "", "simulacrum.greater.website")
+		if appErr == nil || appErr.Code != appErrCodeBadRequest || appErr.Message != "local_id must not contain /, :, or @" {
+			t.Fatalf("unexpected appErr: %#v", appErr)
+		}
+	})
+
+	t.Run("malformed domain parameter", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, _, appErr := parseSoulSearchDomainAndLocal("medic", "bad_domain", "")
+		if appErr == nil || appErr.Code != appErrCodeBadRequest || strings.TrimSpace(appErr.Message) == "" {
+			t.Fatalf("unexpected appErr: %#v", appErr)
+		}
+	})
+}
+
+func TestHandleSoulPublicSearch_BareLocalFormsResolveAgainstTrustedHost(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		q    string
+	}{
+		{name: "plain", q: "medic"},
+		{name: "at_prefix", q: "@medic"},
+		{name: "trailing_slash", q: "medic/"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tdb := newSoulPublicTestDB()
+			s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
+			agentID := "0x" + strings.Repeat("ad", 32)
+
+			tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+			tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+				*dest = models.Domain{
+					Domain:             "simulacrum.greater.website",
+					InstanceSlug:       "simulacrum",
+					Status:             models.DomainStatusVerified,
+					Type:               models.DomainTypePrimary,
+					VerificationMethod: "managed",
+				}
+			}).Once()
+			tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+				*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: "simulacrum.greater.website"}
+			}).Once()
+			tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+				*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+			}).Once()
+			tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+				*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
+			}).Once()
+
+			ctx := &apptheory.Context{Request: apptheory.Request{
+				Headers: map[string][]string{"host": {"dev.simulacrum.greater.website"}},
+				Query:   map[string][]string{"q": {tc.q}},
+			}}
+			assertSoulPublicSearchResponse(t, s, ctx, agentID)
+		})
+	}
+}
+
+func TestHandleSoulPublicSearch_BareLocalFailsClosedWithoutTrustedHost(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true, Stage: "lab"}}
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{"host": {"lesser.host"}},
+		Query:   map[string][]string{"q": {"medic"}},
+	}}
+	_, err := s.handleSoulPublicSearch(ctx)
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != appErrCodeBadRequest || appErr.Message != "q must include a domain unless the request host maps to a verified instance domain (or provide domain=)" {
+		t.Fatalf("unexpected err: %#v", err)
+	}
+}
+
 func TestGetSoulAgentReputation_ValidatesInput(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_public_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_more_internal_test.go
@@ -479,13 +479,17 @@ func TestAgentHasBoundaryKeywordIndex_ErrorBranch(t *testing.T) {
 func TestParseSoulPublicSearchParams_ClaimLevelLegacyKey(t *testing.T) {
 	t.Parallel()
 
+	tdb := newSoulPublicTestDB()
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+
 	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
 		"q":           {"example.com"},
 		"capability":  {"social"},
 		"claim_level": {"challenge-passed"},
 		"limit":       {"1"},
 	}}}
-	params, appErr := parseSoulPublicSearchParams(ctx)
+	s := &Server{cfg: config.Config{}, store: store.New(tdb.db)}
+	params, appErr := s.parseSoulPublicSearchParams(ctx)
 	if appErr != nil {
 		t.Fatalf("unexpected appErr: %#v", appErr)
 	}
@@ -497,10 +501,10 @@ func TestParseSoulPublicSearchParams_ClaimLevelLegacyKey(t *testing.T) {
 func TestParseSoulSearchDomainAndLocal_MismatchErrors(t *testing.T) {
 	t.Parallel()
 
-	if _, _, _, appErr := parseSoulSearchDomainAndLocal("example.com/agent-a", "other.com"); appErr == nil {
+	if _, _, _, appErr := parseSoulSearchDomainAndLocal("example.com/agent-a", "other.com", ""); appErr == nil {
 		t.Fatalf("expected domain mismatch error")
 	}
-	if _, _, _, appErr := parseSoulSearchDomainAndLocal("example.com", "other.com"); appErr == nil {
+	if _, _, _, appErr := parseSoulSearchDomainAndLocal("example.com", "other.com", ""); appErr == nil {
 		t.Fatalf("expected domain mismatch error")
 	}
 }

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -97,7 +97,15 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Search soul agents (including channel + ens filters) */
+        /**
+         * Search soul agents (including channel + ens filters)
+         * @description Accepted lookup forms include domain-only queries (`q=example.com`), domain-qualified agent queries
+         *     (`q=example.com/medic`), explicit domain plus local queries (`q=medic&domain=example.com`), and bare local
+         *     queries such as `q=medic`, `q=@medic`, or `q=medic/` when the request host maps to a verified instance domain.
+         *
+         *     The endpoint stays fail-closed for cross-domain ambiguity: it does not perform an unbounded local-ID scan, and
+         *     requests where `q` and `domain` specify conflicting domains reject with `400`.
+         */
         get: operations["soulSearch"];
         put?: never;
         post?: never;
@@ -1541,6 +1549,15 @@ export interface operations {
     soulSearch: {
         parameters: {
             query?: {
+                /**
+                 * @description Domain-only, domain-qualified, or local query. Bare local queries require either `domain` or a request
+                 *     host that maps to a verified instance domain.
+                 */
+                q?: string;
+                /**
+                 * @description Optional domain override for local queries. Managed stage aliases are canonicalized to the indexed primary
+                 *     instance domain before lookup.
+                 */
                 domain?: string;
                 capability?: string;
                 boundary?: string;


### PR DESCRIPTION
## Summary
This PR resolves the public soul local-ID lookup issue tracked by #146 and its subissues.

- support bare local soul queries in trusted current-instance context using verified request-host domain resolution
- preserve fail-closed behavior for unknown hosts, malformed inputs, and explicit domain conflicts while canonicalizing managed stage aliases
- add regression coverage for the accepted and rejected local-ID query matrix
- document the shipped `/api/v1/soul/search` contract in the repo docs and OpenAPI, and regenerate the checked-in web adapter

## Validation
- `bash gov-infra/verifiers/gov-verify-rubric.sh`

Closes #146
Closes #147
Closes #148
Closes #149