### PR TITLE
feat(portal): complete host mailbox portal migration

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -33,3 +33,14 @@ npm run verify:lesser-host-contracts
 CI and the governance rubric both run this verification so contract drift fails closed.
 
 Release automation packages these artifacts as GitHub Release assets on every `v*` tag.
+
+## Soul comm mailbox contract notes
+
+The mailbox schemas under `../spec/v3/schemas/soul-comm-mailbox-*.schema.json` are the body-facing canonical contract.
+They are instance-key authenticated and keep list/get metadata separate from explicit content fetches.
+
+The portal compatibility schemas `soul-agent-comm-activity-*` and `soul-agent-comm-queue-*` are derived from canonical
+mailbox state for operator/customer portal views. Queue list items intentionally do not include full message bodies; they
+return preview/content metadata and mailbox state only.
+
+Cross-repo migration guidance for body and lesser is in `../soul-comm-mailbox-migration.md`.

--- a/docs/lesser-body-release-contract.md
+++ b/docs/lesser-body-release-contract.md
@@ -111,6 +111,20 @@ The receipt preserves the native `lesser-body` deploy fields and adds host-side 
 This provenance object is the canonical consumer-visible record of which verified `lesser-body` release assets were used
 for the managed deploy.
 
+
+## Soul comm mailbox MCP contract
+
+`lesser-body` does not own canonical mailbox state. For soul comm tools it is the MCP facade over host's
+instance-authenticated mailbox contract:
+
+- list/get tools call host mailbox metadata endpoints and return redacted previews/state
+- full message bodies are fetched only by explicit content tools
+- read/unread/archive/delete tools mutate host's canonical mailbox state
+- body must not persist a durable mailbox-content or read-state store of its own
+
+See `docs/soul-comm-mailbox-migration.md` for the migration order, backward-compatibility expectations, rate limits,
+auth, audit, and lesser projection semantics.
+
 ## Follow-on MCP expectation
 
 The `RUN_MODE=lesser-mcp` phase does not consume the `lesser-body` release assets directly. It consumes the deployed body

--- a/docs/managed-instance-provisioning.md
+++ b/docs/managed-instance-provisioning.md
@@ -71,6 +71,8 @@ It assumes:
      `lambdaAssetRoot`, so the instance’s API Gateway exposes:
      - `POST https://api.<stageDomain>/mcp/{actor}`
      - `GET  https://api.<stageDomain>/.well-known/mcp.json`
+   - for soul comm mailbox tools, `lesser-body` calls host's instance-authenticated mailbox APIs and treats host as the
+     source of truth for delivery metadata, bounded content, and read/archive/delete state.
 
 7) **Register with lesser.host**
    - store instance endpoints from the receipt.
@@ -178,6 +180,18 @@ From Lesser (inputs for `lesser-body`):
 
 From `lesser-body` (inputs for Lesser API Gateway `/mcp/{actor}` wiring):
 - `/${app}/${stage}/lesser-body/exports/v1/mcp_lambda_arn`
+
+
+## Soul comm mailbox migration
+
+Managed provisioning does not move mailbox authority into the tenant account. Host mints and stores the instance API key
+hash during registration; body uses the raw instance-side token at runtime to call host's mailbox APIs. The boundary is:
+
+- host owns canonical mailbox rows, bounded encrypted content, provider status, and read/archive/delete state
+- lesser receives notification projections for UX/activity only
+- body exposes MCP tools over host and must not store durable mailbox truth locally
+
+See `docs/soul-comm-mailbox-migration.md` for backward compatibility, rate-limit, auth, audit, and projection details.
 
 ## Smoke test (MCP)
 

--- a/docs/soul-comm-mailbox-migration.md
+++ b/docs/soul-comm-mailbox-migration.md
@@ -1,0 +1,112 @@
+# Soul comm mailbox migration path
+
+This document records the cross-repo migration from legacy soul comm delivery surfaces to the bounded, host-authoritative
+mailbox contract approved in ADR 0005 and implemented by `lesser-host`.
+
+The intent is to keep authority in one place:
+
+- **host** owns canonical comm objects: `deliveryId`, `messageId`, `threadId`, provider status, delivery metadata,
+  bounded content, and read/unread/archive/delete state.
+- **lesser** receives notification projections only. It may render summaries or ActivityPub/UX notifications, but it is
+  not the mailbox source of truth.
+- **body** remains the MCP facade. It gates scope/profile, calls host's instance-authenticated mailbox APIs, and returns
+  MCP-shaped tool results without storing mailbox truth locally.
+
+## Migration phases
+
+1. **Host canonical capture is present**
+   - inbound email/SMS/voice capture writes canonical `SoulCommMailboxMessage` rows and bounded content objects before
+     projection work is queued to lesser.
+   - outbound `POST /api/v1/soul/comm/send` writes canonical mailbox rows in addition to the legacy delivery status
+     record.
+   - legacy activity and queue rows may still be written for compatibility, but new reads should not depend on them.
+
+2. **Host mailbox APIs become the body contract**
+   - `GET /api/v1/soul/comm/contactability/{agentId}` resolves exact-agent receive/send affordances.
+   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages` lists redacted canonical messages.
+   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages/{deliveryId}` returns canonical metadata for one delivery.
+   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages/{deliveryId}/content` returns full content only by explicit
+     delivery fetch.
+   - read state APIs mutate canonical state:
+     - `POST .../{deliveryId}/read`
+     - `POST .../{deliveryId}/unread`
+     - `POST .../{deliveryId}/archive`
+     - `POST .../{deliveryId}/unarchive`
+     - `POST .../{deliveryId}/delete`
+
+3. **Portal reads canonical mailbox state**
+   - portal activity and inbound queue views read host mailbox rows rather than legacy activity/queue tables.
+   - list responses contain preview/content metadata and mailbox state only; full bodies are not returned by portal list
+     views.
+
+4. **Body implements MCP tools over host**
+   - `email_get` / `email_read` list or fetch metadata from host list/get endpoints.
+   - `email_get_content` calls host's explicit content endpoint.
+   - `email_mark_read`, `email_mark_unread`, archive, and delete tools call the canonical state endpoints.
+   - body must not copy full message bodies or read/archive/delete state into a durable body-owned mailbox store.
+
+5. **Lesser keeps projections non-authoritative**
+   - lesser may receive notifications for UX/activity and may keep local notification summaries.
+   - lesser must treat `deliveryId`/`threadId` and read state as host-owned. If a lesser UX needs full content or state,
+     it should call through the host/body contract instead of becoming the mailbox authority.
+
+## Backward compatibility
+
+- `POST /api/v1/soul/comm/send` and `GET /api/v1/soul/comm/status/{messageId}` remain available for existing outbound
+  send/status callers.
+- Legacy `SoulAgentCommActivity` and `SoulAgentCommQueue` records may continue to be written during the migration window,
+  but they are no longer authoritative for portal/body mailbox behavior.
+- Portal queue responses no longer include a `body` field. They expose redacted `preview`, `content.available`, content
+  byte/hash metadata, and mailbox state. Full content requires the explicit content endpoint.
+- Body should tolerate instances that have not yet generated canonical mailbox rows by returning an empty mailbox result
+  or a clear capability-not-ready error rather than reconstructing mailbox state from legacy rows.
+
+## Auth and tenant isolation
+
+- Mailbox body-facing endpoints use **strict instance API key auth**: bearer raw key -> `sha256(raw_key)` -> stored
+  `InstanceKey` hash match. Host never stores or logs raw instance keys.
+- The authenticated instance slug must match the agent's verified domain/instance relationship before mailbox rows are
+  listed, fetched, or mutated.
+- Portal views continue to use operator/customer sessions and existing domain/instance ownership checks. Portal reads are
+  instance+agent-scoped and do not allow cross-tenant mailbox scans.
+- Contactability is exact-agent only. There is no global search/list affordance for mailbox contactability.
+
+## Rate limits and bounded content
+
+- Body-facing mailbox list/get/content/state endpoints are rate-limited with the control-plane comm API limits.
+- Lists are bounded and paginated where applicable; list responses include metadata/previews only.
+- Full content is stored for the retention window defined by `SoulCommMailboxRetentionDays` and the mailbox content bucket
+  lifecycle. Host must not turn mailbox content into permanent semantic memory.
+- Content objects are encrypted at rest and addressed only through host-owned content pointers. Storage bucket/key values
+  are never returned in list responses.
+
+## Audit and evidence
+
+- Explicit content reads write audit evidence with action `soul_comm_mailbox.content_read`.
+- Read/unread/archive/delete operations append immutable mailbox state-change events alongside the current-row mutation.
+- Delivery/provider facts remain in canonical mailbox metadata so operators can reconcile provider status without reading
+  tenant message bodies.
+- Governance evidence for this exception lives in `gov-infra` via the CMP-4 bounded mailbox verifier and ADR 0005.
+
+## Projection semantics for lesser
+
+Lesser projections are intentionally lossy summaries:
+
+- projection identity: `deliveryId`, `messageId`, `threadId`, `agentId`, channel type, direction, and timestamp
+- projection content: subject and preview only, not full body
+- projection state: optional notification state for UX only; canonical read/archive/delete state stays in host
+- projection retry: duplicate projections should be idempotent by `deliveryId`
+
+If lesser needs to display authoritative state or full content, the request path should be: client/body scope check -> host
+mailbox API -> response. Lesser should not synthesize or persist mailbox truth.
+
+## Body MCP implementation checklist
+
+Before body enables host-dependent mailbox tools against a stage:
+
+- host has deployed the Host 2+3+4 mailbox changes to that stage
+- body has an instance API key for the managed instance and never logs the raw token
+- body calls host list/get endpoints for metadata and host content endpoint only for explicit content reads
+- body maps host rate-limit and auth failures to MCP errors without retry storms
+- body writes no durable mailbox-content/read-state store of its own
+- lesser consumes projections as notifications, not source-of-truth mailbox records

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -135,6 +135,12 @@ This is an explicit, governance-documented exception to host's normal metadata-o
 exception is limited to soul comm mailbox delivery artifacts and does not authorize cross-tenant search, tenant content
 analytics, or body-owned mailbox storage.
 
+The cross-repo migration path is documented in `docs/soul-comm-mailbox-migration.md`. In particular:
+
+- body implements MCP tools by calling host's instance-authenticated mailbox APIs; it does not become a mailbox database.
+- lesser projections are notification summaries only and should remain idempotent by `deliveryId`.
+- portal list views read canonical mailbox state but keep the list/content split: previews and content metadata only.
+
 ### `update-registration` contract (lesser-body / MCP endpoint compatible)
 
 `POST /api/v1/soul/agents/{agentId}/update-registration` publishes the **current** registration JSON to S3 at:

--- a/docs/spec/v3/schemas/soul-agent-comm-activity-item.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-activity-item.schema.json
@@ -8,11 +8,30 @@
   "properties": {
     "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
     "activity_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "delivery_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "thread_id": { "type": "string", "minLength": 1, "maxLength": 128 },
     "channel_type": { "type": "string", "enum": ["email", "sms", "voice"] },
     "direction": { "type": "string", "enum": ["inbound", "outbound"] },
     "counterparty": { "type": "string", "minLength": 1, "maxLength": 512 },
     "action": { "type": "string", "minLength": 1, "maxLength": 64 },
     "message_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "status": { "type": "string", "enum": ["accepted", "sent", "delivered", "queued", "failed", "bounced", "dropped"] },
+    "subject": { "type": "string", "minLength": 1, "maxLength": 998 },
+    "preview": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "content": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available"],
+      "properties": {
+        "available": { "type": "boolean" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "mime_type": { "type": "string", "minLength": 1, "maxLength": 255 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
+      }
+    },
+    "read": { "type": "boolean" },
+    "archived": { "type": "boolean" },
+    "deleted": { "type": "boolean" },
     "in_reply_to": { "type": "string", "minLength": 1, "maxLength": 128 },
     "boundary_check": { "type": "string", "enum": ["passed", "violated", "skipped"] },
     "preference_respected": { "type": "boolean" },

--- a/docs/spec/v3/schemas/soul-agent-comm-queue-item.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-comm-queue-item.schema.json
@@ -4,20 +4,36 @@
   "title": "Soul agent queued communication item",
   "type": "object",
   "additionalProperties": false,
-  "required": ["agent_id", "message_id", "channel_type", "body", "received_at", "scheduled_delivery_time", "status"],
+  "required": ["agent_id", "message_id", "channel_type", "received_at", "scheduled_delivery_time", "status"],
   "properties": {
     "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+    "delivery_id": { "type": "string", "minLength": 1, "maxLength": 128 },
     "message_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "thread_id": { "type": "string", "minLength": 1, "maxLength": 128 },
     "channel_type": { "type": "string", "enum": ["email", "sms", "voice"] },
     "from_address": { "type": "string", "format": "email" },
     "from_number": { "type": "string", "pattern": "^\\+[1-9]\\d{1,14}$" },
     "from_soul_agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
     "from_display_name": { "type": "string", "minLength": 1, "maxLength": 256 },
     "subject": { "type": "string", "minLength": 1, "maxLength": 998 },
-    "body": { "type": "string", "minLength": 1 },
+    "preview": { "type": "string", "minLength": 1, "maxLength": 512 },
+    "content": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["available"],
+      "properties": {
+        "available": { "type": "boolean" },
+        "bytes": { "type": "integer", "minimum": 0 },
+        "mime_type": { "type": "string", "minLength": 1, "maxLength": 255 },
+        "sha256": { "type": "string", "pattern": "^[0-9a-fA-F]{64}$" }
+      }
+    },
     "in_reply_to": { "type": "string", "minLength": 1, "maxLength": 128 },
     "received_at": { "type": "string", "format": "date-time" },
     "scheduled_delivery_time": { "type": "string", "format": "date-time" },
-    "status": { "type": "string", "enum": ["queued", "delivered", "expired"] }
+    "status": { "type": "string", "enum": ["queued", "delivered", "expired"] },
+    "read": { "type": "boolean" },
+    "archived": { "type": "boolean" },
+    "deleted": { "type": "boolean" }
   }
 }

--- a/internal/controlplane/handlers_soul_comm_portal.go
+++ b/internal/controlplane/handlers_soul_comm_portal.go
@@ -1,9 +1,9 @@
 package controlplane
 
 import (
-	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -12,39 +12,99 @@ import (
 )
 
 type soulAgentCommActivityResponse struct {
-	Version    string                          `json:"version"`
-	Activities []*models.SoulAgentCommActivity `json:"activities"`
-	Count      int                             `json:"count"`
+	Version    string                      `json:"version"`
+	Activities []soulAgentCommActivityItem `json:"activities"`
+	Count      int                         `json:"count"`
 }
 
 type soulAgentCommQueueResponse struct {
-	Version string                       `json:"version"`
-	Items   []*models.SoulAgentCommQueue `json:"items"`
-	Count   int                          `json:"count"`
+	Version string                   `json:"version"`
+	Items   []soulAgentCommQueueItem `json:"items"`
+	Count   int                      `json:"count"`
+}
+
+type soulAgentCommActivityItem struct {
+	AgentID             string                            `json:"agent_id"`
+	ActivityID          string                            `json:"activity_id"`
+	DeliveryID          string                            `json:"delivery_id,omitempty"`
+	ThreadID            string                            `json:"thread_id,omitempty"`
+	ChannelType         string                            `json:"channel_type"`
+	Direction           string                            `json:"direction"`
+	Counterparty        string                            `json:"counterparty,omitempty"`
+	Action              string                            `json:"action,omitempty"`
+	MessageID           string                            `json:"message_id,omitempty"`
+	Status              string                            `json:"status,omitempty"`
+	Subject             string                            `json:"subject,omitempty"`
+	Preview             string                            `json:"preview,omitempty"`
+	Content             soulAgentCommPortalContentSummary `json:"content"`
+	Read                bool                              `json:"read"`
+	Archived            bool                              `json:"archived"`
+	Deleted             bool                              `json:"deleted"`
+	BoundaryCheck       string                            `json:"boundary_check,omitempty"`
+	PreferenceRespected *bool                             `json:"preference_respected,omitempty"`
+	Timestamp           string                            `json:"timestamp"`
+}
+
+type soulAgentCommQueueItem struct {
+	AgentID               string                            `json:"agent_id"`
+	DeliveryID            string                            `json:"delivery_id,omitempty"`
+	MessageID             string                            `json:"message_id"`
+	ThreadID              string                            `json:"thread_id,omitempty"`
+	ChannelType           string                            `json:"channel_type"`
+	FromAddress           string                            `json:"from_address,omitempty"`
+	FromNumber            string                            `json:"from_number,omitempty"`
+	FromSoulAgentID       string                            `json:"from_soul_agent_id,omitempty"`
+	FromDisplayName       string                            `json:"from_display_name,omitempty"`
+	Subject               string                            `json:"subject,omitempty"`
+	Preview               string                            `json:"preview,omitempty"`
+	Content               soulAgentCommPortalContentSummary `json:"content"`
+	ReceivedAt            string                            `json:"received_at"`
+	ScheduledDeliveryTime string                            `json:"scheduled_delivery_time"`
+	Status                string                            `json:"status"`
+	Read                  bool                              `json:"read"`
+	Archived              bool                              `json:"archived"`
+	Deleted               bool                              `json:"deleted"`
+}
+
+type soulAgentCommPortalContentSummary struct {
+	Available bool   `json:"available"`
+	Bytes     int64  `json:"bytes,omitempty"`
+	MimeType  string `json:"mime_type,omitempty"`
+	SHA256    string `json:"sha256,omitempty"`
 }
 
 type soulAgentCommListContext struct {
-	AgentIDHex string
-	Limit      int
+	AgentIDHex   string
+	InstanceSlug string
+	Limit        int
 }
 
 func (s *Server) requireSoulAgentWithDomainAccess(ctx *apptheory.Context, agentIDHex string) (*models.SoulAgentIdentity, *apptheory.AppError) {
+	identity, _, _, appErr := s.requireSoulAgentWithDomainAccessDetails(ctx, agentIDHex)
+	return identity, appErr
+}
+
+func (s *Server) requireSoulAgentWithDomainAccessDetails(
+	ctx *apptheory.Context,
+	agentIDHex string,
+) (*models.SoulAgentIdentity, *models.Domain, *models.Instance, *apptheory.AppError) {
 	if s == nil || ctx == nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+		return nil, nil, nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
 	identity, err := s.getSoulAgentIdentity(ctx.Context(), agentIDHex)
 	if theoryErrors.IsNotFound(err) {
-		return nil, &apptheory.AppError{Code: "app.not_found", Message: "agent not found"}
+		return nil, nil, nil, &apptheory.AppError{Code: "app.not_found", Message: "agent not found"}
 	}
 	if err != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+		return nil, nil, nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	if _, _, accessErr := s.requireSoulDomainAccess(ctx, strings.TrimSpace(identity.Domain)); accessErr != nil {
-		return nil, accessErr
+	domain, instance, accessErr := s.requireSoulDomainAccess(ctx, strings.TrimSpace(identity.Domain))
+	if accessErr != nil {
+		return nil, nil, nil, accessErr
 	}
-	return identity, nil
+	return identity, domain, instance, nil
 }
 
 func (s *Server) loadSoulAgentCommListContext(ctx *apptheory.Context) (soulAgentCommListContext, *apptheory.AppError) {
@@ -63,42 +123,203 @@ func (s *Server) loadSoulAgentCommListContext(ctx *apptheory.Context) (soulAgent
 		return soulAgentCommListContext{}, appErr
 	}
 
-	if _, appErr := s.requireSoulAgentWithDomainAccess(ctx, agentIDHex); appErr != nil {
+	_, _, instance, appErr := s.requireSoulAgentWithDomainAccessDetails(ctx, agentIDHex)
+	if appErr != nil {
 		return soulAgentCommListContext{}, appErr
 	}
 
 	return soulAgentCommListContext{
-		AgentIDHex: agentIDHex,
-		Limit:      parseLimit(queryFirst(ctx, "limit"), 50, 1, 200),
+		AgentIDHex:   agentIDHex,
+		InstanceSlug: strings.ToLower(strings.TrimSpace(instance.Slug)),
+		Limit:        parseLimit(queryFirst(ctx, "limit"), 50, 1, 200),
 	}, nil
 }
 
-func (s *Server) listSoulAgentCommActivities(ctx *apptheory.Context, agentIDHex string, limit int) ([]*models.SoulAgentCommActivity, *apptheory.AppError) {
-	var items []*models.SoulAgentCommActivity
-	if err := s.store.DB.WithContext(ctx.Context()).
-		Model(&models.SoulAgentCommActivity{}).
-		Where("PK", "=", fmt.Sprintf("SOUL#AGENT#%s", agentIDHex)).
-		Where("SK", "BEGINS_WITH", "COMM#").
-		OrderBy("SK", "DESC").
-		Limit(limit).
-		All(&items); err != nil {
+func (s *Server) listSoulAgentCommActivities(
+	ctx *apptheory.Context,
+	listCtx soulAgentCommListContext,
+) ([]soulAgentCommActivityItem, *apptheory.AppError) {
+	messages, appErr := s.listSoulAgentCommMailboxRows(ctx, listCtx, "DESC", listCtx.Limit)
+	if appErr != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list communication activity"}
+	}
+
+	items := make([]soulAgentCommActivityItem, 0, len(messages))
+	for _, msg := range messages {
+		if msg == nil || msg.Deleted {
+			continue
+		}
+		items = append(items, soulAgentCommActivityFromMailbox(msg))
 	}
 	return items, nil
 }
 
-func (s *Server) listSoulAgentCommQueueItems(ctx *apptheory.Context, agentIDHex string, limit int) ([]*models.SoulAgentCommQueue, *apptheory.AppError) {
-	var items []*models.SoulAgentCommQueue
-	if err := s.store.DB.WithContext(ctx.Context()).
-		Model(&models.SoulAgentCommQueue{}).
-		Where("PK", "=", fmt.Sprintf("COMM#QUEUE#%s", agentIDHex)).
-		Where("SK", "BEGINS_WITH", "MSG#").
-		OrderBy("SK", "ASC").
-		Limit(limit).
-		All(&items); err != nil {
+func (s *Server) listSoulAgentCommQueueItems(
+	ctx *apptheory.Context,
+	listCtx soulAgentCommListContext,
+) ([]soulAgentCommQueueItem, *apptheory.AppError) {
+	messages, appErr := s.listSoulAgentCommMailboxRows(ctx, listCtx, "ASC", soulAgentCommPortalQueueScanLimit(listCtx.Limit))
+	if appErr != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list queued messages"}
 	}
+
+	items := make([]soulAgentCommQueueItem, 0, minInt(listCtx.Limit, len(messages)))
+	for _, msg := range messages {
+		if len(items) >= listCtx.Limit {
+			break
+		}
+		if !isPortalQueuedMailboxItem(msg) {
+			continue
+		}
+		items = append(items, soulAgentCommQueueFromMailbox(msg))
+	}
 	return items, nil
+}
+
+func (s *Server) listSoulAgentCommMailboxRows(
+	ctx *apptheory.Context,
+	listCtx soulAgentCommListContext,
+	order string,
+	limit int,
+) ([]*models.SoulCommMailboxMessage, *apptheory.AppError) {
+	var items []*models.SoulCommMailboxMessage
+	order = strings.ToUpper(strings.TrimSpace(order))
+	if order != "ASC" {
+		order = "DESC"
+	}
+	if err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulCommMailboxMessage{}).
+		Where("PK", "=", models.SoulCommMailboxAgentPK(listCtx.InstanceSlug, listCtx.AgentIDHex)).
+		OrderBy("SK", order).
+		Limit(limit).
+		All(&items); err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return items, nil
+}
+
+func soulAgentCommActivityFromMailbox(item *models.SoulCommMailboxMessage) soulAgentCommActivityItem {
+	return soulAgentCommActivityItem{
+		AgentID:      strings.ToLower(strings.TrimSpace(item.AgentID)),
+		ActivityID:   mailboxPortalActivityID(item),
+		DeliveryID:   strings.TrimSpace(item.DeliveryID),
+		ThreadID:     strings.TrimSpace(item.ThreadID),
+		ChannelType:  strings.TrimSpace(item.ChannelType),
+		Direction:    strings.TrimSpace(item.Direction),
+		Counterparty: mailboxPortalCounterparty(item),
+		Action:       mailboxPortalAction(item),
+		MessageID:    strings.TrimSpace(item.MessageID),
+		Status:       strings.TrimSpace(item.Status),
+		Subject:      strings.TrimSpace(item.Subject),
+		Preview:      strings.TrimSpace(item.Preview),
+		Content:      mailboxPortalContentSummary(item),
+		Read:         item.Read,
+		Archived:     item.Archived,
+		Deleted:      item.Deleted,
+		Timestamp:    formatMailboxTime(mailboxPortalTime(item.CreatedAt, item.UpdatedAt)),
+	}
+}
+
+func soulAgentCommQueueFromMailbox(item *models.SoulCommMailboxMessage) soulAgentCommQueueItem {
+	return soulAgentCommQueueItem{
+		AgentID:               strings.ToLower(strings.TrimSpace(item.AgentID)),
+		DeliveryID:            strings.TrimSpace(item.DeliveryID),
+		MessageID:             strings.TrimSpace(item.MessageID),
+		ThreadID:              strings.TrimSpace(item.ThreadID),
+		ChannelType:           strings.TrimSpace(item.ChannelType),
+		FromAddress:           strings.TrimSpace(item.FromAddress),
+		FromNumber:            strings.TrimSpace(item.FromNumber),
+		FromSoulAgentID:       strings.ToLower(strings.TrimSpace(item.FromSoulAgentID)),
+		FromDisplayName:       strings.TrimSpace(item.FromDisplayName),
+		Subject:               strings.TrimSpace(item.Subject),
+		Preview:               strings.TrimSpace(item.Preview),
+		Content:               mailboxPortalContentSummary(item),
+		ReceivedAt:            formatMailboxTime(mailboxPortalTime(item.CreatedAt, item.UpdatedAt)),
+		ScheduledDeliveryTime: formatMailboxTime(mailboxPortalTime(item.UpdatedAt, item.CreatedAt)),
+		Status:                strings.TrimSpace(item.Status),
+		Read:                  item.Read,
+		Archived:              item.Archived,
+		Deleted:               item.Deleted,
+	}
+}
+
+func mailboxPortalContentSummary(item *models.SoulCommMailboxMessage) soulAgentCommPortalContentSummary {
+	if item == nil {
+		return soulAgentCommPortalContentSummary{}
+	}
+	return soulAgentCommPortalContentSummary{
+		Available: item.HasContent && !item.Deleted,
+		Bytes:     item.ContentBytes,
+		MimeType:  strings.TrimSpace(item.ContentMimeType),
+		SHA256:    strings.TrimSpace(item.ContentSHA256),
+	}
+}
+
+func mailboxPortalActivityID(item *models.SoulCommMailboxMessage) string {
+	for _, candidate := range []string{item.DeliveryID, item.MessageID, item.ThreadID} {
+		if trimmed := strings.TrimSpace(candidate); trimmed != "" {
+			return trimmed
+		}
+	}
+	return "mailbox"
+}
+
+func mailboxPortalCounterparty(item *models.SoulCommMailboxMessage) string {
+	if strings.EqualFold(strings.TrimSpace(item.Direction), models.SoulCommDirectionOutbound) {
+		return firstNonEmptySoulCommPortal(item.ToSoulAgentID, item.ToAddress, item.ToNumber, item.ToDisplayName)
+	}
+	return firstNonEmptySoulCommPortal(item.FromSoulAgentID, item.FromAddress, item.FromNumber, item.FromDisplayName)
+}
+
+func mailboxPortalAction(item *models.SoulCommMailboxMessage) string {
+	status := strings.ToLower(strings.TrimSpace(item.Status))
+	if status == models.SoulCommMailboxStatusFailed ||
+		status == models.SoulCommMailboxStatusBounced ||
+		status == models.SoulCommMailboxStatusDropped {
+		return status
+	}
+	if strings.EqualFold(strings.TrimSpace(item.Direction), models.SoulCommDirectionOutbound) {
+		return "send"
+	}
+	return "receive"
+}
+
+func mailboxPortalTime(primary time.Time, fallback time.Time) time.Time {
+	if !primary.IsZero() {
+		return primary
+	}
+	return fallback
+}
+
+func isPortalQueuedMailboxItem(item *models.SoulCommMailboxMessage) bool {
+	if item == nil || item.Deleted {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(item.Direction), models.SoulCommDirectionInbound) &&
+		strings.EqualFold(strings.TrimSpace(item.Status), models.SoulCommMailboxStatusQueued)
+}
+
+func soulAgentCommPortalQueueScanLimit(limit int) int {
+	if limit <= 0 {
+		return 50
+	}
+	return minInt(limit*4, 200)
+}
+
+func firstNonEmptySoulCommPortal(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func minInt(a int, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 func (s *Server) handleSoulAgentCommActivity(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -107,7 +328,7 @@ func (s *Server) handleSoulAgentCommActivity(ctx *apptheory.Context) (*apptheory
 		return nil, appErr
 	}
 
-	items, appErr := s.listSoulAgentCommActivities(ctx, listCtx.AgentIDHex, listCtx.Limit)
+	items, appErr := s.listSoulAgentCommActivities(ctx, listCtx)
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -125,7 +346,7 @@ func (s *Server) handleSoulAgentCommQueue(ctx *apptheory.Context) (*apptheory.Re
 		return nil, appErr
 	}
 
-	items, appErr := s.listSoulAgentCommQueueItems(ctx, listCtx.AgentIDHex, listCtx.Limit)
+	items, appErr := s.listSoulAgentCommQueueItems(ctx, listCtx)
 	if appErr != nil {
 		return nil, appErr
 	}

--- a/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
+++ b/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
@@ -166,133 +166,170 @@ func TestRequireSoulAgentWithDomainAccess(t *testing.T) {
 	}
 }
 
-func TestHandleSoulAgentCommPortalHandlers(t *testing.T) {
+func TestHandleSoulAgentCommActivityReadsMailbox(t *testing.T) {
 	t.Parallel()
 
 	agentID := soulLifecycleTestAgentIDHex
+	ctx := soulAgentCommPortalCtx(agentID)
+
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+	tdb.qMailbox.On("All", mock.Anything).Return(errors.New("boom")).Once()
+	s := newSoulPortalServer(tdb)
+	if _, err := s.handleSoulAgentCommActivity(ctx); err == nil {
+		t.Fatalf("expected list error")
+	}
+
+	tdb2 := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb2, agentID, models.SoulAgentStatusActive)
+	expectPortalMailboxRows(t, tdb2.qMailbox, []*models.SoulCommMailboxMessage{
+		portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered),
+	})
+	s = newSoulPortalServer(tdb2)
+	resp, err := s.handleSoulAgentCommActivity(ctx)
+	if err != nil || resp.Status != http.StatusOK {
+		t.Fatalf("unexpected response: %#v %v", resp, err)
+	}
+	assertPortalResponseRedacted(t, "activity", resp.Body)
+
+	var out soulAgentCommActivityResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal activity: %v", err)
+	}
+	if out.Count != 1 || out.Activities[0].DeliveryID != "delivery-1" || out.Activities[0].Content.SHA256 != "sha256-body" {
+		t.Fatalf("unexpected canonical activity response: %#v", out)
+	}
+}
+
+func TestHandleSoulAgentCommQueueReadsMailbox(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+	expectPortalMailboxRows(t, tdb.qMailbox, portalQueueMailboxRows(agentID))
+
+	s := newSoulPortalServer(tdb)
+	resp, err := s.handleSoulAgentCommQueue(soulAgentCommPortalCtx(agentID))
+	if err != nil || resp.Status != http.StatusOK {
+		t.Fatalf("unexpected response: %#v %v", resp, err)
+	}
+	assertPortalResponseRedacted(t, "queue", resp.Body)
+
+	var out soulAgentCommQueueResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal queue: %v", err)
+	}
+	if out.Count != 1 || out.Items[0].DeliveryID != "delivery-1" || out.Items[0].Preview != "redacted preview" {
+		t.Fatalf("unexpected canonical queue response: %#v", out)
+	}
+}
+
+func TestHandleSoulAgentCommStatusBranches(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+	s := newSoulPortalServer(tdb)
+
+	badCtx := adminCtx()
+	badCtx.Params = map[string]string{"agentId": agentID, "messageId": ""}
+	if _, err := s.handleSoulAgentCommStatus(badCtx); err == nil {
+		t.Fatalf("expected invalid message id error")
+	}
+
+	statusCtx := soulAgentCommStatusCtx(agentID, "msg-1")
+	tdb.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(theoryErrors.ErrItemNotFound).Once()
+	if _, err := s.handleSoulAgentCommStatus(statusCtx); err == nil {
+		t.Fatalf("expected not found error")
+	}
+
+	expectSoulCommStatusMismatch(t, agentID, statusCtx)
+	expectSoulCommStatusSuccess(t, agentID, statusCtx)
+}
+
+func soulAgentCommPortalCtx(agentID string) *apptheory.Context {
 	ctx := adminCtx()
 	ctx.Params = map[string]string{"agentId": agentID}
+	return ctx
+}
 
-	t.Run("activity error and success", func(t *testing.T) {
-		tdb := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
-		tdb.qMailbox.On("All", mock.Anything).Return(errors.New("boom")).Once()
-		s := newSoulPortalServer(tdb)
-		if _, err := s.handleSoulAgentCommActivity(ctx); err == nil {
-			t.Fatalf("expected list error")
-		}
+func soulAgentCommStatusCtx(agentID string, messageID string) *apptheory.Context {
+	ctx := adminCtx()
+	ctx.Params = map[string]string{"agentId": agentID, "messageId": messageID}
+	return ctx
+}
 
-		tdb2 := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb2, agentID, models.SoulAgentStatusActive)
-		tdb2.qMailbox.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
-			*dest = []*models.SoulCommMailboxMessage{portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered)}
-		}).Once()
-		s = newSoulPortalServer(tdb2)
-		resp, err := s.handleSoulAgentCommActivity(ctx)
-		if err != nil || resp.Status != http.StatusOK {
-			t.Fatalf("unexpected response: %#v %v", resp, err)
-		}
-		if body := string(resp.Body); strings.Contains(body, "mailbox-bucket") || strings.Contains(body, "mailbox/v1/secret") {
-			t.Fatalf("activity leaked content storage pointer: %s", body)
-		}
-		var out soulAgentCommActivityResponse
-		if err := json.Unmarshal(resp.Body, &out); err != nil {
-			t.Fatalf("unmarshal activity: %v", err)
-		}
-		if out.Count != 1 || out.Activities[0].DeliveryID != "delivery-1" || out.Activities[0].Content.SHA256 != "sha256-body" {
-			t.Fatalf("unexpected canonical activity response: %#v", out)
-		}
-	})
+func expectPortalMailboxRows(t *testing.T, q *ttmocks.MockQuery, rows []*models.SoulCommMailboxMessage) {
+	t.Helper()
+	q.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		*dest = rows
+	}).Once()
+}
 
-	t.Run("queue success", func(t *testing.T) {
-		tdb := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
-		tdb.qMailbox.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
-			delivered := portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered)
-			delivered.DeliveryID = "delivery-delivered"
-			outbound := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
-			outbound.DeliveryID = "delivery-outbound"
-			outbound.Direction = models.SoulCommDirectionOutbound
-			deleted := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
-			deleted.DeliveryID = "delivery-deleted"
-			deleted.Deleted = true
-			*dest = []*models.SoulCommMailboxMessage{
-				portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued),
-				delivered,
-				outbound,
-				deleted,
-			}
-		}).Once()
-		s := newSoulPortalServer(tdb)
-		resp, err := s.handleSoulAgentCommQueue(ctx)
-		if err != nil || resp.Status != http.StatusOK {
-			t.Fatalf("unexpected response: %#v %v", resp, err)
-		}
-		body := string(resp.Body)
-		if strings.Contains(body, `"body"`) || strings.Contains(body, "mailbox-bucket") || strings.Contains(body, "mailbox/v1/secret") {
-			t.Fatalf("queue leaked full body or content storage pointer: %s", body)
-		}
-		var out soulAgentCommQueueResponse
-		if err := json.Unmarshal(resp.Body, &out); err != nil {
-			t.Fatalf("unmarshal queue: %v", err)
-		}
-		if out.Count != 1 || out.Items[0].DeliveryID != "delivery-1" || out.Items[0].Preview != "redacted preview" {
-			t.Fatalf("unexpected canonical queue response: %#v", out)
-		}
-	})
+func portalQueueMailboxRows(agentID string) []*models.SoulCommMailboxMessage {
+	delivered := portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered)
+	delivered.DeliveryID = "delivery-delivered"
+	outbound := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
+	outbound.DeliveryID = "delivery-outbound"
+	outbound.Direction = models.SoulCommDirectionOutbound
+	deleted := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
+	deleted.DeliveryID = "delivery-deleted"
+	deleted.Deleted = true
+	return []*models.SoulCommMailboxMessage{
+		portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued),
+		delivered,
+		outbound,
+		deleted,
+	}
+}
 
-	t.Run("status branches", func(t *testing.T) {
-		tdb := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
-		s := newSoulPortalServer(tdb)
+func assertPortalResponseRedacted(t *testing.T, label string, body []byte) {
+	t.Helper()
+	text := string(body)
+	if strings.Contains(text, `"body"`) || strings.Contains(text, "mailbox-bucket") || strings.Contains(text, "mailbox/v1/secret") {
+		t.Fatalf("%s leaked full body or content storage pointer: %s", label, text)
+	}
+}
 
-		badCtx := adminCtx()
-		badCtx.Params = map[string]string{"agentId": agentID, "messageId": ""}
-		if _, err := s.handleSoulAgentCommStatus(badCtx); err == nil {
-			t.Fatalf("expected invalid message id error")
-		}
+func expectSoulCommStatusMismatch(t *testing.T, agentID string, statusCtx *apptheory.Context) {
+	t.Helper()
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+	tdb.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+		*dest = models.SoulCommMessageStatus{MessageID: "msg-1", AgentID: "0xother"}
+	}).Once()
+	s := newSoulPortalServer(tdb)
+	if _, err := s.handleSoulAgentCommStatus(statusCtx); err == nil {
+		t.Fatalf("expected mismatched agent error")
+	}
+}
 
-		statusCtx := adminCtx()
-		statusCtx.Params = map[string]string{"agentId": agentID, "messageId": "msg-1"}
-		tdb.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(theoryErrors.ErrItemNotFound).Once()
-		if _, err := s.handleSoulAgentCommStatus(statusCtx); err == nil {
-			t.Fatalf("expected not found error")
+func expectSoulCommStatusSuccess(t *testing.T, agentID string, statusCtx *apptheory.Context) {
+	t.Helper()
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+	tdb.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+		*dest = models.SoulCommMessageStatus{
+			MessageID:         "msg-1",
+			AgentID:           agentID,
+			Status:            "sent",
+			ChannelType:       "email",
+			Provider:          commDeliveryProviderMigadu,
+			ProviderMessageID: "provider-1",
+			CreatedAt:         time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC),
+			UpdatedAt:         time.Date(2026, 3, 5, 12, 5, 0, 0, time.UTC),
 		}
-
-		tdb2 := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb2, agentID, models.SoulAgentStatusActive)
-		tdb2.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
-			*dest = models.SoulCommMessageStatus{MessageID: "msg-1", AgentID: "0xother"}
-		}).Once()
-		s = newSoulPortalServer(tdb2)
-		if _, err := s.handleSoulAgentCommStatus(statusCtx); err == nil {
-			t.Fatalf("expected mismatched agent error")
-		}
-
-		tdb3 := newSoulCommPortalTestDB()
-		seedSoulAgentPortalAccess(t, tdb3, agentID, models.SoulAgentStatusActive)
-		tdb3.qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
-			*dest = models.SoulCommMessageStatus{
-				MessageID:         "msg-1",
-				AgentID:           agentID,
-				Status:            "sent",
-				ChannelType:       "email",
-				Provider:          commDeliveryProviderMigadu,
-				ProviderMessageID: "provider-1",
-				CreatedAt:         time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC),
-				UpdatedAt:         time.Date(2026, 3, 5, 12, 5, 0, 0, time.UTC),
-			}
-		}).Once()
-		s = newSoulPortalServer(tdb3)
-		resp, err := s.handleSoulAgentCommStatus(statusCtx)
-		if err != nil || resp.Status != http.StatusOK {
-			t.Fatalf("unexpected response: %#v %v", resp, err)
-		}
-	})
+	}).Once()
+	s := newSoulPortalServer(tdb)
+	resp, err := s.handleSoulAgentCommStatus(statusCtx)
+	if err != nil || resp.Status != http.StatusOK {
+		t.Fatalf("unexpected response: %#v %v", resp, err)
+	}
 }
 
 func TestHandleSoulFailures_RecordBranches(t *testing.T) {

--- a/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
+++ b/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 
+	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -24,6 +26,7 @@ type soulCommPortalTestDB struct {
 	base     soulLifecycleTestDB
 	qAct     *ttmocks.MockQuery
 	qQueue   *ttmocks.MockQuery
+	qMailbox *ttmocks.MockQuery
 	qStatus  *ttmocks.MockQuery
 	qFailure *ttmocks.MockQuery
 }
@@ -32,15 +35,17 @@ func newSoulCommPortalTestDB() soulCommPortalTestDB {
 	base := newSoulLifecycleTestDB()
 	qAct := new(ttmocks.MockQuery)
 	qQueue := new(ttmocks.MockQuery)
+	qMailbox := new(ttmocks.MockQuery)
 	qStatus := new(ttmocks.MockQuery)
 	qFailure := new(ttmocks.MockQuery)
 
 	base.db.On("Model", mock.AnythingOfType("*models.SoulAgentCommActivity")).Return(qAct).Maybe()
 	base.db.On("Model", mock.AnythingOfType("*models.SoulAgentCommQueue")).Return(qQueue).Maybe()
+	base.db.On("Model", mock.AnythingOfType("*models.SoulCommMailboxMessage")).Return(qMailbox).Maybe()
 	base.db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
 	base.db.On("Model", mock.AnythingOfType("*models.SoulAgentFailure")).Return(qFailure).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qAct, qQueue, qStatus, qFailure} {
+	for _, q := range []*ttmocks.MockQuery{qAct, qQueue, qMailbox, qStatus, qFailure} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
@@ -53,6 +58,7 @@ func newSoulCommPortalTestDB() soulCommPortalTestDB {
 		base:     base,
 		qAct:     qAct,
 		qQueue:   qQueue,
+		qMailbox: qMailbox,
 		qStatus:  qStatus,
 		qFailure: qFailure,
 	}
@@ -100,6 +106,34 @@ func newSoulPortalServer(tdb soulCommPortalTestDB) *Server {
 	}
 }
 
+func portalMailboxMessage(agentID string, status string) *models.SoulCommMailboxMessage {
+	now := time.Date(2026, 4, 25, 18, 0, 0, 0, time.UTC)
+	return &models.SoulCommMailboxMessage{
+		DeliveryID:      "delivery-1",
+		MessageID:       "message-1",
+		ThreadID:        "thread-1",
+		InstanceSlug:    "inst1",
+		AgentID:         agentID,
+		Direction:       models.SoulCommDirectionInbound,
+		ChannelType:     commChannelEmail,
+		Provider:        commDeliveryProviderMigadu,
+		Status:          status,
+		FromAddress:     "sender@example.com",
+		ToAddress:       "agent@example.com",
+		Subject:         "Hello",
+		Preview:         "redacted preview",
+		ContentStorage:  commmailbox.ContentStorageS3,
+		ContentBucket:   "mailbox-bucket",
+		ContentKey:      "mailbox/v1/secret/content",
+		ContentSHA256:   "sha256-body",
+		ContentBytes:    42,
+		ContentMimeType: "text/plain",
+		HasContent:      true,
+		CreatedAt:       now,
+		UpdatedAt:       now,
+	}
+}
+
 func TestRequireSoulAgentWithDomainAccess(t *testing.T) {
 	t.Parallel()
 
@@ -142,7 +176,7 @@ func TestHandleSoulAgentCommPortalHandlers(t *testing.T) {
 	t.Run("activity error and success", func(t *testing.T) {
 		tdb := newSoulCommPortalTestDB()
 		seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
-		tdb.qAct.On("All", mock.Anything).Return(errors.New("boom")).Once()
+		tdb.qMailbox.On("All", mock.Anything).Return(errors.New("boom")).Once()
 		s := newSoulPortalServer(tdb)
 		if _, err := s.handleSoulAgentCommActivity(ctx); err == nil {
 			t.Fatalf("expected list error")
@@ -150,28 +184,62 @@ func TestHandleSoulAgentCommPortalHandlers(t *testing.T) {
 
 		tdb2 := newSoulCommPortalTestDB()
 		seedSoulAgentPortalAccess(t, tdb2, agentID, models.SoulAgentStatusActive)
-		tdb2.qAct.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
-			*dest = []*models.SoulAgentCommActivity{{AgentID: agentID, MessageID: "m1"}}
+		tdb2.qMailbox.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+			*dest = []*models.SoulCommMailboxMessage{portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered)}
 		}).Once()
 		s = newSoulPortalServer(tdb2)
 		resp, err := s.handleSoulAgentCommActivity(ctx)
 		if err != nil || resp.Status != http.StatusOK {
 			t.Fatalf("unexpected response: %#v %v", resp, err)
 		}
+		if body := string(resp.Body); strings.Contains(body, "mailbox-bucket") || strings.Contains(body, "mailbox/v1/secret") {
+			t.Fatalf("activity leaked content storage pointer: %s", body)
+		}
+		var out soulAgentCommActivityResponse
+		if err := json.Unmarshal(resp.Body, &out); err != nil {
+			t.Fatalf("unmarshal activity: %v", err)
+		}
+		if out.Count != 1 || out.Activities[0].DeliveryID != "delivery-1" || out.Activities[0].Content.SHA256 != "sha256-body" {
+			t.Fatalf("unexpected canonical activity response: %#v", out)
+		}
 	})
 
 	t.Run("queue success", func(t *testing.T) {
 		tdb := newSoulCommPortalTestDB()
 		seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
-		tdb.qQueue.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommQueue")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommQueue](t, args, 0)
-			*dest = []*models.SoulAgentCommQueue{{AgentID: agentID, MessageID: "m1"}}
+		tdb.qMailbox.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+			delivered := portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered)
+			delivered.DeliveryID = "delivery-delivered"
+			outbound := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
+			outbound.DeliveryID = "delivery-outbound"
+			outbound.Direction = models.SoulCommDirectionOutbound
+			deleted := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
+			deleted.DeliveryID = "delivery-deleted"
+			deleted.Deleted = true
+			*dest = []*models.SoulCommMailboxMessage{
+				portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued),
+				delivered,
+				outbound,
+				deleted,
+			}
 		}).Once()
 		s := newSoulPortalServer(tdb)
 		resp, err := s.handleSoulAgentCommQueue(ctx)
 		if err != nil || resp.Status != http.StatusOK {
 			t.Fatalf("unexpected response: %#v %v", resp, err)
+		}
+		body := string(resp.Body)
+		if strings.Contains(body, `"body"`) || strings.Contains(body, "mailbox-bucket") || strings.Contains(body, "mailbox/v1/secret") {
+			t.Fatalf("queue leaked full body or content storage pointer: %s", body)
+		}
+		var out soulAgentCommQueueResponse
+		if err := json.Unmarshal(resp.Body, &out); err != nil {
+			t.Fatalf("unmarshal queue: %v", err)
+		}
+		if out.Count != 1 || out.Items[0].DeliveryID != "delivery-1" || out.Items[0].Preview != "redacted preview" {
+			t.Fatalf("unexpected canonical queue response: %#v", out)
 		}
 	})
 

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -1503,6 +1503,8 @@ export interface components {
         "soul-agent-comm-activity-item.schema": {
             agent_id: string;
             activity_id: string;
+            delivery_id?: string;
+            thread_id?: string;
             /** @enum {string} */
             channel_type: "email" | "sms" | "voice";
             /** @enum {string} */
@@ -1510,6 +1512,19 @@ export interface components {
             counterparty?: string;
             action?: string;
             message_id?: string;
+            /** @enum {string} */
+            status?: "accepted" | "sent" | "delivered" | "queued" | "failed" | "bounced" | "dropped";
+            subject?: string;
+            preview?: string;
+            content?: {
+                available: boolean;
+                bytes?: number;
+                mime_type?: string;
+                sha256?: string;
+            };
+            read?: boolean;
+            archived?: boolean;
+            deleted?: boolean;
             in_reply_to?: string;
             /** @enum {string} */
             boundary_check?: "passed" | "violated" | "skipped";
@@ -1527,7 +1542,9 @@ export interface components {
         /** Soul agent queued communication item */
         "soul-agent-comm-queue-item.schema": {
             agent_id: string;
+            delivery_id?: string;
             message_id: string;
+            thread_id?: string;
             /** @enum {string} */
             channel_type: "email" | "sms" | "voice";
             /** Format: email */
@@ -1536,7 +1553,13 @@ export interface components {
             from_soul_agent_id?: string;
             from_display_name?: string;
             subject?: string;
-            body: string;
+            preview?: string;
+            content?: {
+                available: boolean;
+                bytes?: number;
+                mime_type?: string;
+                sha256?: string;
+            };
             in_reply_to?: string;
             /** Format: date-time */
             received_at: string;
@@ -1544,6 +1567,9 @@ export interface components {
             scheduled_delivery_time: string;
             /** @enum {string} */
             status: "queued" | "delivered" | "expired";
+            read?: boolean;
+            archived?: boolean;
+            deleted?: boolean;
         };
         /** GET /api/v1/soul/agents/{agentId}/comm/queue response */
         "soul-agent-comm-queue.response.schema": {

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -2290,7 +2290,12 @@
 							<Card variant="outlined" padding="md">
 								<div class="soul-agent__item">
 									<div class="soul-agent__item-left">
-										<Text size="sm" weight="medium">{act.direction} · {act.channel_type} · {act.action || '—'}</Text>
+										<Text size="sm" weight="medium">
+											{act.direction} · {act.channel_type} · {act.action || '—'}
+											{#if act.status}
+												· {act.status}
+											{/if}
+										</Text>
 										<Text size="sm" color="secondary">
 											<span class="soul-agent__mono">{act.timestamp}</span>
 											{#if act.counterparty}
@@ -2302,6 +2307,28 @@
 												message <span class="soul-agent__mono">{act.message_id}</span>
 											</Text>
 										{/if}
+										{#if act.delivery_id}
+											<Text size="sm" color="secondary">
+												delivery <span class="soul-agent__mono">{act.delivery_id}</span>
+											</Text>
+										{/if}
+										{#if act.thread_id}
+											<Text size="sm" color="secondary">
+												thread <span class="soul-agent__mono">{act.thread_id}</span>
+											</Text>
+										{/if}
+										{#if act.subject}
+											<Text size="sm" color="secondary">subject {act.subject}</Text>
+										{/if}
+										{#if act.preview}
+											<Text size="sm" color="secondary">preview {act.preview}</Text>
+										{/if}
+										<Text size="sm" color="secondary">
+											state {act.read ? 'read' : 'unread'}{act.archived ? ' · archived' : ''}{act.deleted ? ' · deleted' : ''}
+											{#if act.content?.available}
+												· content {act.content.bytes ?? 0} bytes
+											{/if}
+										</Text>
 										{#if act.in_reply_to}
 											<Text size="sm" color="secondary">
 												inReplyTo <span class="soul-agent__mono">{act.in_reply_to}</span>
@@ -2365,7 +2392,7 @@
 
 				<div class="soul-agent__divider"></div>
 
-				<Heading level={4} size="base">Queued inbound</Heading>
+				<Heading level={4} size="base">Inbound mailbox queue</Heading>
 				{#if commQueue?.items?.length}
 					<div class="soul-agent__list">
 						{#each commQueue.items as item (item.message_id + item.scheduled_delivery_time)}
@@ -2384,6 +2411,20 @@
 										{#if item.subject}
 											<Text size="sm" color="secondary">subject {item.subject}</Text>
 										{/if}
+										{#if item.preview}
+											<Text size="sm" color="secondary">preview {item.preview}</Text>
+										{/if}
+										{#if item.delivery_id}
+											<Text size="sm" color="secondary">
+												delivery <span class="soul-agent__mono">{item.delivery_id}</span>
+											</Text>
+										{/if}
+										<Text size="sm" color="secondary">
+											state {item.read ? 'read' : 'unread'}{item.archived ? ' · archived' : ''}{item.deleted ? ' · deleted' : ''}
+											{#if item.content?.available}
+												· content {item.content.bytes ?? 0} bytes
+											{/if}
+										</Text>
 									</div>
 								</div>
 							</Card>


### PR DESCRIPTION
## Milestone
Host 4 — Portal + migration for Soul Comm Mailbox v1

## Classification
host-portal / host-comm / cross-repo coordination / operational-reliability / docs

## Surfaces affected
- Control-plane portal comm handlers
- Portal web communication section
- Soul comm v3 JSON schemas and generated web REST adapter
- Body/lesser mailbox migration documentation

## Specialist walks referenced
- Governance rubric: portal list/content split preserved; gov-infra verifier passes 29/0/0.
- Provisioning / managed-update / release verification: docs only; no release-verification bypass.
- Soul registry: soul comm surface only; no on-chain contract or mint/governance signer changes.
- Trust API / CSP / instance-auth: no trust API changes; web changes keep first-party Svelte markup only and no CSP loosening.
- Framework: idiomatic AppTheory/TableTheory consumption; no framework patches.

## Multi-tenant isolation impact
Elevated but preserved. Portal reads remain session-authenticated and domain/instance-owned; mailbox queries are scoped by `COMM#MAILBOX#INSTANCE#{instanceSlug}#AGENT#{agentId}`. No cross-tenant scan, no raw storage pointers in list responses, no full body in portal lists.

## On-chain impact
None.

## Consumer impact
- Operators/customers see portal comm activity/queue backed by canonical mailbox state.
- Body gets documented migration guidance for MCP tools over host mailbox APIs.
- Lesser gets documented projection-only semantics.

## Tasks
- [x] #170 Align portal comm views to canonical mailbox state
- [x] #172 Document body/lesser mailbox migration path

## Validation
- `go test ./...`
- `go vet ./...`
- `go mod verify`
- `gofmt -l $(git ls-files '*.go')` (empty)
- `git diff --check`
- `cd web && npm ci && npm run lint && npm run typecheck && npm test && npm run verify:lesser-host-contracts`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to `host-v2`
- [ ] Deployed to lab with Host 2/3/4 mailbox changes
- [ ] Lab soak complete with portal/body mailbox smoke checks
- [ ] Deployed to live only after operator authorization
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
Required after host lab deploy: body can implement MCP mailbox tools against the documented host contract; lesser keeps mailbox projections non-authoritative.

## Advisor-brief authorization (if applicable)
N/A — Aron approved this roadmap directly.
