### PR TITLE
[codex] Fix soul search stage-domain lookup

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1263,8 +1263,8 @@ paths:
           in: query
           required: false
           description: |
-            Optional domain override for local queries. Managed stage aliases are canonicalized to the indexed primary
-            instance domain before lookup.
+            Optional domain override for local queries. Stage-qualified domains stay exact for lookup and are not
+            canonicalized to the base instance domain.
           schema:
             type: string
         - name: capability

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -60,8 +60,8 @@ Accepted lookup forms:
 - current-instance bare local query: `q=medic`, `q=@medic`, or `q=medic/` when the request host maps to a verified
   instance domain in the control plane
 
-Managed stage aliases are canonicalized before lookup. For example, `domain=dev.simulacrum.greater.website` resolves
-through the managed primary domain index for `simulacrum.greater.website`.
+Managed stage domains stay exact for lookup. For example, `domain=dev.simulacrum.greater.website` searches the
+stage-scoped soul index for `dev.simulacrum.greater.website` rather than rewriting to `simulacrum.greater.website`.
 
 Security boundaries:
 

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/domains"
 	"github.com/equaltoai/lesser-host/internal/httpx"
-	"github.com/equaltoai/lesser-host/internal/manageddomain"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/soulsearch"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -393,11 +392,6 @@ func (s *Server) resolveSoulSearchDomainAndLocal(ctx *apptheory.Context, q strin
 	if domain == "" {
 		return "", localID, localExact, nil
 	}
-
-	domain, appErr = s.canonicalizeSoulSearchDomain(ctx.Context(), domain)
-	if appErr != nil {
-		return "", "", false, appErr
-	}
 	return domain, localID, localExact, nil
 }
 
@@ -453,7 +447,7 @@ func (s *Server) canonicalizeSoulSearchRawDomain(ctx *apptheory.Context, domainR
 	if appErr != nil {
 		return "", appErr
 	}
-	return s.canonicalizeSoulSearchDomain(ctx.Context(), domain)
+	return domain, nil
 }
 
 func (s *Server) resolveSoulSearchCurrentDomainIfNeeded(ctx *apptheory.Context, q string, domainRaw string) (string, *apptheory.AppError) {
@@ -1317,35 +1311,6 @@ func normalizeSoulSearchLocalQuery(raw string) (string, *apptheory.AppError) {
 	return localID, nil
 }
 
-func (s *Server) canonicalizeSoulSearchDomain(ctx context.Context, domain string) (string, *apptheory.AppError) {
-	if s == nil || s.store == nil || s.store.DB == nil {
-		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-
-	domain = strings.TrimSpace(domain)
-	if domain == "" {
-		return "", nil
-	}
-	if _, ok := manageddomain.BaseDomainFromStageDomain(s.cfg.Stage, domain); !ok {
-		return domain, nil
-	}
-
-	item, err := s.loadManagedStageAwareDomain(ctx, domain)
-	if err != nil {
-		if theoryErrors.IsNotFound(err) {
-			return domain, nil
-		}
-		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-	if item == nil || !domainIsVerifiedOrActive(item.Status) {
-		return domain, nil
-	}
-	if canonical := strings.TrimSpace(item.Domain); canonical != "" {
-		return canonical, nil
-	}
-	return domain, nil
-}
-
 func (s *Server) resolveTrustedSoulSearchCurrentDomain(ctx *apptheory.Context) (string, *apptheory.AppError) {
 	if s == nil || s.store == nil || s.store.DB == nil {
 		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
@@ -1369,7 +1334,7 @@ func (s *Server) resolveTrustedSoulSearchCurrentDomain(ctx *apptheory.Context) (
 	if item == nil || !domainIsVerifiedOrActive(item.Status) {
 		return "", nil
 	}
-	return strings.TrimSpace(item.Domain), nil
+	return hostDomain, nil
 }
 
 func normalizeSoulSearchRequestHost(raw string) string {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"net/http"
 	"strings"
@@ -226,7 +227,7 @@ func TestHandleSoulPublicSearch_CurrentInstanceBareLocalQuery(t *testing.T) {
 	}).Once()
 	tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
-		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "dev.simulacrum.greater.website", LocalID: "medic"}}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
@@ -238,28 +239,46 @@ func TestHandleSoulPublicSearch_CurrentInstanceBareLocalQuery(t *testing.T) {
 		Query:   map[string][]string{"q": {"medic"}},
 	}}
 	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+	assertSoulDomainIndexLookup(t, tdb.qDomIdx, "dev.simulacrum.greater.website")
 }
 
-func TestHandleSoulPublicSearch_DomainParamManagedAliasCanonicalizes(t *testing.T) {
+func TestHandleSoulPublicSearch_DomainParamManagedStageDomainStaysExact(t *testing.T) {
 	t.Parallel()
 
-	agentID, s := newManagedAliasSoulSearchTestServer(t, "ac")
+	agentID, s, tdb := newManagedAliasSoulSearchTestServer(t, "ac")
 	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
 		"domain": {"dev.simulacrum.greater.website"},
 		"q":      {"medic"},
 	}}}
 	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+	assertSoulDomainIndexLookup(t, tdb.qDomIdx, "dev.simulacrum.greater.website")
 }
 
-func TestHandleSoulPublicSearch_QDomainAndDomainParamAliasCanonicalizeTogether(t *testing.T) {
+func TestHandleSoulPublicSearch_StageQualifiedQueryStaysExact(t *testing.T) {
 	t.Parallel()
 
-	agentID, s := newManagedAliasSoulSearchTestServer(t, "ad")
+	agentID, s, tdb := newManagedAliasSoulSearchTestServer(t, "ad")
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
+		"q": {"dev.simulacrum.greater.website/medic"},
+	}}}
+	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+	assertSoulDomainIndexLookup(t, tdb.qDomIdx, "dev.simulacrum.greater.website")
+}
+
+func TestHandleSoulPublicSearch_StageAndBaseDomainsConflict(t *testing.T) {
+	t.Parallel()
+
+	_, s, _ := newManagedAliasSoulSearchTestServer(t, "ad")
 	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
 		"domain": {"dev.simulacrum.greater.website"},
 		"q":      {"simulacrum.greater.website/medic"},
 	}}}
-	assertSoulPublicSearchResponse(t, s, ctx, agentID)
+
+	_, err := s.handleSoulPublicSearch(ctx)
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != appErrCodeBadRequest || appErr.Message != "q domain does not match domain parameter" {
+		t.Fatalf("unexpected err: %#v", err)
+	}
 }
 
 func TestHandleSoulPublicSearch_QualifiedQuerySkipsCurrentHostResolution(t *testing.T) {
@@ -285,7 +304,7 @@ func TestHandleSoulPublicSearch_QualifiedQuerySkipsCurrentHostResolution(t *test
 	assertSoulPublicSearchResponse(t, s, ctx, agentID)
 }
 
-func newManagedAliasSoulSearchTestServer(t *testing.T, agentHexByte string) (string, *Server) {
+func newManagedAliasSoulSearchTestServer(t *testing.T, agentHexByte string) (string, *Server, soulPublicTestDB) {
 	t.Helper()
 
 	agentID := "0x" + strings.Repeat(agentHexByte, 32)
@@ -309,14 +328,14 @@ func newManagedAliasSoulSearchTestServer(t *testing.T, agentHexByte string) (str
 	}).Once()
 	tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
-		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+		*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "dev.simulacrum.greater.website", LocalID: "medic"}}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
 	}).Once()
 
-	return agentID, s
+	return agentID, s, tdb
 }
 
 func TestSetSoulPublicHeaders(t *testing.T) {
@@ -1145,6 +1164,28 @@ func assertSoulPublicSearchResponse(t *testing.T, s *Server, ctx *apptheory.Cont
 	if out.Count != 1 || len(out.Results) != 1 || out.Results[0].AgentID != expectedAgentID {
 		t.Fatalf("unexpected response: %#v", out)
 	}
+}
+
+func assertSoulDomainIndexLookup(t *testing.T, q *ttmocks.MockQuery, expectedDomain string) {
+	t.Helper()
+
+	wantPK := fmt.Sprintf("SOUL#DOMAIN#%s", expectedDomain)
+	for _, call := range q.Calls {
+		if call.Method != "Where" || len(call.Arguments) != 3 {
+			continue
+		}
+		field, fieldOK := call.Arguments.Get(0).(string)
+		op, opOK := call.Arguments.Get(1).(string)
+		value, valueOK := call.Arguments.Get(2).(string)
+		if !fieldOK || !opOK || !valueOK {
+			continue
+		}
+		if field == "PK" && op == "=" && value == wantPK {
+			return
+		}
+	}
+
+	t.Fatalf("expected soul domain lookup for %q; calls=%#v", wantPK, q.Calls)
 }
 
 func mockSoulPublicGetAgentChannelsSuccess(

--- a/internal/controlplane/handlers_soul_public_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_more_internal_test.go
@@ -607,7 +607,7 @@ func TestHandleSoulPublicSearch_BareLocalFormsResolveAgainstTrustedHost(t *testi
 			}).Once()
 			tdb.qDomIdx.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
 				dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
-				*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "simulacrum.greater.website", LocalID: "medic"}}
+				*dest = []*models.SoulDomainAgentIndex{{AgentID: agentID, Domain: "dev.simulacrum.greater.website", LocalID: "medic"}}
 			}).Once()
 			tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 				dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
@@ -619,6 +619,7 @@ func TestHandleSoulPublicSearch_BareLocalFormsResolveAgainstTrustedHost(t *testi
 				Query:   map[string][]string{"q": {tc.q}},
 			}}
 			assertSoulPublicSearchResponse(t, s, ctx, agentID)
+			assertSoulDomainIndexLookup(t, tdb.qDomIdx, "dev.simulacrum.greater.website")
 		})
 	}
 }

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -1555,8 +1555,8 @@ export interface operations {
                  */
                 q?: string;
                 /**
-                 * @description Optional domain override for local queries. Managed stage aliases are canonicalized to the indexed primary
-                 *     instance domain before lookup.
+                 * @description Optional domain override for local queries. Stage-qualified domains stay exact for lookup and are not
+                 *     canonicalized to the base instance domain.
                  */
                 domain?: string;
                 capability?: string;


### PR DESCRIPTION
## Summary
Fixes #151 by preserving exact stage-qualified domains in soul search instead of rewriting them to the managed base domain before lookup.

## What changed
- stopped canonicalizing user-supplied soul search domains from `dev.<base>` to `<base>`
- kept trusted-host bare-local lookup verification, but now returns the exact host domain for stage-scoped searches
- strengthened soul search tests to assert the exact `SOUL#DOMAIN#...` partition being queried
- updated soul search docs/OpenAPI wording and regenerated the web adapter

## Root cause
Soul search reused managed stage-alias resolution that maps a stage host back to the base managed domain for instance ownership checks. That is correct for ownership/auth flows, but incorrect for soul search because stage-qualified domains are first-class namespaces with their own local-ID index partitions.

## Validation
- `GOTOOLCHAIN=auto go test ./internal/controlplane -run 'TestHandleSoulPublicSearch_(CurrentInstanceBareLocalQuery|DomainParamManagedStageDomainStaysExact|StageQualifiedQueryStaysExact|StageAndBaseDomainsConflict)|TestHandleSoulPublicSearch_BareLocalFormsResolveAgainstTrustedHost'`
- `cd web && npm run verify:lesser-host-contracts`
- `bash gov-infra/verifiers/gov-verify-rubric.sh`
