### PR TITLE
feat(comm): add host-authoritative mailbox storage capture

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -103,6 +103,23 @@ export class LesserHostStack extends cdk.Stack {
 			autoDeleteObjects: stage !== 'live',
 		});
 
+		const soulCommMailboxRetentionDays = 90;
+		const soulCommMailboxBucket = new s3.Bucket(this, 'SoulCommMailboxBucket', {
+			bucketName: `${namePrefix}-${cdk.Aws.ACCOUNT_ID}-${cdk.Aws.REGION}-soul-comm-mailbox`,
+			blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+			enforceSSL: true,
+			encryption: s3.BucketEncryption.KMS_MANAGED,
+			lifecycleRules: [
+				{
+					id: 'ExpireSoulCommMailboxContent',
+					prefix: 'mailbox/v1/',
+					expiration: cdk.Duration.days(soulCommMailboxRetentionDays),
+				},
+			],
+			removalPolicy,
+			autoDeleteObjects: stage !== 'live',
+		});
+
 		const previewDLQ = new sqs.Queue(this, 'PreviewDLQ', {
 			queueName: `${namePrefix}-preview-dlq`,
 			retentionPeriod: cdk.Duration.days(14),
@@ -425,6 +442,8 @@ export class LesserHostStack extends cdk.Stack {
 			SAFETY_QUEUE_URL: safetyQueue.queueUrl,
 			PROVISION_QUEUE_URL: provisionQueue.queueUrl,
 			COMM_QUEUE_URL: commQueue.queueUrl,
+			SOUL_COMM_MAILBOX_BUCKET_NAME: soulCommMailboxBucket.bucketName,
+			SOUL_COMM_MAILBOX_RETENTION_DAYS: String(soulCommMailboxRetentionDays),
 			BOOTSTRAP_WALLET_ADDRESS: bootstrapWalletAddress,
 			WEBAUTHN_RP_ID: webAuthnRPID,
 			WEBAUTHN_ORIGINS: webAuthnOrigins,
@@ -566,6 +585,8 @@ export class LesserHostStack extends cdk.Stack {
 			STAGE: stage,
 			STATE_TABLE_NAME: stateTable.tableName,
 			COMM_QUEUE_URL: commQueue.queueUrl,
+			SOUL_COMM_MAILBOX_BUCKET_NAME: soulCommMailboxBucket.bucketName,
+			SOUL_COMM_MAILBOX_RETENTION_DAYS: String(soulCommMailboxRetentionDays),
 			SOUL_ENABLED: soulEnabled,
 			MANAGED_ORG_VENDING_ROLE_ARN: managedOrgVendingRoleArn,
 			MANAGED_INSTANCE_ROLE_NAME: managedInstanceRoleName,
@@ -592,6 +613,8 @@ export class LesserHostStack extends cdk.Stack {
 		stateTable.grantReadWriteData(provisionWorkerFn);
 		stateTable.grantReadWriteData(commWorkerFn);
 		artifactsBucket.grantReadWrite(controlPlaneFn);
+		soulCommMailboxBucket.grantReadWrite(controlPlaneFn);
+		soulCommMailboxBucket.grantReadWrite(commWorkerFn);
 		soulPackBucket.grantReadWrite(controlPlaneFn);
 		soulPackBucket.grantReadWrite(soulReputationWorkerFn);
 		artifactsBucket.grantReadWrite(trustFn);
@@ -1554,6 +1577,7 @@ export class LesserHostStack extends cdk.Stack {
 		new cdk.CfnOutput(this, 'StateTableName', { value: stateTable.tableName });
 			new cdk.CfnOutput(this, 'ArtifactsBucketName', { value: artifactsBucket.bucketName });
 			new cdk.CfnOutput(this, 'InboundEmailBucketName', { value: inboundEmailBucket.bucketName });
+			new cdk.CfnOutput(this, 'SoulCommMailboxBucketName', { value: soulCommMailboxBucket.bucketName });
 			new cdk.CfnOutput(this, 'SoulEmailInboundDomain', { value: soulEmailInboundDomain });
 			new cdk.CfnOutput(this, 'InboundEmailMXRecord', {
 				value: `10 inbound-smtp.${cdk.Aws.REGION}.amazonaws.com`,

--- a/internal/commmailbox/content_store.go
+++ b/internal/commmailbox/content_store.go
@@ -1,0 +1,205 @@
+// Package commmailbox contains shared bounded content-storage helpers for the
+// host-authoritative soul comm mailbox.
+package commmailbox
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+const (
+	// ContentKeyPrefix is the lifecycle-bound S3 prefix used by CDK.
+	ContentKeyPrefix = "mailbox/v1/"
+	// ContentStorageS3 marks mailbox content pointers backed by S3.
+	ContentStorageS3 = "s3"
+)
+
+// ContentInput is the body payload stored for one canonical mailbox delivery.
+type ContentInput struct {
+	DeliveryID      string
+	InstanceSlug    string
+	AgentID         string
+	MessageID       string
+	Direction       string
+	ChannelType     string
+	Body            string
+	ContentMimeType string
+}
+
+// ContentPointer identifies a lifecycle-bound encrypted content object.
+type ContentPointer struct {
+	Storage     string
+	Bucket      string
+	Key         string
+	SHA256      string
+	Bytes       int64
+	ContentType string
+}
+
+// ContentStore writes bounded mailbox content and returns content pointers.
+type ContentStore interface {
+	PutContent(ctx context.Context, input ContentInput) (ContentPointer, error)
+}
+
+type s3API interface {
+	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
+}
+
+// S3Store stores mailbox content in the dedicated CDK-managed mailbox bucket.
+type S3Store struct {
+	bucket string
+
+	once   sync.Once
+	client s3API
+	err    error
+}
+
+// NewS3Store constructs an S3-backed content store.
+func NewS3Store(bucket string) *S3Store {
+	return &S3Store{bucket: strings.TrimSpace(bucket)}
+}
+
+// NewS3StoreWithClient constructs an S3-backed content store with an injected client.
+func NewS3StoreWithClient(bucket string, client s3API) *S3Store {
+	st := NewS3Store(bucket)
+	if client != nil {
+		st.once.Do(func() {})
+		st.client = client
+	}
+	return st
+}
+
+// PutContent writes content to the configured mailbox bucket and returns a
+// pointer + digest. The bucket enforces encryption at rest and lifecycle expiry.
+func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPointer, error) {
+	if s == nil {
+		return ContentPointer{}, fmt.Errorf("mailbox content store is nil")
+	}
+	bucket := strings.TrimSpace(s.bucket)
+	if bucket == "" {
+		return ContentPointer{}, fmt.Errorf("mailbox content bucket is not configured")
+	}
+	if strings.TrimSpace(input.DeliveryID) == "" {
+		return ContentPointer{}, fmt.Errorf("deliveryId is required")
+	}
+	if strings.TrimSpace(input.AgentID) == "" {
+		return ContentPointer{}, fmt.Errorf("agentId is required")
+	}
+	body := []byte(input.Body)
+	if len(bytes.TrimSpace(body)) == 0 {
+		return ContentPointer{}, fmt.Errorf("content body is required")
+	}
+
+	client, err := s.s3Client(ctx)
+	if err != nil {
+		return ContentPointer{}, err
+	}
+
+	sum := sha256.Sum256(body)
+	digest := hex.EncodeToString(sum[:])
+	contentType := strings.TrimSpace(input.ContentMimeType)
+	if contentType == "" {
+		contentType = DefaultContentType(input.ChannelType)
+	}
+	key := ContentKey(input.InstanceSlug, input.AgentID, input.DeliveryID)
+
+	_, err = client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(bucket),
+		Key:         aws.String(key),
+		Body:        bytes.NewReader(body),
+		ContentType: aws.String(contentType),
+		Metadata: map[string]string{
+			"delivery-id":   strings.TrimSpace(input.DeliveryID),
+			"agent-id":      strings.ToLower(strings.TrimSpace(input.AgentID)),
+			"instance-slug": strings.ToLower(strings.TrimSpace(input.InstanceSlug)),
+			"message-id":    strings.TrimSpace(input.MessageID),
+			"direction":     strings.ToLower(strings.TrimSpace(input.Direction)),
+			"channel-type":  strings.ToLower(strings.TrimSpace(input.ChannelType)),
+			"sha256":        digest,
+		},
+	})
+	if err != nil {
+		return ContentPointer{}, err
+	}
+
+	return ContentPointer{
+		Storage:     ContentStorageS3,
+		Bucket:      bucket,
+		Key:         key,
+		SHA256:      digest,
+		Bytes:       int64(len(body)),
+		ContentType: contentType,
+	}, nil
+}
+
+func (s *S3Store) s3Client(ctx context.Context) (s3API, error) {
+	if s == nil {
+		return nil, fmt.Errorf("mailbox content store is nil")
+	}
+	s.once.Do(func() {
+		cfg, err := awsconfig.LoadDefaultConfig(ctx)
+		if err != nil {
+			s.err = err
+			return
+		}
+		s.client = s3.NewFromConfig(cfg)
+	})
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.client == nil {
+		return nil, fmt.Errorf("s3 client not initialized")
+	}
+	return s.client, nil
+}
+
+// ContentKey returns the S3 object key for a mailbox delivery body.
+func ContentKey(instanceSlug string, agentID string, deliveryID string) string {
+	return ContentKeyPrefix +
+		"instances/" + safeSegment(instanceSlug) +
+		"/agents/" + safeSegment(agentID) +
+		"/deliveries/" + safeSegment(deliveryID) +
+		"/content"
+}
+
+// DefaultContentType returns the content type used when a provider does not supply one.
+func DefaultContentType(channelType string) string {
+	switch strings.ToLower(strings.TrimSpace(channelType)) {
+	case "email", "sms", "voice":
+		return "text/plain; charset=utf-8"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func safeSegment(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return "unknown"
+	}
+	var b strings.Builder
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+		case r == '-' || r == '_' || r == '.':
+			b.WriteRune(r)
+		}
+	}
+	if b.Len() == 0 {
+		sum := sha256.Sum256([]byte(value))
+		return hex.EncodeToString(sum[:])[:24]
+	}
+	return b.String()
+}

--- a/internal/commmailbox/content_store_test.go
+++ b/internal/commmailbox/content_store_test.go
@@ -1,0 +1,67 @@
+package commmailbox
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+type fakeS3PutClient struct {
+	input *s3.PutObjectInput
+}
+
+func (f *fakeS3PutClient) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
+	f.input = in
+	return &s3.PutObjectOutput{}, nil
+}
+
+func TestS3StorePutContent(t *testing.T) {
+	client := &fakeS3PutClient{}
+	store := NewS3StoreWithClient("mailbox-bucket", client)
+
+	ptr, err := store.PutContent(context.Background(), ContentInput{
+		DeliveryID:      "comm-delivery-1",
+		InstanceSlug:    "Demo",
+		AgentID:         "0xABC",
+		MessageID:       "msg-1",
+		Direction:       "Inbound",
+		ChannelType:     "Email",
+		Body:            "Hello mailbox",
+		ContentMimeType: "text/plain",
+	})
+	if err != nil {
+		t.Fatalf("PutContent: %v", err)
+	}
+	if ptr.Storage != ContentStorageS3 || ptr.Bucket != "mailbox-bucket" || ptr.Bytes != int64(len("Hello mailbox")) || ptr.SHA256 == "" {
+		t.Fatalf("unexpected pointer: %#v", ptr)
+	}
+	if !strings.HasPrefix(ptr.Key, ContentKeyPrefix+"instances/demo/agents/0xabc/deliveries/comm-delivery-1/") {
+		t.Fatalf("unexpected key: %q", ptr.Key)
+	}
+	if client.input == nil || aws.ToString(client.input.Bucket) != "mailbox-bucket" || aws.ToString(client.input.Key) != ptr.Key {
+		t.Fatalf("unexpected put input: %#v", client.input)
+	}
+	body, _ := io.ReadAll(client.input.Body)
+	if string(body) != "Hello mailbox" {
+		t.Fatalf("unexpected stored body: %q", string(body))
+	}
+	if client.input.Metadata["delivery-id"] != "comm-delivery-1" || client.input.Metadata["sha256"] != ptr.SHA256 {
+		t.Fatalf("unexpected metadata: %#v", client.input.Metadata)
+	}
+}
+
+func TestS3StorePutContentValidation(t *testing.T) {
+	if _, err := NewS3StoreWithClient("", &fakeS3PutClient{}).PutContent(context.Background(), ContentInput{DeliveryID: "d", AgentID: "a", Body: "b"}); err == nil {
+		t.Fatalf("expected missing bucket error")
+	}
+	if _, err := NewS3StoreWithClient("bucket", &fakeS3PutClient{}).PutContent(context.Background(), ContentInput{AgentID: "a", Body: "b"}); err == nil {
+		t.Fatalf("expected missing delivery error")
+	}
+	if _, err := NewS3StoreWithClient("bucket", &fakeS3PutClient{}).PutContent(context.Background(), ContentInput{DeliveryID: "d", AgentID: "a", Body: "   "}); err == nil {
+		t.Fatalf("expected missing body error")
+	}
+}

--- a/internal/commworker/mailbox_capture.go
+++ b/internal/commworker/mailbox_capture.go
@@ -1,0 +1,203 @@
+package commworker
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type inboundMailboxCapture struct {
+	agentID      string
+	channel      string
+	provider     string
+	notif        InboundNotification
+	inst         *models.Instance
+	status       string
+	storeContent bool
+	actor        string
+	detailsJSON  string
+}
+
+func (s *Server) mailboxCaptureEnabled() bool {
+	return s != nil && s.store != nil && s.mailboxContentStore != nil
+}
+
+func (s *Server) captureInboundMailbox(ctx context.Context, in inboundMailboxCapture) error {
+	if !s.mailboxCaptureEnabled() || in.inst == nil {
+		return nil
+	}
+
+	receivedAt := parseRFC3339Time(in.notif.ReceivedAt, s.now())
+	messageID := strings.TrimSpace(in.notif.MessageID)
+	instanceSlug := strings.ToLower(strings.TrimSpace(in.inst.Slug))
+	agentID := strings.ToLower(strings.TrimSpace(in.agentID))
+	channel := strings.ToLower(strings.TrimSpace(in.channel))
+	status := strings.ToLower(strings.TrimSpace(in.status))
+	if status == "" {
+		status = models.SoulCommMailboxStatusAccepted
+	}
+	threadRoot := messageID
+	inReplyTo := ""
+	if in.notif.InReplyTo != nil {
+		inReplyTo = strings.TrimSpace(*in.notif.InReplyTo)
+		if inReplyTo != "" {
+			threadRoot = inReplyTo
+		}
+	}
+	deliveryID := models.SoulCommMailboxDeliveryID(instanceSlug, agentID, models.SoulCommDirectionInbound, messageID)
+	threadID := models.SoulCommMailboxThreadID(instanceSlug, agentID, channel, threadRoot)
+
+	var ptr commmailbox.ContentPointer
+	contentStoredAt := time.Time{}
+	if in.storeContent {
+		var err error
+		ptr, err = s.mailboxContentStore.PutContent(ctx, commmailbox.ContentInput{
+			DeliveryID:      deliveryID,
+			InstanceSlug:    instanceSlug,
+			AgentID:         agentID,
+			MessageID:       messageID,
+			Direction:       models.SoulCommDirectionInbound,
+			ChannelType:     channel,
+			Body:            in.notif.Body,
+			ContentMimeType: in.notif.BodyMimeType,
+		})
+		if err != nil {
+			return err
+		}
+		contentStoredAt = s.now()
+	}
+
+	msg := &models.SoulCommMailboxMessage{
+		DeliveryID:        deliveryID,
+		MessageID:         messageID,
+		ThreadID:          threadID,
+		InstanceSlug:      instanceSlug,
+		AgentID:           agentID,
+		Direction:         models.SoulCommDirectionInbound,
+		ChannelType:       channel,
+		Provider:          in.provider,
+		ProviderMessageID: messageID,
+		Status:            status,
+		FromAddress:       strings.TrimSpace(in.notif.From.Address),
+		FromNumber:        strings.TrimSpace(in.notif.From.Number),
+		FromDisplayName:   strings.TrimSpace(in.notif.From.DisplayName),
+		ToAddress:         inboundPartyAddress(in.notif.To),
+		ToNumber:          inboundPartyNumber(in.notif.To),
+		ToSoulAgentID:     agentID,
+		Subject:           strings.TrimSpace(in.notif.Subject),
+		Preview:           models.SoulCommMailboxPreview(in.notif.Body),
+		HasContent:        in.storeContent,
+		Read:              false,
+		CreatedAt:         receivedAt,
+		UpdatedAt:         receivedAt,
+	}
+	if in.notif.From.SoulAgentID != nil {
+		msg.FromSoulAgentID = strings.TrimSpace(*in.notif.From.SoulAgentID)
+	}
+	if in.notif.To != nil {
+		msg.ToDisplayName = strings.TrimSpace(in.notif.To.DisplayName)
+	}
+	if ptr.Storage != "" {
+		msg.ContentStorage = ptr.Storage
+		msg.ContentBucket = ptr.Bucket
+		msg.ContentKey = ptr.Key
+		msg.ContentSHA256 = ptr.SHA256
+		msg.ContentBytes = ptr.Bytes
+		msg.ContentMimeType = ptr.ContentType
+		msg.ContentStoredAt = contentStoredAt
+	}
+	if err := msg.BeforeCreate(); err != nil {
+		return err
+	}
+	if err := s.store.PutMailboxMessage(ctx, msg); err != nil {
+		return err
+	}
+
+	eventTime := receivedAt
+	if !contentStoredAt.IsZero() && contentStoredAt.After(eventTime) {
+		eventTime = contentStoredAt
+	}
+	return s.store.PutMailboxEvent(ctx, &models.SoulCommMailboxEvent{
+		DeliveryID:   deliveryID,
+		MessageID:    messageID,
+		ThreadID:     threadID,
+		InstanceSlug: instanceSlug,
+		AgentID:      agentID,
+		Direction:    models.SoulCommDirectionInbound,
+		ChannelType:  channel,
+		EventType:    models.SoulCommMailboxEventCreated,
+		Status:       status,
+		Actor:        strings.TrimSpace(in.actor),
+		DetailsJSON:  strings.TrimSpace(in.detailsJSON),
+		CreatedAt:    eventTime,
+	})
+}
+
+func (s *Server) updateInboundMailboxStatus(ctx context.Context, agentID string, channel string, notif InboundNotification, inst *models.Instance, status string, actor string, detailsJSON string) error {
+	if !s.mailboxCaptureEnabled() || inst == nil {
+		return nil
+	}
+
+	receivedAt := parseRFC3339Time(notif.ReceivedAt, s.now())
+	messageID := strings.TrimSpace(notif.MessageID)
+	instanceSlug := strings.ToLower(strings.TrimSpace(inst.Slug))
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	channel = strings.ToLower(strings.TrimSpace(channel))
+	threadRoot := messageID
+	if notif.InReplyTo != nil && strings.TrimSpace(*notif.InReplyTo) != "" {
+		threadRoot = strings.TrimSpace(*notif.InReplyTo)
+	}
+	deliveryID := models.SoulCommMailboxDeliveryID(instanceSlug, agentID, models.SoulCommDirectionInbound, messageID)
+	threadID := models.SoulCommMailboxThreadID(instanceSlug, agentID, channel, threadRoot)
+
+	msg := &models.SoulCommMailboxMessage{
+		DeliveryID:   deliveryID,
+		MessageID:    messageID,
+		ThreadID:     threadID,
+		InstanceSlug: instanceSlug,
+		AgentID:      agentID,
+		Direction:    models.SoulCommDirectionInbound,
+		ChannelType:  channel,
+		Status:       status,
+		CreatedAt:    receivedAt,
+		UpdatedAt:    s.now(),
+	}
+	if err := msg.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := s.store.UpdateMailboxMessageStatus(ctx, msg); err != nil {
+		return err
+	}
+
+	return s.store.PutMailboxEvent(ctx, &models.SoulCommMailboxEvent{
+		DeliveryID:   deliveryID,
+		MessageID:    messageID,
+		ThreadID:     threadID,
+		InstanceSlug: instanceSlug,
+		AgentID:      agentID,
+		Direction:    models.SoulCommDirectionInbound,
+		ChannelType:  channel,
+		EventType:    models.SoulCommMailboxEventStateChanged,
+		Status:       strings.ToLower(strings.TrimSpace(status)),
+		Actor:        strings.TrimSpace(actor),
+		DetailsJSON:  strings.TrimSpace(detailsJSON),
+		CreatedAt:    s.now(),
+	})
+}
+
+func inboundPartyAddress(p *InboundParty) string {
+	if p == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.Address)
+}
+
+func inboundPartyNumber(p *InboundParty) string {
+	if p == nil {
+		return ""
+	}
+	return strings.TrimSpace(p.Number)
+}

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/manageddomain"
 	hostsecrets "github.com/equaltoai/lesser-host/internal/secrets"
@@ -56,6 +57,8 @@ type Server struct {
 	ssmGetParameter func(ctx context.Context, name string) (string, error)
 	migaduSendSMTP  func(ctx context.Context, username string, password string, from string, recipients []string, data []byte) error
 
+	mailboxContentStore commmailbox.ContentStore
+
 	fetchInstanceKeyPlaintext func(ctx context.Context, inst *models.Instance) (string, error)
 	deliverNotification       func(ctx context.Context, deliverURL string, apiKey string, notif InboundNotification) error
 
@@ -77,6 +80,9 @@ func NewServer(cfg config.Config, st commStore, stsClient stsAPI, secretsClient 
 			return hostsecrets.GetSSMParameter(ctx, nil, name)
 		},
 		migaduSendSMTP: defaultMigaduSendSMTP,
+	}
+	if strings.TrimSpace(cfg.SoulCommMailboxBucketName) != "" {
+		s.mailboxContentStore = commmailbox.NewS3Store(cfg.SoulCommMailboxBucketName)
 	}
 	s.fetchInstanceKeyPlaintext = s.defaultFetchInstanceKeyPlaintext
 	s.deliverNotification = defaultDeliverNotification
@@ -138,7 +144,19 @@ func (s *Server) processInbound(ctx context.Context, _ string, msg QueueMessage)
 		return nil
 	}
 
-	if s.handleInactiveInbound(ctx, agentID, channel, notif, identity) {
+	inst, instOK, err := s.resolveAgentInstance(ctx, identity)
+	if err != nil {
+		return err
+	}
+	if !instOK || inst == nil {
+		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(strings.TrimSpace(agentID)), strings.ToLower(strings.TrimSpace(identity.Domain)), channel, strings.TrimSpace(notif.MessageID))
+		_ = s.recordInboundActivity(ctx, agentID, channel, notif, "drop", false)
+		return nil
+	}
+
+	provider := strings.ToLower(strings.TrimSpace(msg.Provider))
+
+	if s.handleInactiveInbound(ctx, agentID, channel, notif, identity, inst, provider) {
 		s.logInboundDrop("inactive_identity", "", "", msg.Kind, channel, strings.TrimSpace(notif.MessageID), nil)
 		return nil
 	}
@@ -148,11 +166,22 @@ func (s *Server) processInbound(ctx context.Context, _ string, msg QueueMessage)
 		return err
 	}
 	if !ok {
+		_ = s.captureInboundMailbox(ctx, inboundMailboxCapture{
+			agentID:      agentID,
+			channel:      channel,
+			provider:     provider,
+			notif:        notif,
+			inst:         inst,
+			status:       models.SoulCommMailboxStatusDropped,
+			storeContent: false,
+			actor:        "comm-worker",
+			detailsJSON:  `{"reason":"unroutable_channel"}`,
+		})
 		s.logInboundDrop("unroutable_channel", "", "", msg.Kind, channel, strings.TrimSpace(notif.MessageID), nil)
 		return nil
 	}
 
-	handled, err := s.handleDeferredInbound(ctx, agentID, channel, notif, prefs)
+	handled, err := s.handleDeferredInbound(ctx, agentID, channel, notif, prefs, inst, provider)
 	if err != nil {
 		return err
 	}
@@ -161,7 +190,7 @@ func (s *Server) processInbound(ctx context.Context, _ string, msg QueueMessage)
 		return nil
 	}
 
-	return s.deliverResolvedInbound(ctx, agentID, channel, notif, identity)
+	return s.deliverResolvedInbound(ctx, agentID, channel, notif, identity, inst, provider)
 }
 
 func (s *Server) resolveInboundIdentity(ctx context.Context, channel string, to *InboundParty) (string, *models.SoulAgentIdentity, bool, error) {
@@ -192,12 +221,23 @@ func soulLifecycleStatus(identity *models.SoulAgentIdentity) string {
 	return strings.TrimSpace(identity.Status)
 }
 
-func (s *Server) handleInactiveInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity) bool {
+func (s *Server) handleInactiveInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity, inst *models.Instance, provider string) bool {
 	status := soulLifecycleStatus(identity)
 	if status == models.SoulAgentStatusActive {
 		return false
 	}
 
+	_ = s.captureInboundMailbox(ctx, inboundMailboxCapture{
+		agentID:      agentID,
+		channel:      channel,
+		provider:     provider,
+		notif:        notif,
+		inst:         inst,
+		status:       models.SoulCommMailboxStatusBounced,
+		storeContent: false,
+		actor:        "comm-worker",
+		detailsJSON:  `{"reason":"inactive_identity"}`,
+	})
 	_ = s.recordInboundActivity(ctx, agentID, channel, notif, "bounce", false)
 	_ = s.maybeBounceEmail(ctx, agentID, status, channel, notif, 0, 0, 0, 0)
 	return true
@@ -233,10 +273,10 @@ func channelReadyForInbound(ch *models.SoulAgentChannel) bool {
 	return strings.TrimSpace(ch.Status) == models.SoulChannelStatusActive && ch.Verified
 }
 
-func (s *Server) handleDeferredInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, prefs *models.SoulAgentContactPreferences) (bool, error) {
+func (s *Server) handleDeferredInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, prefs *models.SoulAgentContactPreferences, inst *models.Instance, provider string) (bool, error) {
 	now := s.now()
 
-	rateLimited, err := s.handleRateLimitedInbound(ctx, agentID, channel, notif, prefs, now)
+	rateLimited, err := s.handleRateLimitedInbound(ctx, agentID, channel, notif, prefs, inst, provider, now)
 	if err != nil || rateLimited {
 		return rateLimited, err
 	}
@@ -245,6 +285,19 @@ func (s *Server) handleDeferredInbound(ctx context.Context, agentID string, chan
 	if available {
 		return false, nil
 	}
+	if err := s.captureInboundMailbox(ctx, inboundMailboxCapture{
+		agentID:      agentID,
+		channel:      channel,
+		provider:     provider,
+		notif:        notif,
+		inst:         inst,
+		status:       models.SoulCommMailboxStatusQueued,
+		storeContent: true,
+		actor:        "comm-worker",
+		detailsJSON:  `{"reason":"outside_availability"}`,
+	}); err != nil {
+		return false, err
+	}
 	if err := s.queueInbound(ctx, agentID, channel, notif, nextDelivery); err != nil {
 		return false, err
 	}
@@ -252,7 +305,7 @@ func (s *Server) handleDeferredInbound(ctx context.Context, agentID string, chan
 	return true, nil
 }
 
-func (s *Server) handleRateLimitedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, prefs *models.SoulAgentContactPreferences, now time.Time) (bool, error) {
+func (s *Server) handleRateLimitedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, prefs *models.SoulAgentContactPreferences, inst *models.Instance, provider string, now time.Time) (bool, error) {
 	maxHour, maxDay := inboundRateLimits(prefs, channel)
 	hourCount, err := s.countInboundReceivesSince(ctx, agentID, channel, now.Add(-1*time.Hour), 250)
 	if err != nil {
@@ -266,24 +319,45 @@ func (s *Server) handleRateLimitedInbound(ctx context.Context, agentID string, c
 		return false, nil
 	}
 
+	_ = s.captureInboundMailbox(ctx, inboundMailboxCapture{
+		agentID:      agentID,
+		channel:      channel,
+		provider:     provider,
+		notif:        notif,
+		inst:         inst,
+		status:       models.SoulCommMailboxStatusBounced,
+		storeContent: false,
+		actor:        "comm-worker",
+		detailsJSON:  `{"reason":"rate_limited"}`,
+	})
 	_ = s.recordInboundActivity(ctx, agentID, channel, notif, "bounce", false)
 	_ = s.maybeBounceEmail(ctx, agentID, "rate_limited", channel, notif, maxHour, maxDay, hourCount, dayCount)
 	return true, nil
 }
 
-func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity) error {
+func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity, inst *models.Instance, provider string) error {
 	// Best-effort: annotate soul-to-soul sender identity.
 	s.maybeAnnotateSenderSoul(ctx, &notif)
 	s.maybeAnnotateRecipientAddress(ctx, agentID, channel, notif.To)
 
-	inst, ok, err := s.resolveAgentInstance(ctx, identity)
-	if err != nil {
-		return err
-	}
-	if !ok || inst == nil {
+	if inst == nil {
 		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(strings.TrimSpace(agentID)), strings.ToLower(strings.TrimSpace(identity.Domain)), strings.ToLower(strings.TrimSpace(channel)), strings.TrimSpace(notif.MessageID))
 		_ = s.recordInboundActivity(ctx, agentID, channel, notif, "drop", false)
 		return nil
+	}
+
+	if err := s.captureInboundMailbox(ctx, inboundMailboxCapture{
+		agentID:      agentID,
+		channel:      channel,
+		provider:     provider,
+		notif:        notif,
+		inst:         inst,
+		status:       models.SoulCommMailboxStatusAccepted,
+		storeContent: true,
+		actor:        "comm-worker",
+		detailsJSON:  `{"projection":"lesser_notification"}`,
+	}); err != nil {
+		return err
 	}
 
 	apiKey, err := s.fetchInstanceKeyPlaintext(ctx, inst)
@@ -296,6 +370,10 @@ func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, cha
 		return fmt.Errorf("instance delivery url is empty")
 	}
 	if err := s.deliverNotification(ctx, deliverURL, apiKey, notif); err != nil {
+		return err
+	}
+
+	if err := s.updateInboundMailboxStatus(ctx, agentID, channel, notif, inst, models.SoulCommMailboxStatusDelivered, "comm-worker", `{"projection":"lesser_notification"}`); err != nil {
 		return err
 	}
 

--- a/internal/commworker/server_internal_test.go
+++ b/internal/commworker/server_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
@@ -13,6 +14,22 @@ const (
 	testAgentBobEmail  = "agent-bob@lessersoul.ai"
 	testInstanceAPIKey = "lhk_test"
 )
+
+type fakeMailboxContentStore struct {
+	inputs []commmailbox.ContentInput
+}
+
+func (f *fakeMailboxContentStore) PutContent(_ context.Context, input commmailbox.ContentInput) (commmailbox.ContentPointer, error) {
+	f.inputs = append(f.inputs, input)
+	return commmailbox.ContentPointer{
+		Storage:     commmailbox.ContentStorageS3,
+		Bucket:      "mailbox-bucket",
+		Key:         commmailbox.ContentKey(input.InstanceSlug, input.AgentID, input.DeliveryID),
+		SHA256:      "sha256-test",
+		Bytes:       int64(len(input.Body)),
+		ContentType: commmailbox.DefaultContentType(input.ChannelType),
+	}, nil
+}
 
 type fakeStore struct {
 	emailIndex map[string]string
@@ -27,6 +44,10 @@ type fakeStore struct {
 
 	activities map[string][]*models.SoulAgentCommActivity
 	queued     []*models.SoulAgentCommQueue
+
+	mailboxMessages []*models.SoulCommMailboxMessage
+	mailboxEvents   []*models.SoulCommMailboxEvent
+	mailboxUpdates  []*models.SoulCommMailboxMessage
 }
 
 func (f *fakeStore) LookupAgentByEmail(_ context.Context, email string) (string, bool, error) {
@@ -102,6 +123,30 @@ func (f *fakeStore) PutCommQueue(_ context.Context, item *models.SoulAgentCommQu
 	return nil
 }
 
+func (f *fakeStore) PutMailboxMessage(_ context.Context, item *models.SoulCommMailboxMessage) error {
+	if f == nil {
+		return nil
+	}
+	f.mailboxMessages = append(f.mailboxMessages, item)
+	return nil
+}
+
+func (f *fakeStore) PutMailboxEvent(_ context.Context, item *models.SoulCommMailboxEvent) error {
+	if f == nil {
+		return nil
+	}
+	f.mailboxEvents = append(f.mailboxEvents, item)
+	return nil
+}
+
+func (f *fakeStore) UpdateMailboxMessageStatus(_ context.Context, item *models.SoulCommMailboxMessage) error {
+	if f == nil {
+		return nil
+	}
+	f.mailboxUpdates = append(f.mailboxUpdates, item)
+	return nil
+}
+
 func (f *fakeStore) GetDomain(_ context.Context, domain string) (*models.Domain, bool, error) {
 	if f == nil || f.domains == nil {
 		return nil, false, nil
@@ -147,6 +192,12 @@ func TestProcessInbound_QueuesOutsideAvailabilityWindow(t *testing.T) {
 				},
 				UpdatedAt: now,
 			},
+		},
+		domains: map[string]*models.Domain{
+			"demo.greater.website": {Domain: "demo.greater.website", InstanceSlug: "demo"},
+		},
+		instances: map[string]*models.Instance{
+			"demo": {Slug: "demo", HostedBaseDomain: "demo.greater.website"},
 		},
 	}
 
@@ -221,6 +272,12 @@ func TestProcessInbound_BouncesWhenRateLimited(t *testing.T) {
 			agentID: {
 				{AgentID: agentID, ChannelType: "email", Direction: models.SoulCommDirectionInbound, Action: "receive", Timestamp: now.Add(-10 * time.Minute)},
 			},
+		},
+		domains: map[string]*models.Domain{
+			"demo.greater.website": {Domain: "demo.greater.website", InstanceSlug: "demo"},
+		},
+		instances: map[string]*models.Instance{
+			"demo": {Slug: "demo", HostedBaseDomain: "demo.greater.website"},
 		},
 	}
 
@@ -323,5 +380,83 @@ func TestProcessInbound_DeliversToInstance(t *testing.T) {
 	}
 	if gotURL != "https://api.dev.demo.greater.website/api/v1/notifications/deliver" {
 		t.Fatalf("unexpected deliver url: %q", gotURL)
+	}
+}
+
+func TestProcessInbound_CapturesMailboxBeforeLesserProjection(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	agentID := commStoreTestAgentID
+	to := testAgentBobEmail
+
+	fs := &fakeStore{
+		emailIndex: map[string]string{to: agentID},
+		identities: map[string]*models.SoulAgentIdentity{
+			agentID: {AgentID: agentID, Domain: "demo.greater.website", LifecycleStatus: models.SoulAgentStatusActive, Status: models.SoulAgentStatusActive},
+		},
+		channels: map[string]*models.SoulAgentChannel{
+			agentID + "#email": {AgentID: agentID, ChannelType: "email", Identifier: to, Status: models.SoulChannelStatusActive, Verified: true, ProvisionedAt: now.Add(-time.Hour)},
+		},
+		prefs: map[string]*models.SoulAgentContactPreferences{
+			agentID: {AgentID: agentID, Preferred: "email", AvailabilitySchedule: "always", UpdatedAt: now},
+		},
+		domains: map[string]*models.Domain{
+			"demo.greater.website": {Domain: "demo.greater.website", InstanceSlug: "demo"},
+		},
+		instances: map[string]*models.Instance{
+			"demo": {Slug: "demo", HostedBaseDomain: "demo.greater.website", HostedAccountID: "123", LesserHostInstanceKeySecretARN: "arn:aws:secretsmanager:us-east-1:123:secret:test"},
+		},
+	}
+
+	content := &fakeMailboxContentStore{}
+	s := NewServer(config.Config{Stage: "lab"}, fs, nil, nil)
+	s.mailboxContentStore = content
+	s.now = func() time.Time { return now }
+	s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) { return testInstanceAPIKey, nil }
+	s.deliverNotification = func(_ context.Context, _ string, _ string, _ InboundNotification) error {
+		if len(content.inputs) != 1 {
+			t.Fatalf("expected content stored before lesser notification projection, got %d writes", len(content.inputs))
+		}
+		if len(fs.mailboxMessages) != 1 || fs.mailboxMessages[0].Status != models.SoulCommMailboxStatusAccepted {
+			t.Fatalf("expected accepted mailbox row before projection, got %#v", fs.mailboxMessages)
+		}
+		return nil
+	}
+
+	msg := QueueMessage{
+		Kind:     QueueMessageKindInbound,
+		Provider: "migadu",
+		Notification: InboundNotification{
+			Type:         "communication:inbound",
+			Channel:      "email",
+			From:         InboundParty{Address: "alice@example.com", DisplayName: "Alice"},
+			To:           &InboundParty{Address: to},
+			Subject:      "Hello",
+			Body:         "Full inbound body",
+			BodyMimeType: "text/plain",
+			ReceivedAt:   now.Format(time.RFC3339Nano),
+			MessageID:    "comm-msg-capture",
+		},
+	}
+
+	if err := s.processInbound(context.Background(), "req", msg); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(fs.mailboxMessages) != 1 {
+		t.Fatalf("expected one mailbox row, got %d", len(fs.mailboxMessages))
+	}
+	row := fs.mailboxMessages[0]
+	if !row.HasContent || row.ContentBucket != "mailbox-bucket" || row.ContentKey == "" || row.ContentSHA256 == "" {
+		t.Fatalf("expected content pointer on mailbox row: %#v", row)
+	}
+	if row.InstanceSlug != "demo" || row.AgentID != agentID || row.Direction != models.SoulCommDirectionInbound || row.Provider != "migadu" {
+		t.Fatalf("unexpected mailbox scope/provenance: %#v", row)
+	}
+	if len(fs.mailboxUpdates) != 1 || fs.mailboxUpdates[0].Status != models.SoulCommMailboxStatusDelivered {
+		t.Fatalf("expected delivered status update, got %#v", fs.mailboxUpdates)
+	}
+	if len(fs.mailboxEvents) != 2 || fs.mailboxEvents[0].EventType != models.SoulCommMailboxEventCreated || fs.mailboxEvents[1].EventType != models.SoulCommMailboxEventStateChanged {
+		t.Fatalf("expected created/state events, got %#v", fs.mailboxEvents)
 	}
 }

--- a/internal/commworker/server_internal_test.go
+++ b/internal/commworker/server_internal_test.go
@@ -386,11 +386,42 @@ func TestProcessInbound_DeliversToInstance(t *testing.T) {
 func TestProcessInbound_CapturesMailboxBeforeLesserProjection(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC)
+	fx := newInboundMailboxCaptureFixture(time.Date(2026, 3, 2, 12, 0, 0, 0, time.UTC))
+	fx.server.deliverNotification = func(_ context.Context, _ string, _ string, _ InboundNotification) error {
+		assertInboundMailboxCapturedBeforeProjection(t, fx)
+		return nil
+	}
+
+	msg := newMailboxCaptureInboundMessage(fx.now, fx.to)
+	if err := fx.server.processInbound(context.Background(), "req", msg); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	assertInboundMailboxCapturedAfterProjection(t, fx)
+}
+
+type inboundMailboxCaptureFixture struct {
+	now     time.Time
+	agentID string
+	to      string
+	store   *fakeStore
+	content *fakeMailboxContentStore
+	server  *Server
+}
+
+func newInboundMailboxCaptureFixture(now time.Time) inboundMailboxCaptureFixture {
 	agentID := commStoreTestAgentID
 	to := testAgentBobEmail
+	fs := newRoutableInboundFakeStore(now, agentID, to)
+	content := &fakeMailboxContentStore{}
+	s := NewServer(config.Config{Stage: "lab"}, fs, nil, nil)
+	s.mailboxContentStore = content
+	s.now = func() time.Time { return now }
+	s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) { return testInstanceAPIKey, nil }
+	return inboundMailboxCaptureFixture{now: now, agentID: agentID, to: to, store: fs, content: content, server: s}
+}
 
-	fs := &fakeStore{
+func newRoutableInboundFakeStore(now time.Time, agentID string, to string) *fakeStore {
+	return &fakeStore{
 		emailIndex: map[string]string{to: agentID},
 		identities: map[string]*models.SoulAgentIdentity{
 			agentID: {AgentID: agentID, Domain: "demo.greater.website", LifecycleStatus: models.SoulAgentStatusActive, Status: models.SoulAgentStatusActive},
@@ -408,23 +439,10 @@ func TestProcessInbound_CapturesMailboxBeforeLesserProjection(t *testing.T) {
 			"demo": {Slug: "demo", HostedBaseDomain: "demo.greater.website", HostedAccountID: "123", LesserHostInstanceKeySecretARN: "arn:aws:secretsmanager:us-east-1:123:secret:test"},
 		},
 	}
+}
 
-	content := &fakeMailboxContentStore{}
-	s := NewServer(config.Config{Stage: "lab"}, fs, nil, nil)
-	s.mailboxContentStore = content
-	s.now = func() time.Time { return now }
-	s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) { return testInstanceAPIKey, nil }
-	s.deliverNotification = func(_ context.Context, _ string, _ string, _ InboundNotification) error {
-		if len(content.inputs) != 1 {
-			t.Fatalf("expected content stored before lesser notification projection, got %d writes", len(content.inputs))
-		}
-		if len(fs.mailboxMessages) != 1 || fs.mailboxMessages[0].Status != models.SoulCommMailboxStatusAccepted {
-			t.Fatalf("expected accepted mailbox row before projection, got %#v", fs.mailboxMessages)
-		}
-		return nil
-	}
-
-	msg := QueueMessage{
+func newMailboxCaptureInboundMessage(now time.Time, to string) QueueMessage {
+	return QueueMessage{
 		Kind:     QueueMessageKindInbound,
 		Provider: "migadu",
 		Notification: InboundNotification{
@@ -439,24 +457,48 @@ func TestProcessInbound_CapturesMailboxBeforeLesserProjection(t *testing.T) {
 			MessageID:    "comm-msg-capture",
 		},
 	}
+}
 
-	if err := s.processInbound(context.Background(), "req", msg); err != nil {
-		t.Fatalf("unexpected err: %v", err)
+func assertInboundMailboxCapturedBeforeProjection(t *testing.T, fx inboundMailboxCaptureFixture) {
+	t.Helper()
+	if len(fx.content.inputs) != 1 {
+		t.Fatalf("expected content stored before lesser notification projection, got %d writes", len(fx.content.inputs))
 	}
-	if len(fs.mailboxMessages) != 1 {
-		t.Fatalf("expected one mailbox row, got %d", len(fs.mailboxMessages))
+	if len(fx.store.mailboxMessages) != 1 || fx.store.mailboxMessages[0].Status != models.SoulCommMailboxStatusAccepted {
+		t.Fatalf("expected accepted mailbox row before projection, got %#v", fx.store.mailboxMessages)
 	}
-	row := fs.mailboxMessages[0]
+}
+
+func assertInboundMailboxCapturedAfterProjection(t *testing.T, fx inboundMailboxCaptureFixture) {
+	t.Helper()
+	if len(fx.store.mailboxMessages) != 1 {
+		t.Fatalf("expected one mailbox row, got %d", len(fx.store.mailboxMessages))
+	}
+	assertInboundMailboxRow(t, fx.store.mailboxMessages[0], fx.agentID)
+	assertInboundMailboxStatusUpdate(t, fx.store.mailboxUpdates)
+	assertInboundMailboxEvents(t, fx.store.mailboxEvents)
+}
+
+func assertInboundMailboxRow(t *testing.T, row *models.SoulCommMailboxMessage, agentID string) {
+	t.Helper()
 	if !row.HasContent || row.ContentBucket != "mailbox-bucket" || row.ContentKey == "" || row.ContentSHA256 == "" {
 		t.Fatalf("expected content pointer on mailbox row: %#v", row)
 	}
 	if row.InstanceSlug != "demo" || row.AgentID != agentID || row.Direction != models.SoulCommDirectionInbound || row.Provider != "migadu" {
 		t.Fatalf("unexpected mailbox scope/provenance: %#v", row)
 	}
-	if len(fs.mailboxUpdates) != 1 || fs.mailboxUpdates[0].Status != models.SoulCommMailboxStatusDelivered {
-		t.Fatalf("expected delivered status update, got %#v", fs.mailboxUpdates)
+}
+
+func assertInboundMailboxStatusUpdate(t *testing.T, updates []*models.SoulCommMailboxMessage) {
+	t.Helper()
+	if len(updates) != 1 || updates[0].Status != models.SoulCommMailboxStatusDelivered {
+		t.Fatalf("expected delivered status update, got %#v", updates)
 	}
-	if len(fs.mailboxEvents) != 2 || fs.mailboxEvents[0].EventType != models.SoulCommMailboxEventCreated || fs.mailboxEvents[1].EventType != models.SoulCommMailboxEventStateChanged {
-		t.Fatalf("expected created/state events, got %#v", fs.mailboxEvents)
+}
+
+func assertInboundMailboxEvents(t *testing.T, events []*models.SoulCommMailboxEvent) {
+	t.Helper()
+	if len(events) != 2 || events[0].EventType != models.SoulCommMailboxEventCreated || events[1].EventType != models.SoulCommMailboxEventStateChanged {
+		t.Fatalf("expected created/state events, got %#v", events)
 	}
 }

--- a/internal/commworker/store.go
+++ b/internal/commworker/store.go
@@ -23,6 +23,10 @@ type commStore interface {
 	PutCommActivity(ctx context.Context, item *models.SoulAgentCommActivity) error
 	PutCommQueue(ctx context.Context, item *models.SoulAgentCommQueue) error
 
+	PutMailboxMessage(ctx context.Context, item *models.SoulCommMailboxMessage) error
+	PutMailboxEvent(ctx context.Context, item *models.SoulCommMailboxEvent) error
+	UpdateMailboxMessageStatus(ctx context.Context, item *models.SoulCommMailboxMessage) error
+
 	GetDomain(ctx context.Context, domain string) (*models.Domain, bool, error)
 	GetInstance(ctx context.Context, slug string) (*models.Instance, bool, error)
 }
@@ -200,6 +204,44 @@ func (s *dynamoStore) PutCommQueue(ctx context.Context, item *models.SoulAgentCo
 		return fmt.Errorf("queue item is nil")
 	}
 	return s.db.WithContext(ctx).Model(item).CreateOrUpdate()
+}
+
+func (s *dynamoStore) PutMailboxMessage(ctx context.Context, item *models.SoulCommMailboxMessage) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("store not initialized")
+	}
+	if item == nil {
+		return fmt.Errorf("mailbox message is nil")
+	}
+	err := s.db.WithContext(ctx).Model(item).IfNotExists().Create()
+	if theoryErrors.IsConditionFailed(err) {
+		return nil
+	}
+	return err
+}
+
+func (s *dynamoStore) PutMailboxEvent(ctx context.Context, item *models.SoulCommMailboxEvent) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("store not initialized")
+	}
+	if item == nil {
+		return fmt.Errorf("mailbox event is nil")
+	}
+	err := s.db.WithContext(ctx).Model(item).IfNotExists().Create()
+	if theoryErrors.IsConditionFailed(err) {
+		return nil
+	}
+	return err
+}
+
+func (s *dynamoStore) UpdateMailboxMessageStatus(ctx context.Context, item *models.SoulCommMailboxMessage) error {
+	if s == nil || s.db == nil {
+		return fmt.Errorf("store not initialized")
+	}
+	if item == nil {
+		return fmt.Errorf("mailbox message is nil")
+	}
+	return s.db.WithContext(ctx).Model(item).IfExists().Update("Status", "UpdatedAt")
 }
 
 func (s *dynamoStore) GetDomain(ctx context.Context, domain string) (*models.Domain, bool, error) {

--- a/internal/commworker/store_internal_test.go
+++ b/internal/commworker/store_internal_test.go
@@ -232,75 +232,83 @@ func runGetDomainAndInstanceTest(t *testing.T, ctx context.Context) {
 
 func TestDynamoStoreListAndPut(t *testing.T) {
 	ctx := context.Background()
+	assertNilStoreListRecentCommActivities(t, ctx)
+	t.Run("list activities clamps default limit", func(t *testing.T) { runListActivitiesDefaultLimitTest(t, ctx) })
+	t.Run("list activities clamps maximum limit", func(t *testing.T) { runListActivitiesMaxLimitTest(t, ctx) })
+	t.Run("put helpers validate nil", func(t *testing.T) { runPutHelperNilValidationTest(t, ctx) })
+	t.Run("put helpers write", func(t *testing.T) { runPutHelperWriteTest(t, ctx) })
+}
 
+func assertNilStoreListRecentCommActivities(t *testing.T, ctx context.Context) {
+	t.Helper()
 	var nilStore *dynamoStore
 	if _, err := nilStore.ListRecentCommActivities(ctx, commStoreTestAgentID, 10); err == nil {
 		t.Fatalf("expected store not initialized error")
 	}
+}
 
-	t.Run("list activities clamps default limit", func(t *testing.T) {
-		tdb := newCommStoreTestDB()
-		tdb.qAct.On("Limit", 250).Return(tdb.qAct).Once()
-		tdb.qAct.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
-			*dest = []*models.SoulAgentCommActivity{{AgentID: commStoreTestAgentID}}
-		}).Once()
+func runListActivitiesDefaultLimitTest(t *testing.T, ctx context.Context) {
+	t.Helper()
+	tdb := newCommStoreTestDB()
+	tdb.qAct.On("Limit", 250).Return(tdb.qAct).Once()
+	tdb.qAct.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		*dest = []*models.SoulAgentCommActivity{{AgentID: commStoreTestAgentID}}
+	}).Once()
 
-		st := &dynamoStore{db: tdb.db}
-		items, err := st.ListRecentCommActivities(ctx, commStoreTestAgentID, -1)
-		if err != nil || len(items) != 1 {
-			t.Fatalf("unexpected activities result: items=%#v err=%v", items, err)
-		}
-	})
+	st := &dynamoStore{db: tdb.db}
+	items, err := st.ListRecentCommActivities(ctx, commStoreTestAgentID, -1)
+	if err != nil || len(items) != 1 {
+		t.Fatalf("unexpected activities result: items=%#v err=%v", items, err)
+	}
+}
 
-	t.Run("list activities clamps maximum limit", func(t *testing.T) {
-		tdb := newCommStoreTestDB()
-		tdb.qAct.On("Limit", 1000).Return(tdb.qAct).Once()
-		tdb.qAct.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
-			*dest = []*models.SoulAgentCommActivity{}
-		}).Once()
+func runListActivitiesMaxLimitTest(t *testing.T, ctx context.Context) {
+	t.Helper()
+	tdb := newCommStoreTestDB()
+	tdb.qAct.On("Limit", 1000).Return(tdb.qAct).Once()
+	tdb.qAct.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		*dest = []*models.SoulAgentCommActivity{}
+	}).Once()
 
-		st := &dynamoStore{db: tdb.db}
-		items, err := st.ListRecentCommActivities(ctx, commStoreTestAgentID, 5000)
-		if err != nil || len(items) != 0 {
-			t.Fatalf("unexpected activities result: items=%#v err=%v", items, err)
-		}
-	})
+	st := &dynamoStore{db: tdb.db}
+	items, err := st.ListRecentCommActivities(ctx, commStoreTestAgentID, 5000)
+	if err != nil || len(items) != 0 {
+		t.Fatalf("unexpected activities result: items=%#v err=%v", items, err)
+	}
+}
 
-	t.Run("put helpers validate nil and write", func(t *testing.T) {
-		tdb := newCommStoreTestDB()
-		st := &dynamoStore{db: tdb.db}
+func runPutHelperNilValidationTest(t *testing.T, ctx context.Context) {
+	t.Helper()
+	st := &dynamoStore{db: newCommStoreTestDB().db}
+	assertError(t, st.PutCommActivity(ctx, nil), "expected error for nil activity")
+	assertError(t, st.PutCommQueue(ctx, nil), "expected error for nil queue item")
+	assertError(t, st.PutMailboxMessage(ctx, nil), "expected error for nil mailbox message")
+	assertError(t, st.PutMailboxEvent(ctx, nil), "expected error for nil mailbox event")
+	assertError(t, st.UpdateMailboxMessageStatus(ctx, nil), "expected error for nil mailbox update")
+}
 
-		if err := st.PutCommActivity(ctx, nil); err == nil {
-			t.Fatalf("expected error for nil activity")
-		}
-		if err := st.PutCommQueue(ctx, nil); err == nil {
-			t.Fatalf("expected error for nil queue item")
-		}
-		if err := st.PutMailboxMessage(ctx, nil); err == nil {
-			t.Fatalf("expected error for nil mailbox message")
-		}
-		if err := st.PutMailboxEvent(ctx, nil); err == nil {
-			t.Fatalf("expected error for nil mailbox event")
-		}
-		if err := st.UpdateMailboxMessageStatus(ctx, nil); err == nil {
-			t.Fatalf("expected error for nil mailbox update")
-		}
-		if err := st.PutCommActivity(ctx, &models.SoulAgentCommActivity{AgentID: commStoreTestAgentID}); err != nil {
-			t.Fatalf("PutCommActivity: %v", err)
-		}
-		if err := st.PutCommQueue(ctx, &models.SoulAgentCommQueue{AgentID: commStoreTestAgentID}); err != nil {
-			t.Fatalf("PutCommQueue: %v", err)
-		}
-		if err := st.PutMailboxMessage(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}); err != nil {
-			t.Fatalf("PutMailboxMessage: %v", err)
-		}
-		if err := st.PutMailboxEvent(ctx, &models.SoulCommMailboxEvent{AgentID: commStoreTestAgentID}); err != nil {
-			t.Fatalf("PutMailboxEvent: %v", err)
-		}
-		if err := st.UpdateMailboxMessageStatus(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}); err != nil {
-			t.Fatalf("UpdateMailboxMessageStatus: %v", err)
-		}
-	})
+func runPutHelperWriteTest(t *testing.T, ctx context.Context) {
+	t.Helper()
+	st := &dynamoStore{db: newCommStoreTestDB().db}
+	assertNoError(t, st.PutCommActivity(ctx, &models.SoulAgentCommActivity{AgentID: commStoreTestAgentID}), "PutCommActivity")
+	assertNoError(t, st.PutCommQueue(ctx, &models.SoulAgentCommQueue{AgentID: commStoreTestAgentID}), "PutCommQueue")
+	assertNoError(t, st.PutMailboxMessage(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}), "PutMailboxMessage")
+	assertNoError(t, st.PutMailboxEvent(ctx, &models.SoulCommMailboxEvent{AgentID: commStoreTestAgentID}), "PutMailboxEvent")
+	assertNoError(t, st.UpdateMailboxMessageStatus(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}), "UpdateMailboxMessageStatus")
+}
+
+func assertError(t *testing.T, err error, message string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal(message)
+	}
+}
+
+func assertNoError(t *testing.T, err error, label string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("%s: %v", label, err)
+	}
 }

--- a/internal/commworker/store_internal_test.go
+++ b/internal/commworker/store_internal_test.go
@@ -29,6 +29,8 @@ type commStoreTestDB struct {
 	qPrefs   *ttmocks.MockQuery
 	qAct     *ttmocks.MockQuery
 	qQueue   *ttmocks.MockQuery
+	qMailbox *ttmocks.MockQuery
+	qEvent   *ttmocks.MockQuery
 	qDomain  *ttmocks.MockQuery
 	qInst    *ttmocks.MockQuery
 }
@@ -42,6 +44,8 @@ func newCommStoreTestDB() commStoreTestDB {
 	qPrefs := new(ttmocks.MockQuery)
 	qAct := new(ttmocks.MockQuery)
 	qQueue := new(ttmocks.MockQuery)
+	qMailbox := new(ttmocks.MockQuery)
+	qEvent := new(ttmocks.MockQuery)
 	qDomain := new(ttmocks.MockQuery)
 	qInst := new(ttmocks.MockQuery)
 
@@ -53,15 +57,22 @@ func newCommStoreTestDB() commStoreTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentContactPreferences")).Return(qPrefs).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qAct).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentCommQueue")).Return(qQueue).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMailboxMessage")).Return(qMailbox).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMailboxEvent")).Return(qEvent).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qEmail, qPhone, qIdent, qChannel, qPrefs, qAct, qQueue, qDomain, qInst} {
+	for _, q := range []*ttmocks.MockQuery{qEmail, qPhone, qIdent, qChannel, qPrefs, qAct, qQueue, qMailbox, qEvent, qDomain, qInst} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
+		q.On("IfNotExists").Return(q).Maybe()
+		q.On("IfExists").Return(q).Maybe()
+		q.On("Create").Return(nil).Maybe()
 		q.On("CreateOrUpdate").Return(nil).Maybe()
+		q.On("Update", mock.Anything).Return(nil).Maybe()
 	}
+	qMailbox.On("Update", "Status", "UpdatedAt").Return(nil).Maybe()
 
 	return commStoreTestDB{
 		db:       db,
@@ -72,6 +83,8 @@ func newCommStoreTestDB() commStoreTestDB {
 		qPrefs:   qPrefs,
 		qAct:     qAct,
 		qQueue:   qQueue,
+		qMailbox: qMailbox,
+		qEvent:   qEvent,
 		qDomain:  qDomain,
 		qInst:    qInst,
 	}
@@ -265,11 +278,29 @@ func TestDynamoStoreListAndPut(t *testing.T) {
 		if err := st.PutCommQueue(ctx, nil); err == nil {
 			t.Fatalf("expected error for nil queue item")
 		}
+		if err := st.PutMailboxMessage(ctx, nil); err == nil {
+			t.Fatalf("expected error for nil mailbox message")
+		}
+		if err := st.PutMailboxEvent(ctx, nil); err == nil {
+			t.Fatalf("expected error for nil mailbox event")
+		}
+		if err := st.UpdateMailboxMessageStatus(ctx, nil); err == nil {
+			t.Fatalf("expected error for nil mailbox update")
+		}
 		if err := st.PutCommActivity(ctx, &models.SoulAgentCommActivity{AgentID: commStoreTestAgentID}); err != nil {
 			t.Fatalf("PutCommActivity: %v", err)
 		}
 		if err := st.PutCommQueue(ctx, &models.SoulAgentCommQueue{AgentID: commStoreTestAgentID}); err != nil {
 			t.Fatalf("PutCommQueue: %v", err)
+		}
+		if err := st.PutMailboxMessage(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}); err != nil {
+			t.Fatalf("PutMailboxMessage: %v", err)
+		}
+		if err := st.PutMailboxEvent(ctx, &models.SoulCommMailboxEvent{AgentID: commStoreTestAgentID}); err != nil {
+			t.Fatalf("PutMailboxEvent: %v", err)
+		}
+		if err := st.UpdateMailboxMessageStatus(ctx, &models.SoulCommMailboxMessage{AgentID: commStoreTestAgentID}); err != nil {
+			t.Fatalf("UpdateMailboxMessageStatus: %v", err)
 		}
 	})
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,12 @@ type Config struct {
 	// InboundEmailS3Prefix is the prefix under InboundEmailBucketName where SES stores raw mail.
 	InboundEmailS3Prefix string
 
+	// SoulCommMailboxBucketName stores bounded canonical mailbox content for soul comm deliveries.
+	SoulCommMailboxBucketName string
+
+	// SoulCommMailboxRetentionDays is the content/object lifecycle window for mailbox bodies.
+	SoulCommMailboxRetentionDays int64
+
 	// ENS gateway (CCIP-Read) configuration.
 	ENSGatewayResolverAddress     string
 	ENSGatewaySigningKeyID        string
@@ -184,11 +190,13 @@ func Load() Config {
 		AppName: "lesser-host",
 		Stage:   stage,
 
-		StateTableName:         stateTableName,
-		PublicBaseURL:          publicBaseURL,
-		SoulEmailInboundDomain: envString("SOUL_EMAIL_INBOUND_DOMAIN"),
-		InboundEmailBucketName: envString("INBOUND_EMAIL_BUCKET_NAME"),
-		InboundEmailS3Prefix:   envStringDefault("INBOUND_EMAIL_S3_PREFIX", "ses/inbound/"),
+		StateTableName:               stateTableName,
+		PublicBaseURL:                publicBaseURL,
+		SoulEmailInboundDomain:       envString("SOUL_EMAIL_INBOUND_DOMAIN"),
+		InboundEmailBucketName:       envString("INBOUND_EMAIL_BUCKET_NAME"),
+		InboundEmailS3Prefix:         envStringDefault("INBOUND_EMAIL_S3_PREFIX", "ses/inbound/"),
+		SoulCommMailboxBucketName:    envString("SOUL_COMM_MAILBOX_BUCKET_NAME"),
+		SoulCommMailboxRetentionDays: envInt64Bounded("SOUL_COMM_MAILBOX_RETENTION_DAYS", 90, 1, 365),
 
 		ENSGatewayResolverAddress:     envString("ENS_GATEWAY_RESOLVER_ADDRESS"),
 		ENSGatewaySigningKeyID:        envString("ENS_GATEWAY_SIGNING_KEY_ID"),

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,9 @@ func TestLoad_Defaults(t *testing.T) {
 	if cfg.SoulV2StrictIntegrity {
 		t.Fatalf("expected strict integrity default off")
 	}
+	if cfg.SoulCommMailboxRetentionDays != 90 {
+		t.Fatalf("expected mailbox retention default 90, got %d", cfg.SoulCommMailboxRetentionDays)
+	}
 }
 
 func TestLoad_SoulV2StrictIntegrity(t *testing.T) {
@@ -91,5 +94,23 @@ func TestLoad_SoulV2StrictIntegrity(t *testing.T) {
 	cfg := Load()
 	if !cfg.SoulV2StrictIntegrity {
 		t.Fatalf("expected strict integrity enabled")
+	}
+}
+
+func TestLoad_SoulCommMailboxConfig(t *testing.T) {
+	t.Setenv("SOUL_COMM_MAILBOX_BUCKET_NAME", " mailbox-bucket ")
+	t.Setenv("SOUL_COMM_MAILBOX_RETENTION_DAYS", "120")
+	cfg := Load()
+	if cfg.SoulCommMailboxBucketName != "mailbox-bucket" {
+		t.Fatalf("unexpected mailbox bucket: %q", cfg.SoulCommMailboxBucketName)
+	}
+	if cfg.SoulCommMailboxRetentionDays != 120 {
+		t.Fatalf("unexpected mailbox retention: %d", cfg.SoulCommMailboxRetentionDays)
+	}
+
+	t.Setenv("SOUL_COMM_MAILBOX_RETENTION_DAYS", "999")
+	cfg = Load()
+	if cfg.SoulCommMailboxRetentionDays != 90 {
+		t.Fatalf("expected invalid retention fallback, got %d", cfg.SoulCommMailboxRetentionDays)
 	}
 }

--- a/internal/controlplane/comm_mailbox_capture.go
+++ b/internal/controlplane/comm_mailbox_capture.go
@@ -1,0 +1,109 @@
+package controlplane
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func (s *Server) outboundMailboxCaptureEnabled() bool {
+	return s != nil && s.store != nil && s.store.DB != nil && s.mailboxContentStore != nil
+}
+
+func (s *Server) captureOutboundMailbox(ctx context.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, messageID string, delivery soulCommSendDelivery, status string, now time.Time) error {
+	if !s.outboundMailboxCaptureEnabled() {
+		return nil
+	}
+	if key == nil {
+		return nil
+	}
+	instanceSlug := strings.ToLower(strings.TrimSpace(key.InstanceSlug))
+	agentID := strings.ToLower(strings.TrimSpace(req.agentIDHex))
+	channel := strings.ToLower(strings.TrimSpace(req.channel))
+	messageID = strings.TrimSpace(messageID)
+	threadRoot := strings.TrimSpace(req.inReplyTo)
+	if threadRoot == "" {
+		threadRoot = messageID
+	}
+	deliveryID := models.SoulCommMailboxDeliveryID(instanceSlug, agentID, models.SoulCommDirectionOutbound, messageID)
+	threadID := models.SoulCommMailboxThreadID(instanceSlug, agentID, channel, threadRoot)
+
+	ptr, err := s.mailboxContentStore.PutContent(ctx, commmailbox.ContentInput{
+		DeliveryID:      deliveryID,
+		InstanceSlug:    instanceSlug,
+		AgentID:         agentID,
+		MessageID:       messageID,
+		Direction:       models.SoulCommDirectionOutbound,
+		ChannelType:     channel,
+		Body:            req.body,
+		ContentMimeType: commmailbox.DefaultContentType(channel),
+	})
+	if err != nil {
+		return err
+	}
+
+	msg := &models.SoulCommMailboxMessage{
+		DeliveryID:        deliveryID,
+		MessageID:         messageID,
+		ThreadID:          threadID,
+		InstanceSlug:      instanceSlug,
+		AgentID:           agentID,
+		Direction:         models.SoulCommDirectionOutbound,
+		ChannelType:       channel,
+		Provider:          delivery.provider,
+		ProviderMessageID: delivery.providerMessageID,
+		Status:            soulCommSendResultStatus(status),
+		FromSoulAgentID:   agentID,
+		Subject:           req.subject,
+		Preview:           models.SoulCommMailboxPreview(req.body),
+		ContentStorage:    ptr.Storage,
+		ContentBucket:     ptr.Bucket,
+		ContentKey:        ptr.Key,
+		ContentSHA256:     ptr.SHA256,
+		ContentBytes:      ptr.Bytes,
+		ContentMimeType:   ptr.ContentType,
+		ContentStoredAt:   now,
+		HasContent:        true,
+		Read:              true,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if channel == commChannelEmail {
+		msg.ToAddress = req.to
+	} else {
+		msg.ToNumber = req.to
+	}
+	if err := msg.BeforeCreate(); err != nil {
+		return err
+	}
+	if err := s.store.DB.WithContext(ctx).Model(msg).IfNotExists().Create(); err != nil && !theoryErrors.IsConditionFailed(err) {
+		return err
+	}
+
+	evt := &models.SoulCommMailboxEvent{
+		DeliveryID:   deliveryID,
+		MessageID:    messageID,
+		ThreadID:     threadID,
+		InstanceSlug: instanceSlug,
+		AgentID:      agentID,
+		Direction:    models.SoulCommDirectionOutbound,
+		ChannelType:  channel,
+		EventType:    models.SoulCommMailboxEventCreated,
+		Status:       msg.Status,
+		Actor:        "instance:" + instanceSlug,
+		DetailsJSON:  `{"source":"soul_comm_send"}`,
+		CreatedAt:    now,
+	}
+	if err := evt.BeforeCreate(); err != nil {
+		return err
+	}
+	if err := s.store.DB.WithContext(ctx).Model(evt).IfNotExists().Create(); err != nil && !theoryErrors.IsConditionFailed(err) {
+		return err
+	}
+	return nil
+}

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -70,6 +70,8 @@ type soulCommSendRequest struct {
 
 type soulCommSendResponse struct {
 	MessageID         string `json:"messageId"`
+	DeliveryID        string `json:"deliveryId,omitempty"`
+	ThreadID          string `json:"threadId,omitempty"`
 	Status            string `json:"status"`
 	Channel           string `json:"channel"`
 	AgentID           string `json:"agentId"`
@@ -239,7 +241,7 @@ func (s *Server) handleSoulCommSend(ctx *apptheory.Context) (*apptheory.Response
 
 	metrics.provider = delivery.provider
 	metrics.status = commMetricSent
-	resp, appErr := soulCommSendJSON(messageID, req, delivery, now)
+	resp, appErr := soulCommSendJSON(messageID, strings.TrimSpace(key.InstanceSlug), req, delivery, now)
 	if appErr != nil {
 		metrics.status = commMetricInternalError
 		return nil, appErr
@@ -1086,6 +1088,11 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 		return apptheory.NewAppTheoryError(commCodeInternal, "failed to record activity").WithStatusCode(http.StatusInternalServerError)
 	}
 
+	if captureErr := s.captureOutboundMailbox(ctx.Context(), key, req, messageID, delivery, statusValue, now); captureErr != nil {
+		metrics.status = commMetricInternalError
+		return apptheory.NewAppTheoryError(commCodeInternal, "failed to record mailbox delivery").WithStatusCode(http.StatusInternalServerError)
+	}
+
 	s.tryWriteAuditLog(ctx, &models.AuditLogEntry{
 		Actor:     fmt.Sprintf("instance:%s", strings.TrimSpace(key.InstanceSlug)),
 		Action:    fmt.Sprintf("soul.comm.send.%s", req.channel),
@@ -1095,8 +1102,8 @@ func (s *Server) recordSoulCommSend(ctx *apptheory.Context, key *models.Instance
 	return nil
 }
 
-func soulCommSendJSON(messageID string, req validatedSoulCommSendRequest, delivery soulCommSendDelivery, now time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
-	return soulCommSendJSONFields(messageID, soulCommSendResultStatus(delivery.initialStatus), req.channel, req.agentIDHex, req.to, delivery.provider, delivery.providerMessageID, now)
+func soulCommSendJSON(messageID string, instanceSlug string, req validatedSoulCommSendRequest, delivery soulCommSendDelivery, now time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
+	return soulCommSendJSONFields(messageID, instanceSlug, soulCommSendResultStatus(delivery.initialStatus), req.channel, req.agentIDHex, req.to, delivery.provider, delivery.providerMessageID, req.inReplyTo, now)
 }
 
 func soulCommSendResultStatus(initialStatus string) string {
@@ -1107,9 +1114,16 @@ func soulCommSendResultStatus(initialStatus string) string {
 	return statusValue
 }
 
-func soulCommSendJSONFields(messageID string, status string, channel string, agentID string, to string, provider string, providerMessageID string, createdAt time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
+func soulCommSendJSONFields(messageID string, instanceSlug string, status string, channel string, agentID string, to string, provider string, providerMessageID string, threadRoot string, createdAt time.Time) (*apptheory.Response, *apptheory.AppTheoryError) {
+	deliveryID := models.SoulCommMailboxDeliveryID(instanceSlug, agentID, models.SoulCommDirectionOutbound, messageID)
+	if strings.TrimSpace(threadRoot) == "" {
+		threadRoot = messageID
+	}
+	threadID := models.SoulCommMailboxThreadID(instanceSlug, agentID, channel, threadRoot)
 	resp, err := apptheory.JSON(http.StatusOK, soulCommSendResponse{
 		MessageID:         strings.TrimSpace(messageID),
+		DeliveryID:        deliveryID,
+		ThreadID:          threadID,
 		Status:            strings.TrimSpace(status),
 		Channel:           strings.TrimSpace(channel),
 		AgentID:           strings.ToLower(strings.TrimSpace(agentID)),
@@ -1125,11 +1139,11 @@ func soulCommSendJSONFields(messageID string, status string, channel string, age
 }
 
 func soulCommSendJSONFromStatusItem(item models.SoulCommMessageStatus) (*apptheory.Response, *apptheory.AppTheoryError) {
-	return soulCommSendJSONFields(item.MessageID, item.Status, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.CreatedAt)
+	return soulCommSendJSONFields(item.MessageID, item.InstanceSlug, item.Status, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.MessageID, item.CreatedAt)
 }
 
 func soulCommSendJSONFromIdempotencyItem(item models.SoulCommSendIdempotency) (*apptheory.Response, *apptheory.AppTheoryError) {
-	return soulCommSendJSONFields(item.MessageID, item.ResponseStatus, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.CreatedAt)
+	return soulCommSendJSONFields(item.MessageID, item.InstanceSlug, item.ResponseStatus, item.ChannelType, item.AgentID, item.To, item.Provider, item.ProviderMessageID, item.MessageID, item.CreatedAt)
 }
 
 func soulCommStatusJSON(item models.SoulCommMessageStatus) soulCommStatusResponse {

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -776,6 +776,29 @@ func TestHandleSoulCommStatus_ReturnsStatusRecord(t *testing.T) {
 func TestCaptureOutboundMailboxStoresContentPointer(t *testing.T) {
 	t.Parallel()
 
+	fx := newOutboundMailboxCaptureFixture(t)
+	err := fx.server.captureOutboundMailbox(context.Background(), fx.instanceKey, fx.request, "comm-msg-out", fx.delivery, models.SoulCommMessageStatusSent, fx.now)
+	if err != nil {
+		t.Fatalf("captureOutboundMailbox: %v", err)
+	}
+	assertOutboundMailboxContentWrite(t, fx.content.inputs)
+	assertOutboundMailboxRow(t, *fx.gotMsg)
+	assertOutboundMailboxEvent(t, *fx.gotEvt)
+}
+
+type outboundMailboxCaptureFixture struct {
+	server      *Server
+	content     *fakeControlMailboxContentStore
+	gotMsg      **models.SoulCommMailboxMessage
+	gotEvt      **models.SoulCommMailboxEvent
+	instanceKey *models.InstanceKey
+	request     validatedSoulCommSendRequest
+	delivery    soulCommSendDelivery
+	now         time.Time
+}
+
+func newOutboundMailboxCaptureFixture(t *testing.T) outboundMailboxCaptureFixture {
+	t.Helper()
 	db := ttmocks.NewMockExtendedDB()
 	qMsg := new(ttmocks.MockQuery)
 	qEvt := new(ttmocks.MockQuery)
@@ -792,30 +815,43 @@ func TestCaptureOutboundMailboxStoresContentPointer(t *testing.T) {
 	allowCommQueryOps(qMsg, qEvt)
 
 	content := &fakeControlMailboxContentStore{}
-	s := &Server{store: store.New(db), mailboxContentStore: content}
-	now := time.Date(2026, 4, 25, 14, 0, 0, 0, time.UTC)
-	req := validatedSoulCommSendRequest{
-		channel:    commChannelEmail,
-		agentIDHex: "0xabc",
-		to:         "recipient@example.com",
-		subject:    "Hello",
-		body:       "Outbound body",
+	return outboundMailboxCaptureFixture{
+		server:      &Server{store: store.New(db), mailboxContentStore: content},
+		content:     content,
+		gotMsg:      &gotMsg,
+		gotEvt:      &gotEvt,
+		instanceKey: &models.InstanceKey{InstanceSlug: "Demo"},
+		request: validatedSoulCommSendRequest{
+			channel:    commChannelEmail,
+			agentIDHex: "0xabc",
+			to:         "recipient@example.com",
+			subject:    "Hello",
+			body:       "Outbound body",
+		},
+		delivery: soulCommSendDelivery{provider: commDeliveryProviderMigadu, providerMessageID: "<provider@msg>", initialStatus: models.SoulCommMessageStatusSent},
+		now:      time.Date(2026, 4, 25, 14, 0, 0, 0, time.UTC),
 	}
-	delivery := soulCommSendDelivery{provider: commDeliveryProviderMigadu, providerMessageID: "<provider@msg>", initialStatus: models.SoulCommMessageStatusSent}
-	key := &models.InstanceKey{InstanceSlug: "Demo"}
+}
 
-	if err := s.captureOutboundMailbox(context.Background(), key, req, "comm-msg-out", delivery, models.SoulCommMessageStatusSent, now); err != nil {
-		t.Fatalf("captureOutboundMailbox: %v", err)
+func assertOutboundMailboxContentWrite(t *testing.T, inputs []commmailbox.ContentInput) {
+	t.Helper()
+	if len(inputs) != 1 || inputs[0].Body != "Outbound body" || inputs[0].Direction != models.SoulCommDirectionOutbound {
+		t.Fatalf("unexpected content writes: %#v", inputs)
 	}
-	if len(content.inputs) != 1 || content.inputs[0].Body != "Outbound body" || content.inputs[0].Direction != models.SoulCommDirectionOutbound {
-		t.Fatalf("unexpected content writes: %#v", content.inputs)
-	}
+}
+
+func assertOutboundMailboxRow(t *testing.T, gotMsg *models.SoulCommMailboxMessage) {
+	t.Helper()
 	if gotMsg == nil || gotMsg.InstanceSlug != "demo" || gotMsg.AgentID != "0xabc" || gotMsg.Direction != models.SoulCommDirectionOutbound {
 		t.Fatalf("unexpected mailbox row: %#v", gotMsg)
 	}
 	if !gotMsg.HasContent || gotMsg.ContentBucket != "mailbox-bucket" || gotMsg.ContentSHA256 != "sha256-outbound" || gotMsg.ToAddress != "recipient@example.com" || !gotMsg.Read {
 		t.Fatalf("unexpected mailbox content/state: %#v", gotMsg)
 	}
+}
+
+func assertOutboundMailboxEvent(t *testing.T, gotEvt *models.SoulCommMailboxEvent) {
+	t.Helper()
 	if gotEvt == nil || gotEvt.EventType != models.SoulCommMailboxEventCreated || gotEvt.Actor != "instance:demo" || gotEvt.Status != models.SoulCommMessageStatusSent {
 		t.Fatalf("unexpected mailbox event: %#v", gotEvt)
 	}

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -56,6 +57,22 @@ func assertSoulCommSendResponse(t *testing.T, resp *apptheory.Response, wantStat
 	if wantProviderMessageID != "" && out.ProviderMessageID != wantProviderMessageID {
 		t.Fatalf("expected provider message id %q, got %q", wantProviderMessageID, out.ProviderMessageID)
 	}
+}
+
+type fakeControlMailboxContentStore struct {
+	inputs []commmailbox.ContentInput
+}
+
+func (f *fakeControlMailboxContentStore) PutContent(_ context.Context, input commmailbox.ContentInput) (commmailbox.ContentPointer, error) {
+	f.inputs = append(f.inputs, input)
+	return commmailbox.ContentPointer{
+		Storage:     commmailbox.ContentStorageS3,
+		Bucket:      "mailbox-bucket",
+		Key:         commmailbox.ContentKey(input.InstanceSlug, input.AgentID, input.DeliveryID),
+		SHA256:      "sha256-outbound",
+		Bytes:       int64(len(input.Body)),
+		ContentType: commmailbox.DefaultContentType(input.ChannelType),
+	}, nil
 }
 
 func TestHandleSoulCommSend_UnauthorizedWithoutBearer(t *testing.T) {
@@ -753,5 +770,53 @@ func TestHandleSoulCommStatus_ReturnsStatusRecord(t *testing.T) {
 	}
 	if out.ReplyConfidence == nil || *out.ReplyConfidence != 0.91 {
 		t.Fatalf("expected reply confidence, got %#v", out.ReplyConfidence)
+	}
+}
+
+func TestCaptureOutboundMailboxStoresContentPointer(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qMsg := new(ttmocks.MockQuery)
+	qEvt := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+
+	var gotMsg *models.SoulCommMailboxMessage
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMailboxMessage")).Return(qMsg).Run(func(args mock.Arguments) {
+		gotMsg = testutil.RequireMockArg[*models.SoulCommMailboxMessage](t, args, 0)
+	}).Once()
+	var gotEvt *models.SoulCommMailboxEvent
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMailboxEvent")).Return(qEvt).Run(func(args mock.Arguments) {
+		gotEvt = testutil.RequireMockArg[*models.SoulCommMailboxEvent](t, args, 0)
+	}).Once()
+	allowCommQueryOps(qMsg, qEvt)
+
+	content := &fakeControlMailboxContentStore{}
+	s := &Server{store: store.New(db), mailboxContentStore: content}
+	now := time.Date(2026, 4, 25, 14, 0, 0, 0, time.UTC)
+	req := validatedSoulCommSendRequest{
+		channel:    commChannelEmail,
+		agentIDHex: "0xabc",
+		to:         "recipient@example.com",
+		subject:    "Hello",
+		body:       "Outbound body",
+	}
+	delivery := soulCommSendDelivery{provider: commDeliveryProviderMigadu, providerMessageID: "<provider@msg>", initialStatus: models.SoulCommMessageStatusSent}
+	key := &models.InstanceKey{InstanceSlug: "Demo"}
+
+	if err := s.captureOutboundMailbox(context.Background(), key, req, "comm-msg-out", delivery, models.SoulCommMessageStatusSent, now); err != nil {
+		t.Fatalf("captureOutboundMailbox: %v", err)
+	}
+	if len(content.inputs) != 1 || content.inputs[0].Body != "Outbound body" || content.inputs[0].Direction != models.SoulCommDirectionOutbound {
+		t.Fatalf("unexpected content writes: %#v", content.inputs)
+	}
+	if gotMsg == nil || gotMsg.InstanceSlug != "demo" || gotMsg.AgentID != "0xabc" || gotMsg.Direction != models.SoulCommDirectionOutbound {
+		t.Fatalf("unexpected mailbox row: %#v", gotMsg)
+	}
+	if !gotMsg.HasContent || gotMsg.ContentBucket != "mailbox-bucket" || gotMsg.ContentSHA256 != "sha256-outbound" || gotMsg.ToAddress != "recipient@example.com" || !gotMsg.Read {
+		t.Fatalf("unexpected mailbox content/state: %#v", gotMsg)
+	}
+	if gotEvt == nil || gotEvt.EventType != models.SoulCommMailboxEventCreated || gotEvt.Actor != "instance:demo" || gotEvt.Status != models.SoulCommMessageStatusSent {
+		t.Fatalf("unexpected mailbox event: %#v", gotEvt)
 	}
 }

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -3,10 +3,12 @@ package controlplane
 import (
 	"context"
 	"log"
+	"strings"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 
 	"github.com/equaltoai/lesser-host/internal/artifacts"
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/commworker"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
@@ -19,13 +21,14 @@ type soulPackStore interface {
 
 // Server implements the control plane API.
 type Server struct {
-	cfg       config.Config
-	store     *store.Store
-	webAuthn  webAuthnEngine
-	queues    *queueClient
-	r53       *route53Client
-	soulPacks soulPackStore
-	dialEVM   ethRPCDialer
+	cfg                 config.Config
+	store               *store.Store
+	webAuthn            webAuthnEngine
+	queues              *queueClient
+	r53                 *route53Client
+	soulPacks           soulPackStore
+	mailboxContentStore commmailbox.ContentStore
+	dialEVM             ethRPCDialer
 
 	ssmGetParameter     func(ctx context.Context, name string) (string, error)
 	ssmPutSecureValue   func(ctx context.Context, name string, value string, overwrite bool) error
@@ -71,6 +74,9 @@ func NewServer(cfg config.Config, st *store.Store) *Server {
 		telnyxRelease:       defaultTelnyxReleasePhoneNumber,
 		telnyxSendSMS:       defaultTelnyxSendSMS,
 		telnyxCallVoice:     defaultTelnyxCreateVoiceCall,
+	}
+	if strings.TrimSpace(cfg.SoulCommMailboxBucketName) != "" {
+		srv.mailboxContentStore = commmailbox.NewS3Store(cfg.SoulCommMailboxBucketName)
 	}
 	srv.enqueueCommMessage = srv.queues.enqueueCommMessage
 	return srv

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -41,5 +41,7 @@ func LambdaInit() (DB, error) {
 		&models.RenderArtifact{},
 		&models.AuditLogEntry{},
 		&models.VanityDomainRequest{},
+		&models.SoulCommMailboxMessage{},
+		&models.SoulCommMailboxEvent{},
 	)
 }

--- a/internal/store/models/soul_comm_mailbox.go
+++ b/internal/store/models/soul_comm_mailbox.go
@@ -1,0 +1,459 @@
+package models
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	theorymodel "github.com/theory-cloud/tabletheory/pkg/model"
+)
+
+// SoulCommMailboxRetentionDays is the bounded retention window for canonical
+// soul comm mailbox metadata. Content objects use the same lifecycle duration
+// in the CDK-managed mailbox bucket.
+const SoulCommMailboxRetentionDays = 90
+
+// SoulCommMailbox* constants define canonical mailbox state values.
+const (
+	SoulCommMailboxStatusAccepted  = "accepted"
+	SoulCommMailboxStatusSent      = "sent"
+	SoulCommMailboxStatusDelivered = "delivered"
+	SoulCommMailboxStatusQueued    = "queued"
+	SoulCommMailboxStatusFailed    = "failed"
+	SoulCommMailboxStatusBounced   = "bounced"
+	SoulCommMailboxStatusDropped   = "dropped"
+)
+
+// SoulCommMailboxEvent* constants define immutable mailbox event types.
+const (
+	SoulCommMailboxEventCreated          = "created"
+	SoulCommMailboxEventContentStored    = "content_stored"
+	SoulCommMailboxEventProjectionQueued = "projection_queued"
+	SoulCommMailboxEventStateChanged     = "state_changed"
+)
+
+// SoulCommMailboxMessage stores the canonical current mailbox row for a soul
+// comm delivery. The partition key scopes every list query to a specific
+// instance + agent pair; direct delivery and thread lookups use tenant-scoped
+// GSIs.
+//
+// Keys:
+//
+//	PK: COMM#MAILBOX#INSTANCE#{instanceSlug}#AGENT#{agentId}
+//	SK: MSG#{timestamp}#{deliveryId}
+//	GSI1PK: COMM#MAILBOX#DELIVERY#{deliveryId}
+//	GSI1SK: CURRENT
+//	GSI2PK: COMM#MAILBOX#INSTANCE#{instanceSlug}#AGENT#{agentId}#THREAD#{threadId}
+//	GSI2SK: MSG#{timestamp}#{deliveryId}
+//
+// The current row is mutable only for mailbox state and provider status; identity,
+// provenance, and content identity fields are protected by TableTheory write
+// policy metadata.
+type SoulCommMailboxMessage struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	DeliveryID   string `theorydb:"attr:deliveryId" json:"delivery_id"`
+	MessageID    string `theorydb:"attr:messageId" json:"message_id"`
+	ThreadID     string `theorydb:"attr:threadId" json:"thread_id"`
+	InstanceSlug string `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	AgentID      string `theorydb:"attr:agentId" json:"agent_id"`
+
+	Direction   string `theorydb:"attr:direction" json:"direction"`      // inbound|outbound
+	ChannelType string `theorydb:"attr:channelType" json:"channel_type"` // email|sms|voice
+
+	Provider          string `theorydb:"attr:provider" json:"provider,omitempty"`
+	ProviderMessageID string `theorydb:"attr:providerMessageId" json:"provider_message_id,omitempty"`
+	Status            string `theorydb:"attr:status" json:"status"`
+
+	FromAddress     string `theorydb:"attr:fromAddress" json:"from_address,omitempty"`
+	FromNumber      string `theorydb:"attr:fromNumber" json:"from_number,omitempty"`
+	FromSoulAgentID string `theorydb:"attr:fromSoulAgentId" json:"from_soul_agent_id,omitempty"`
+	FromDisplayName string `theorydb:"attr:fromDisplayName" json:"from_display_name,omitempty"`
+	ToAddress       string `theorydb:"attr:toAddress" json:"to_address,omitempty"`
+	ToNumber        string `theorydb:"attr:toNumber" json:"to_number,omitempty"`
+	ToSoulAgentID   string `theorydb:"attr:toSoulAgentId" json:"to_soul_agent_id,omitempty"`
+	ToDisplayName   string `theorydb:"attr:toDisplayName" json:"to_display_name,omitempty"`
+
+	Subject string `theorydb:"attr:subject" json:"subject,omitempty"`
+	Preview string `theorydb:"attr:preview" json:"preview,omitempty"`
+
+	ContentStorage  string    `theorydb:"attr:contentStorage" json:"content_storage,omitempty"`
+	ContentBucket   string    `theorydb:"attr:contentBucket" json:"content_bucket,omitempty"`
+	ContentKey      string    `theorydb:"attr:contentKey" json:"content_key,omitempty"`
+	ContentSHA256   string    `theorydb:"attr:contentSha256" json:"content_sha256,omitempty"`
+	ContentBytes    int64     `theorydb:"attr:contentBytes" json:"content_bytes,omitempty"`
+	ContentMimeType string    `theorydb:"attr:contentMimeType" json:"content_mime_type,omitempty"`
+	ContentStoredAt time.Time `theorydb:"attr:contentStoredAt" json:"content_stored_at,omitempty"`
+	HasContent      bool      `theorydb:"attr:hasContent" json:"has_content"`
+
+	Read     bool `theorydb:"attr:read" json:"read"`
+	Archived bool `theorydb:"attr:archived" json:"archived"`
+	Deleted  bool `theorydb:"attr:deleted" json:"deleted"`
+
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+}
+
+// TableName returns the database table name for SoulCommMailboxMessage.
+func (SoulCommMailboxMessage) TableName() string { return MainTableName() }
+
+// WritePolicy protects immutable identity, provenance, and content identity
+// fields while leaving mailbox state fields mutable for Host 3 APIs.
+func (SoulCommMailboxMessage) WritePolicy() theorymodel.WritePolicy {
+	return theorymodel.WritePolicy{
+		Mode: theorymodel.WritePolicyModeMutable,
+		ProtectedAttributes: []string{
+			"deliveryId",
+			"messageId",
+			"threadId",
+			"instanceSlug",
+			"agentId",
+			"direction",
+			"channelType",
+			"provider",
+			"providerMessageId",
+			"contentStorage",
+			"contentBucket",
+			"contentKey",
+			"contentSha256",
+			"contentBytes",
+			"contentMimeType",
+			"contentStoredAt",
+			"createdAt",
+		},
+	}
+}
+
+// BeforeCreate sets defaults and keys before creating a mailbox current row.
+func (m *SoulCommMailboxMessage) BeforeCreate() error {
+	now := time.Now().UTC()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	if m.UpdatedAt.IsZero() {
+		m.UpdatedAt = m.CreatedAt
+	}
+	if strings.TrimSpace(m.Direction) == "" {
+		m.Direction = SoulCommDirectionInbound
+	}
+	if strings.TrimSpace(m.Status) == "" {
+		m.Status = SoulCommMailboxStatusAccepted
+	}
+	if strings.TrimSpace(m.ThreadID) == "" {
+		m.ThreadID = SoulCommMailboxThreadID(m.InstanceSlug, m.AgentID, m.ChannelType, m.MessageID)
+	}
+	if strings.TrimSpace(m.DeliveryID) == "" {
+		m.DeliveryID = SoulCommMailboxDeliveryID(m.InstanceSlug, m.AgentID, m.Direction, m.MessageID)
+	}
+	if m.HasContent && strings.TrimSpace(m.ContentStorage) == "" {
+		m.ContentStorage = "s3"
+	}
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("deliveryId", m.DeliveryID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("threadId", m.ThreadID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("channelType", m.ChannelType); err != nil {
+		return err
+	}
+	if err := requireOneOf("direction", m.Direction, SoulCommDirectionInbound, SoulCommDirectionOutbound); err != nil {
+		return err
+	}
+	if err := validateSoulCommMailboxStatus(m.Status); err != nil {
+		return err
+	}
+	if m.HasContent {
+		if err := requireNonEmpty("contentStorage", m.ContentStorage); err != nil {
+			return err
+		}
+		if err := requireNonEmpty("contentBucket", m.ContentBucket); err != nil {
+			return err
+		}
+		if err := requireNonEmpty("contentKey", m.ContentKey); err != nil {
+			return err
+		}
+		if err := requireNonEmpty("contentSha256", m.ContentSHA256); err != nil {
+			return err
+		}
+		if m.ContentBytes <= 0 {
+			return fmt.Errorf("contentBytes must be positive")
+		}
+	}
+	return nil
+}
+
+// BeforeUpdate updates timestamps and keys before mutating a mailbox current row.
+func (m *SoulCommMailboxMessage) BeforeUpdate() error {
+	m.UpdatedAt = time.Now().UTC()
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("deliveryId", m.DeliveryID); err != nil {
+		return err
+	}
+	return validateSoulCommMailboxStatus(m.Status)
+}
+
+// UpdateKeys updates database keys for a mailbox current row.
+func (m *SoulCommMailboxMessage) UpdateKeys() error {
+	m.DeliveryID = strings.TrimSpace(m.DeliveryID)
+	m.MessageID = strings.TrimSpace(m.MessageID)
+	m.ThreadID = strings.TrimSpace(m.ThreadID)
+	m.InstanceSlug = strings.ToLower(strings.TrimSpace(m.InstanceSlug))
+	m.AgentID = strings.ToLower(strings.TrimSpace(m.AgentID))
+	m.Direction = strings.ToLower(strings.TrimSpace(m.Direction))
+	m.ChannelType = strings.ToLower(strings.TrimSpace(m.ChannelType))
+	m.Provider = strings.ToLower(strings.TrimSpace(m.Provider))
+	m.ProviderMessageID = strings.TrimSpace(m.ProviderMessageID)
+	m.Status = strings.ToLower(strings.TrimSpace(m.Status))
+	m.FromAddress = strings.TrimSpace(m.FromAddress)
+	m.FromNumber = strings.TrimSpace(m.FromNumber)
+	m.FromSoulAgentID = strings.ToLower(strings.TrimSpace(m.FromSoulAgentID))
+	m.FromDisplayName = strings.TrimSpace(m.FromDisplayName)
+	m.ToAddress = strings.TrimSpace(m.ToAddress)
+	m.ToNumber = strings.TrimSpace(m.ToNumber)
+	m.ToSoulAgentID = strings.ToLower(strings.TrimSpace(m.ToSoulAgentID))
+	m.ToDisplayName = strings.TrimSpace(m.ToDisplayName)
+	m.Subject = strings.TrimSpace(m.Subject)
+	m.Preview = SoulCommMailboxPreview(m.Preview)
+	m.ContentStorage = strings.ToLower(strings.TrimSpace(m.ContentStorage))
+	m.ContentBucket = strings.TrimSpace(m.ContentBucket)
+	m.ContentKey = strings.TrimSpace(m.ContentKey)
+	m.ContentSHA256 = strings.ToLower(strings.TrimSpace(m.ContentSHA256))
+	m.ContentMimeType = strings.TrimSpace(m.ContentMimeType)
+
+	ts := m.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z")
+	m.PK = SoulCommMailboxAgentPK(m.InstanceSlug, m.AgentID)
+	m.SK = fmt.Sprintf("MSG#%s#%s", ts, m.DeliveryID)
+	m.GSI1PK = SoulCommMailboxDeliveryPK(m.DeliveryID)
+	m.GSI1SK = "CURRENT"
+	m.GSI2PK = SoulCommMailboxThreadPK(m.InstanceSlug, m.AgentID, m.ThreadID)
+	m.GSI2SK = fmt.Sprintf("MSG#%s#%s", ts, m.DeliveryID)
+	m.TTL = m.CreatedAt.UTC().Add(SoulCommMailboxRetentionDays * 24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for SoulCommMailboxMessage.
+func (m *SoulCommMailboxMessage) GetPK() string { return m.PK }
+
+// GetSK returns the sort key for SoulCommMailboxMessage.
+func (m *SoulCommMailboxMessage) GetSK() string { return m.SK }
+
+// SoulCommMailboxEvent stores immutable audit/history events for a mailbox
+// delivery. Events intentionally avoid message body content.
+type SoulCommMailboxEvent struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	GSI1PK string `theorydb:"index:gsi1,pk,attr:gsi1PK,omitempty" json:"-"`
+	GSI1SK string `theorydb:"index:gsi1,sk,attr:gsi1SK,omitempty" json:"-"`
+	GSI2PK string `theorydb:"index:gsi2,pk,attr:gsi2PK,omitempty" json:"-"`
+	GSI2SK string `theorydb:"index:gsi2,sk,attr:gsi2SK,omitempty" json:"-"`
+
+	EventID      string    `theorydb:"attr:eventId" json:"event_id"`
+	DeliveryID   string    `theorydb:"attr:deliveryId" json:"delivery_id"`
+	MessageID    string    `theorydb:"attr:messageId" json:"message_id,omitempty"`
+	ThreadID     string    `theorydb:"attr:threadId" json:"thread_id,omitempty"`
+	InstanceSlug string    `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	AgentID      string    `theorydb:"attr:agentId" json:"agent_id"`
+	Direction    string    `theorydb:"attr:direction" json:"direction"`
+	ChannelType  string    `theorydb:"attr:channelType" json:"channel_type"`
+	EventType    string    `theorydb:"attr:eventType" json:"event_type"`
+	Status       string    `theorydb:"attr:status" json:"status,omitempty"`
+	Actor        string    `theorydb:"attr:actor" json:"actor,omitempty"`
+	DetailsJSON  string    `theorydb:"attr:detailsJson" json:"details_json,omitempty"`
+	CreatedAt    time.Time `theorydb:"attr:createdAt" json:"created_at"`
+}
+
+// TableName returns the database table name for SoulCommMailboxEvent.
+func (SoulCommMailboxEvent) TableName() string { return MainTableName() }
+
+// WritePolicy makes mailbox event rows append-only.
+func (SoulCommMailboxEvent) WritePolicy() theorymodel.WritePolicy {
+	return theorymodel.WritePolicy{Mode: theorymodel.WritePolicyModeWriteOnce}
+}
+
+// BeforeCreate sets defaults and keys before creating an immutable event row.
+func (e *SoulCommMailboxEvent) BeforeCreate() error {
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = time.Now().UTC()
+	}
+	if strings.TrimSpace(e.EventID) == "" {
+		e.EventID = SoulCommMailboxEventID(e.EventType, e.DeliveryID, e.Status, e.CreatedAt)
+	}
+	if err := e.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("eventId", e.EventID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("deliveryId", e.DeliveryID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", e.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", e.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("eventType", e.EventType); err != nil {
+		return err
+	}
+	if strings.TrimSpace(e.Status) != "" {
+		return validateSoulCommMailboxStatus(e.Status)
+	}
+	return nil
+}
+
+// UpdateKeys updates database keys for a mailbox event row.
+func (e *SoulCommMailboxEvent) UpdateKeys() error {
+	e.EventID = strings.TrimSpace(e.EventID)
+	e.DeliveryID = strings.TrimSpace(e.DeliveryID)
+	e.MessageID = strings.TrimSpace(e.MessageID)
+	e.ThreadID = strings.TrimSpace(e.ThreadID)
+	e.InstanceSlug = strings.ToLower(strings.TrimSpace(e.InstanceSlug))
+	e.AgentID = strings.ToLower(strings.TrimSpace(e.AgentID))
+	e.Direction = strings.ToLower(strings.TrimSpace(e.Direction))
+	e.ChannelType = strings.ToLower(strings.TrimSpace(e.ChannelType))
+	e.EventType = strings.ToLower(strings.TrimSpace(e.EventType))
+	e.Status = strings.ToLower(strings.TrimSpace(e.Status))
+	e.Actor = strings.TrimSpace(e.Actor)
+	e.DetailsJSON = strings.TrimSpace(e.DetailsJSON)
+
+	ts := e.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z")
+	e.PK = SoulCommMailboxDeliveryPK(e.DeliveryID)
+	e.SK = fmt.Sprintf("EVENT#%s#%s", ts, e.EventID)
+	e.GSI1PK = SoulCommMailboxAgentPK(e.InstanceSlug, e.AgentID)
+	e.GSI1SK = fmt.Sprintf("EVENT#%s#%s", ts, e.EventID)
+	if e.ThreadID != "" {
+		e.GSI2PK = SoulCommMailboxThreadPK(e.InstanceSlug, e.AgentID, e.ThreadID)
+		e.GSI2SK = fmt.Sprintf("EVENT#%s#%s", ts, e.EventID)
+	} else {
+		e.GSI2PK = ""
+		e.GSI2SK = ""
+	}
+	e.TTL = e.CreatedAt.UTC().Add(SoulCommMailboxRetentionDays * 24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for SoulCommMailboxEvent.
+func (e *SoulCommMailboxEvent) GetPK() string { return e.PK }
+
+// GetSK returns the sort key for SoulCommMailboxEvent.
+func (e *SoulCommMailboxEvent) GetSK() string { return e.SK }
+
+// SoulCommMailboxAgentPK scopes mailbox reads to one instance/agent pair.
+func SoulCommMailboxAgentPK(instanceSlug string, agentID string) string {
+	return fmt.Sprintf("COMM#MAILBOX#INSTANCE#%s#AGENT#%s", strings.ToLower(strings.TrimSpace(instanceSlug)), strings.ToLower(strings.TrimSpace(agentID)))
+}
+
+// SoulCommMailboxDeliveryPK returns the delivery lookup partition key.
+func SoulCommMailboxDeliveryPK(deliveryID string) string {
+	return fmt.Sprintf("COMM#MAILBOX#DELIVERY#%s", strings.TrimSpace(deliveryID))
+}
+
+// SoulCommMailboxThreadPK scopes thread reads to one instance/agent pair.
+func SoulCommMailboxThreadPK(instanceSlug string, agentID string, threadID string) string {
+	return fmt.Sprintf("%s#THREAD#%s", SoulCommMailboxAgentPK(instanceSlug, agentID), strings.TrimSpace(threadID))
+}
+
+// SoulCommMailboxDeliveryID returns a deterministic canonical delivery id.
+func SoulCommMailboxDeliveryID(instanceSlug string, agentID string, direction string, messageID string) string {
+	root := strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(instanceSlug)),
+		strings.ToLower(strings.TrimSpace(agentID)),
+		strings.ToLower(strings.TrimSpace(direction)),
+		strings.TrimSpace(messageID),
+	}, "|")
+	return "comm-delivery-" + shortHash(root, 24)
+}
+
+// SoulCommMailboxThreadID returns a deterministic thread id scoped to one agent.
+func SoulCommMailboxThreadID(instanceSlug string, agentID string, channelType string, rootMessageID string) string {
+	root := strings.TrimSpace(rootMessageID)
+	if root == "" {
+		root = "root"
+	}
+	payload := strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(instanceSlug)),
+		strings.ToLower(strings.TrimSpace(agentID)),
+		strings.ToLower(strings.TrimSpace(channelType)),
+		root,
+	}, "|")
+	return "comm-thread-" + shortHash(payload, 24)
+}
+
+// SoulCommMailboxEventID returns a deterministic-ish event id for append rows.
+func SoulCommMailboxEventID(eventType string, deliveryID string, status string, createdAt time.Time) string {
+	root := strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(eventType)),
+		strings.TrimSpace(deliveryID),
+		strings.ToLower(strings.TrimSpace(status)),
+		createdAt.UTC().Format(time.RFC3339Nano),
+	}, "|")
+	return "comm-mailbox-event-" + shortHash(root, 20)
+}
+
+// SoulCommMailboxPreview collapses message body text into a bounded redacted
+// preview for list responses. The full body remains in the explicit content
+// object, not in list-oriented fields.
+func SoulCommMailboxPreview(body string) string {
+	body = strings.Join(strings.Fields(strings.TrimSpace(body)), " ")
+	const maxRunes = 160
+	if utf8.RuneCountInString(body) <= maxRunes {
+		return body
+	}
+	runes := []rune(body)
+	return string(runes[:maxRunes]) + "…"
+}
+
+func validateSoulCommMailboxStatus(status string) error {
+	return requireOneOf(
+		"status",
+		strings.ToLower(strings.TrimSpace(status)),
+		SoulCommMailboxStatusAccepted,
+		SoulCommMailboxStatusSent,
+		SoulCommMailboxStatusDelivered,
+		SoulCommMailboxStatusQueued,
+		SoulCommMailboxStatusFailed,
+		SoulCommMailboxStatusBounced,
+		SoulCommMailboxStatusDropped,
+	)
+}
+
+func shortHash(value string, length int) string {
+	sum := sha256.Sum256([]byte(value))
+	hexValue := hex.EncodeToString(sum[:])
+	if length <= 0 || length > len(hexValue) {
+		return hexValue
+	}
+	return hexValue[:length]
+}

--- a/internal/store/models/soul_comm_mailbox.go
+++ b/internal/store/models/soul_comm_mailbox.go
@@ -138,7 +138,14 @@ func (SoulCommMailboxMessage) WritePolicy() theorymodel.WritePolicy {
 
 // BeforeCreate sets defaults and keys before creating a mailbox current row.
 func (m *SoulCommMailboxMessage) BeforeCreate() error {
-	now := time.Now().UTC()
+	m.applyCreateDefaults(time.Now().UTC())
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	return m.validateCreate()
+}
+
+func (m *SoulCommMailboxMessage) applyCreateDefaults(now time.Time) {
 	if m.CreatedAt.IsZero() {
 		m.CreatedAt = now
 	}
@@ -160,26 +167,24 @@ func (m *SoulCommMailboxMessage) BeforeCreate() error {
 	if m.HasContent && strings.TrimSpace(m.ContentStorage) == "" {
 		m.ContentStorage = "s3"
 	}
-	if err := m.UpdateKeys(); err != nil {
-		return err
+}
+
+func (m *SoulCommMailboxMessage) validateCreate() error {
+	checks := []struct {
+		field string
+		value string
+	}{
+		{field: "deliveryId", value: m.DeliveryID},
+		{field: "messageId", value: m.MessageID},
+		{field: "threadId", value: m.ThreadID},
+		{field: "instanceSlug", value: m.InstanceSlug},
+		{field: "agentId", value: m.AgentID},
+		{field: "channelType", value: m.ChannelType},
 	}
-	if err := requireNonEmpty("deliveryId", m.DeliveryID); err != nil {
-		return err
-	}
-	if err := requireNonEmpty("messageId", m.MessageID); err != nil {
-		return err
-	}
-	if err := requireNonEmpty("threadId", m.ThreadID); err != nil {
-		return err
-	}
-	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
-		return err
-	}
-	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
-		return err
-	}
-	if err := requireNonEmpty("channelType", m.ChannelType); err != nil {
-		return err
+	for _, check := range checks {
+		if err := requireNonEmpty(check.field, check.value); err != nil {
+			return err
+		}
 	}
 	if err := requireOneOf("direction", m.Direction, SoulCommDirectionInbound, SoulCommDirectionOutbound); err != nil {
 		return err
@@ -187,22 +192,29 @@ func (m *SoulCommMailboxMessage) BeforeCreate() error {
 	if err := validateSoulCommMailboxStatus(m.Status); err != nil {
 		return err
 	}
-	if m.HasContent {
-		if err := requireNonEmpty("contentStorage", m.ContentStorage); err != nil {
+	return m.validateContentPointer()
+}
+
+func (m *SoulCommMailboxMessage) validateContentPointer() error {
+	if !m.HasContent {
+		return nil
+	}
+	checks := []struct {
+		field string
+		value string
+	}{
+		{field: "contentStorage", value: m.ContentStorage},
+		{field: "contentBucket", value: m.ContentBucket},
+		{field: "contentKey", value: m.ContentKey},
+		{field: "contentSha256", value: m.ContentSHA256},
+	}
+	for _, check := range checks {
+		if err := requireNonEmpty(check.field, check.value); err != nil {
 			return err
 		}
-		if err := requireNonEmpty("contentBucket", m.ContentBucket); err != nil {
-			return err
-		}
-		if err := requireNonEmpty("contentKey", m.ContentKey); err != nil {
-			return err
-		}
-		if err := requireNonEmpty("contentSha256", m.ContentSHA256); err != nil {
-			return err
-		}
-		if m.ContentBytes <= 0 {
-			return fmt.Errorf("contentBytes must be positive")
-		}
+	}
+	if m.ContentBytes <= 0 {
+		return fmt.Errorf("contentBytes must be positive")
 	}
 	return nil
 }

--- a/internal/store/models/soul_comm_mailbox_test.go
+++ b/internal/store/models/soul_comm_mailbox_test.go
@@ -1,0 +1,218 @@
+package models
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	theorycore "github.com/theory-cloud/tabletheory/pkg/core"
+	theoryerrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	theorymodel "github.com/theory-cloud/tabletheory/pkg/model"
+	theoryquery "github.com/theory-cloud/tabletheory/pkg/query"
+)
+
+func TestSoulCommMailboxMessageKeysAndRetention(t *testing.T) {
+	created := time.Date(2026, 4, 25, 12, 30, 0, 0, time.UTC)
+	msg := &SoulCommMailboxMessage{
+		InstanceSlug:      " Demo ",
+		AgentID:           " 0xABC ",
+		Direction:         SoulCommDirectionInbound,
+		ChannelType:       " Email ",
+		MessageID:         "<provider-msg-1>",
+		Provider:          "Migadu",
+		ProviderMessageID: "provider-msg-1",
+		FromAddress:       "sender@example.com",
+		ToAddress:         "agent@example.com",
+		Subject:           "Hello",
+		Preview:           strings.Repeat("word ", 80),
+		HasContent:        true,
+		ContentStorage:    "s3",
+		ContentBucket:     "bucket",
+		ContentKey:        "mailbox/v1/agent/0xabc/delivery/content",
+		ContentSHA256:     "ABCDEF",
+		ContentBytes:      12,
+		ContentMimeType:   "text/plain",
+		ContentStoredAt:   created,
+		CreatedAt:         created,
+	}
+
+	if err := msg.BeforeCreate(); err != nil {
+		t.Fatalf("BeforeCreate: %v", err)
+	}
+
+	if msg.InstanceSlug != "demo" || msg.AgentID != "0xabc" || msg.ChannelType != "email" || msg.Provider != "migadu" {
+		t.Fatalf("expected normalized identifiers, got %#v", msg)
+	}
+	if msg.DeliveryID == "" || !strings.HasPrefix(msg.DeliveryID, "comm-delivery-") {
+		t.Fatalf("unexpected delivery id: %q", msg.DeliveryID)
+	}
+	if msg.ThreadID == "" || !strings.HasPrefix(msg.ThreadID, "comm-thread-") {
+		t.Fatalf("unexpected thread id: %q", msg.ThreadID)
+	}
+	wantPK := SoulCommMailboxAgentPK("demo", "0xabc")
+	if msg.PK != wantPK || !strings.HasPrefix(msg.SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
+		t.Fatalf("unexpected keys: pk=%q sk=%q", msg.PK, msg.SK)
+	}
+	if msg.GSI1PK != SoulCommMailboxDeliveryPK(msg.DeliveryID) || msg.GSI1SK != "CURRENT" {
+		t.Fatalf("unexpected delivery index: %q/%q", msg.GSI1PK, msg.GSI1SK)
+	}
+	if msg.GSI2PK != SoulCommMailboxThreadPK("demo", "0xabc", msg.ThreadID) || !strings.HasPrefix(msg.GSI2SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
+		t.Fatalf("unexpected thread index: %q/%q", msg.GSI2PK, msg.GSI2SK)
+	}
+	if got, want := msg.TTL, created.Add(SoulCommMailboxRetentionDays*24*time.Hour).Unix(); got != want {
+		t.Fatalf("unexpected ttl: got %d want %d", got, want)
+	}
+	if len([]rune(msg.Preview)) > 161 || !strings.HasSuffix(msg.Preview, "…") {
+		t.Fatalf("expected bounded preview, got %q", msg.Preview)
+	}
+}
+
+func TestSoulCommMailboxEventWriteOnceKeys(t *testing.T) {
+	created := time.Date(2026, 4, 25, 12, 45, 0, 0, time.UTC)
+	evt := &SoulCommMailboxEvent{
+		DeliveryID:   "comm-delivery-1",
+		MessageID:    "msg-1",
+		ThreadID:     "comm-thread-1",
+		InstanceSlug: "Demo",
+		AgentID:      "0xABC",
+		Direction:    SoulCommDirectionOutbound,
+		ChannelType:  "email",
+		EventType:    SoulCommMailboxEventCreated,
+		Status:       SoulCommMailboxStatusSent,
+		Actor:        "instance:demo",
+		CreatedAt:    created,
+	}
+	if err := evt.BeforeCreate(); err != nil {
+		t.Fatalf("BeforeCreate: %v", err)
+	}
+	if evt.PK != SoulCommMailboxDeliveryPK("comm-delivery-1") || !strings.HasPrefix(evt.SK, "EVENT#2026-04-25T12:45:00.000000000Z#") {
+		t.Fatalf("unexpected event keys: %q/%q", evt.PK, evt.SK)
+	}
+	if evt.GSI1PK != SoulCommMailboxAgentPK("demo", "0xabc") || evt.GSI2PK != SoulCommMailboxThreadPK("demo", "0xabc", "comm-thread-1") {
+		t.Fatalf("unexpected event indexes: %q %q", evt.GSI1PK, evt.GSI2PK)
+	}
+	if got, want := evt.TTL, created.Add(SoulCommMailboxRetentionDays*24*time.Hour).Unix(); got != want {
+		t.Fatalf("unexpected ttl: got %d want %d", got, want)
+	}
+}
+
+func TestSoulCommMailboxWritePolicies(t *testing.T) {
+	msg := &SoulCommMailboxMessage{
+		DeliveryID:   "comm-delivery-1",
+		MessageID:    "msg-1",
+		ThreadID:     "comm-thread-1",
+		InstanceSlug: "demo",
+		AgentID:      "0xabc",
+		Direction:    SoulCommDirectionInbound,
+		ChannelType:  "email",
+		Status:       SoulCommMailboxStatusAccepted,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := msg.BeforeCreate(); err != nil {
+		t.Fatalf("message BeforeCreate: %v", err)
+	}
+	q, _ := newMailboxPolicyQuery(t, msg)
+	if err := q.Update("Read"); err != nil {
+		t.Fatalf("expected read state update to be allowed: %v", err)
+	}
+	q, _ = newMailboxPolicyQuery(t, msg)
+	if err := q.Update("deliveryId"); !errors.Is(err, theoryerrors.ErrProtectedFieldMutation) {
+		t.Fatalf("expected deliveryId protected-field error, got %v", err)
+	}
+	q, _ = newMailboxPolicyQuery(t, msg)
+	if err := q.Update("contentKey"); !errors.Is(err, theoryerrors.ErrProtectedFieldMutation) {
+		t.Fatalf("expected contentKey protected-field error, got %v", err)
+	}
+
+	evt := &SoulCommMailboxEvent{
+		EventID:      "event-1",
+		DeliveryID:   "comm-delivery-1",
+		InstanceSlug: "demo",
+		AgentID:      "0xabc",
+		Direction:    SoulCommDirectionInbound,
+		ChannelType:  "email",
+		EventType:    SoulCommMailboxEventCreated,
+		CreatedAt:    time.Now().UTC(),
+	}
+	if err := evt.BeforeCreate(); err != nil {
+		t.Fatalf("event BeforeCreate: %v", err)
+	}
+	q, _ = newMailboxPolicyQuery(t, evt)
+	if err := q.CreateOrUpdate(); !errors.Is(err, theoryerrors.ErrImmutableModelMutation) {
+		t.Fatalf("expected immutable upsert error, got %v", err)
+	}
+}
+
+type mailboxPolicyMetadata struct{ meta *theorymodel.Metadata }
+
+func (m mailboxPolicyMetadata) TableName() string { return m.meta.TableName }
+
+func (m mailboxPolicyMetadata) PrimaryKey() theorycore.KeySchema {
+	schema := theorycore.KeySchema{}
+	if m.meta.PrimaryKey != nil && m.meta.PrimaryKey.PartitionKey != nil {
+		schema.PartitionKey = m.meta.PrimaryKey.PartitionKey.Name
+	}
+	if m.meta.PrimaryKey != nil && m.meta.PrimaryKey.SortKey != nil {
+		schema.SortKey = m.meta.PrimaryKey.SortKey.Name
+	}
+	return schema
+}
+
+func (m mailboxPolicyMetadata) Indexes() []theorycore.IndexSchema { return nil }
+
+func (m mailboxPolicyMetadata) AttributeMetadata(field string) *theorycore.AttributeMetadata {
+	if meta := m.meta.Fields[field]; meta != nil {
+		return mailboxPolicyAttributeMetadata(meta)
+	}
+	if meta := m.meta.FieldsByDBName[field]; meta != nil {
+		return mailboxPolicyAttributeMetadata(meta)
+	}
+	return nil
+}
+
+func (m mailboxPolicyMetadata) VersionFieldName() string             { return "" }
+func (m mailboxPolicyMetadata) RawMetadata() *theorymodel.Metadata   { return m.meta }
+func (m mailboxPolicyMetadata) WritePolicy() theorymodel.WritePolicy { return m.meta.WritePolicy }
+
+func mailboxPolicyAttributeMetadata(field *theorymodel.FieldMetadata) *theorycore.AttributeMetadata {
+	typeName := ""
+	if field.Type != nil {
+		typeName = field.Type.String()
+	}
+	return &theorycore.AttributeMetadata{
+		Name:         field.Name,
+		Type:         typeName,
+		DynamoDBName: field.DBName,
+		Tags:         field.Tags,
+	}
+}
+
+type mailboxPolicyExecutor struct{}
+
+func (mailboxPolicyExecutor) ExecuteQuery(*theorycore.CompiledQuery, any) error { return nil }
+func (mailboxPolicyExecutor) ExecuteScan(*theorycore.CompiledQuery, any) error  { return nil }
+func (mailboxPolicyExecutor) ExecutePutItem(*theorycore.CompiledQuery, map[string]types.AttributeValue) error {
+	return nil
+}
+func (mailboxPolicyExecutor) ExecuteUpdateItem(*theorycore.CompiledQuery, map[string]types.AttributeValue) error {
+	return nil
+}
+func (mailboxPolicyExecutor) ExecuteDeleteItem(*theorycore.CompiledQuery, map[string]types.AttributeValue) error {
+	return nil
+}
+
+func newMailboxPolicyQuery(t *testing.T, item any) (*theoryquery.Query, *mailboxPolicyExecutor) {
+	t.Helper()
+	registry := theorymodel.NewRegistry()
+	if err := registry.Register(item); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	meta, err := registry.GetMetadata(item)
+	if err != nil {
+		t.Fatalf("metadata: %v", err)
+	}
+	exec := &mailboxPolicyExecutor{}
+	return theoryquery.New(item, mailboxPolicyMetadata{meta: meta}, exec), exec
+}

--- a/internal/store/models/soul_comm_mailbox_test.go
+++ b/internal/store/models/soul_comm_mailbox_test.go
@@ -15,7 +15,18 @@ import (
 
 func TestSoulCommMailboxMessageKeysAndRetention(t *testing.T) {
 	created := time.Date(2026, 4, 25, 12, 30, 0, 0, time.UTC)
-	msg := &SoulCommMailboxMessage{
+	msg := newSoulCommMailboxMessageForTest(created)
+	if err := msg.BeforeCreate(); err != nil {
+		t.Fatalf("BeforeCreate: %v", err)
+	}
+	assertMailboxMessageNormalized(t, msg)
+	assertMailboxMessageIDs(t, msg)
+	assertMailboxMessageKeys(t, msg)
+	assertMailboxMessageRetentionAndPreview(t, msg, created)
+}
+
+func newSoulCommMailboxMessageForTest(created time.Time) *SoulCommMailboxMessage {
+	return &SoulCommMailboxMessage{
 		InstanceSlug:      " Demo ",
 		AgentID:           " 0xABC ",
 		Direction:         SoulCommDirectionInbound,
@@ -37,35 +48,61 @@ func TestSoulCommMailboxMessageKeysAndRetention(t *testing.T) {
 		ContentStoredAt:   created,
 		CreatedAt:         created,
 	}
+}
 
-	if err := msg.BeforeCreate(); err != nil {
-		t.Fatalf("BeforeCreate: %v", err)
+func assertMailboxMessageNormalized(t *testing.T, msg *SoulCommMailboxMessage) {
+	t.Helper()
+	if msg.InstanceSlug != "demo" {
+		t.Fatalf("unexpected instance slug: %q", msg.InstanceSlug)
 	}
+	if msg.AgentID != "0xabc" {
+		t.Fatalf("unexpected agent id: %q", msg.AgentID)
+	}
+	if msg.ChannelType != "email" || msg.Provider != "migadu" {
+		t.Fatalf("unexpected channel/provider: %q/%q", msg.ChannelType, msg.Provider)
+	}
+}
 
-	if msg.InstanceSlug != "demo" || msg.AgentID != "0xabc" || msg.ChannelType != "email" || msg.Provider != "migadu" {
-		t.Fatalf("expected normalized identifiers, got %#v", msg)
-	}
+func assertMailboxMessageIDs(t *testing.T, msg *SoulCommMailboxMessage) {
+	t.Helper()
 	if msg.DeliveryID == "" || !strings.HasPrefix(msg.DeliveryID, "comm-delivery-") {
 		t.Fatalf("unexpected delivery id: %q", msg.DeliveryID)
 	}
 	if msg.ThreadID == "" || !strings.HasPrefix(msg.ThreadID, "comm-thread-") {
 		t.Fatalf("unexpected thread id: %q", msg.ThreadID)
 	}
+}
+
+func assertMailboxMessageKeys(t *testing.T, msg *SoulCommMailboxMessage) {
+	t.Helper()
 	wantPK := SoulCommMailboxAgentPK("demo", "0xabc")
-	if msg.PK != wantPK || !strings.HasPrefix(msg.SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
-		t.Fatalf("unexpected keys: pk=%q sk=%q", msg.PK, msg.SK)
+	if msg.PK != wantPK {
+		t.Fatalf("unexpected pk: %q", msg.PK)
+	}
+	if !strings.HasPrefix(msg.SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
+		t.Fatalf("unexpected sk: %q", msg.SK)
 	}
 	if msg.GSI1PK != SoulCommMailboxDeliveryPK(msg.DeliveryID) || msg.GSI1SK != "CURRENT" {
 		t.Fatalf("unexpected delivery index: %q/%q", msg.GSI1PK, msg.GSI1SK)
 	}
-	if msg.GSI2PK != SoulCommMailboxThreadPK("demo", "0xabc", msg.ThreadID) || !strings.HasPrefix(msg.GSI2SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
-		t.Fatalf("unexpected thread index: %q/%q", msg.GSI2PK, msg.GSI2SK)
+	if msg.GSI2PK != SoulCommMailboxThreadPK("demo", "0xabc", msg.ThreadID) {
+		t.Fatalf("unexpected thread pk: %q", msg.GSI2PK)
 	}
+	if !strings.HasPrefix(msg.GSI2SK, "MSG#2026-04-25T12:30:00.000000000Z#") {
+		t.Fatalf("unexpected thread sk: %q", msg.GSI2SK)
+	}
+}
+
+func assertMailboxMessageRetentionAndPreview(t *testing.T, msg *SoulCommMailboxMessage, created time.Time) {
+	t.Helper()
 	if got, want := msg.TTL, created.Add(SoulCommMailboxRetentionDays*24*time.Hour).Unix(); got != want {
 		t.Fatalf("unexpected ttl: got %d want %d", got, want)
 	}
-	if len([]rune(msg.Preview)) > 161 || !strings.HasSuffix(msg.Preview, "…") {
+	if len([]rune(msg.Preview)) > 161 {
 		t.Fatalf("expected bounded preview, got %q", msg.Preview)
+	}
+	if !strings.HasSuffix(msg.Preview, "…") {
+		t.Fatalf("expected truncated preview, got %q", msg.Preview)
 	}
 }
 


### PR DESCRIPTION
## Milestone
Host 2 — Soul Comm Mailbox storage + canonical capture (#163–#166)

This implements the storage/capture milestone for the approved host-authoritative bounded soul comm mailbox roadmap. It intentionally does **not** expose Body-callable mailbox list/get/content/read-state APIs yet; those remain Host 3 (#167–#172). Body should still defer host-dependent mailbox tools until Host 3 lands.

## Classification
security / tenant-isolation / host-comm / operational-reliability

## Surfaces affected
- `internal/store/models`, `internal/store`: canonical mailbox current/event models and TableTheory registration.
- `internal/commmailbox`: bounded S3 content pointer writer with checksum metadata.
- `internal/config`: mailbox bucket + retention configuration.
- `cdk/`: encrypted mailbox content bucket, 90-day lifecycle, env wiring, and least-privilege grants to control-plane + comm-worker.
- `internal/commworker`: inbound canonical mailbox capture before lesser notification projection.
- `internal/controlplane`: outbound send capture and additive `deliveryId` / `threadId` response fields.

## Specialist walks referenced
- Governance rubric: Host 1 CMP-4 bounded mailbox authority is preserved; verifier remains green (29/0/0).
- Provisioning / managed-update / release verification: none; no managed release verification changes.
- Soul registry: no on-chain or soul-registry contract changes.
- Trust API / CSP / instance-auth: no trust API endpoint/CSP changes; existing hash-only instance auth for comm send is preserved; no raw instance keys are stored or logged.
- Framework: TableTheory write policies are used for protected identity/provenance/content fields and write-once event rows.

## Multi-tenant isolation impact
Elevated scrutiny. Mailbox keys are scoped by `instanceSlug` + `agentId`; delivery/thread GSIs remain tenant-scoped by canonical delivery/thread IDs. Content is retained in a dedicated encrypted S3 bucket with lifecycle expiration and access limited to control-plane + comm-worker Lambdas.

## On-chain impact
None.

## Consumer impact
- Managed operators/customers: host now records canonical inbound/outbound mailbox rows and bounded content pointers for soul comms.
- `lesser`: still receives notification projections only; mailbox authority is not delegated to lesser in this milestone.
- `body`: still no Body-callable mailbox APIs in this milestone; Host 3 remains the blocking implementation for MCP tools.

## Tasks
- [x] Add Soul Comm Mailbox TableTheory models (#163)
- [x] Add encrypted bounded comm content storage (#164)
- [x] Persist inbound canonical mailbox deliveries (#165)
- [x] Persist outbound canonical mailbox deliveries (#166)

## Validation
- `go test ./internal/store/models ./internal/commworker ./internal/controlplane`
- `go test ./...`
- `go vet ./...`
- `go mod verify`
- `git ls-files '*.go' | xargs gofmt -l` (empty)
- `git diff --check`
- `cd cdk && npm ci && npm run synth`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` (PASS 29 / FAIL 0 / BLOCKED 0)

## Stage rollout plan (handoff after merge)
- [ ] Merged to `host-v2`
- [ ] Deployed to lab after operator approval
- [ ] Lab smoke checks: control-plane API health, comm send path, comm worker queue/capture path, mailbox bucket existence/lifecycle
- [ ] Host 3 mailbox APIs implemented before Body enables host-backed MCP mailbox tools
- [ ] `host-v2` eventually reviewed/merged to `main`
- [ ] Live deploy only after lab soak and explicit operator authorization

## Cross-repo coordination
Required with `body` after Host 3 only. This PR is a prerequisite, not the Body-ready contract.

## Advisor-brief authorization
Not advisor-dispatched; Aron approved the host-authoritative bounded mailbox roadmap directly.

Closes #163
Closes #164
Closes #165
Closes #166
