### PR TITLE
fix(security): remediate M1 ingress privacy findings

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -854,6 +854,13 @@ export class LesserHostStack extends cdk.Stack {
 				resourceName: `lesser-host/soul/${stage}/*`,
 			}),
 		];
+		const commWebhookSsmParamArns = [
+			cdk.Stack.of(this).formatArn({
+				service: 'ssm',
+				resource: 'parameter',
+				resourceName: `lesser-host/comm/${stage}/webhook`,
+			}),
+		];
 		controlPlaneFn.addToRolePolicy(
 			new iam.PolicyStatement({
 				actions: ['ssm:GetParameter', 'ssm:GetParameters'],
@@ -864,6 +871,12 @@ export class LesserHostStack extends cdk.Stack {
 			new iam.PolicyStatement({
 				actions: ['ssm:GetParameter', 'ssm:GetParameters'],
 				resources: telnyxSsmParamArns,
+			}),
+		);
+		controlPlaneFn.addToRolePolicy(
+			new iam.PolicyStatement({
+				actions: ['ssm:GetParameter', 'ssm:GetParameters'],
+				resources: commWebhookSsmParamArns,
 			}),
 		);
 		controlPlaneFn.addToRolePolicy(

--- a/internal/commmailbox/content_store.go
+++ b/internal/commmailbox/content_store.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 const (
@@ -63,15 +65,15 @@ type ContentStore interface {
 type s3API interface {
 	PutObject(ctx context.Context, params *s3.PutObjectInput, optFns ...func(*s3.Options)) (*s3.PutObjectOutput, error)
 	GetObject(ctx context.Context, params *s3.GetObjectInput, optFns ...func(*s3.Options)) (*s3.GetObjectOutput, error)
+	HeadObject(ctx context.Context, params *s3.HeadObjectInput, optFns ...func(*s3.Options)) (*s3.HeadObjectOutput, error)
 }
 
 // S3Store stores mailbox content in the dedicated CDK-managed mailbox bucket.
 type S3Store struct {
 	bucket string
 
-	once   sync.Once
+	mu     sync.Mutex
 	client s3API
-	err    error
 }
 
 // NewS3Store constructs an S3-backed content store.
@@ -83,7 +85,6 @@ func NewS3Store(bucket string) *S3Store {
 func NewS3StoreWithClient(bucket string, client s3API) *S3Store {
 	st := NewS3Store(bucket)
 	if client != nil {
-		st.once.Do(func() {})
 		st.client = client
 	}
 	return st
@@ -128,6 +129,7 @@ func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPo
 		Key:         aws.String(key),
 		Body:        bytes.NewReader(body),
 		ContentType: aws.String(contentType),
+		IfNoneMatch: aws.String("*"),
 		Metadata: map[string]string{
 			"delivery-id":   strings.TrimSpace(input.DeliveryID),
 			"agent-id":      strings.ToLower(strings.TrimSpace(input.AgentID)),
@@ -139,6 +141,9 @@ func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPo
 		},
 	})
 	if err != nil {
+		if isS3PreconditionFailed(err) {
+			return s.existingPointer(ctx, client, bucket, key, contentType)
+		}
 		return ContentPointer{}, err
 	}
 
@@ -150,6 +155,42 @@ func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPo
 		Bytes:       int64(len(body)),
 		ContentType: contentType,
 	}, nil
+}
+
+func (s *S3Store) existingPointer(ctx context.Context, client s3API, bucket string, key string, fallbackContentType string) (ContentPointer, error) {
+	out, err := client.HeadObject(ctx, &s3.HeadObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		return ContentPointer{}, err
+	}
+	digest := strings.ToLower(strings.TrimSpace(out.Metadata["sha256"]))
+	contentType := strings.TrimSpace(fallbackContentType)
+	if out.ContentType != nil && strings.TrimSpace(*out.ContentType) != "" {
+		contentType = strings.TrimSpace(*out.ContentType)
+	}
+	var bytes int64
+	if out.ContentLength != nil {
+		bytes = *out.ContentLength
+	}
+	return ContentPointer{
+		Storage:     ContentStorageS3,
+		Bucket:      bucket,
+		Key:         key,
+		SHA256:      digest,
+		Bytes:       bytes,
+		ContentType: contentType,
+	}, nil
+}
+
+func isS3PreconditionFailed(err error) bool {
+	var apiErr smithy.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	code := strings.ToLower(strings.TrimSpace(apiErr.ErrorCode()))
+	return code == "preconditionfailed" || code == "precondition failed"
 }
 
 // GetContent reads a bounded mailbox content object and verifies its digest when
@@ -209,20 +250,16 @@ func (s *S3Store) s3Client(ctx context.Context) (s3API, error) {
 	if s == nil {
 		return nil, fmt.Errorf("mailbox content store is nil")
 	}
-	s.once.Do(func() {
-		cfg, err := awsconfig.LoadDefaultConfig(ctx)
-		if err != nil {
-			s.err = err
-			return
-		}
-		s.client = s3.NewFromConfig(cfg)
-	})
-	if s.err != nil {
-		return nil, s.err
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.client != nil {
+		return s.client, nil
 	}
-	if s.client == nil {
-		return nil, fmt.Errorf("s3 client not initialized")
+	cfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, err
 	}
+	s.client = s3.NewFromConfig(cfg)
 	return s.client, nil
 }
 

--- a/internal/commmailbox/content_store_test.go
+++ b/internal/commmailbox/content_store_test.go
@@ -2,22 +2,30 @@ package commmailbox
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 type fakeS3PutClient struct {
 	input       *s3.PutObjectInput
+	headInput   *s3.HeadObjectInput
 	getBody     string
 	contentType string
+	putErr      error
+	headOutput  *s3.HeadObjectOutput
 }
 
 func (f *fakeS3PutClient) PutObject(_ context.Context, in *s3.PutObjectInput, _ ...func(*s3.Options)) (*s3.PutObjectOutput, error) {
 	f.input = in
+	if f.putErr != nil {
+		return nil, f.putErr
+	}
 	return &s3.PutObjectOutput{}, nil
 }
 
@@ -27,6 +35,14 @@ func (f *fakeS3PutClient) GetObject(_ context.Context, in *s3.GetObjectInput, _ 
 		Body:        io.NopCloser(strings.NewReader(f.getBody)),
 		ContentType: aws.String(f.contentType),
 	}, nil
+}
+
+func (f *fakeS3PutClient) HeadObject(_ context.Context, in *s3.HeadObjectInput, _ ...func(*s3.Options)) (*s3.HeadObjectOutput, error) {
+	f.headInput = in
+	if f.headOutput != nil {
+		return f.headOutput, nil
+	}
+	return &s3.HeadObjectOutput{}, nil
 }
 
 func TestS3StorePutContent(t *testing.T) {
@@ -55,12 +71,56 @@ func TestS3StorePutContent(t *testing.T) {
 	if client.input == nil || aws.ToString(client.input.Bucket) != "mailbox-bucket" || aws.ToString(client.input.Key) != ptr.Key {
 		t.Fatalf("unexpected put input: %#v", client.input)
 	}
+	if aws.ToString(client.input.IfNoneMatch) != "*" {
+		t.Fatalf("expected immutable put with If-None-Match, got %#v", client.input.IfNoneMatch)
+	}
 	body, _ := io.ReadAll(client.input.Body)
 	if string(body) != "Hello mailbox" {
 		t.Fatalf("unexpected stored body: %q", string(body))
 	}
 	if client.input.Metadata["delivery-id"] != "comm-delivery-1" || client.input.Metadata["sha256"] != ptr.SHA256 {
 		t.Fatalf("unexpected metadata: %#v", client.input.Metadata)
+	}
+}
+
+func TestS3StorePutContentReturnsExistingPointerOnReplay(t *testing.T) {
+	preconditionErr := &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "object exists"}
+	client := &fakeS3PutClient{
+		putErr: preconditionErr,
+		headOutput: &s3.HeadObjectOutput{
+			ContentLength: aws.Int64(13),
+			ContentType:   aws.String("text/plain"),
+			Metadata:      map[string]string{"sha256": "existing-digest"},
+		},
+	}
+	store := NewS3StoreWithClient("mailbox-bucket", client)
+
+	ptr, err := store.PutContent(context.Background(), ContentInput{
+		DeliveryID:   "comm-delivery-replay",
+		InstanceSlug: "Demo",
+		AgentID:      "0xABC",
+		MessageID:    "msg-1",
+		Direction:    "Inbound",
+		ChannelType:  "Email",
+		Body:         "Replay body",
+	})
+	if err != nil {
+		t.Fatalf("PutContent replay: %v", err)
+	}
+	if ptr.SHA256 != "existing-digest" || ptr.Bytes != 13 || ptr.ContentType != "text/plain" {
+		t.Fatalf("unexpected replay pointer: %#v", ptr)
+	}
+	if client.headInput == nil || aws.ToString(client.headInput.Key) != ptr.Key {
+		t.Fatalf("expected head of existing key, got %#v", client.headInput)
+	}
+}
+
+func TestS3StorePutContentReturnsNonPreconditionErrors(t *testing.T) {
+	client := &fakeS3PutClient{putErr: errors.New("boom")}
+	store := NewS3StoreWithClient("mailbox-bucket", client)
+	_, err := store.PutContent(context.Background(), ContentInput{DeliveryID: "d", AgentID: "a", Body: "body"})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected put error, got %v", err)
 	}
 }
 

--- a/internal/commworker/helpers_internal_test.go
+++ b/internal/commworker/helpers_internal_test.go
@@ -490,8 +490,12 @@ func testBounceFormattingHelpers(t *testing.T) {
 		t.Fatalf("unexpected bounce message id: %q", got)
 	}
 	rfc := string(buildPlaintextEmailRFC5322("from@example.com", "to@example.com", "Subject\r\nBad", "Line1\nLine2", "<id>", "<parent>"))
-	if !strings.Contains(rfc, "Subject: Subject  Bad\r\n") || !strings.Contains(rfc, "In-Reply-To: <parent>\r\n") || !strings.Contains(rfc, "Line1\r\nLine2\r\n") {
+	if !strings.Contains(rfc, "Subject: Subject Bad\r\n") || !strings.Contains(rfc, "In-Reply-To: <parent>\r\n") || !strings.Contains(rfc, "Line1\r\nLine2\r\n") {
 		t.Fatalf("unexpected RFC5322 body: %q", rfc)
+	}
+	injected := string(buildPlaintextEmailRFC5322("from@example.com", "to@example.com", "Subject", "Body", "<id>\r\nX-Bad: yes", "<parent>\r\nX-Bad: yes"))
+	if strings.Contains(injected, "\r\nX-Bad: yes") {
+		t.Fatalf("header injection was not neutralized: %q", injected)
 	}
 }
 

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -149,7 +149,7 @@ func (s *Server) processInbound(ctx context.Context, _ string, msg QueueMessage)
 		return err
 	}
 	if !instOK || inst == nil {
-		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(strings.TrimSpace(agentID)), strings.ToLower(strings.TrimSpace(identity.Domain)), channel, strings.TrimSpace(notif.MessageID))
+		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(safeLogToken(agentID)), strings.ToLower(safeLogToken(identity.Domain)), strings.ToLower(safeLogToken(channel)), safeLogToken(notif.MessageID))
 		_ = s.recordInboundActivity(ctx, agentID, channel, notif, "drop", false)
 		return nil
 	}
@@ -341,7 +341,7 @@ func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, cha
 	s.maybeAnnotateRecipientAddress(ctx, agentID, channel, notif.To)
 
 	if inst == nil {
-		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(strings.TrimSpace(agentID)), strings.ToLower(strings.TrimSpace(identity.Domain)), strings.ToLower(strings.TrimSpace(channel)), strings.TrimSpace(notif.MessageID))
+		s.logfMessage("commworker: inbound delivery dropped missing_instance agent=%s domain=%s channel=%s message=%s", strings.ToLower(safeLogToken(agentID)), strings.ToLower(safeLogToken(identity.Domain)), strings.ToLower(safeLogToken(channel)), safeLogToken(notif.MessageID))
 		_ = s.recordInboundActivity(ctx, agentID, channel, notif, "drop", false)
 		return nil
 	}
@@ -1065,17 +1065,36 @@ func (s *Server) logfMessage(format string, args ...any) {
 func (s *Server) logInboundDrop(reason string, requestID string, sqsMessageID string, kind string, channel string, messageID string, err error) {
 	msg := fmt.Sprintf(
 		"commworker: inbound message dropped reason=%s request=%s sqs_message=%s kind=%s channel=%s message=%s",
-		strings.TrimSpace(reason),
-		strings.TrimSpace(requestID),
-		strings.TrimSpace(sqsMessageID),
-		strings.TrimSpace(kind),
-		strings.ToLower(strings.TrimSpace(channel)),
-		strings.TrimSpace(messageID),
+		safeLogToken(reason),
+		safeLogToken(requestID),
+		safeLogToken(sqsMessageID),
+		safeLogToken(kind),
+		strings.ToLower(safeLogToken(channel)),
+		safeLogToken(messageID),
 	)
 	if err != nil {
 		msg += fmt.Sprintf(" err=%v", err)
 	}
 	s.logfMessage("%s", msg)
+}
+
+func safeLogToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		default:
+			if r < 0x20 || r == 0x7f {
+				return -1
+			}
+			return r
+		}
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }
 
 func getSecretsManagerSecretPlaintext(ctx context.Context, sm secretsManagerAPI, secretArn string) (string, error) {
@@ -1283,9 +1302,9 @@ func buildBounceMessageID(fromMailbox string, inReplyTo string) string {
 }
 
 func buildPlaintextEmailRFC5322(from string, to string, subject string, body string, messageID string, inReplyTo string) []byte {
-	from = strings.TrimSpace(from)
-	to = strings.TrimSpace(to)
-	subject = strings.ReplaceAll(strings.ReplaceAll(strings.TrimSpace(subject), "\r", " "), "\n", " ")
+	from = safeRFC5322HeaderValue(from)
+	to = safeRFC5322HeaderValue(to)
+	subject = safeRFC5322HeaderValue(subject)
 	body = strings.TrimSpace(body)
 	if body != "" {
 		body = strings.ReplaceAll(body, "\r\n", "\n")
@@ -1303,12 +1322,12 @@ func buildPlaintextEmailRFC5322(from string, to string, subject string, body str
 		b.WriteString("Subject: " + subject + "\r\n")
 	}
 	b.WriteString("Date: " + time.Now().UTC().Format(time.RFC1123Z) + "\r\n")
-	if strings.TrimSpace(messageID) != "" {
-		b.WriteString("Message-ID: " + strings.TrimSpace(messageID) + "\r\n")
+	if safeRFC5322HeaderValue(messageID) != "" {
+		b.WriteString("Message-ID: " + safeRFC5322HeaderValue(messageID) + "\r\n")
 	}
-	if strings.TrimSpace(inReplyTo) != "" {
-		b.WriteString("In-Reply-To: " + strings.TrimSpace(inReplyTo) + "\r\n")
-		b.WriteString("References: " + strings.TrimSpace(inReplyTo) + "\r\n")
+	if safeRFC5322HeaderValue(inReplyTo) != "" {
+		b.WriteString("In-Reply-To: " + safeRFC5322HeaderValue(inReplyTo) + "\r\n")
+		b.WriteString("References: " + safeRFC5322HeaderValue(inReplyTo) + "\r\n")
 	}
 	b.WriteString("MIME-Version: 1.0\r\n")
 	b.WriteString("Content-Type: text/plain; charset=UTF-8\r\n")
@@ -1316,6 +1335,25 @@ func buildPlaintextEmailRFC5322(from string, to string, subject string, body str
 	b.WriteString("\r\n")
 	b.WriteString(body)
 	return b.Bytes()
+}
+
+func safeRFC5322HeaderValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		default:
+			if r < 0x20 || r == 0x7f {
+				return -1
+			}
+			return r
+		}
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }
 
 func newToken(nBytes int) (string, error) {

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -408,6 +408,9 @@ func (s *Server) lookupRecipientCanonicalAddress(ctx context.Context, agentID st
 	if err != nil || !ok || ch == nil {
 		return ""
 	}
+	if !channelReadyForInbound(ch) || strings.ToLower(strings.TrimSpace(ch.Provider)) != "migadu" {
+		return ""
+	}
 
 	emailAddress := strings.ToLower(strings.TrimSpace(ch.Identifier))
 	if emailAddress == "" {

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -683,6 +683,7 @@ func TestProcessInbound_PhoneDeliveryIncludesCanonicalRecipientAddress(t *testin
 				AgentID:       agentID,
 				ChannelType:   models.SoulChannelTypeEmail,
 				Identifier:    testAgentBobEmail,
+				Provider:      "migadu",
 				Status:        models.SoulChannelStatusActive,
 				Verified:      true,
 				ProvisionedAt: now.Add(-time.Hour),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,6 +32,16 @@ type Config struct {
 	// SoulCommMailboxRetentionDays is the content/object lifecycle window for mailbox bodies.
 	SoulCommMailboxRetentionDays int64
 
+	// CommWebhookSharedSecretSSMParam stores the HMAC shared secret for
+	// first-party comm webhook adapters that cannot use provider-native
+	// signatures.
+	CommWebhookSharedSecretSSMParam string
+
+	// TelnyxWebhookPublicKey is Telnyx's Ed25519 webhook verification public
+	// key. It is public key material, not a secret; deployments may also store it
+	// in the `/lesser-host/telnyx` JSON parameter as `webhook_public_key`.
+	TelnyxWebhookPublicKey string
+
 	// ENS gateway (CCIP-Read) configuration.
 	ENSGatewayResolverAddress     string
 	ENSGatewaySigningKeyID        string
@@ -197,6 +207,11 @@ func Load() Config {
 		InboundEmailS3Prefix:         envStringDefault("INBOUND_EMAIL_S3_PREFIX", "ses/inbound/"),
 		SoulCommMailboxBucketName:    envString("SOUL_COMM_MAILBOX_BUCKET_NAME"),
 		SoulCommMailboxRetentionDays: envInt64Bounded("SOUL_COMM_MAILBOX_RETENTION_DAYS", 90, 1, 365),
+		CommWebhookSharedSecretSSMParam: envStringDefault(
+			"COMM_WEBHOOK_SHARED_SECRET_SSM_PARAM",
+			fmt.Sprintf("/lesser-host/comm/%s/webhook", stage),
+		),
+		TelnyxWebhookPublicKey: envString("TELNYX_WEBHOOK_PUBLIC_KEY"),
 
 		ENSGatewayResolverAddress:     envString("ENS_GATEWAY_RESOLVER_ADDRESS"),
 		ENSGatewaySigningKeyID:        envString("ENS_GATEWAY_SIGNING_KEY_ID"),

--- a/internal/controlplane/comm_webhook_auth.go
+++ b/internal/controlplane/comm_webhook_auth.go
@@ -1,0 +1,178 @@
+package controlplane
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/httpx"
+	hostsecrets "github.com/equaltoai/lesser-host/internal/secrets"
+)
+
+const (
+	commWebhookTimestampTolerance = 5 * time.Minute
+	commWebhookSignatureHeader    = "x-lesser-host-signature"
+	commWebhookTimestampHeader    = "x-lesser-host-timestamp"
+)
+
+func (s *Server) requireCommWebhookAdapterAuth(ctx *apptheory.Context) *apptheory.AppTheoryError {
+	if s == nil || ctx == nil {
+		return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+	secret, err := s.loadCommWebhookSharedSecret(ctx.Context())
+	if err != nil || strings.TrimSpace(secret) == "" {
+		return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+	timestamp := strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, commWebhookTimestampHeader))
+	signature := strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, commWebhookSignatureHeader))
+	if !validRecentUnixTimestamp(timestamp, commWebhookTimestampTolerance) {
+		return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+	if !verifyHMACWebhookSignature(secret, timestamp, ctx.Request.Body, signature) {
+		return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+	return nil
+}
+
+func (s *Server) requireTelnyxCommWebhookAuth(ctx *apptheory.Context) *apptheory.AppTheoryError {
+	if s == nil || ctx == nil {
+		return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+	}
+	if hasTelnyxSignatureHeaders(ctx) {
+		publicKey, err := s.loadTelnyxWebhookPublicKey(ctx.Context())
+		if err != nil || len(publicKey) != ed25519.PublicKeySize {
+			return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+		}
+		timestamp := strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, "telnyx-timestamp"))
+		signature := strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, "telnyx-signature-ed25519"))
+		if !validRecentUnixTimestamp(timestamp, commWebhookTimestampTolerance) {
+			return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+		}
+		if !verifyTelnyxWebhookSignature(publicKey, timestamp, ctx.Request.Body, signature) {
+			return apptheory.NewAppTheoryError("comm.unauthorized", "unauthorized").WithStatusCode(http.StatusUnauthorized)
+		}
+		return nil
+	}
+	return s.requireCommWebhookAdapterAuth(ctx)
+}
+
+func hasTelnyxSignatureHeaders(ctx *apptheory.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	return strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, "telnyx-timestamp")) != "" ||
+		strings.TrimSpace(httpx.FirstHeaderValue(ctx.Request.Headers, "telnyx-signature-ed25519")) != ""
+}
+
+func (s *Server) loadCommWebhookSharedSecret(ctx context.Context) (string, error) {
+	if s == nil || s.ssmGetParameter == nil {
+		return "", fmt.Errorf("ssm getter is not configured")
+	}
+	param := strings.TrimSpace(s.cfg.CommWebhookSharedSecretSSMParam)
+	if param == "" {
+		return "", fmt.Errorf("comm webhook secret parameter is not configured")
+	}
+	return s.ssmGetParameter(ctx, param)
+}
+
+func (s *Server) loadTelnyxWebhookPublicKey(ctx context.Context) ([]byte, error) {
+	if s == nil {
+		return nil, fmt.Errorf("server is nil")
+	}
+	if key, err := decodeEd25519PublicKey(s.cfg.TelnyxWebhookPublicKey); err == nil {
+		return key, nil
+	}
+	if s.ssmGetParameter == nil {
+		return nil, fmt.Errorf("ssm getter is not configured")
+	}
+	raw, err := s.ssmGetParameter(ctx, hostsecrets.TelnyxAPITokenSSMParameterName)
+	if err != nil {
+		return nil, err
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &obj); err != nil {
+		return nil, err
+	}
+	for _, key := range []string{"webhook_public_key", "webhookPublicKey", "public_key", "publicKey"} {
+		if value, ok := obj[key].(string); ok {
+			return decodeEd25519PublicKey(value)
+		}
+	}
+	return nil, fmt.Errorf("telnyx webhook public key is not configured")
+}
+
+func verifyHMACWebhookSignature(secret string, timestamp string, body []byte, signature string) bool {
+	secret = strings.TrimSpace(secret)
+	signature = strings.TrimSpace(signature)
+	if strings.HasPrefix(strings.ToLower(signature), "sha256=") {
+		signature = strings.TrimSpace(signature[len("sha256="):])
+	}
+	if secret == "" || timestamp == "" || signature == "" {
+		return false
+	}
+	got, err := hex.DecodeString(signature)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(timestamp))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	want := mac.Sum(nil)
+	return hmac.Equal(got, want)
+}
+
+func verifyTelnyxWebhookSignature(publicKey ed25519.PublicKey, timestamp string, body []byte, signature string) bool {
+	if len(publicKey) != ed25519.PublicKeySize || strings.TrimSpace(timestamp) == "" || strings.TrimSpace(signature) == "" {
+		return false
+	}
+	sig, err := base64.StdEncoding.DecodeString(strings.TrimSpace(signature))
+	if err != nil || len(sig) != ed25519.SignatureSize {
+		return false
+	}
+	payload := append([]byte(strings.TrimSpace(timestamp)+"|"), body...)
+	return ed25519.Verify(publicKey, payload, sig)
+}
+
+func validRecentUnixTimestamp(raw string, tolerance time.Duration) bool {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return false
+	}
+	sec, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return false
+	}
+	ts := time.Unix(sec, 0)
+	now := time.Now()
+	if ts.After(now.Add(tolerance)) {
+		return false
+	}
+	return now.Sub(ts) <= tolerance
+}
+
+func decodeEd25519PublicKey(raw string) (ed25519.PublicKey, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, fmt.Errorf("empty public key")
+	}
+	if decoded, err := base64.StdEncoding.DecodeString(raw); err == nil && len(decoded) == ed25519.PublicKeySize {
+		return ed25519.PublicKey(decoded), nil
+	}
+	decoded, err := hex.DecodeString(raw)
+	if err != nil || len(decoded) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("invalid ed25519 public key")
+	}
+	return ed25519.PublicKey(decoded), nil
+}

--- a/internal/controlplane/deps_http_internal_test.go
+++ b/internal/controlplane/deps_http_internal_test.go
@@ -215,7 +215,7 @@ func handleTelnyxVoiceCallRequest(t *testing.T, w http.ResponseWriter, r *http.R
 		t.Fatalf("unexpected StatusCallback: %q", got)
 	}
 	w.WriteHeader(http.StatusAccepted)
-	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"call_control_id": "call-control-1"}})
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"call_control_id": commVoiceCallControlID}})
 }
 
 type smtpCapture struct {
@@ -405,7 +405,7 @@ func TestDefaultTelnyxCreateVoiceCall(t *testing.T) {
 		t.Fatalf("expected validation error for empty sender")
 	}
 	callID, err := defaultTelnyxCreateVoiceCall(context.Background(), "+15551234567", "+15557654321", "https://lab.lesser.host/webhooks/comm/voice/texml/comm-msg-1", "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-1")
-	if err != nil || callID != "call-control-1" {
+	if err != nil || callID != commVoiceCallControlID {
 		t.Fatalf("create voice call: id=%q err=%v", callID, err)
 	}
 }

--- a/internal/controlplane/deps_http_internal_test.go
+++ b/internal/controlplane/deps_http_internal_test.go
@@ -426,8 +426,8 @@ func TestDefaultMigaduCreateMailbox_SuccessConflictAndErrors(t *testing.T) {
 	if err := defaultMigaduCreateMailbox(context.Background(), "agent", "", "pw"); err != nil {
 		t.Fatalf("create mailbox: %v", err)
 	}
-	if err := defaultMigaduCreateMailbox(context.Background(), "exists", "Agent", "pw"); err != nil {
-		t.Fatalf("expected conflict to be treated as success: %v", err)
+	if err := defaultMigaduCreateMailbox(context.Background(), "exists", "Agent", "pw"); err == nil {
+		t.Fatalf("expected mailbox conflict to fail closed")
 	}
 	if err := defaultMigaduCreateMailbox(context.Background(), "broken", "Agent", "pw"); err == nil {
 		t.Fatalf("expected server error")

--- a/internal/controlplane/deps_migadu.go
+++ b/internal/controlplane/deps_migadu.go
@@ -87,9 +87,12 @@ func defaultMigaduCreateMailbox(ctx context.Context, localPart string, name stri
 	}
 	defer resp.Body.Close()
 
-	// Migadu returns 201 Created on success, and typically 409 Conflict if the mailbox already exists.
+	// Migadu returns 201 Created on success. A 409 Conflict means the mailbox
+	// belongs to an existing provider-side resource and must not be treated as
+	// success; doing so would let a later forwarding call mutate a mailbox this
+	// agent did not create.
 	switch resp.StatusCode {
-	case http.StatusOK, http.StatusCreated, http.StatusConflict:
+	case http.StatusOK, http.StatusCreated:
 		return nil
 	}
 

--- a/internal/controlplane/handlers_comm_voice_outbound.go
+++ b/internal/controlplane/handlers_comm_voice_outbound.go
@@ -191,6 +191,9 @@ func (s *Server) handleCommVoiceGatherWebhook(ctx *apptheory.Context) (*apptheor
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
 	}
+	if authErr := s.requireTelnyxCommWebhookAuth(ctx); authErr != nil {
+		return nil, authErr
+	}
 
 	messageID := strings.TrimSpace(ctx.Param("messageId"))
 	if messageID == "" {

--- a/internal/controlplane/handlers_comm_voice_outbound.go
+++ b/internal/controlplane/handlers_comm_voice_outbound.go
@@ -480,10 +480,19 @@ func (s *Server) updateOutboundVoiceStatusFromWebhook(ctx *apptheory.Context, me
 	if err != nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	if strings.TrimSpace(statusItem.MessageID) == "" {
+		statusItem.MessageID = messageID
+	}
 
-	_, to, callID, _, durationSeconds := extractTelnyxVoiceFields(tel)
+	from, to, callID, _, durationSeconds := extractTelnyxVoiceFields(tel)
 	if durationSeconds > 0 {
-		_ = s.meterTelnyxVoiceCall(ctx, to, callID, durationSeconds)
+		if err := s.validateOutboundVoiceBillingSource(ctx, &statusItem, from, to); err != nil {
+			return err
+		}
+		billingCallID := outboundVoiceBillingCallID(messageID, callID, tel.Data.EventType)
+		if err := s.meterOutboundTelnyxVoiceCall(ctx, &statusItem, billingCallID, durationSeconds); err != nil {
+			return &apptheory.AppError{Code: "app.internal", Message: "failed to meter voice call"}
+		}
 	}
 
 	nextStatus, errorCode, errorMessage, shouldUpdate := mapTelnyxVoiceEventToSoulStatus(strings.TrimSpace(tel.Data.EventType), durationSeconds, strings.TrimSpace(statusItem.Status))
@@ -503,6 +512,40 @@ func (s *Server) updateOutboundVoiceStatusFromWebhook(ctx *apptheory.Context, me
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	return nil
+}
+
+func (s *Server) validateOutboundVoiceBillingSource(ctx *apptheory.Context, statusItem *models.SoulCommMessageStatus, fromNumber string, toNumber string) error {
+	if statusItem == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	instruction, ok, err := s.loadSoulCommVoiceInstruction(ctx, statusItem.MessageID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	_ = instruction.UpdateKeys()
+	expectedAgentID := strings.ToLower(strings.TrimSpace(statusItem.AgentID))
+	if !strings.EqualFold(strings.TrimSpace(instruction.AgentID), expectedAgentID) {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
+	}
+	if strings.TrimSpace(fromNumber) != "" && normalizeCommPhoneE164(fromNumber) != normalizeCommPhoneE164(instruction.From) {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
+	}
+	if strings.TrimSpace(toNumber) != "" && normalizeCommPhoneE164(toNumber) != normalizeCommPhoneE164(instruction.To) {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
+	}
+	return nil
+}
+
+func outboundVoiceBillingCallID(messageID string, callID string, eventType string) string {
+	callID = strings.TrimSpace(callID)
+	eventType = strings.TrimSpace(eventType)
+	if callID == "" || (eventType != "" && strings.EqualFold(callID, eventType)) {
+		return strings.TrimSpace(messageID)
+	}
+	return callID
 }
 
 func mapTelnyxVoiceEventToSoulStatus(eventType string, durationSeconds int64, currentStatus string) (status string, errorCode string, errorMessage string, shouldUpdate bool) {

--- a/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
+++ b/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
@@ -24,6 +24,7 @@ import (
 const (
 	commVoiceReplyBody      = "Yes, please call back tomorrow."
 	commVoiceReplyMessageID = "comm-msg-1-reply-call-1"
+	commVoiceCallControlID  = "call-control-1"
 )
 
 func voiceInstructionFixture() models.SoulCommVoiceInstruction {
@@ -459,7 +460,7 @@ func TestMaybeHandleOutboundVoiceStatusWebhook(t *testing.T) {
 			"data": map[string]any{
 				"event_type": "call.answered",
 				"payload": map[string]any{
-					"call_control_id": "call-control-1",
+					"call_control_id": commVoiceCallControlID,
 				},
 			},
 		})
@@ -482,6 +483,105 @@ func TestMaybeHandleOutboundVoiceStatusWebhook(t *testing.T) {
 			t.Fatalf("expected 200 response, got %#v", resp)
 		}
 	})
+}
+
+func TestMaybeHandleOutboundVoiceStatusWebhook_BillsOutboundExternalRecipient(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDBStrict()
+	qStatus := new(ttmocks.MockQuery)
+	qVoice := new(ttmocks.MockQuery)
+	qBudget := new(ttmocks.MockQuery)
+	tx := new(ttmocks.MockTransactionBuilder)
+	db.TransactWriteBuilder = tx
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(qStatus).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(qVoice).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(qBudget).Maybe()
+	for _, q := range []*ttmocks.MockQuery{qStatus, qVoice, qBudget} {
+		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	}
+	qStatus.On("IfExists").Return(qStatus).Maybe()
+	qStatus.On("Update", mock.Anything).Return(nil).Twice()
+	qBudget.On("ConsistentRead").Return(qBudget).Maybe()
+
+	status := models.SoulCommMessageStatus{
+		MessageID:    "comm-msg-voice",
+		InstanceSlug: commWebhookTestInstanceSlug,
+		AgentID:      "0xabc",
+		ChannelType:  commChannelVoice,
+		To:           "+15557654321",
+		Provider:     commDeliveryProviderTelnyx,
+		Status:       models.SoulCommMessageStatusAccepted,
+		CreatedAt:    time.Now().UTC(),
+		UpdatedAt:    time.Now().UTC(),
+	}
+	qStatus.On("First", mock.AnythingOfType("*models.SoulCommMessageStatus")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommMessageStatus](t, args, 0)
+		*dest = status
+	}).Twice()
+	qVoice.On("First", mock.AnythingOfType("*models.SoulCommVoiceInstruction")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCommVoiceInstruction](t, args, 0)
+		*dest = models.SoulCommVoiceInstruction{
+			MessageID: status.MessageID,
+			AgentID:   status.AgentID,
+			From:      "+15550142",
+			To:        status.To,
+			Body:      "hello",
+			CreatedAt: time.Now().UTC(),
+			UpdatedAt: time.Now().UTC(),
+		}
+	}).Twice()
+	qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: commWebhookTestInstanceSlug, IncludedCredits: 100, UsedCredits: 0}
+	}).Twice()
+
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(theoryErrors.ErrConditionFailed).Once()
+	tx.On("Create", mock.Anything, mock.Anything).Return(tx).Once().Run(func(args mock.Arguments) {
+		entry := testutil.RequireMockArg[*models.UsageLedgerEntry](t, args, 0)
+		if entry.InstanceSlug != commWebhookTestInstanceSlug || entry.Target != commVoiceCallControlID || entry.RequestID != commVoiceCallControlID {
+			t.Fatalf("unexpected outbound voice ledger identity: %#v", entry)
+		}
+		if entry.ActorURI != "soul_agent:0xabc" || entry.RequestedCredits != 16 || entry.DebitedCredits != 16 {
+			t.Fatalf("unexpected outbound voice ledger accounting: %#v", entry)
+		}
+	})
+	tx.On("UpdateWithBuilder", mock.Anything, mock.Anything, mock.Anything).Return(tx).Once()
+
+	body, err := json.Marshal(map[string]any{
+		"data": map[string]any{
+			"event_type": "call.hangup",
+			"payload": map[string]any{
+				"from":             "+15550142",
+				"to":               "+15557654321",
+				"call_control_id":  commVoiceCallControlID,
+				"duration_seconds": 61,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	s := &Server{store: store.New(db)}
+	for i := 0; i < 2; i++ {
+		resp, handled, callErr := s.maybeHandleOutboundVoiceStatusWebhook(&apptheory.Context{
+			Params:  map[string]string{"messageId": status.MessageID},
+			Request: apptheory.Request{Body: body},
+		})
+		if callErr != nil {
+			t.Fatalf("callback %d unexpected err: %v", i+1, callErr)
+		}
+		if !handled || resp == nil || resp.Status != http.StatusOK {
+			t.Fatalf("callback %d expected handled 200, got handled=%v resp=%#v", i+1, handled, resp)
+		}
+	}
+
+	db.AssertExpectations(t)
+	tx.AssertExpectations(t)
 }
 
 func TestMapTelnyxVoiceEventToSoulStatus(t *testing.T) {

--- a/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
+++ b/internal/controlplane/handlers_comm_voice_outbound_internal_test.go
@@ -86,11 +86,20 @@ func newVoiceGatherCaptureServer(t *testing.T) (*Server, func() *commworker.Queu
 	var queued *commworker.QueueMessage
 	s := &Server{
 		store: store.New(db),
-		cfg:   config.Config{SoulEnabled: true},
+		cfg: config.Config{
+			SoulEnabled:                     true,
+			CommWebhookSharedSecretSSMParam: "/test/comm/webhook",
+		},
 		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
 			cp := msg
 			queued = &cp
 			return nil
+		},
+		ssmGetParameter: func(_ context.Context, name string) (string, error) {
+			if name != "/test/comm/webhook" {
+				return "", context.Canceled
+			}
+			return commWebhookTestSecret, nil
 		},
 	}
 	return s, func() *commworker.QueueMessage { return queued }
@@ -322,7 +331,7 @@ func TestHandleCommVoiceGatherWebhook_CapturesSpeechReplyAndUpdatesStatus(t *tes
 
 	resp, callErr := s.handleCommVoiceGatherWebhook(&apptheory.Context{
 		Params:  map[string]string{"messageId": "comm-msg-1"},
-		Request: apptheory.Request{Body: body},
+		Request: signedCommWebhookRequest(t, body),
 	})
 	if callErr != nil {
 		t.Fatalf("unexpected err: %v", callErr)
@@ -360,10 +369,19 @@ func TestHandleCommVoiceGatherWebhook_EmptyGatherResultAcknowledges(t *testing.T
 
 	s := &Server{
 		store: store.New(db),
-		cfg:   config.Config{SoulEnabled: true},
+		cfg: config.Config{
+			SoulEnabled:                     true,
+			CommWebhookSharedSecretSSMParam: "/test/comm/webhook",
+		},
 		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
 			t.Fatalf("enqueue should not be called for empty gather result")
 			return nil
+		},
+		ssmGetParameter: func(_ context.Context, name string) (string, error) {
+			if name != "/test/comm/webhook" {
+				return "", context.Canceled
+			}
+			return commWebhookTestSecret, nil
 		},
 	}
 
@@ -378,7 +396,7 @@ func TestHandleCommVoiceGatherWebhook_EmptyGatherResultAcknowledges(t *testing.T
 
 	resp, callErr := s.handleCommVoiceGatherWebhook(&apptheory.Context{
 		Params:  map[string]string{"messageId": "comm-msg-1"},
-		Request: apptheory.Request{Body: body},
+		Request: signedCommWebhookRequest(t, body),
 	})
 	if callErr != nil {
 		t.Fatalf("unexpected err: %v", callErr)

--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -141,18 +141,7 @@ func (s *Server) handleCommSMSInboundWebhook(ctx *apptheory.Context) (*apptheory
 	var notif commworker.InboundNotification
 	if err := httpx.ParseJSON(ctx, &notif); err == nil && strings.TrimSpace(notif.Type) != "" {
 		notif.Channel = commChannelSMS
-		msg := commworker.QueueMessage{
-			Kind:         commworker.QueueMessageKindInbound,
-			Provider:     commDeliveryProviderTelnyx,
-			Notification: notif,
-		}
-		if err := msg.Validate(); err != nil {
-			return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
-		}
-		if err := s.enqueueCommMessage(ctx.Context(), msg); err != nil {
-			return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue"}
-		}
-		return apptheory.JSON(http.StatusOK, map[string]any{"ok": true})
+		return s.enqueueCommInboundWebhook(ctx, notif, commDeliveryProviderTelnyx)
 	}
 
 	// Telnyx webhook payload.
@@ -165,30 +154,21 @@ func (s *Server) handleCommSMSInboundWebhook(ctx *apptheory.Context) (*apptheory
 		return apptheory.JSON(http.StatusOK, map[string]any{"ok": true, "skipped": eventType})
 	}
 
-	from := strings.TrimSpace(tel.Data.Payload.From.PhoneNumber)
-	to := ""
-	if len(tel.Data.Payload.To) > 0 {
-		to = strings.TrimSpace(tel.Data.Payload.To[0].PhoneNumber)
+	msg := telnyxSMSWebhookQueueMessage(tel)
+	if err := msg.Validate(); err != nil {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
 	}
-	body := strings.TrimSpace(tel.Data.Payload.Text)
-	messageID := strings.TrimSpace(tel.Data.Payload.ID)
-	receivedAt := strings.TrimSpace(tel.Data.OccurredAt)
-	if receivedAt == "" {
-		receivedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	if err := s.enqueueCommMessage(ctx.Context(), msg); err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue"}
 	}
+	return apptheory.JSON(http.StatusOK, map[string]any{"ok": true})
+}
 
+func (s *Server) enqueueCommInboundWebhook(ctx *apptheory.Context, notif commworker.InboundNotification, provider string) (*apptheory.Response, error) {
 	msg := commworker.QueueMessage{
-		Kind:     commworker.QueueMessageKindInbound,
-		Provider: commDeliveryProviderTelnyx,
-		Notification: commworker.InboundNotification{
-			Type:       "communication:inbound",
-			Channel:    commChannelSMS,
-			From:       commworker.InboundParty{Number: from},
-			To:         &commworker.InboundParty{Number: to},
-			Body:       body,
-			ReceivedAt: receivedAt,
-			MessageID:  messageID,
-		},
+		Kind:         commworker.QueueMessageKindInbound,
+		Provider:     provider,
+		Notification: notif,
 	}
 	if err := msg.Validate(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid webhook payload"}
@@ -197,6 +177,31 @@ func (s *Server) handleCommSMSInboundWebhook(ctx *apptheory.Context) (*apptheory
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue"}
 	}
 	return apptheory.JSON(http.StatusOK, map[string]any{"ok": true})
+}
+
+func telnyxSMSWebhookQueueMessage(tel telnyxInboundWebhook) commworker.QueueMessage {
+	from := strings.TrimSpace(tel.Data.Payload.From.PhoneNumber)
+	to := ""
+	if len(tel.Data.Payload.To) > 0 {
+		to = strings.TrimSpace(tel.Data.Payload.To[0].PhoneNumber)
+	}
+	receivedAt := strings.TrimSpace(tel.Data.OccurredAt)
+	if receivedAt == "" {
+		receivedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+	return commworker.QueueMessage{
+		Kind:     commworker.QueueMessageKindInbound,
+		Provider: commDeliveryProviderTelnyx,
+		Notification: commworker.InboundNotification{
+			Type:       "communication:inbound",
+			Channel:    commChannelSMS,
+			From:       commworker.InboundParty{Number: from},
+			To:         &commworker.InboundParty{Number: to},
+			Body:       strings.TrimSpace(tel.Data.Payload.Text),
+			ReceivedAt: receivedAt,
+			MessageID:  strings.TrimSpace(tel.Data.Payload.ID),
+		},
+	}
 }
 
 func (s *Server) handleCommVoiceInboundWebhook(ctx *apptheory.Context) (*apptheory.Response, error) {

--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -10,6 +10,7 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/billing"
 	"github.com/equaltoai/lesser-host/internal/commworker"
@@ -441,8 +442,8 @@ func (s *Server) meterTelnyxVoiceCall(ctx *apptheory.Context, toNumber string, c
 	}
 	_ = updateBudget.UpdateKeys()
 
-	return s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
-		tx.Put(ledger)
+	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+		tx.Create(ledger)
 		tx.UpdateWithBuilder(updateBudget, func(ub core.UpdateBuilder) error {
 			ub.Add("UsedCredits", credits)
 			ub.Set("UpdatedAt", now)
@@ -450,6 +451,10 @@ func (s *Server) meterTelnyxVoiceCall(ctx *apptheory.Context, toNumber string, c
 		}, tabletheory.IfExists())
 		return nil
 	})
+	if theoryErrors.IsConditionFailed(err) {
+		return nil
+	}
+	return err
 }
 
 func (s *Server) resolveTelnyxVoiceBudget(ctx *apptheory.Context, toNumber string) (string, string, models.InstanceBudgetMonth, time.Time, error) {

--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -62,6 +62,9 @@ func (s *Server) handleCommEmailInboundWebhook(ctx *apptheory.Context) (*apptheo
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
 	}
+	if authErr := s.requireCommWebhookAdapterAuth(ctx); authErr != nil {
+		return nil, authErr
+	}
 
 	// Prefer the stable communication:inbound payload shape.
 	var notif commworker.InboundNotification
@@ -128,6 +131,9 @@ func (s *Server) handleCommSMSInboundWebhook(ctx *apptheory.Context) (*apptheory
 	}
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
+	}
+	if authErr := s.requireTelnyxCommWebhookAuth(ctx); authErr != nil {
+		return nil, authErr
 	}
 
 	// Accept already-normalized communication:inbound payloads.
@@ -199,6 +205,9 @@ func (s *Server) handleCommVoiceInboundWebhook(ctx *apptheory.Context) (*apptheo
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
 	}
+	if authErr := s.requireTelnyxCommWebhookAuth(ctx); authErr != nil {
+		return nil, authErr
+	}
 
 	// Accept already-normalized communication:inbound payloads.
 	var notif commworker.InboundNotification
@@ -251,6 +260,9 @@ func (s *Server) handleCommVoiceStatusWebhook(ctx *apptheory.Context) (*apptheor
 	}
 	if !s.cfg.SoulEnabled {
 		return apptheory.JSON(http.StatusNotFound, map[string]any{"ok": false})
+	}
+	if authErr := s.requireTelnyxCommWebhookAuth(ctx); authErr != nil {
+		return nil, authErr
 	}
 	if resp, handled, err := s.maybeHandleOutboundVoiceStatusWebhook(ctx); handled || err != nil {
 		return resp, err

--- a/internal/controlplane/handlers_comm_webhooks.go
+++ b/internal/controlplane/handlers_comm_webhooks.go
@@ -406,8 +406,42 @@ func (s *Server) meterTelnyxVoiceCall(ctx *apptheory.Context, toNumber string, c
 	if err != nil {
 		return nil
 	}
-	month := now.Format("2006-01")
+	return s.meterTelnyxVoiceUsage(ctx, agentID, instanceSlug, budget, now, callID, durationSeconds)
+}
 
+func (s *Server) meterOutboundTelnyxVoiceCall(ctx *apptheory.Context, statusItem *models.SoulCommMessageStatus, callID string, durationSeconds int64) error {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
+		return fmt.Errorf("store not initialized")
+	}
+	if statusItem == nil || strings.TrimSpace(callID) == "" || durationSeconds <= 0 {
+		return nil
+	}
+	statusCopy := *statusItem
+	_ = statusCopy.UpdateKeys()
+	if statusCopy.ChannelType != commChannelVoice {
+		return fmt.Errorf("outbound voice status has channel %q", statusCopy.ChannelType)
+	}
+	if statusCopy.Provider != "" && statusCopy.Provider != commDeliveryProviderTelnyx {
+		return fmt.Errorf("outbound voice status has provider %q", statusCopy.Provider)
+	}
+	if strings.TrimSpace(statusCopy.AgentID) == "" || strings.TrimSpace(statusCopy.InstanceSlug) == "" {
+		return fmt.Errorf("outbound voice status missing billable identity")
+	}
+	budget, now, err := s.loadTelnyxVoiceBudgetMonth(ctx, statusCopy.InstanceSlug)
+	if err != nil {
+		return err
+	}
+	return s.meterTelnyxVoiceUsage(ctx, statusCopy.AgentID, statusCopy.InstanceSlug, budget, now, callID, durationSeconds)
+}
+
+func (s *Server) meterTelnyxVoiceUsage(ctx *apptheory.Context, agentID string, instanceSlug string, budget models.InstanceBudgetMonth, now time.Time, callID string, durationSeconds int64) error {
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	instanceSlug = strings.TrimSpace(instanceSlug)
+	callID = strings.TrimSpace(callID)
+	if agentID == "" || instanceSlug == "" || callID == "" || durationSeconds <= 0 {
+		return nil
+	}
+	month := now.Format("2006-01")
 	minutes := (durationSeconds + 59) / 60
 	if minutes <= 0 {
 		return nil
@@ -447,7 +481,7 @@ func (s *Server) meterTelnyxVoiceCall(ctx *apptheory.Context, toNumber string, c
 	}
 	_ = updateBudget.UpdateKeys()
 
-	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+	err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
 		tx.Create(ledger)
 		tx.UpdateWithBuilder(updateBudget, func(ub core.UpdateBuilder) error {
 			ub.Add("UsedCredits", credits)
@@ -492,16 +526,30 @@ func (s *Server) resolveTelnyxVoiceBudget(ctx *apptheory.Context, toNumber strin
 		return "", "", budget, now, err
 	}
 
+	budget, now, err = s.loadTelnyxVoiceBudgetMonth(ctx, instanceSlug)
+	if err != nil {
+		return "", "", budget, now, err
+	}
+
+	return agentID, instanceSlug, budget, now, nil
+}
+
+func (s *Server) loadTelnyxVoiceBudgetMonth(ctx *apptheory.Context, instanceSlug string) (models.InstanceBudgetMonth, time.Time, error) {
+	var budget models.InstanceBudgetMonth
+	now := time.Now().UTC()
+	instanceSlug = strings.TrimSpace(instanceSlug)
+	if instanceSlug == "" {
+		return budget, now, fmt.Errorf("instance slug is required")
+	}
 	if err := s.store.DB.WithContext(ctx.Context()).
 		Model(&models.InstanceBudgetMonth{}).
 		Where("PK", "=", fmt.Sprintf("INSTANCE#%s", instanceSlug)).
 		Where("SK", "=", fmt.Sprintf("BUDGET#%s", now.Format("2006-01"))).
 		ConsistentRead().
 		First(&budget); err != nil {
-		return "", "", budget, now, err
+		return budget, now, err
 	}
-
-	return agentID, instanceSlug, budget, now, nil
+	return budget, now, nil
 }
 
 func (s *Server) loadTelnyxVoiceInstanceSlug(ctx *apptheory.Context, identity *models.SoulAgentIdentity) (string, error) {

--- a/internal/controlplane/handlers_comm_webhooks_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_internal_test.go
@@ -9,21 +9,17 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 
 	"github.com/equaltoai/lesser-host/internal/commworker"
-	"github.com/equaltoai/lesser-host/internal/config"
 )
 
 func TestHandleCommEmailInboundWebhook_EnqueuesNormalizedPayload(t *testing.T) {
 	t.Parallel()
 
 	var got *commworker.QueueMessage
-	s := &Server{
-		cfg: config.Config{SoulEnabled: true},
-		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
-			cp := msg
-			got = &cp
-			return nil
-		},
-	}
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		cp := msg
+		got = &cp
+		return nil
+	})
 
 	body, _ := json.Marshal(commworker.InboundNotification{
 		Type:    "communication:inbound",
@@ -41,7 +37,7 @@ func TestHandleCommEmailInboundWebhook_EnqueuesNormalizedPayload(t *testing.T) {
 
 	ctx := &apptheory.Context{
 		RequestID: "r-webhook-email-1",
-		Request:   apptheory.Request{Body: body},
+		Request:   signedCommWebhookRequest(t, body),
 	}
 
 	resp, err := s.handleCommEmailInboundWebhook(ctx)
@@ -63,14 +59,11 @@ func TestHandleCommEmailInboundWebhook_EnqueuesLegacyFlatPayload(t *testing.T) {
 	t.Parallel()
 
 	var got *commworker.QueueMessage
-	s := &Server{
-		cfg: config.Config{SoulEnabled: true},
-		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
-			cp := msg
-			got = &cp
-			return nil
-		},
-	}
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		cp := msg
+		got = &cp
+		return nil
+	})
 
 	body, _ := json.Marshal(map[string]any{
 		"to":         "agent-bob@lessersoul.ai",
@@ -84,7 +77,7 @@ func TestHandleCommEmailInboundWebhook_EnqueuesLegacyFlatPayload(t *testing.T) {
 
 	ctx := &apptheory.Context{
 		RequestID: "r-webhook-email-2",
-		Request:   apptheory.Request{Body: body},
+		Request:   signedCommWebhookRequest(t, body),
 	}
 
 	resp, err := s.handleCommEmailInboundWebhook(ctx)
@@ -109,14 +102,11 @@ func TestHandleCommSMSInboundWebhook_EnqueuesTelnyxPayload(t *testing.T) {
 	t.Parallel()
 
 	var got *commworker.QueueMessage
-	s := &Server{
-		cfg: config.Config{SoulEnabled: true},
-		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
-			cp := msg
-			got = &cp
-			return nil
-		},
-	}
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		cp := msg
+		got = &cp
+		return nil
+	})
 
 	body, _ := json.Marshal(map[string]any{
 		"data": map[string]any{
@@ -133,7 +123,7 @@ func TestHandleCommSMSInboundWebhook_EnqueuesTelnyxPayload(t *testing.T) {
 
 	ctx := &apptheory.Context{
 		RequestID: "r-webhook-sms-1",
-		Request:   apptheory.Request{Body: body},
+		Request:   signedCommWebhookRequest(t, body),
 	}
 
 	resp, err := s.handleCommSMSInboundWebhook(ctx)
@@ -158,14 +148,11 @@ func TestHandleCommVoiceInboundWebhook_EnqueuesTelnyxPayload(t *testing.T) {
 	t.Parallel()
 
 	var got *commworker.QueueMessage
-	s := &Server{
-		cfg: config.Config{SoulEnabled: true},
-		enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
-			cp := msg
-			got = &cp
-			return nil
-		},
-	}
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		cp := msg
+		got = &cp
+		return nil
+	})
 
 	body, _ := json.Marshal(map[string]any{
 		"data": map[string]any{
@@ -182,7 +169,7 @@ func TestHandleCommVoiceInboundWebhook_EnqueuesTelnyxPayload(t *testing.T) {
 
 	ctx := &apptheory.Context{
 		RequestID: "r-webhook-voice-1",
-		Request:   apptheory.Request{Body: body},
+		Request:   signedCommWebhookRequest(t, body),
 	}
 
 	resp, err := s.handleCommVoiceInboundWebhook(ctx)

--- a/internal/controlplane/handlers_comm_webhooks_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_internal_test.go
@@ -67,7 +67,7 @@ func TestHandleCommEmailInboundWebhook_EnqueuesLegacyFlatPayload(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]any{
 		"to":         "agent-bob@lessersoul.ai",
-		"from":       "alice@example.com",
+		"from":       commSendTestEmailRecipient,
 		"fromName":   "Alice",
 		"subject":    "Hello",
 		"body":       "Test",
@@ -93,7 +93,7 @@ func TestHandleCommEmailInboundWebhook_EnqueuesLegacyFlatPayload(t *testing.T) {
 	if got.Notification.To == nil || got.Notification.To.Address != "agent-bob@lessersoul.ai" {
 		t.Fatalf("expected to address, got %#v", got.Notification.To)
 	}
-	if got.Notification.From.Address != "alice@example.com" {
+	if got.Notification.From.Address != commSendTestEmailRecipient {
 		t.Fatalf("expected from address, got %#v", got.Notification.From)
 	}
 }

--- a/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
@@ -2,8 +2,14 @@ package controlplane
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -53,6 +59,7 @@ const (
 	commWebhookFailedToEnqueue  = "failed to enqueue"
 	commWebhookCallHangup       = "call.hangup"
 	commWebhookTestInstanceSlug = "inst1"
+	commWebhookTestSecret       = "test-webhook-secret"
 )
 
 type commWebhookHandler func(*Server, *apptheory.Context) (*apptheory.Response, error)
@@ -73,6 +80,24 @@ func TestHandleCommEmailInboundWebhook_MissingQueueReturnsInternal(t *testing.T)
 	requireWebhookAppError(t, err, appErrCodeInternal, "internal error")
 }
 
+func TestHandleCommEmailInboundWebhook_RejectsUnsignedPayload(t *testing.T) {
+	t.Parallel()
+
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		t.Fatalf("enqueue should not be called for unsigned payload: %#v", msg)
+		return nil
+	})
+	body := marshalCommWebhookBody(t, commworker.InboundNotification{
+		Type:      "communication:inbound",
+		Channel:   "email",
+		From:      commworker.InboundParty{Address: "alice@example.com"},
+		To:        &commworker.InboundParty{Address: "agent@lessersoul.ai"},
+		MessageID: "msg-unsigned",
+	})
+	_, err := s.handleCommEmailInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	requireWebhookAppError(t, err, "comm.unauthorized", "unauthorized")
+}
+
 func TestHandleCommEmailInboundWebhook_InvalidNormalizedPayloadRejected(t *testing.T) {
 	t.Parallel()
 
@@ -87,7 +112,7 @@ func TestHandleCommEmailInboundWebhook_InvalidNormalizedPayloadRejected(t *testi
 		"receivedAt": commWebhookReceivedAt,
 		"messageId":  "msg-1",
 	})
-	_, err := s.handleCommEmailInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	_, err := s.handleCommEmailInboundWebhook(signedCommWebhookCtx(t, body))
 	requireWebhookAppError(t, err, appErrCodeBadRequest, "invalid webhook payload")
 }
 
@@ -107,7 +132,7 @@ func TestHandleCommEmailInboundWebhook_LegacyPayloadDefaultsReceivedAt(t *testin
 		"body":      "Test",
 		"messageId": "comm-msg-legacy",
 	})
-	resp, err := s.handleCommEmailInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	resp, err := s.handleCommEmailInboundWebhook(signedCommWebhookCtx(t, body))
 	requireCommWebhookOK(t, resp, err)
 	if got == nil {
 		t.Fatalf("expected queued message")
@@ -131,7 +156,7 @@ func TestHandleCommEmailInboundWebhook_EnqueueFailureReturnsInternal(t *testing.
 		ReceivedAt: commWebhookReceivedAt,
 		MessageID:  "msg-2",
 	})
-	_, err := s.handleCommEmailInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	_, err := s.handleCommEmailInboundWebhook(signedCommWebhookCtx(t, body))
 	requireWebhookAppError(t, err, appErrCodeInternal, commWebhookFailedToEnqueue)
 }
 
@@ -159,11 +184,84 @@ func TestHandleCommSMSInboundWebhook_NormalizesPayload(t *testing.T) {
 	}, "sms")
 }
 
+func TestHandleCommSMSInboundWebhook_AcceptsValidTelnyxSignature(t *testing.T) {
+	t.Parallel()
+
+	var got *commworker.QueueMessage
+	s, privateKey := newTelnyxWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		cp := msg
+		got = &cp
+		return nil
+	})
+	body := marshalCommWebhookBody(t, map[string]any{
+		"data": map[string]any{
+			"event_type": "message.received",
+			"payload": map[string]any{
+				"id":   "telnyx-msg-signed",
+				"text": "Hello",
+				"from": map[string]any{"phone_number": "+15550142"},
+				"to":   []map[string]any{{"phone_number": "+15550143"}},
+			},
+		},
+	})
+	resp, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: signedTelnyxWebhookRequest(t, privateKey, body, time.Now())})
+	requireCommWebhookOK(t, resp, err)
+	if got == nil || got.Notification.MessageID != "telnyx-msg-signed" {
+		t.Fatalf("expected signed Telnyx notification, got %#v", got)
+	}
+}
+
+func TestHandleCommSMSInboundWebhook_RejectsInvalidTelnyxSignature(t *testing.T) {
+	t.Parallel()
+
+	s, privateKey := newTelnyxWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		t.Fatalf("enqueue should not be called for invalid signature: %#v", msg)
+		return nil
+	})
+	body := marshalCommWebhookBody(t, map[string]any{
+		"data": map[string]any{
+			"event_type": "message.received",
+			"payload": map[string]any{
+				"id":   "telnyx-msg-invalid",
+				"text": "Hello",
+				"from": map[string]any{"phone_number": "+15550142"},
+				"to":   []map[string]any{{"phone_number": "+15550143"}},
+			},
+		},
+	})
+	req := signedTelnyxWebhookRequest(t, privateKey, body, time.Now())
+	req.Body = append([]byte(`{"tampered":true}`), body...)
+	_, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: req})
+	requireWebhookAppError(t, err, "comm.unauthorized", "unauthorized")
+}
+
+func TestHandleCommSMSInboundWebhook_RejectsStaleSignature(t *testing.T) {
+	t.Parallel()
+
+	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+		t.Fatalf("enqueue should not be called for stale signature: %#v", msg)
+		return nil
+	})
+	body := marshalCommWebhookBody(t, map[string]any{
+		"data": map[string]any{
+			"event_type": "message.received",
+			"payload": map[string]any{
+				"id":   "telnyx-msg-stale",
+				"text": "Hello",
+				"from": map[string]any{"phone_number": "+15550142"},
+				"to":   []map[string]any{{"phone_number": "+15550143"}},
+			},
+		},
+	})
+	_, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: signedCommWebhookRequestAt(t, body, time.Now().Add(-10*time.Minute))})
+	requireWebhookAppError(t, err, "comm.unauthorized", "unauthorized")
+}
+
 func TestHandleCommSMSInboundWebhook_InvalidPayloadRejected(t *testing.T) {
 	t.Parallel()
 
 	s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error { return nil })
-	_, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: []byte("{")}})
+	_, err := s.handleCommSMSInboundWebhook(signedCommWebhookCtx(t, []byte("{")))
 	requireWebhookAppError(t, err, appErrCodeBadRequest, "invalid webhook payload")
 }
 
@@ -184,7 +282,7 @@ func TestHandleCommSMSInboundWebhook_EnqueueFailureReturnsInternal(t *testing.T)
 			},
 		},
 	})
-	_, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	_, err := s.handleCommSMSInboundWebhook(signedCommWebhookCtx(t, body))
 	requireWebhookAppError(t, err, appErrCodeInternal, commWebhookFailedToEnqueue)
 }
 
@@ -207,7 +305,7 @@ func TestHandleCommSMSInboundWebhook_SkipsNonInboundTelnyxEvents(t *testing.T) {
 		},
 	})
 
-	resp, err := s.handleCommSMSInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	resp, err := s.handleCommSMSInboundWebhook(signedCommWebhookCtx(t, body))
 	requireCommWebhookOK(t, resp, err)
 
 	var got map[string]any
@@ -253,7 +351,7 @@ func TestHandleCommVoiceInboundWebhook_TelnyxFallbackCallIDAndReceivedAt(t *test
 			},
 		},
 	})
-	resp, err := s.handleCommVoiceInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	resp, err := s.handleCommVoiceInboundWebhook(signedCommWebhookCtx(t, body))
 	requireCommWebhookOK(t, resp, err)
 	if got == nil {
 		t.Fatalf("expected queued message")
@@ -274,7 +372,7 @@ func TestHandleCommVoiceInboundWebhook_InvalidTelnyxPayloadRejected(t *testing.T
 			"payload":    map[string]any{},
 		},
 	})
-	_, err := s.handleCommVoiceInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	_, err := s.handleCommVoiceInboundWebhook(signedCommWebhookCtx(t, body))
 	requireWebhookAppError(t, err, appErrCodeBadRequest, "invalid webhook payload")
 }
 
@@ -293,7 +391,7 @@ func TestHandleCommVoiceInboundWebhook_EnqueueFailureReturnsInternal(t *testing.
 		ReceivedAt: commWebhookReceivedAt,
 		MessageID:  "voice-msg-2",
 	})
-	_, err := s.handleCommVoiceInboundWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+	_, err := s.handleCommVoiceInboundWebhook(signedCommWebhookCtx(t, body))
 	requireWebhookAppError(t, err, appErrCodeInternal, commWebhookFailedToEnqueue)
 }
 
@@ -318,14 +416,11 @@ func TestHandleCommVoiceStatusWebhook_DelegatesAndDisabled(t *testing.T) {
 
 	t.Run("delegates to inbound handler", func(t *testing.T) {
 		var got *commworker.QueueMessage
-		s := &Server{
-			cfg: config.Config{SoulEnabled: true},
-			enqueueCommMessage: func(_ context.Context, msg commworker.QueueMessage) error {
-				cp := msg
-				got = &cp
-				return nil
-			},
-		}
+		s := newCommWebhookServer(func(_ context.Context, msg commworker.QueueMessage) error {
+			cp := msg
+			got = &cp
+			return nil
+		})
 		body, _ := json.Marshal(commworker.InboundNotification{
 			Type:       "communication:inbound",
 			Channel:    "voice",
@@ -335,7 +430,7 @@ func TestHandleCommVoiceStatusWebhook_DelegatesAndDisabled(t *testing.T) {
 			ReceivedAt: commWebhookReceivedAt,
 			MessageID:  "voice-status-1",
 		})
-		resp, err := s.handleCommVoiceStatusWebhook(&apptheory.Context{Request: apptheory.Request{Body: body}})
+		resp, err := s.handleCommVoiceStatusWebhook(signedCommWebhookCtx(t, body))
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
@@ -597,8 +692,65 @@ func assertNotFound() error {
 
 func newCommWebhookServer(enqueue func(context.Context, commworker.QueueMessage) error) *Server {
 	return &Server{
-		cfg:                config.Config{SoulEnabled: true},
+		cfg:                config.Config{SoulEnabled: true, CommWebhookSharedSecretSSMParam: "/test/comm/webhook"},
 		enqueueCommMessage: enqueue,
+		ssmGetParameter: func(_ context.Context, name string) (string, error) {
+			if name != "/test/comm/webhook" {
+				return "", context.Canceled
+			}
+			return commWebhookTestSecret, nil
+		},
+	}
+}
+
+func newTelnyxWebhookServer(enqueue func(context.Context, commworker.QueueMessage) error) (*Server, ed25519.PrivateKey) {
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		panic(err)
+	}
+	s := newCommWebhookServer(enqueue)
+	s.cfg.TelnyxWebhookPublicKey = base64.StdEncoding.EncodeToString(publicKey)
+	return s, privateKey
+}
+
+func signedCommWebhookCtx(t *testing.T, body []byte) *apptheory.Context {
+	t.Helper()
+	return &apptheory.Context{Request: signedCommWebhookRequest(t, body)}
+}
+
+func signedCommWebhookRequest(t *testing.T, body []byte) apptheory.Request {
+	t.Helper()
+	return signedCommWebhookRequestAt(t, body, time.Now())
+}
+
+func signedCommWebhookRequestAt(t *testing.T, body []byte, at time.Time) apptheory.Request {
+	t.Helper()
+	ts := strconv.FormatInt(at.Unix(), 10)
+	mac := hmac.New(sha256.New, []byte(commWebhookTestSecret))
+	mac.Write([]byte(ts))
+	mac.Write([]byte("."))
+	mac.Write(body)
+	return apptheory.Request{
+		Body: body,
+		Headers: map[string][]string{
+			"x-lesser-host-timestamp": {ts},
+			"x-lesser-host-signature": {"sha256=" + hex.EncodeToString(mac.Sum(nil))},
+		},
+	}
+}
+
+func signedTelnyxWebhookRequest(t *testing.T, privateKey ed25519.PrivateKey, body []byte, at time.Time) apptheory.Request {
+	t.Helper()
+	ts := strconv.FormatInt(at.Unix(), 10)
+	payload := append([]byte(ts+"|"), body...)
+	return apptheory.Request{
+		Body: body,
+		Headers: map[string][]string{
+			"telnyx-timestamp":         {ts},
+			"telnyx-signature-ed25519": {base64.StdEncoding.EncodeToString(ed25519.Sign(privateKey, payload))},
+			"x-lesser-host-timestamp":  {"ignored"},
+			"x-lesser-host-signature":  {"ignored"},
+		},
 	}
 }
 
@@ -632,7 +784,7 @@ func assertNormalizedCommWebhook(t *testing.T, handler commWebhookHandler, notif
 		got = &cp
 		return nil
 	})
-	resp, err := handler(s, &apptheory.Context{Request: apptheory.Request{Body: marshalCommWebhookBody(t, notification)}})
+	resp, err := handler(s, signedCommWebhookCtx(t, marshalCommWebhookBody(t, notification)))
 	requireCommWebhookOK(t, resp, err)
 	if got == nil || got.Notification.Channel != wantChannel || got.Provider != "telnyx" {
 		t.Fatalf("expected normalized %s notification, got %#v", wantChannel, got)
@@ -654,6 +806,12 @@ func requireCommWebhookOK(t *testing.T, resp *apptheory.Response, err error) {
 
 func requireWebhookAppError(t *testing.T, err error, code string, message string) {
 	t.Helper()
+	if appErr, ok := apptheory.AsAppTheoryError(err); ok {
+		if appErr.Code != code || appErr.Message != message {
+			t.Fatalf("expected %s %q, got %v", code, message, appErr)
+		}
+		return
+	}
 	appErr := requireAppError(t, err)
 	if appErr.Code != code || appErr.Message != message {
 		t.Fatalf("expected %s %q, got %v", code, message, appErr)

--- a/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
@@ -58,11 +58,105 @@ const (
 	commWebhookReceivedAt       = "2026-03-05T12:00:00Z"
 	commWebhookFailedToEnqueue  = "failed to enqueue"
 	commWebhookCallHangup       = "call.hangup"
+	commWebhookJSONContentType  = "application/json"
+	commWebhookSecretSSMParam   = "/test/comm/webhook"
 	commWebhookTestInstanceSlug = "inst1"
 	commWebhookTestSecret       = "test-webhook-secret"
 )
 
 type commWebhookHandler func(*Server, *apptheory.Context) (*apptheory.Response, error)
+
+func TestTelnyxSMSWebhookQueueMessage_NormalizesPayload(t *testing.T) {
+	t.Parallel()
+
+	var tel telnyxInboundWebhook
+	tel.Data.OccurredAt = "2026-03-05T12:00:00Z"
+	tel.Data.Payload.ID = " msg-1 "
+	tel.Data.Payload.Text = " sms webhook body "
+	tel.Data.Payload.From.PhoneNumber = " +15550142 "
+	tel.Data.Payload.To = append(tel.Data.Payload.To, struct {
+		PhoneNumber string `json:"phone_number"`
+	}{PhoneNumber: " +15550143 "})
+
+	msg := telnyxSMSWebhookQueueMessage(tel)
+	if msg.Provider != commDeliveryProviderTelnyx || msg.Kind != commworker.QueueMessageKindInbound {
+		t.Fatalf("unexpected queue metadata: %#v", msg)
+	}
+	if msg.Notification.Channel != commChannelSMS || msg.Notification.MessageID != "msg-1" || msg.Notification.Body != "sms webhook body" {
+		t.Fatalf("unexpected notification payload: %#v", msg.Notification)
+	}
+	if msg.Notification.From.Number != "+15550142" || msg.Notification.To == nil || msg.Notification.To.Number != "+15550143" {
+		t.Fatalf("unexpected telnyx parties: %#v", msg.Notification)
+	}
+}
+
+func TestExtractTelnyxVoiceFields(t *testing.T) {
+	t.Parallel()
+
+	if from, to, callID, occurredAt, duration := extractTelnyxVoiceFields(nil); from != "" || to != "" || callID != "" || occurredAt != "" || duration != 0 {
+		t.Fatalf("expected nil payload to produce empty fields")
+	}
+
+	tel := &telnyxVoiceWebhook{}
+	tel.Data.EventType = commWebhookCallHangup
+	tel.Data.OccurredAt = commWebhookReceivedAt
+	tel.Data.Payload = map[string]any{
+		"from":             map[string]any{"phoneNumber": " +15550142 "},
+		"to":               map[string]any{"number": " +15550143 "},
+		"call_session_id":  " call-1 ",
+		"duration_seconds": json.Number("61"),
+	}
+	from, to, callID, occurredAt, duration := extractTelnyxVoiceFields(tel)
+	if from != "+15550142" || to != "+15550143" || callID != "call-1" || occurredAt != commWebhookReceivedAt || duration != 61 {
+		t.Fatalf("unexpected extracted voice fields: from=%q to=%q callID=%q occurredAt=%q duration=%d", from, to, callID, occurredAt, duration)
+	}
+}
+
+func TestBuildTelnyxVoiceNotificationFallback(t *testing.T) {
+	t.Parallel()
+
+	notif, to, callID, duration := buildTelnyxVoiceNotification([]byte(" "), &telnyxVoiceWebhook{Data: struct {
+		EventType  string         `json:"event_type"`
+		OccurredAt string         `json:"occurred_at"`
+		Payload    map[string]any `json:"payload"`
+	}{EventType: commWebhookCallHangup, Payload: map[string]any{"duration": float64(2)}}})
+	if notif.Body != commWebhookCallHangup || notif.BodyMimeType != commWebhookJSONContentType || notif.Channel != commChannelVoice {
+		t.Fatalf("unexpected fallback voice notification: %#v", notif)
+	}
+	if to != "" || callID != commWebhookCallHangup || duration != 2 {
+		t.Fatalf("unexpected fallback voice fields: to=%q callID=%q duration=%d", to, callID, duration)
+	}
+}
+
+func TestTelnyxPrimitivePayloadReaders(t *testing.T) {
+	t.Parallel()
+
+	if got := readTelnyxPhoneValue(" +15550142 "); got != "+15550142" {
+		t.Fatalf("unexpected string phone value %q", got)
+	}
+	if got := readTelnyxPhoneValue(map[string]any{"phone_number": " +15550143 "}); got != "+15550143" {
+		t.Fatalf("unexpected phone_number value %q", got)
+	}
+	if got := readTelnyxPhoneValue(map[string]any{"number": " +15550144 "}); got != "+15550144" {
+		t.Fatalf("unexpected number value %q", got)
+	}
+	if got := readTelnyxPhonePayload(map[string]any{"to": map[string]any{"phoneNumber": " +15550145 "}}, "to"); got != "+15550145" {
+		t.Fatalf("unexpected payload phone value %q", got)
+	}
+
+	payload := map[string]any{"string": "12", "bad": "nope", "int": 3, "int64": int64(4), "float": float64(5), "json": json.Number("6")}
+	for key, want := range map[string]int64{"string": 12, "int": 3, "int64": 4, "float": 5, "json": 6} {
+		if got := readTelnyxInt64Payload(payload, key); got != want {
+			t.Fatalf("readTelnyxInt64Payload(%q)=%d want %d", key, got, want)
+		}
+	}
+	if got := readTelnyxInt64Payload(payload, "bad", "missing"); got != 0 {
+		t.Fatalf("expected bad/missing integer fields to return zero, got %d", got)
+	}
+	if value, ok := coerceTelnyxInt64([]string{"bad"}); ok || value != 0 {
+		t.Fatalf("expected unsupported integer type to fail, got value=%d ok=%v", value, ok)
+	}
+}
 
 func TestHandleCommEmailInboundWebhook_Disabled(t *testing.T) {
 	t.Parallel()
@@ -108,7 +202,7 @@ func TestHandleCommEmailInboundWebhook_InvalidNormalizedPayloadRejected(t *testi
 	body := marshalCommWebhookBody(t, map[string]any{
 		"type":       "communication:inbound",
 		"from":       map[string]any{"address": "alice@example.com"},
-		"body":       "hello",
+		"body":       "legacy webhook body",
 		"receivedAt": commWebhookReceivedAt,
 		"messageId":  "msg-1",
 	})
@@ -716,10 +810,10 @@ func assertNotFound() error {
 
 func newCommWebhookServer(enqueue func(context.Context, commworker.QueueMessage) error) *Server {
 	return &Server{
-		cfg:                config.Config{SoulEnabled: true, CommWebhookSharedSecretSSMParam: "/test/comm/webhook"},
+		cfg:                config.Config{SoulEnabled: true, CommWebhookSharedSecretSSMParam: commWebhookSecretSSMParam},
 		enqueueCommMessage: enqueue,
 		ssmGetParameter: func(_ context.Context, name string) (string, error) {
-			if name != "/test/comm/webhook" {
+			if name != commWebhookSecretSSMParam {
 				return "", context.Canceled
 			}
 			return commWebhookTestSecret, nil

--- a/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
+++ b/internal/controlplane/handlers_comm_webhooks_more_internal_test.go
@@ -641,7 +641,7 @@ func TestMeterTelnyxVoiceCall_CreatesLedgerAndBudgetUpdate(t *testing.T) {
 		*dest = models.InstanceBudgetMonth{InstanceSlug: commWebhookTestInstanceSlug, IncludedCredits: 12, UsedCredits: 5}
 	}).Once()
 
-	tb.On("Put", mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+	tb.On("Create", mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
 		entry := testutil.RequireMockArg[*models.UsageLedgerEntry](t, args, 0)
 		if entry.InstanceSlug != commWebhookTestInstanceSlug {
 			t.Fatalf("expected instance slug %s, got %q", commWebhookTestInstanceSlug, entry.InstanceSlug)
@@ -674,6 +674,30 @@ func TestMeterTelnyxVoiceCall_CreatesLedgerAndBudgetUpdate(t *testing.T) {
 
 	if err := s.meterTelnyxVoiceCall(ctx, "+1 (555) 0142", "call-1", 61); err != nil {
 		t.Fatalf("unexpected err: %v", err)
+	}
+}
+
+func TestMeterTelnyxVoiceCall_DuplicateLedgerIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	tdb := newCommWebhookTestDB()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tdb.db.TransactWriteBuilder = tb
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(theoryErrors.ErrConditionFailed).Once()
+
+	s := &Server{store: store.New(tdb.db)}
+	expectCommWebhookPhoneAgent(t, tdb.qPhone, "0xabc")
+	expectCommWebhookIdentity(t, tdb.qIdentity, "0xabc", "example.com")
+	expectCommWebhookDomain(t, tdb.qDomain, commWebhookTestInstanceSlug)
+	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: commWebhookTestInstanceSlug, IncludedCredits: 12, UsedCredits: 5}
+	}).Once()
+	tb.On("Create", mock.Anything, mock.Anything).Return(tb).Once()
+	tb.On("UpdateWithBuilder", mock.Anything, mock.Anything, mock.Anything).Return(tb).Once()
+
+	if err := s.meterTelnyxVoiceCall(&apptheory.Context{}, "+15550142", "call-1", 60); err != nil {
+		t.Fatalf("expected duplicate ledger to be idempotent, got %v", err)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -67,8 +67,8 @@ func (s *Server) handleSoulBeginProvisionEmailChannel(ctx *apptheory.Context) (*
 	if appErr != nil {
 		return nil, appErr
 	}
-	if appErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); appErr != nil {
-		return nil, appErr
+	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); availabilityErr != nil {
+		return nil, availabilityErr
 	}
 
 	// Load the current registration as the base document (v2 or v3).
@@ -134,8 +134,8 @@ func (s *Server) handleSoulProvisionEmailChannel(ctx *apptheory.Context) (*appth
 	if appErr != nil {
 		return nil, appErr
 	}
-	if appErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); appErr != nil {
-		return nil, appErr
+	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); availabilityErr != nil {
+		return nil, availabilityErr
 	}
 
 	// Load the current registration as the base document (v2 or v3).
@@ -506,18 +506,42 @@ func resolveSoulProvisionEmailAddress(identity *models.SoulAgentIdentity, reques
 func (s *Server) validateSoulProvisionEmailAddressAvailability(ctx context.Context, agentIDHex string, address string) *apptheory.AppError {
 	emailIdx := &models.SoulEmailAgentIndex{Email: address}
 	_ = emailIdx.UpdateKeys()
+	return s.validateSoulProvisionIndexAvailability(ctx, &models.SoulEmailAgentIndex{}, emailIdx.PK, emailIdx.SK, agentIDHex, "email address is already provisioned", "failed to validate email mapping", func() any {
+		return &models.SoulEmailAgentIndex{}
+	}, func(existing any) string {
+		if idx, ok := existing.(*models.SoulEmailAgentIndex); ok && idx != nil {
+			return idx.AgentID
+		}
+		return ""
+	})
+}
 
-	var existingIdx models.SoulEmailAgentIndex
+func (s *Server) validateSoulProvisionIndexAvailability(
+	ctx context.Context,
+	model any,
+	pk string,
+	sk string,
+	agentIDHex string,
+	conflictMessage string,
+	internalMessage string,
+	newExisting func() any,
+	owner func(any) string,
+) *apptheory.AppError {
+	existing := newExisting()
 	lookupErr := s.store.DB.WithContext(ctx).
-		Model(&models.SoulEmailAgentIndex{}).
-		Where("PK", "=", emailIdx.PK).
-		Where("SK", "=", emailIdx.SK).
-		First(&existingIdx)
-	if lookupErr == nil && strings.TrimSpace(existingIdx.AgentID) != "" && !strings.EqualFold(strings.TrimSpace(existingIdx.AgentID), agentIDHex) {
-		return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
+		Model(model).
+		Where("PK", "=", pk).
+		Where("SK", "=", sk).
+		First(existing)
+	if lookupErr == nil {
+		existingAgentID := strings.TrimSpace(owner(existing))
+		if existingAgentID != "" && !strings.EqualFold(existingAgentID, agentIDHex) {
+			return &apptheory.AppError{Code: "app.conflict", Message: conflictMessage}
+		}
+		return nil
 	}
-	if lookupErr != nil && !theoryErrors.IsNotFound(lookupErr) {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate email mapping"}
+	if !theoryErrors.IsNotFound(lookupErr) {
+		return &apptheory.AppError{Code: "app.internal", Message: internalMessage}
 	}
 	return nil
 }
@@ -525,7 +549,7 @@ func (s *Server) validateSoulProvisionEmailAddressAvailability(ctx context.Conte
 func (s *Server) soulAgentEmailPasswordSSMParam(agentIDHex string) string {
 	stage := strings.ToLower(strings.TrimSpace(s.cfg.Stage))
 	if stage == "" {
-		stage = "lab"
+		stage = defaultControlPlaneStage
 	}
 	agentIDHex = strings.ToLower(strings.TrimSpace(agentIDHex))
 	// #nosec G101 -- SSM parameter path, not a hardcoded credential.

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/secrets"
@@ -64,6 +65,9 @@ func (s *Server) handleSoulBeginProvisionEmailChannel(ctx *apptheory.Context) (*
 
 	localNorm, address, ensName, appErr := resolveSoulProvisionEmailAddress(identity, req.LocalPart)
 	if appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); appErr != nil {
 		return nil, appErr
 	}
 
@@ -128,6 +132,9 @@ func (s *Server) handleSoulProvisionEmailChannel(ctx *apptheory.Context) (*appth
 
 	localNorm, address, ensName, appErr := resolveSoulProvisionEmailAddress(identity, req.LocalPart)
 	if appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); appErr != nil {
 		return nil, appErr
 	}
 
@@ -299,7 +306,7 @@ func upsertProvisionedEmailChannel(ctx context.Context, s *Server, agentIDHex st
 	if createErr := s.store.DB.WithContext(ctx).Model(channel).CreateOrUpdate(); createErr != nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to record email channel"}
 	}
-	return nil
+	return s.ensureSoulEmailAgentIndex(ctx, &models.SoulEmailAgentIndex{Email: address, AgentID: agentIDHex})
 }
 
 type soulProvisionEmailBuildInput struct {
@@ -474,16 +481,45 @@ func (s *Server) requireSoulProvisionIdentity(ctx *apptheory.Context) (string, *
 }
 
 func resolveSoulProvisionEmailAddress(identity *models.SoulAgentIdentity, requestedLocalPart string) (string, string, string, *apptheory.AppError) {
+	if identity == nil {
+		return "", "", "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	canonicalLocal, err := soul.NormalizeLocalAgentID(identity.LocalID)
+	if err != nil || canonicalLocal == "" {
+		return "", "", "", &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
+	}
 	localPart := strings.TrimSpace(requestedLocalPart)
 	if localPart == "" {
-		localPart = strings.TrimSpace(identity.LocalID)
+		localPart = canonicalLocal
 	}
 	localNorm, err := soul.NormalizeLocalAgentID(localPart)
 	if err != nil {
 		return "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "localPart is invalid"}
 	}
-	ensName := strings.TrimSpace(identity.LocalID) + ".lessersoul.eth"
+	if localNorm != canonicalLocal {
+		return "", "", "", &apptheory.AppError{Code: "app.conflict", Message: "localPart must match agent local id"}
+	}
+	ensName := soulCanonicalENSName(canonicalLocal)
 	return localNorm, localNorm + "@lessersoul.ai", ensName, nil
+}
+
+func (s *Server) validateSoulProvisionEmailAddressAvailability(ctx context.Context, agentIDHex string, address string) *apptheory.AppError {
+	emailIdx := &models.SoulEmailAgentIndex{Email: address}
+	_ = emailIdx.UpdateKeys()
+
+	var existingIdx models.SoulEmailAgentIndex
+	lookupErr := s.store.DB.WithContext(ctx).
+		Model(&models.SoulEmailAgentIndex{}).
+		Where("PK", "=", emailIdx.PK).
+		Where("SK", "=", emailIdx.SK).
+		First(&existingIdx)
+	if lookupErr == nil && strings.TrimSpace(existingIdx.AgentID) != "" && !strings.EqualFold(strings.TrimSpace(existingIdx.AgentID), agentIDHex) {
+		return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
+	}
+	if lookupErr != nil && !theoryErrors.IsNotFound(lookupErr) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate email mapping"}
+	}
+	return nil
 }
 
 func (s *Server) soulAgentEmailPasswordSSMParam(agentIDHex string) string {

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -144,6 +144,24 @@ func TestHandleSoulProvisionEmail_BeginThenConfirm_PublishesV3WithChannelAndIsId
 	assertProvisionEmailIdempotent(t, fixture, confirmBody)
 }
 
+func TestResolveSoulProvisionEmailAddress_RequiresAgentLocalID(t *testing.T) {
+	t.Parallel()
+
+	identity := &models.SoulAgentIdentity{LocalID: "agent-alice"}
+	_, _, _, appErr := resolveSoulProvisionEmailAddress(identity, "victim")
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "localPart must match agent local id" {
+		t.Fatalf("expected local id conflict, got %v", appErr)
+	}
+
+	local, address, ens, appErr := resolveSoulProvisionEmailAddress(identity, "")
+	if appErr != nil {
+		t.Fatalf("expected canonical local id success, got %v", appErr)
+	}
+	if local != "agent-alice" || address != provisionTestEmailAddress || ens != provisionTestEmailENSName {
+		t.Fatalf("unexpected resolved address: local=%q address=%q ens=%q", local, address, ens)
+	}
+}
+
 func newProvisionEmailE2EFixture(t *testing.T) *provisionEmailE2EFixture {
 	t.Helper()
 
@@ -253,6 +271,8 @@ func seedProvisionEmailE2EAccess(t *testing.T, fixture *provisionEmailE2EFixture
 	fixture.tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	fixture.tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
+	fixture.tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Times(3)
+	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -292,7 +292,7 @@ func upsertProvisionedPhoneChannel(ctx context.Context, s *Server, agentIDHex st
 	if createErr := s.store.DB.WithContext(ctx).Model(channel).CreateOrUpdate(); createErr != nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to record phone channel"}
 	}
-	return nil
+	return s.ensureSoulPhoneAgentIndex(ctx, &models.SoulPhoneAgentIndex{Phone: number, AgentID: agentIDHex})
 }
 
 func (s *Server) handleSoulDeprovisionPhoneChannel(ctx *apptheory.Context) (*apptheory.Response, error) {

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -149,20 +149,14 @@ func (s *Server) handleSoulProvisionPhoneChannel(ctx *apptheory.Context) (*appth
 func (s *Server) validateSoulProvisionPhoneNumberAvailability(ctx context.Context, agentIDHex string, number string) *apptheory.AppError {
 	phoneIdx := &models.SoulPhoneAgentIndex{Phone: number}
 	_ = phoneIdx.UpdateKeys()
-
-	var existingIdx models.SoulPhoneAgentIndex
-	lookupErr := s.store.DB.WithContext(ctx).
-		Model(&models.SoulPhoneAgentIndex{}).
-		Where("PK", "=", phoneIdx.PK).
-		Where("SK", "=", phoneIdx.SK).
-		First(&existingIdx)
-	if lookupErr == nil && strings.TrimSpace(existingIdx.AgentID) != "" && !strings.EqualFold(strings.TrimSpace(existingIdx.AgentID), agentIDHex) {
-		return &apptheory.AppError{Code: "app.conflict", Message: "phone number is already provisioned"}
-	}
-	if lookupErr != nil && !theoryErrors.IsNotFound(lookupErr) {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate phone mapping"}
-	}
-	return nil
+	return s.validateSoulProvisionIndexAvailability(ctx, &models.SoulPhoneAgentIndex{}, phoneIdx.PK, phoneIdx.SK, agentIDHex, "phone number is already provisioned", "failed to validate phone mapping", func() any {
+		return &models.SoulPhoneAgentIndex{}
+	}, func(existing any) string {
+		if idx, ok := existing.(*models.SoulPhoneAgentIndex); ok && idx != nil {
+			return idx.AgentID
+		}
+		return ""
+	})
 }
 
 func (s *Server) prepareSoulProvisionPhoneChannel(

--- a/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
@@ -471,7 +471,8 @@ func TestHandleSoulProvisionPhoneChannel_SuccessPublishesRegistrationAndRecordsP
 	packs := &fakeSoulPackStore{}
 	seedProvisionPhoneRegistration(t, packs, identity)
 
-	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Twice()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)

--- a/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
@@ -138,7 +138,8 @@ func seedProvisionPhoneE2EAccess(t *testing.T, fixture *provisionPhoneE2EFixture
 	fixture.tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	fixture.tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
-	fixture.tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	fixture.tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Twice()
+	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)

--- a/internal/controlplane/handlers_soul_comm_portal.go
+++ b/internal/controlplane/handlers_soul_comm_portal.go
@@ -158,7 +158,7 @@ func (s *Server) listSoulAgentCommQueueItems(
 	ctx *apptheory.Context,
 	listCtx soulAgentCommListContext,
 ) ([]soulAgentCommQueueItem, *apptheory.AppError) {
-	messages, appErr := s.listSoulAgentCommMailboxRows(ctx, listCtx, "ASC", soulAgentCommPortalQueueScanLimit(listCtx.Limit))
+	messages, appErr := s.listSoulAgentCommMailboxRowsMatching(ctx, listCtx, "ASC", 100, isPortalQueuedMailboxItem)
 	if appErr != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list queued messages"}
 	}
@@ -172,6 +172,36 @@ func (s *Server) listSoulAgentCommQueueItems(
 			continue
 		}
 		items = append(items, soulAgentCommQueueFromMailbox(msg))
+	}
+	return items, nil
+}
+
+func (s *Server) listSoulAgentCommMailboxRowsMatching(
+	ctx *apptheory.Context,
+	listCtx soulAgentCommListContext,
+	order string,
+	pageLimit int,
+	matches func(*models.SoulCommMailboxMessage) bool,
+) ([]*models.SoulCommMailboxMessage, *apptheory.AppError) {
+	items := make([]*models.SoulCommMailboxMessage, 0, listCtx.Limit)
+	cursor := ""
+	for len(items) < listCtx.Limit {
+		page, hasMore, nextCursor, appErr := s.listSoulAgentCommMailboxRowsPage(ctx, listCtx, order, pageLimit, cursor)
+		if appErr != nil {
+			return nil, appErr
+		}
+		for _, msg := range page {
+			if matches == nil || matches(msg) {
+				items = append(items, msg)
+				if len(items) >= listCtx.Limit {
+					break
+				}
+			}
+		}
+		if !hasMore || strings.TrimSpace(nextCursor) == "" {
+			break
+		}
+		cursor = nextCursor
 	}
 	return items, nil
 }
@@ -196,6 +226,36 @@ func (s *Server) listSoulAgentCommMailboxRows(
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	return items, nil
+}
+
+func (s *Server) listSoulAgentCommMailboxRowsPage(
+	ctx *apptheory.Context,
+	listCtx soulAgentCommListContext,
+	order string,
+	limit int,
+	cursor string,
+) ([]*models.SoulCommMailboxMessage, bool, string, *apptheory.AppError) {
+	var items []*models.SoulCommMailboxMessage
+	order = strings.ToUpper(strings.TrimSpace(order))
+	if order != "ASC" {
+		order = "DESC"
+	}
+	q := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulCommMailboxMessage{}).
+		Where("PK", "=", models.SoulCommMailboxAgentPK(listCtx.InstanceSlug, listCtx.AgentIDHex)).
+		OrderBy("SK", order).
+		Limit(limit)
+	if strings.TrimSpace(cursor) != "" {
+		q = q.Cursor(strings.TrimSpace(cursor))
+	}
+	paged, err := q.AllPaginated(&items)
+	if err != nil {
+		return nil, false, "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if paged == nil {
+		return items, false, "", nil
+	}
+	return items, paged.HasMore, strings.TrimSpace(paged.NextCursor), nil
 }
 
 func soulAgentCommActivityFromMailbox(item *models.SoulCommMailboxMessage) soulAgentCommActivityItem {
@@ -297,13 +357,6 @@ func isPortalQueuedMailboxItem(item *models.SoulCommMailboxMessage) bool {
 	}
 	return strings.EqualFold(strings.TrimSpace(item.Direction), models.SoulCommDirectionInbound) &&
 		strings.EqualFold(strings.TrimSpace(item.Status), models.SoulCommMailboxStatusQueued)
-}
-
-func soulAgentCommPortalQueueScanLimit(limit int) int {
-	if limit <= 0 {
-		return 50
-	}
-	return minInt(limit*4, 200)
 }
 
 func firstNonEmptySoulCommPortal(values ...string) string {

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -44,6 +44,7 @@ const (
 	commMetricProviderRejected    = "provider_rejected"
 	commMetricInsufficientCredits = "insufficient_credits"
 	commMetricPreferenceViolation = "preference_violation"
+	commMetricBoundaryViolation   = "boundary_violation"
 	commMetricSent                = "sent"
 
 	commCodeInvalidRequest      = "comm.invalid_request"
@@ -52,6 +53,7 @@ const (
 	commCodeProviderUnavailable = "comm.provider_unavailable"
 	commCodeInsufficientCredits = "comm.insufficient_credits"
 	commCodePreferenceViolation = "comm.preference_violation"
+	commCodeBoundaryViolation   = "comm.boundary_violation"
 	commCodeIdempotencyConflict = "comm.idempotency_conflict"
 )
 
@@ -277,12 +279,26 @@ func parseSoulCommSendRequest(ctx *apptheory.Context, metrics *soulCommSendMetri
 		metrics.status = commMetricInvalidRequest
 		return validatedSoulCommSendRequest{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "to is required").WithStatusCode(http.StatusBadRequest)
 	}
+	var cc []string
+	var bcc []string
 	subject := strings.TrimSpace(req.Subject)
 	switch channel {
 	case commChannelEmail:
-		if _, err := mail.ParseAddress(to); err != nil {
+		var addrErr *apptheory.AppTheoryError
+		to, addrErr = normalizeCommEmailRequestAddress(to, "to")
+		if addrErr != nil {
 			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "to must be an email address").WithStatusCode(http.StatusBadRequest)
+			return validatedSoulCommSendRequest{}, addrErr
+		}
+		cc, addrErr = normalizeCommEmailRequestList(req.CC, "cc")
+		if addrErr != nil {
+			metrics.status = commMetricInvalidRequest
+			return validatedSoulCommSendRequest{}, addrErr
+		}
+		bcc, addrErr = normalizeCommEmailRequestList(req.BCC, "bcc")
+		if addrErr != nil {
+			metrics.status = commMetricInvalidRequest
+			return validatedSoulCommSendRequest{}, addrErr
 		}
 		if subject == "" {
 			metrics.status = commMetricInvalidRequest
@@ -316,8 +332,8 @@ func parseSoulCommSendRequest(ctx *apptheory.Context, metrics *soulCommSendMetri
 		channel:        channel,
 		agentIDHex:     agentIDHex,
 		to:             to,
-		cc:             req.CC,
-		bcc:            req.BCC,
+		cc:             cc,
+		bcc:            bcc,
 		replyTo:        strings.TrimSpace(req.ReplyTo),
 		subject:        subject,
 		body:           body,
@@ -411,54 +427,64 @@ func (s *Server) enforceSoulCommSendGuards(ctx *apptheory.Context, identity *mod
 		return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError("comm.rate_limited", "rate limited").WithStatusCode(http.StatusTooManyRequests)
 	}
 	if req.inReplyTo != "" {
+		if appErr := s.enforceSoulCommReplyBoundary(ctx, req, now, metrics); appErr != nil {
+			return soulCommSendGuardDecision{}, appErr
+		}
 		return soulCommSendGuardDecision{}, nil
 	}
 	return s.enforceSoulCommFirstContactPolicy(ctx, identity, req, now, metrics)
 }
 
 func (s *Server) enforceSoulCommFirstContactPolicy(ctx *apptheory.Context, identity *models.SoulAgentIdentity, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics) (soulCommSendGuardDecision, *apptheory.AppTheoryError) {
-	recipientAgentID, prefs, appErr := s.loadSoulCommFirstContactRecipient(ctx.Context(), req)
+	recipients, appErr := s.loadSoulCommFirstContactRecipients(ctx.Context(), req)
 	if appErr != nil {
 		return soulCommSendGuardDecision{}, appErr
 	}
-	if recipientAgentID == "" || prefs == nil {
+	if len(recipients) == 0 {
 		return soulCommSendGuardDecision{}, nil
 	}
 
 	enforced := false
-	if prefs.FirstContactRequireSoul {
-		enforced = true
-		if identity == nil || strings.TrimSpace(identity.AgentID) == "" {
-			return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(ctx, req, now, metrics, "recipient first-contact policy requires a soul sender")
+	for _, recipient := range recipients {
+		prefs := recipient.preferences
+		if strings.TrimSpace(recipient.agentID) == "" || prefs == nil {
+			continue
 		}
-	}
+		if prefs.FirstContactRequireSoul {
+			enforced = true
+			if identity == nil || strings.TrimSpace(identity.AgentID) == "" {
+				return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(ctx, req, recipient.address, now, metrics, "recipient first-contact policy requires a soul sender")
+			}
+		}
 
-	if prefs.FirstContactRequireReputation != nil {
-		enforced = true
-		rep, err := s.getSoulAgentReputation(ctx.Context(), req.agentIDHex)
-		if err != nil && !theoryErrors.IsNotFound(err) {
-			metrics.status = commMetricInternalError
-			return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+		if prefs.FirstContactRequireReputation != nil {
+			enforced = true
+			rep, err := s.getSoulAgentReputation(ctx.Context(), req.agentIDHex)
+			if err != nil && !theoryErrors.IsNotFound(err) {
+				metrics.status = commMetricInternalError
+				return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+			}
+			score := 0.0
+			if rep != nil {
+				score = rep.Composite
+			}
+			if rep == nil || score < *prefs.FirstContactRequireReputation {
+				return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(
+					ctx,
+					req,
+					recipient.address,
+					now,
+					metrics,
+					fmt.Sprintf("recipient first-contact policy requires soul reputation >= %.2f", *prefs.FirstContactRequireReputation),
+				)
+			}
 		}
-		score := 0.0
-		if rep != nil {
-			score = rep.Composite
-		}
-		if rep == nil || score < *prefs.FirstContactRequireReputation {
-			return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(
-				ctx,
-				req,
-				now,
-				metrics,
-				fmt.Sprintf("recipient first-contact policy requires soul reputation >= %.2f", *prefs.FirstContactRequireReputation),
-			)
-		}
-	}
 
-	// `introductionExpected` is currently advisory because the send contract does not yet
-	// include a structured introduction field to validate against.
-	if prefs.FirstContactIntroductionExpected {
-		enforced = true
+		// `introductionExpected` is currently advisory because the send contract does not yet
+		// include a structured introduction field to validate against.
+		if prefs.FirstContactIntroductionExpected {
+			enforced = true
+		}
 	}
 	if enforced {
 		return soulCommSendGuardDecision{preferenceRespected: boolPtr(true)}, nil
@@ -466,8 +492,30 @@ func (s *Server) enforceSoulCommFirstContactPolicy(ctx *apptheory.Context, ident
 	return soulCommSendGuardDecision{}, nil
 }
 
-func (s *Server) loadSoulCommFirstContactRecipient(ctx context.Context, req validatedSoulCommSendRequest) (string, *models.SoulAgentContactPreferences, *apptheory.AppTheoryError) {
-	agentID, found, err := s.lookupSoulCommRecipientAgentID(ctx, req.channel, req.to)
+type soulCommFirstContactRecipient struct {
+	address     string
+	agentID     string
+	preferences *models.SoulAgentContactPreferences
+}
+
+func (s *Server) loadSoulCommFirstContactRecipients(ctx context.Context, req validatedSoulCommSendRequest) ([]soulCommFirstContactRecipient, *apptheory.AppTheoryError) {
+	addresses := soulCommBoundaryRecipients(req)
+	out := make([]soulCommFirstContactRecipient, 0, len(addresses))
+	for _, address := range addresses {
+		agentID, prefs, appErr := s.loadSoulCommFirstContactRecipient(ctx, req.channel, address)
+		if appErr != nil {
+			return nil, appErr
+		}
+		if agentID == "" || prefs == nil {
+			continue
+		}
+		out = append(out, soulCommFirstContactRecipient{address: address, agentID: agentID, preferences: prefs})
+	}
+	return out, nil
+}
+
+func (s *Server) loadSoulCommFirstContactRecipient(ctx context.Context, channel string, address string) (string, *models.SoulAgentContactPreferences, *apptheory.AppTheoryError) {
+	agentID, found, err := s.lookupSoulCommRecipientAgentID(ctx, channel, address)
 	if err != nil {
 		return "", nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
@@ -483,6 +531,129 @@ func (s *Server) loadSoulCommFirstContactRecipient(ctx context.Context, req vali
 		return "", nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 	return agentID, prefs, nil
+}
+
+func soulCommBoundaryRecipients(req validatedSoulCommSendRequest) []string {
+	recipients := []string{strings.TrimSpace(req.to)}
+	if req.channel == commChannelEmail {
+		recipients = append(recipients, req.cc...)
+		recipients = append(recipients, req.bcc...)
+		recipients = normalizeCommEmailList(recipients)
+	} else {
+		recipients[0] = normalizeCommPhoneE164(recipients[0])
+	}
+	out := make([]string, 0, len(recipients))
+	seen := map[string]struct{}{}
+	for _, recipient := range recipients {
+		recipient = strings.TrimSpace(recipient)
+		if recipient == "" {
+			continue
+		}
+		key := strings.ToLower(recipient)
+		if req.channel != commChannelEmail {
+			key = recipient
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, recipient)
+	}
+	return out
+}
+
+func (s *Server) enforceSoulCommReplyBoundary(ctx *apptheory.Context, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+	if strings.TrimSpace(req.providerReplyTo) != "" && strings.TrimSpace(req.threadID) != "" && len(req.cc) == 0 && len(req.bcc) == 0 {
+		return nil
+	}
+	recipients := soulCommBoundaryRecipients(req)
+	if len(recipients) == 0 {
+		return s.denySoulCommReplyBoundary(ctx, req, req.to, now, metrics, "reply boundary requires a recipient")
+	}
+	activities, err := s.listSoulCommReplyBoundaryActivities(ctx.Context(), req.agentIDHex, req.channel, 500)
+	if err != nil {
+		metrics.status = commMetricInternalError
+		return apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	for _, recipient := range recipients {
+		if !soulCommReplyBoundaryMatchesRecipient(activities, req.channel, recipient, req.inReplyTo) {
+			return s.denySoulCommReplyBoundary(ctx, req, recipient, now, metrics, "inReplyTo does not match a prior conversation with every recipient")
+		}
+	}
+	return nil
+}
+
+func (s *Server) listSoulCommReplyBoundaryActivities(ctx context.Context, agentIDHex string, channelType string, scanLimit int) ([]*models.SoulAgentCommActivity, error) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return nil, fmt.Errorf("store not configured")
+	}
+	agentIDHex = strings.ToLower(strings.TrimSpace(agentIDHex))
+	channelType = strings.ToLower(strings.TrimSpace(channelType))
+	if agentIDHex == "" || channelType == "" {
+		return nil, fmt.Errorf("agent and channelType are required")
+	}
+	if scanLimit <= 0 {
+		scanLimit = 250
+	}
+	if scanLimit > 1000 {
+		scanLimit = 1000
+	}
+	var items []*models.SoulAgentCommActivity
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulAgentCommActivity{}).
+		Where("PK", "=", fmt.Sprintf("SOUL#AGENT#%s", agentIDHex)).
+		Where("SK", "BEGINS_WITH", "COMM#").
+		OrderBy("SK", "DESC").
+		Limit(scanLimit).
+		All(&items)
+	return items, err
+}
+
+func soulCommReplyBoundaryMatchesRecipient(items []*models.SoulAgentCommActivity, channelType string, recipient string, inReplyTo string) bool {
+	channelType = strings.ToLower(strings.TrimSpace(channelType))
+	recipient = soulCommNormalizeBoundaryCounterparty(channelType, recipient)
+	inReplyTo = strings.TrimSpace(inReplyTo)
+	if recipient == "" || inReplyTo == "" {
+		return false
+	}
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(item.ChannelType)) != channelType {
+			continue
+		}
+		if soulCommNormalizeBoundaryCounterparty(channelType, item.Counterparty) != recipient {
+			continue
+		}
+		if soulCommReplyTokenMatches(item.MessageID, inReplyTo) || soulCommReplyTokenMatches(item.InReplyTo, inReplyTo) {
+			return true
+		}
+	}
+	return false
+}
+
+func soulCommNormalizeBoundaryCounterparty(channelType string, counterparty string) string {
+	counterparty = strings.TrimSpace(counterparty)
+	if strings.ToLower(strings.TrimSpace(channelType)) == commChannelEmail {
+		if addr, err := mail.ParseAddress(counterparty); err == nil && addr != nil && strings.TrimSpace(addr.Address) != "" {
+			return strings.ToLower(strings.TrimSpace(addr.Address))
+		}
+		return strings.ToLower(counterparty)
+	}
+	return normalizeCommPhoneE164(counterparty)
+}
+
+func soulCommReplyTokenMatches(stored string, requested string) bool {
+	stored = strings.Trim(strings.TrimSpace(stored), "<>")
+	requested = strings.Trim(strings.TrimSpace(requested), "<>")
+	if stored == "" || requested == "" {
+		return false
+	}
+	if strings.EqualFold(stored, requested) {
+		return true
+	}
+	return strings.EqualFold(emailMessageIDReference(stored), emailMessageIDReference(requested))
 }
 
 func (s *Server) lookupSoulCommRecipientAgentID(ctx context.Context, channel string, to string) (string, bool, error) {
@@ -530,8 +701,17 @@ func (s *Server) lookupSoulCommRecipientAgentID(ctx context.Context, channel str
 	}
 }
 
-func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedSoulCommSendRequest, now time.Time, metrics *soulCommSendMetrics, message string) *apptheory.AppTheoryError {
+func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, message string) *apptheory.AppTheoryError {
 	metrics.status = commMetricPreferenceViolation
+	return s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckSkipped, commCodePreferenceViolation, message)
+}
+
+func (s *Server) denySoulCommReplyBoundary(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, message string) *apptheory.AppTheoryError {
+	metrics.status = commMetricBoundaryViolation
+	return s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckViolated, commCodeBoundaryViolation, message)
+}
+
+func (s *Server) recordSoulCommGuardViolation(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, boundaryCheck string, code string, message string) *apptheory.AppTheoryError {
 	violationID := strings.TrimSpace(ctx.RequestID)
 	if violationID == "" {
 		if token, tokenErr := generateRandomSecret(8); tokenErr == nil {
@@ -544,17 +724,17 @@ func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedS
 		ActivityID:          "comm-pref-deny-" + violationID,
 		ChannelType:         req.channel,
 		Direction:           models.SoulCommDirectionOutbound,
-		Counterparty:        req.to,
+		Counterparty:        strings.TrimSpace(recipient),
 		Action:              "send",
 		MessageID:           "",
-		InReplyTo:           "",
-		BoundaryCheck:       models.SoulCommBoundaryCheckSkipped,
+		InReplyTo:           req.inReplyTo,
+		BoundaryCheck:       boundaryCheck,
 		PreferenceRespected: &preferenceRespected,
 		Timestamp:           now,
 	}
 	_ = activity.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(activity).Create()
-	return apptheory.NewAppTheoryError(commCodePreferenceViolation, message).WithStatusCode(http.StatusForbidden)
+	return apptheory.NewAppTheoryError(code, message).WithStatusCode(http.StatusForbidden)
 }
 
 func newSoulCommSendMessageID() (string, *apptheory.AppTheoryError) {
@@ -1457,6 +1637,36 @@ func validateCommEmailAddress(value string, field string) *apptheory.AppTheoryEr
 		return apptheory.NewAppTheoryError(commCodeInvalidRequest, field+" must be an email address").WithStatusCode(http.StatusBadRequest)
 	}
 	return nil
+}
+
+func normalizeCommEmailRequestAddress(value string, field string) (string, *apptheory.AppTheoryError) {
+	addr, err := mail.ParseAddress(strings.TrimSpace(value))
+	if err != nil || addr == nil || strings.TrimSpace(addr.Address) == "" {
+		return "", apptheory.NewAppTheoryError(commCodeInvalidRequest, field+" must be an email address").WithStatusCode(http.StatusBadRequest)
+	}
+	return strings.ToLower(strings.TrimSpace(addr.Address)), nil
+}
+
+func normalizeCommEmailRequestList(in []string, field string) ([]string, *apptheory.AppTheoryError) {
+	out := make([]string, 0, len(in))
+	seen := map[string]struct{}{}
+	for _, raw := range in {
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			continue
+		}
+		email, appErr := normalizeCommEmailRequestAddress(raw, field)
+		if appErr != nil {
+			return nil, appErr
+		}
+		if _, ok := seen[email]; ok {
+			continue
+		}
+		seen[email] = struct{}{}
+		out = append(out, email)
+	}
+	sort.Strings(out)
+	return out, nil
 }
 
 func normalizeCommEmailList(in []string) []string {

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -282,34 +282,16 @@ func parseSoulCommSendRequest(ctx *apptheory.Context, metrics *soulCommSendMetri
 	var cc []string
 	var bcc []string
 	subject := strings.TrimSpace(req.Subject)
+	var recipientErr *apptheory.AppTheoryError
 	switch channel {
 	case commChannelEmail:
-		var addrErr *apptheory.AppTheoryError
-		to, addrErr = normalizeCommEmailRequestAddress(to, "to")
-		if addrErr != nil {
-			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, addrErr
-		}
-		cc, addrErr = normalizeCommEmailRequestList(req.CC, "cc")
-		if addrErr != nil {
-			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, addrErr
-		}
-		bcc, addrErr = normalizeCommEmailRequestList(req.BCC, "bcc")
-		if addrErr != nil {
-			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, addrErr
-		}
-		if subject == "" {
-			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "subject is required for email").WithStatusCode(http.StatusBadRequest)
-		}
+		to, cc, bcc, recipientErr = validateSoulCommEmailRequestRecipients(to, req.CC, req.BCC, subject)
 	default:
-		to = normalizeCommPhoneE164(to)
-		if !soulE164Regex.MatchString(to) {
-			metrics.status = commMetricInvalidRequest
-			return validatedSoulCommSendRequest{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "to must be an E.164 phone number").WithStatusCode(http.StatusBadRequest)
-		}
+		to, recipientErr = validateSoulCommPhoneRequestRecipient(to)
+	}
+	if recipientErr != nil {
+		metrics.status = commMetricInvalidRequest
+		return validatedSoulCommSendRequest{}, recipientErr
 	}
 
 	body := strings.TrimSpace(req.Body)
@@ -340,6 +322,33 @@ func parseSoulCommSendRequest(ctx *apptheory.Context, metrics *soulCommSendMetri
 		inReplyTo:      inReplyTo,
 		idempotencyKey: idempotencyKey,
 	}, nil
+}
+
+func validateSoulCommEmailRequestRecipients(to string, ccRaw []string, bccRaw []string, subject string) (string, []string, []string, *apptheory.AppTheoryError) {
+	to, appErr := normalizeCommEmailRequestAddress(to, "to")
+	if appErr != nil {
+		return "", nil, nil, appErr
+	}
+	cc, appErr := normalizeCommEmailRequestList(ccRaw, "cc")
+	if appErr != nil {
+		return "", nil, nil, appErr
+	}
+	bcc, appErr := normalizeCommEmailRequestList(bccRaw, "bcc")
+	if appErr != nil {
+		return "", nil, nil, appErr
+	}
+	if strings.TrimSpace(subject) == "" {
+		return "", nil, nil, apptheory.NewAppTheoryError(commCodeInvalidRequest, "subject is required for email").WithStatusCode(http.StatusBadRequest)
+	}
+	return to, cc, bcc, nil
+}
+
+func validateSoulCommPhoneRequestRecipient(to string) (string, *apptheory.AppTheoryError) {
+	to = normalizeCommPhoneE164(to)
+	if !soulE164Regex.MatchString(to) {
+		return "", apptheory.NewAppTheoryError(commCodeInvalidRequest, "to must be an E.164 phone number").WithStatusCode(http.StatusBadRequest)
+	}
+	return to, nil
 }
 
 func (s *Server) loadSoulCommSendRoute(ctx context.Context, key *models.InstanceKey, req validatedSoulCommSendRequest, metrics *soulCommSendMetrics) (soulCommSendRoute, *apptheory.AppTheoryError) {
@@ -446,43 +455,11 @@ func (s *Server) enforceSoulCommFirstContactPolicy(ctx *apptheory.Context, ident
 
 	enforced := false
 	for _, recipient := range recipients {
-		prefs := recipient.preferences
-		if strings.TrimSpace(recipient.agentID) == "" || prefs == nil {
-			continue
+		recipientEnforced, recipientErr := s.enforceSoulCommRecipientFirstContactPolicy(ctx, identity, req, recipient, now, metrics)
+		if recipientErr != nil {
+			return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, recipientErr
 		}
-		if prefs.FirstContactRequireSoul {
-			enforced = true
-			if identity == nil || strings.TrimSpace(identity.AgentID) == "" {
-				return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(ctx, req, recipient.address, now, metrics, "recipient first-contact policy requires a soul sender")
-			}
-		}
-
-		if prefs.FirstContactRequireReputation != nil {
-			enforced = true
-			rep, err := s.getSoulAgentReputation(ctx.Context(), req.agentIDHex)
-			if err != nil && !theoryErrors.IsNotFound(err) {
-				metrics.status = commMetricInternalError
-				return soulCommSendGuardDecision{}, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
-			}
-			score := 0.0
-			if rep != nil {
-				score = rep.Composite
-			}
-			if rep == nil || score < *prefs.FirstContactRequireReputation {
-				return soulCommSendGuardDecision{preferenceRespected: boolPtr(false)}, s.denySoulCommFirstContact(
-					ctx,
-					req,
-					recipient.address,
-					now,
-					metrics,
-					fmt.Sprintf("recipient first-contact policy requires soul reputation >= %.2f", *prefs.FirstContactRequireReputation),
-				)
-			}
-		}
-
-		// `introductionExpected` is currently advisory because the send contract does not yet
-		// include a structured introduction field to validate against.
-		if prefs.FirstContactIntroductionExpected {
+		if recipientEnforced {
 			enforced = true
 		}
 	}
@@ -490,6 +467,45 @@ func (s *Server) enforceSoulCommFirstContactPolicy(ctx *apptheory.Context, ident
 		return soulCommSendGuardDecision{preferenceRespected: boolPtr(true)}, nil
 	}
 	return soulCommSendGuardDecision{}, nil
+}
+
+func (s *Server) enforceSoulCommRecipientFirstContactPolicy(ctx *apptheory.Context, identity *models.SoulAgentIdentity, req validatedSoulCommSendRequest, recipient soulCommFirstContactRecipient, now time.Time, metrics *soulCommSendMetrics) (bool, *apptheory.AppTheoryError) {
+	prefs := recipient.preferences
+	if strings.TrimSpace(recipient.agentID) == "" || prefs == nil {
+		return false, nil
+	}
+	if prefs.FirstContactRequireSoul && (identity == nil || strings.TrimSpace(identity.AgentID) == "") {
+		return true, s.denySoulCommFirstContact(ctx, req, recipient.address, now, metrics, "recipient first-contact policy requires a soul sender")
+	}
+	if prefs.FirstContactRequireReputation != nil {
+		if appErr := s.enforceSoulCommRecipientReputationPolicy(ctx, req, recipient, *prefs.FirstContactRequireReputation, now, metrics); appErr != nil {
+			return true, appErr
+		}
+	}
+	return prefs.FirstContactRequireSoul || prefs.FirstContactRequireReputation != nil || prefs.FirstContactIntroductionExpected, nil
+}
+
+func (s *Server) enforceSoulCommRecipientReputationPolicy(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient soulCommFirstContactRecipient, minReputation float64, now time.Time, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+	rep, err := s.getSoulAgentReputation(ctx.Context(), req.agentIDHex)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		metrics.status = commMetricInternalError
+		return apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+	}
+	score := 0.0
+	if rep != nil {
+		score = rep.Composite
+	}
+	if rep != nil && score >= minReputation {
+		return nil
+	}
+	return s.denySoulCommFirstContact(
+		ctx,
+		req,
+		recipient.address,
+		now,
+		metrics,
+		fmt.Sprintf("recipient first-contact policy requires soul reputation >= %.2f", minReputation),
+	)
 }
 
 type soulCommFirstContactRecipient struct {

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -36,9 +36,24 @@ func allowCommQueryOps(queries ...*ttmocks.MockQuery) {
 		q.On("Update", mock.Anything).Return(nil).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
-		q.On("All", mock.Anything).Return(nil).Maybe()
 		q.On("Create").Return(nil).Maybe()
 	}
+}
+
+func expectCommReplyBoundaryActivity(t *testing.T, q *ttmocks.MockQuery, channel string, counterparty string, messageID string) {
+	t.Helper()
+	q.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		*dest = []*models.SoulAgentCommActivity{
+			{
+				ChannelType:  channel,
+				Direction:    models.SoulCommDirectionInbound,
+				Counterparty: counterparty,
+				MessageID:    messageID,
+				Timestamp:    time.Now().Add(-time.Minute).UTC(),
+			},
+		}
+	}).Once()
 }
 
 func assertSoulCommSendResponse(t *testing.T, resp *apptheory.Response, wantStatus string, wantProvider string, wantChannel string, wantProviderMessageID string) {
@@ -251,6 +266,7 @@ func TestHandleSoulCommSend_SendsEmailAndRecordsStatus(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	expectCommReplyBoundaryActivity(t, qCommActivity, commChannelEmail, commSendTestEmailRecipient, "comm-msg-xyz")
 
 	var sendCalled bool
 	s := &Server{
@@ -381,6 +397,7 @@ func TestHandleSoulCommSend_SendsSMSAndDebitsCredits(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	expectCommReplyBoundaryActivity(t, qCommActivity, commChannelSMS, "+15550143", "telnyx-msg-1")
 
 	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
@@ -499,6 +516,7 @@ func TestHandleSoulCommSend_StartsVoiceCallAndStoresInstruction(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	expectCommReplyBoundaryActivity(t, qCommActivity, commChannelVoice, "+15550143", "call-back-1")
 
 	var voiceCalled bool
 	s := &Server{
@@ -575,7 +593,6 @@ func TestHandleSoulCommSend_SMSInsufficientCreditsBlocksSend(t *testing.T) {
 		q.On("IfExists").Return(q).Maybe()
 		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("Update", mock.Anything).Return(nil).Maybe()
-		q.On("All", mock.Anything).Return(nil).Maybe()
 	}
 
 	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(nil).Run(func(args mock.Arguments) {
@@ -619,6 +636,7 @@ func TestHandleSoulCommSend_SMSInsufficientCreditsBlocksSend(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	expectCommReplyBoundaryActivity(t, qCommActivity, commChannelSMS, "+15550143", "telnyx-msg-1")
 
 	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -533,7 +533,7 @@ func TestHandleSoulCommSend_StartsVoiceCallAndStoresInstruction(t *testing.T) {
 			if !strings.HasPrefix(statusCallbackURL, "https://lab.lesser.host/webhooks/comm/voice/status/comm-msg-") {
 				t.Fatalf("unexpected statusCallbackURL: %q", statusCallbackURL)
 			}
-			return "call-control-1", nil
+			return commVoiceCallControlID, nil
 		},
 	}
 
@@ -562,7 +562,7 @@ func TestHandleSoulCommSend_StartsVoiceCallAndStoresInstruction(t *testing.T) {
 	if !voiceCalled {
 		t.Fatalf("expected telnyx voice call")
 	}
-	assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusAccepted, commDeliveryProviderTelnyx, commChannelVoice, "call-control-1")
+	assertSoulCommSendResponse(t, resp, models.SoulCommMessageStatusAccepted, commDeliveryProviderTelnyx, commChannelVoice, commVoiceCallControlID)
 }
 
 func TestHandleSoulCommSend_SMSInsufficientCreditsBlocksSend(t *testing.T) {

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -285,7 +286,7 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 	t.Run("email provider not configured", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
 
 		body := mustMarshalCommSendBody(t, map[string]any{
@@ -303,7 +304,7 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 	t.Run("email provider unavailable", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		s := &Server{
 			store: store.New(tdb.db),
 			cfg:   config.Config{SoulEnabled: true},
@@ -330,7 +331,7 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 	t.Run("email provider rejected", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		s := &Server{
 			store: store.New(tdb.db),
 			cfg:   config.Config{SoulEnabled: true},
@@ -360,7 +361,7 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 	t.Run("voice unsupported", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "phone")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypePhone)
 		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
 
 		body := mustMarshalCommSendBody(t, map[string]any{
@@ -399,7 +400,7 @@ func TestHandleSoulCommSend_IdempotencyBehavior(t *testing.T) {
 	t.Run("returns original success without redispatch", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 		resetCommMockQueryChain(tdb.qIdem)
 		resetCommMockQueryChain(tdb.qStatus)
@@ -454,7 +455,7 @@ func TestHandleSoulCommSend_IdempotencyBehavior(t *testing.T) {
 	t.Run("returns accepted while original request is still processing", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 		resetCommMockQueryChain(tdb.qIdem)
 		resetCommMockQueryChain(tdb.qStatus)
@@ -498,7 +499,7 @@ func TestHandleSoulCommSend_IdempotencyBehavior(t *testing.T) {
 	t.Run("rejects same key for different payload", func(t *testing.T) {
 		tdb := newSoulCommSendMoreTestDB()
 		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
-		expectActiveCommRoute(t, tdb, agentID, "email")
+		expectActiveCommRoute(t, tdb, agentID, models.SoulChannelTypeEmail)
 		tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 		resetCommMockQueryChain(tdb.qIdem)
 		tdb.qIdem.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
@@ -1395,6 +1396,134 @@ func TestIsCommProviderUnavailable_RecognizesExpectedErrors(t *testing.T) {
 	}
 }
 
+func TestParseSoulCommSendRequest_NormalizesAllRecipients(t *testing.T) {
+	t.Parallel()
+
+	inReplyTo := " <comm-msg-prev@lessersoul.ai> "
+	body, _ := json.Marshal(soulCommSendRequest{
+		Channel:        " EMAIL ",
+		AgentID:        strings.ToUpper(soulLifecycleTestAgentIDHex),
+		To:             "Alice <ALICE@example.com>",
+		CC:             []string{" Bob <bob@example.com> ", "bob@example.com", ""},
+		BCC:            []string{" CAROL@example.com "},
+		Subject:        " Hello ",
+		Body:           " Body ",
+		ReplyTo:        " reply@example.com ",
+		InReplyTo:      &inReplyTo,
+		IdempotencyKey: " idem-1 ",
+	})
+	metrics := newSoulCommSendMetrics(" ", " ")
+
+	req, appErr := parseSoulCommSendRequest(newCommSendCtx(body, nil), metrics)
+	if appErr != nil {
+		t.Fatalf("unexpected appErr: %v", appErr)
+	}
+	if req.channel != commChannelEmail || req.agentIDHex != soulLifecycleTestAgentIDHex || req.to != "alice@example.com" {
+		t.Fatalf("unexpected normalized request identity/channel/to: %#v", req)
+	}
+	if !reflect.DeepEqual(req.cc, []string{"bob@example.com"}) || !reflect.DeepEqual(req.bcc, []string{"carol@example.com"}) {
+		t.Fatalf("unexpected normalized cc/bcc: cc=%#v bcc=%#v", req.cc, req.bcc)
+	}
+	if req.subject != "Hello" || req.body != "Body" || req.replyTo != "reply@example.com" || req.inReplyTo != "<comm-msg-prev@lessersoul.ai>" || req.idempotencyKey != "idem-1" {
+		t.Fatalf("unexpected normalized envelope fields: %#v", req)
+	}
+	if metrics.stage != "lab" || metrics.instance != commMetricUnknown || metrics.channel != commChannelEmail {
+		t.Fatalf("unexpected metrics after parse: %#v", metrics)
+	}
+}
+
+func TestParseSoulCommSendRequest_RejectsRecipientFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request soulCommSendRequest
+		message string
+	}{
+		{
+			name: "email missing subject",
+			request: soulCommSendRequest{
+				Channel: commChannelEmail,
+				AgentID: soulLifecycleTestAgentIDHex,
+				To:      "alice@example.com",
+				Body:    "body text",
+			},
+			message: "subject is required for email",
+		},
+		{
+			name: "invalid cc",
+			request: soulCommSendRequest{
+				Channel: commChannelEmail,
+				AgentID: soulLifecycleTestAgentIDHex,
+				To:      "alice@example.com",
+				CC:      []string{"not-an-email"},
+				Subject: "Hello",
+				Body:    "body text",
+			},
+			message: "cc must be an email address",
+		},
+		{
+			name: "invalid sms recipient",
+			request: soulCommSendRequest{
+				Channel: commChannelSMS,
+				AgentID: soulLifecycleTestAgentIDHex,
+				To:      "not-a-phone",
+				Body:    "body text",
+			},
+			message: "to must be an E.164 phone number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body, _ := json.Marshal(tt.request)
+			metrics := newSoulCommSendMetrics("lab", "inst1")
+			_, appErr := parseSoulCommSendRequest(newCommSendCtx(body, nil), metrics)
+			if appErr == nil || appErr.Message != tt.message || appErr.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected %q bad request, got %#v", tt.message, appErr)
+			}
+			if metrics.status != commMetricInvalidRequest {
+				t.Fatalf("expected invalid request metrics, got %#v", metrics)
+			}
+		})
+	}
+}
+
+func TestSoulCommReplyBoundaryMatching(t *testing.T) {
+	t.Parallel()
+
+	items := []*models.SoulAgentCommActivity{
+		nil,
+		{ChannelType: commChannelSMS, Counterparty: "+15550123", MessageID: "sms-1"},
+		{ChannelType: commChannelEmail, Counterparty: "Other <other@example.com>", MessageID: "email-2"},
+		{ChannelType: commChannelEmail, Counterparty: "Alice <ALICE@example.com>", MessageID: "comm-msg-prev"},
+		{ChannelType: commChannelEmail, Counterparty: "bob@example.com", InReplyTo: "<thread-1@lessersoul.ai>"},
+	}
+
+	if !soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "alice@example.com", "<comm-msg-prev@lessersoul.ai>") {
+		t.Fatalf("expected message-id reference to match normalized email recipient")
+	}
+	if !soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "Bob <bob@example.com>", "thread-1") {
+		t.Fatalf("expected prior in-reply-to token to match")
+	}
+	if soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "charlie@example.com", "comm-msg-prev") {
+		t.Fatalf("did not expect unmatched recipient to pass")
+	}
+	if !soulCommReplyBoundaryMatchesRecipient(items, commChannelSMS, "+1 (555) 0123", "sms-1") {
+		t.Fatalf("expected normalized phone recipient to match")
+	}
+
+	recipients := soulCommBoundaryRecipients(validatedSoulCommSendRequest{
+		channel: commChannelEmail,
+		to:      "Alice <ALICE@example.com>",
+		cc:      []string{"bob@example.com", "BOB@example.com"},
+		bcc:     []string{"carol@example.com"},
+	})
+	if !reflect.DeepEqual(recipients, []string{"ALICE@example.com", "BOB@example.com", "carol@example.com"}) {
+		t.Fatalf("unexpected email boundary recipients: %#v", recipients)
+	}
+}
+
 func newCommSendCtx(body []byte, inReplyTo *string) *apptheory.Context {
 	ctx := &apptheory.Context{
 		Request: apptheory.Request{
@@ -1489,12 +1618,12 @@ func expectActiveCommRoute(t *testing.T, tdb soulCommSendMoreTestDB, agentID str
 	expectCommDomain(t, tdb.qDomain, models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified})
 
 	identifier := provisionTestEmailAddress
-	if channelType == "phone" {
+	if channelType == models.SoulChannelTypePhone {
 		identifier = "+15550142"
 	}
 	expectCommChannel(t, tdb.qChannel, models.SoulAgentChannel{
 		AgentID:       agentID,
-		ChannelType:   map[bool]string{true: models.SoulChannelTypePhone, false: models.SoulChannelTypeEmail}[channelType == "phone"],
+		ChannelType:   map[bool]string{true: models.SoulChannelTypePhone, false: models.SoulChannelTypeEmail}[channelType == models.SoulChannelTypePhone],
 		Identifier:    identifier,
 		Verified:      true,
 		ProvisionedAt: time.Now().Add(-time.Hour).UTC(),
@@ -1506,21 +1635,21 @@ func expectActiveCommRoute(t *testing.T, tdb soulCommSendMoreTestDB, agentID str
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
 	counterparty := "alice@example.com"
-	if channelType == "phone" {
+	if channelType == models.SoulChannelTypePhone {
 		counterparty = "+15550143"
 	}
 	tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		activities := []*models.SoulAgentCommActivity{
 			{
-				ChannelType:  map[bool]string{true: commChannelSMS, false: commChannelEmail}[channelType == "phone"],
+				ChannelType:  map[bool]string{true: commChannelSMS, false: commChannelEmail}[channelType == models.SoulChannelTypePhone],
 				Direction:    models.SoulCommDirectionInbound,
 				Counterparty: counterparty,
 				MessageID:    "comm-msg-prev",
 				Timestamp:    time.Now().Add(-time.Minute).UTC(),
 			},
 		}
-		if channelType == "phone" {
+		if channelType == models.SoulChannelTypePhone {
 			activities = append(activities, &models.SoulAgentCommActivity{
 				ChannelType:  commChannelVoice,
 				Direction:    models.SoulCommDirectionInbound,

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -1023,6 +1023,177 @@ func TestEnforceSoulCommSendGuards_RecipientFirstContactPreferences(t *testing.T
 	})
 }
 
+func TestEnforceSoulCommSendGuards_EmailCCBCCFirstContactPreferences(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+	tdb := newSoulCommSendMoreTestDB()
+	tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		*dest = []*models.SoulAgentCommActivity{}
+	}).Twice()
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	expectCommEmailIdx(t, tdb.qEmailIdx, "protected@lessersoul.ai", "0xprotected")
+	minRep := 0.9
+	expectCommPrefs(t, tdb.qPrefs, models.SoulAgentContactPreferences{
+		AgentID:                       "0xprotected",
+		FirstContactRequireReputation: &minRep,
+		UpdatedAt:                     time.Now().UTC(),
+	})
+	tdb.qReputation.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+	decision, appErr := s.enforceSoulCommSendGuards(
+		&apptheory.Context{RequestID: "req-pref-cc-deny"},
+		&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+		validatedSoulCommSendRequest{
+			channel:    commChannelEmail,
+			agentIDHex: agentID,
+			to:         "external@example.com",
+			cc:         []string{"protected@lessersoul.ai"},
+			bcc:        []string{"protected@lessersoul.ai"},
+			subject:    "Hello",
+			body:       "First contact",
+		},
+		time.Now().UTC(),
+		newSoulCommSendMetrics("lab", "inst1"),
+	)
+	if appErr == nil {
+		t.Fatalf("expected preference violation")
+	}
+	if appErr.Code != commCodePreferenceViolation || appErr.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected %s/403, got %q/%d", commCodePreferenceViolation, appErr.Code, appErr.StatusCode)
+	}
+	if decision.preferenceRespected == nil || *decision.preferenceRespected {
+		t.Fatalf("expected preferenceRespected=false, got %#v", decision.preferenceRespected)
+	}
+}
+
+func TestEnforceSoulCommSendGuards_InReplyToRequiresRecipientThread(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+
+	t.Run("arbitrary token rejected", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{}
+		}).Times(3)
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		_, appErr := s.enforceSoulCommSendGuards(
+			&apptheory.Context{RequestID: "req-reply-deny"},
+			&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+			validatedSoulCommSendRequest{
+				channel:    commChannelEmail,
+				agentIDHex: agentID,
+				to:         "alice@example.com",
+				subject:    "Re",
+				body:       "Reply",
+				inReplyTo:  "comm-msg-prev",
+			},
+			time.Now().UTC(),
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr == nil {
+			t.Fatalf("expected boundary violation")
+		}
+		if appErr.Code != commCodeBoundaryViolation || appErr.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected %s/403, got %q/%d", commCodeBoundaryViolation, appErr.Code, appErr.StatusCode)
+		}
+	})
+
+	t.Run("cc recipient must be part of thread", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{}
+		}).Twice()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{
+				{
+					ChannelType:  commChannelEmail,
+					Direction:    models.SoulCommDirectionInbound,
+					Counterparty: "alice@example.com",
+					MessageID:    "comm-msg-prev",
+					Timestamp:    time.Now().Add(-time.Minute).UTC(),
+				},
+			}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		_, appErr := s.enforceSoulCommSendGuards(
+			&apptheory.Context{RequestID: "req-reply-cc-deny"},
+			&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+			validatedSoulCommSendRequest{
+				channel:    commChannelEmail,
+				agentIDHex: agentID,
+				to:         "alice@example.com",
+				cc:         []string{"new@example.com"},
+				subject:    "Re",
+				body:       "Reply",
+				inReplyTo:  "comm-msg-prev",
+			},
+			time.Now().UTC(),
+			newSoulCommSendMetrics("lab", "inst1"),
+		)
+		if appErr == nil {
+			t.Fatalf("expected boundary violation for cc outside thread")
+		}
+		if appErr.Code != commCodeBoundaryViolation || appErr.StatusCode != http.StatusForbidden {
+			t.Fatalf("expected %s/403, got %q/%d", commCodeBoundaryViolation, appErr.Code, appErr.StatusCode)
+		}
+	})
+
+	t.Run("matching recipients pass", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{}
+		}).Twice()
+		tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+			*dest = []*models.SoulAgentCommActivity{
+				{
+					ChannelType:  commChannelEmail,
+					Direction:    models.SoulCommDirectionInbound,
+					Counterparty: "alice@example.com",
+					MessageID:    "comm-msg-prev",
+					Timestamp:    time.Now().Add(-time.Minute).UTC(),
+				},
+				{
+					ChannelType:  commChannelEmail,
+					Direction:    models.SoulCommDirectionInbound,
+					Counterparty: "bob@example.com",
+					MessageID:    "comm-msg-prev",
+					Timestamp:    time.Now().Add(-time.Minute).UTC(),
+				},
+			}
+		}).Once()
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+		if _, appErr := s.enforceSoulCommSendGuards(
+			&apptheory.Context{RequestID: "req-reply-pass"},
+			&models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com"},
+			validatedSoulCommSendRequest{
+				channel:    commChannelEmail,
+				agentIDHex: agentID,
+				to:         "alice@example.com",
+				cc:         []string{"bob@example.com"},
+				subject:    "Re",
+				body:       "Reply",
+				inReplyTo:  "comm-msg-prev",
+			},
+			time.Now().UTC(),
+			newSoulCommSendMetrics("lab", "inst1"),
+		); appErr != nil {
+			t.Fatalf("expected matching reply boundary to pass, got %v", appErr)
+		}
+	})
+}
+
 func TestLookupSoulCommRecipientAgentID_PhoneAndUnsupported(t *testing.T) {
 	t.Parallel()
 
@@ -1334,6 +1505,32 @@ func expectActiveCommRoute(t *testing.T, tdb soulCommSendMoreTestDB, agentID str
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
 		*dest = []*models.SoulAgentCommActivity{}
 	}).Twice()
+	counterparty := "alice@example.com"
+	if channelType == "phone" {
+		counterparty = "+15550143"
+	}
+	tdb.qCommActivity.On("All", mock.AnythingOfType("*[]*models.SoulAgentCommActivity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentCommActivity](t, args, 0)
+		activities := []*models.SoulAgentCommActivity{
+			{
+				ChannelType:  map[bool]string{true: commChannelSMS, false: commChannelEmail}[channelType == "phone"],
+				Direction:    models.SoulCommDirectionInbound,
+				Counterparty: counterparty,
+				MessageID:    "comm-msg-prev",
+				Timestamp:    time.Now().Add(-time.Minute).UTC(),
+			},
+		}
+		if channelType == "phone" {
+			activities = append(activities, &models.SoulAgentCommActivity{
+				ChannelType:  commChannelVoice,
+				Direction:    models.SoulCommDirectionInbound,
+				Counterparty: counterparty,
+				MessageID:    "comm-msg-prev",
+				Timestamp:    time.Now().Add(-time.Minute).UTC(),
+			})
+		}
+		*dest = activities
+	}).Maybe()
 }
 
 func resetCommMockQueryChain(q *ttmocks.MockQuery) {

--- a/internal/controlplane/handlers_soul_discovery_v3.go
+++ b/internal/controlplane/handlers_soul_discovery_v3.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"context"
 	"net/http"
 	"net/mail"
 	"net/url"
@@ -410,20 +411,55 @@ func (s *Server) handleSoulPublicResolveEmail(ctx *apptheory.Context) (*apptheor
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 	}
 
+	emailAddress, appErr := soulResolveEmailParam(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+	item, appErr := s.lookupSoulEmailAgentIndex(ctx.Context(), emailAddress)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	identity, err := s.getSoulAgentIdentity(ctx.Context(), item.AgentID)
+	if theoryErrors.IsNotFound(err) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if !soulIdentityPubliclyResolvable(identity) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	if appErr := s.requirePublicResolvableSoulChannel(ctx, strings.TrimSpace(item.AgentID), models.SoulChannelTypeEmail, emailAddress); appErr != nil {
+		return nil, appErr
+	}
+
+	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
+	return resp, nil
+}
+
+func soulResolveEmailParam(ctx *apptheory.Context) (string, *apptheory.AppError) {
 	raw, _ := url.PathUnescape(strings.TrimSpace(ctx.Param("emailAddress")))
 	if raw == "" {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "emailAddress is required"}
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: "emailAddress is required"}
 	}
 	addr, err := mail.ParseAddress(raw)
 	if err != nil || addr == nil || strings.TrimSpace(addr.Address) == "" {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "emailAddress is invalid"}
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: "emailAddress is invalid"}
 	}
+	return strings.TrimSpace(addr.Address), nil
+}
 
-	idx := &models.SoulEmailAgentIndex{Email: addr.Address}
+func (s *Server) lookupSoulEmailAgentIndex(ctx context.Context, emailAddress string) (*models.SoulEmailAgentIndex, *apptheory.AppError) {
+	idx := &models.SoulEmailAgentIndex{Email: emailAddress}
 	_ = idx.UpdateKeys()
 
 	var item models.SoulEmailAgentIndex
-	err = s.store.DB.WithContext(ctx.Context()).
+	err := s.store.DB.WithContext(ctx).
 		Model(&models.SoulEmailAgentIndex{}).
 		Where("PK", "=", idx.PK).
 		Where("SK", "=", "AGENT").
@@ -437,27 +473,7 @@ func (s *Server) handleSoulPublicResolveEmail(ctx *apptheory.Context) (*apptheor
 	if strings.TrimSpace(item.AgentID) == "" {
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 	}
-
-	identity, err := s.getSoulAgentIdentity(ctx.Context(), item.AgentID)
-	if theoryErrors.IsNotFound(err) {
-		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
-	}
-	if err != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-	if !soulIdentityPubliclyResolvable(identity) {
-		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
-	}
-	if appErr := s.requirePublicResolvableSoulChannel(ctx, strings.TrimSpace(item.AgentID), models.SoulChannelTypeEmail, addr.Address); appErr != nil {
-		return nil, appErr
-	}
-
-	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
-	if err != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
-	return resp, nil
+	return &item, nil
 }
 
 func (s *Server) handleSoulPublicResolvePhone(ctx *apptheory.Context) (*apptheory.Response, error) {

--- a/internal/controlplane/handlers_soul_discovery_v3.go
+++ b/internal/controlplane/handlers_soul_discovery_v3.go
@@ -384,6 +384,12 @@ func (s *Server) handleSoulPublicResolveENSName(ctx *apptheory.Context) (*appthe
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	if !soulIdentityPubliclyResolvable(identity) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	if appErr := s.requirePublicResolvableSoulChannel(ctx, strings.TrimSpace(item.AgentID), models.SoulChannelTypeENS, raw); appErr != nil {
+		return nil, appErr
+	}
 
 	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
 	if err != nil {
@@ -438,6 +444,12 @@ func (s *Server) handleSoulPublicResolveEmail(ctx *apptheory.Context) (*apptheor
 	}
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if !soulIdentityPubliclyResolvable(identity) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	if appErr := s.requirePublicResolvableSoulChannel(ctx, strings.TrimSpace(item.AgentID), models.SoulChannelTypeEmail, addr.Address); appErr != nil {
+		return nil, appErr
 	}
 
 	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
@@ -495,6 +507,12 @@ func (s *Server) handleSoulPublicResolvePhone(ctx *apptheory.Context) (*apptheor
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	if !soulIdentityPubliclyResolvable(identity) {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	if appErr := s.requirePublicResolvableSoulChannel(ctx, strings.TrimSpace(item.AgentID), models.SoulChannelTypePhone, idx.Phone); appErr != nil {
+		return nil, appErr
+	}
 
 	resp, err := apptheory.JSON(http.StatusOK, soulPublicAgentResponse{Version: "1", Agent: s.buildSoulPublicAgentView(ctx.Context(), identity)})
 	if err != nil {
@@ -502,4 +520,60 @@ func (s *Server) handleSoulPublicResolvePhone(ctx *apptheory.Context) (*apptheor
 	}
 	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
 	return resp, nil
+}
+
+func soulIdentityPubliclyResolvable(identity *models.SoulAgentIdentity) bool {
+	if identity == nil {
+		return false
+	}
+	status := strings.ToLower(strings.TrimSpace(identity.LifecycleStatus))
+	if status == "" {
+		status = strings.ToLower(strings.TrimSpace(identity.Status))
+	}
+	return status == models.SoulAgentStatusActive
+}
+
+func (s *Server) requirePublicResolvableSoulChannel(ctx *apptheory.Context, agentIDHex string, channelType string, identifier string) *apptheory.AppError {
+	ch, appErr := loadSoulOptionalItem[models.SoulAgentChannel](s, ctx, agentIDHex, "CHANNEL#"+strings.ToLower(strings.TrimSpace(channelType)))
+	if appErr != nil {
+		return appErr
+	}
+	if ch == nil {
+		return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	chCopy := *ch
+	_ = chCopy.UpdateKeys()
+	switch strings.ToLower(strings.TrimSpace(channelType)) {
+	case models.SoulChannelTypeEmail, models.SoulChannelTypePhone:
+		if !trustedManagedSoulChannelForIndex(&chCopy) {
+			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+		}
+	case models.SoulChannelTypeENS:
+		if chCopy.Status != models.SoulChannelStatusActive {
+			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+		}
+	default:
+		return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	want := strings.TrimSpace(identifier)
+	switch chCopy.ChannelType {
+	case models.SoulChannelTypeEmail:
+		addr, err := mail.ParseAddress(want)
+		if err != nil || addr == nil {
+			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+		}
+		want = strings.ToLower(strings.TrimSpace(addr.Address))
+	case models.SoulChannelTypePhone:
+		phoneIdx := &models.SoulPhoneAgentIndex{Phone: identifier}
+		_ = phoneIdx.UpdateKeys()
+		want = phoneIdx.Phone
+	case models.SoulChannelTypeENS:
+		ensIdx := &models.SoulAgentENSResolution{ENSName: identifier}
+		_ = ensIdx.UpdateKeys()
+		want = ensIdx.ENSName
+	}
+	if !strings.EqualFold(strings.TrimSpace(chCopy.Identifier), want) {
+		return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	return nil
 }

--- a/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
+++ b/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
@@ -95,7 +95,7 @@ func TestSoulPublicDiscoveryV3PhoneChannelFromModel(t *testing.T) {
 	if got == nil {
 		t.Fatalf("expected phone channel")
 	}
-	if got.Number != "+14155550123" || got.Provider != "telnyx" || got.Status != "paused" {
+	if got.Number != "+14155550123" || got.Provider != commDeliveryProviderTelnyx || got.Status != "paused" {
 		t.Fatalf("unexpected phone channel: %#v", got)
 	}
 	if got.VerifiedAt != verifiedAt.Format(time.RFC3339Nano) {

--- a/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
+++ b/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
@@ -498,7 +498,31 @@ func discoverySuccessSetup(setup discoveryResolveSetup, localID string) discover
 			dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 			*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: localID, Status: models.SoulAgentStatusActive}
 		}).Once()
-		tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+		if localID == "agent-phone" {
+			tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+				*dest = models.SoulAgentChannel{
+					AgentID:       agentID,
+					ChannelType:   models.SoulChannelTypePhone,
+					Identifier:    "+14155550123",
+					Provider:      "telnyx",
+					Verified:      true,
+					ProvisionedAt: time.Now().Add(-time.Hour).UTC(),
+					Status:        models.SoulChannelStatusActive,
+				}
+			}).Once()
+			tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+			return
+		}
+		tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+			*dest = models.SoulAgentChannel{
+				AgentID:     agentID,
+				ChannelType: models.SoulChannelTypeENS,
+				Identifier:  "agent.lessersoul.eth",
+				Status:      models.SoulChannelStatusActive,
+			}
+		}).Twice()
 	}
 }
 

--- a/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
+++ b/internal/controlplane/handlers_soul_failures_comm_portal_internal_test.go
@@ -225,6 +225,47 @@ func TestHandleSoulAgentCommQueueReadsMailbox(t *testing.T) {
 	}
 }
 
+func TestHandleSoulAgentCommQueuePaginatesUntilQueuedRows(t *testing.T) {
+	t.Parallel()
+
+	agentID := soulLifecycleTestAgentIDHex
+	tdb := newSoulCommPortalTestDB()
+	seedSoulAgentPortalAccess(t, tdb, agentID, models.SoulAgentStatusActive)
+
+	firstPage := []*models.SoulCommMailboxMessage{
+		portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered),
+		portalMailboxMessage(agentID, models.SoulCommMailboxStatusDelivered),
+	}
+	queued := portalMailboxMessage(agentID, models.SoulCommMailboxStatusQueued)
+	queued.DeliveryID = "delivery-queued-page-2"
+	tdb.qMailbox.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).
+		Return(&core.PaginatedResult{HasMore: true, NextCursor: "cursor-2"}, nil).
+		Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+			*dest = firstPage
+		}).Once()
+	tdb.qMailbox.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).
+		Return(&core.PaginatedResult{}, nil).
+		Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+			*dest = []*models.SoulCommMailboxMessage{queued}
+		}).Once()
+
+	s := newSoulPortalServer(tdb)
+	resp, err := s.handleSoulAgentCommQueue(soulAgentCommPortalCtx(agentID))
+	if err != nil || resp.Status != http.StatusOK {
+		t.Fatalf("unexpected response: %#v %v", resp, err)
+	}
+
+	var out soulAgentCommQueueResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal queue: %v", err)
+	}
+	if out.Count != 1 || out.Items[0].DeliveryID != "delivery-queued-page-2" {
+		t.Fatalf("expected queued row from second page, got %#v", out)
+	}
+}
+
 func TestHandleSoulAgentCommStatusBranches(t *testing.T) {
 	t.Parallel()
 
@@ -263,10 +304,12 @@ func soulAgentCommStatusCtx(agentID string, messageID string) *apptheory.Context
 
 func expectPortalMailboxRows(t *testing.T, q *ttmocks.MockQuery, rows []*models.SoulCommMailboxMessage) {
 	t.Helper()
-	q.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(func(args mock.Arguments) {
+	assign := func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
 		*dest = rows
-	}).Once()
+	}
+	q.On("All", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(nil).Run(assign).Maybe()
+	q.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(assign).Maybe()
 }
 
 func portalQueueMailboxRows(agentID string) []*models.SoulCommMailboxMessage {

--- a/internal/controlplane/handlers_soul_mine.go
+++ b/internal/controlplane/handlers_soul_mine.go
@@ -133,6 +133,9 @@ func (s *Server) listDomainsForInstances(ctx context.Context, instances []*model
 			if domain == "" {
 				continue
 			}
+			if !domainIsVerifiedOrActive(d.Status) {
+				continue
+			}
 			domainSet[domain] = struct{}{}
 		}
 

--- a/internal/controlplane/handlers_soul_mine.go
+++ b/internal/controlplane/handlers_soul_mine.go
@@ -107,45 +107,56 @@ func (s *Server) listDomainsForInstances(ctx context.Context, instances []*model
 
 	domainSet := map[string]struct{}{}
 	for _, inst := range instances {
-		if inst == nil {
+		if inst == nil || strings.TrimSpace(inst.Slug) == "" {
 			continue
 		}
-		slug := strings.ToLower(strings.TrimSpace(inst.Slug))
-		if slug == "" {
-			continue
+		domains, listErr := s.listVerifiedDomainsForInstance(ctx, inst)
+		if listErr != nil {
+			return nil, listErr
 		}
-
-		var domains []*models.Domain
-		err := s.store.DB.WithContext(ctx).
-			Model(&models.Domain{}).
-			Index("gsi1").
-			Where("gsi1PK", "=", fmt.Sprintf("INSTANCE_DOMAINS#%s", slug)).
-			All(&domains)
-		if err != nil && !theoryErrors.IsNotFound(err) {
-			return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list domains"}
-		}
-
-		for _, d := range domains {
-			if d == nil {
-				continue
-			}
-			domain := strings.ToLower(strings.TrimSpace(d.Domain))
-			if domain == "" {
-				continue
-			}
-			if !domainIsVerifiedOrActive(d.Status) {
-				continue
-			}
-			domainSet[domain] = struct{}{}
-		}
-
-		managedDomain := managedInstanceStageDomain(s.cfg.Stage, strings.TrimSpace(inst.HostedBaseDomain))
-		if managedDomain != "" {
-			domainSet[strings.ToLower(strings.TrimSpace(managedDomain))] = struct{}{}
-		}
+		addStringsToSet(domainSet, domains...)
+		addStringsToSet(domainSet, managedInstanceStageDomain(s.cfg.Stage, strings.TrimSpace(inst.HostedBaseDomain)))
 	}
 
 	return domainSet, nil
+}
+
+func (s *Server) listVerifiedDomainsForInstance(ctx context.Context, inst *models.Instance) ([]string, *apptheory.AppError) {
+	slug := strings.ToLower(strings.TrimSpace(inst.Slug))
+	var domains []*models.Domain
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.Domain{}).
+		Index("gsi1").
+		Where("gsi1PK", "=", fmt.Sprintf("INSTANCE_DOMAINS#%s", slug)).
+		All(&domains)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list domains"}
+	}
+
+	out := make([]string, 0, len(domains))
+	for _, d := range domains {
+		domain := verifiedDomainName(d)
+		if domain != "" {
+			out = append(out, domain)
+		}
+	}
+	return out, nil
+}
+
+func verifiedDomainName(d *models.Domain) string {
+	if d == nil || !domainIsVerifiedOrActive(d.Status) {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(d.Domain))
+}
+
+func addStringsToSet(set map[string]struct{}, values ...string) {
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
 }
 
 func (s *Server) listAgentIDsForDomains(ctx context.Context, domainSet map[string]struct{}) ([]string, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_mine_internal_test.go
+++ b/internal/controlplane/handlers_soul_mine_internal_test.go
@@ -73,7 +73,7 @@ func TestHandleSoulListMyAgents_ReturnsOwnedAgents(t *testing.T) {
 
 	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
-		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "inst1"}}
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}}
 	}).Once()
 
 	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -157,7 +157,7 @@ func TestHandleSoulListMyAgents_IncludesManagedStageDomainAgents(t *testing.T) {
 
 	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
-		*dest = []*models.Domain{{Domain: "simulacrum.greater.website", InstanceSlug: "simulacrum"}}
+		*dest = []*models.Domain{{Domain: "simulacrum.greater.website", InstanceSlug: "simulacrum", Status: models.DomainStatusVerified}}
 	}).Once()
 
 	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -205,5 +205,43 @@ func TestHandleSoulListMyAgents_IncludesManagedStageDomainAgents(t *testing.T) {
 	}
 	if out.Agents[0].Agent.Domain != "dev.simulacrum.greater.website" {
 		t.Fatalf("expected managed stage domain, got %#v", out.Agents[0].Agent.Domain)
+	}
+}
+
+func TestHandleSoulListMyAgents_SkipsUnverifiedVanityDomains(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulMineTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulEnabled:                 true,
+			SoulChainID:                 1,
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
+		},
+	}
+
+	tdb.qInst.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{{Slug: "inst1"}}
+	}).Once()
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "victim.example", InstanceSlug: "inst1", Status: models.DomainStatusPending}}
+	}).Once()
+
+	ctx := &apptheory.Context{RequestID: "r1", AuthIdentity: "alice"}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+
+	resp, err := s.handleSoulListMyAgents(ctx)
+	if err != nil {
+		t.Fatalf("handleSoulListMyAgents: %v", err)
+	}
+	var out soulMineAgentsResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Count != 0 || len(out.Agents) != 0 {
+		t.Fatalf("expected pending vanity domain to be ignored, got %#v", out)
 	}
 }

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/ethereum/go-ethereum/common"
@@ -170,11 +171,22 @@ func (s *Server) handleSoulPublicGetReputation(ctx *apptheory.Context) (*apptheo
 }
 
 type soulPublicValidationsResponse struct {
-	Version     string                             `json:"version"`
-	Validations []models.SoulAgentValidationRecord `json:"validations"`
-	Count       int                                `json:"count"`
-	HasMore     bool                               `json:"has_more"`
-	NextCursor  string                             `json:"next_cursor,omitempty"`
+	Version     string                       `json:"version"`
+	Validations []soulPublicValidationRecord `json:"validations"`
+	Count       int                          `json:"count"`
+	HasMore     bool                         `json:"has_more"`
+	NextCursor  string                       `json:"next_cursor,omitempty"`
+}
+
+type soulPublicValidationRecord struct {
+	AgentID       string    `json:"agent_id"`
+	ChallengeID   string    `json:"challenge_id"`
+	ChallengeType string    `json:"challenge_type"`
+	ValidatorID   string    `json:"validator_id"`
+	Result        string    `json:"result"`
+	Score         float64   `json:"score"`
+	OptInStatus   string    `json:"opt_in_status,omitempty"`
+	EvaluatedAt   time.Time `json:"evaluated_at"`
 }
 
 func (s *Server) handleSoulPublicGetValidations(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -212,12 +224,12 @@ func (s *Server) handleSoulPublicGetValidations(ctx *apptheory.Context) (*appthe
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list validations"}
 	}
 
-	out := make([]models.SoulAgentValidationRecord, 0, len(items))
+	out := make([]soulPublicValidationRecord, 0, len(items))
 	for _, item := range items {
 		if item == nil {
 			continue
 		}
-		out = append(out, *item)
+		out = append(out, redactSoulPublicValidationRecord(*item))
 	}
 
 	nextCursor := ""
@@ -239,6 +251,19 @@ func (s *Server) handleSoulPublicGetValidations(ctx *apptheory.Context) (*appthe
 	}
 	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
 	return resp, nil
+}
+
+func redactSoulPublicValidationRecord(item models.SoulAgentValidationRecord) soulPublicValidationRecord {
+	return soulPublicValidationRecord{
+		AgentID:       strings.ToLower(strings.TrimSpace(item.AgentID)),
+		ChallengeID:   strings.TrimSpace(item.ChallengeID),
+		ChallengeType: strings.ToLower(strings.TrimSpace(item.ChallengeType)),
+		ValidatorID:   strings.ToLower(strings.TrimSpace(item.ValidatorID)),
+		Result:        strings.ToLower(strings.TrimSpace(item.Result)),
+		Score:         item.Score,
+		OptInStatus:   strings.ToLower(strings.TrimSpace(item.OptInStatus)),
+		EvaluatedAt:   item.EvaluatedAt,
+	}
 }
 
 type soulSearchResult struct {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -1306,6 +1306,18 @@ func TestHandleSoulPublicResolveEmail_Success(t *testing.T) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
 	}).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:       agentID,
+			ChannelType:   models.SoulChannelTypeEmail,
+			Identifier:    "agent-bob@lessersoul.ai",
+			Provider:      "migadu",
+			Verified:      true,
+			ProvisionedAt: time.Now().Add(-time.Hour).UTC(),
+			Status:        models.SoulChannelStatusActive,
+		}
+	}).Once()
 
 	ctx := &apptheory.Context{Params: map[string]string{"emailAddress": "agent-bob@lessersoul.ai"}}
 	resp, err := s.handleSoulPublicResolveEmail(ctx)

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -824,7 +824,16 @@ func TestHandleSoulPublicGetValidations_PaginatesAndFiltersNilItems(t *testing.T
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentValidationRecord](t, args, 0)
 		*dest = []*models.SoulAgentValidationRecord{
 			nil,
-			{AgentID: agentID, ChallengeID: "c1", ChallengeType: "identity_verify", Result: "pass", EvaluatedAt: time.Now().UTC()},
+			{
+				AgentID:       agentID,
+				ChallengeID:   "c1",
+				ChallengeType: "identity_verify",
+				ValidatorID:   "system",
+				Request:       "raw challenge transcript",
+				Response:      "raw agent response",
+				Result:        "pass",
+				EvaluatedAt:   time.Now().UTC(),
+			},
 		}
 	}).Once()
 
@@ -843,6 +852,12 @@ func TestHandleSoulPublicGetValidations_PaginatesAndFiltersNilItems(t *testing.T
 	}
 	if out.Count != 1 || len(out.Validations) != 1 || !out.HasMore || out.NextCursor != "c2" {
 		t.Fatalf("unexpected response: %#v", out)
+	}
+	if out.Validations[0].ChallengeID != "c1" || out.Validations[0].ValidatorID != "system" {
+		t.Fatalf("unexpected redacted validation: %#v", out.Validations[0])
+	}
+	if jsonContainsAny(resp.Body, `"request"`, `"response"`, "raw challenge transcript", "raw agent response") {
+		t.Fatalf("public validations leaked raw transcript fields: %s", string(resp.Body))
 	}
 }
 

--- a/internal/controlplane/handlers_soul_sovereignty.go
+++ b/internal/controlplane/handlers_soul_sovereignty.go
@@ -36,11 +36,19 @@ type soulValidationOptInRequest struct {
 // --- Response types ---
 
 type soulListDisputesResponse struct {
-	Version    string                    `json:"version"`
-	Disputes   []models.SoulAgentDispute `json:"disputes"`
-	Count      int                       `json:"count"`
-	HasMore    bool                      `json:"has_more"`
-	NextCursor string                    `json:"next_cursor,omitempty"`
+	Version    string              `json:"version"`
+	Disputes   []soulPublicDispute `json:"disputes"`
+	Count      int                 `json:"count"`
+	HasMore    bool                `json:"has_more"`
+	NextCursor string              `json:"next_cursor,omitempty"`
+}
+
+type soulPublicDispute struct {
+	AgentID    string    `json:"agent_id"`
+	DisputeID  string    `json:"dispute_id"`
+	Status     string    `json:"status"`
+	CreatedAt  time.Time `json:"created_at"`
+	ResolvedAt time.Time `json:"resolved_at,omitempty"`
 }
 
 // --- Handlers ---
@@ -187,13 +195,6 @@ func (s *Server) handleSoulValidationOptIn(ctx *apptheory.Context) (*apptheory.R
 	now := time.Now().UTC()
 	challenge.OptInStatus = optInStatus
 
-	if optInStatus == models.SoulValidationOptInStatusDeclined {
-		if appErr := s.recordDeclinedSoulValidation(ctx.Context(), agentIDHex, challenge, optInStatus, now); appErr != nil {
-			return nil, appErr
-		}
-		return apptheory.JSON(http.StatusOK, challenge)
-	}
-
 	challenge.UpdatedAt = now
 	_ = challenge.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(challenge).IfExists().Update("OptInStatus", "UpdatedAt"); err != nil {
@@ -234,35 +235,6 @@ func (s *Server) loadSoulValidationChallengeForOptIn(ctx context.Context, agentI
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "challenge is not in issued status"}
 	}
 	return challenge, nil
-}
-
-func (s *Server) recordDeclinedSoulValidation(ctx context.Context, agentIDHex string, challenge *models.SoulAgentValidationChallenge, optInStatus string, now time.Time) *apptheory.AppError {
-	rec := &models.SoulAgentValidationRecord{
-		AgentID:       agentIDHex,
-		ChallengeID:   strings.TrimSpace(challenge.ChallengeID),
-		ChallengeType: strings.TrimSpace(challenge.ChallengeType),
-		ValidatorID:   strings.TrimSpace(challenge.ValidatorID),
-		Request:       strings.TrimSpace(challenge.Request),
-		Response:      "",
-		Result:        models.SoulValidationResultDeclined,
-		Score:         0,
-		OptInStatus:   optInStatus,
-		EvaluatedAt:   now,
-	}
-	_ = rec.UpdateKeys()
-	if err := s.store.DB.WithContext(ctx).Model(rec).Create(); err != nil {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to record declined validation"}
-	}
-	challenge.Status = models.SoulValidationChallengeStatusEvaluated
-	challenge.Result = models.SoulValidationResultDeclined
-	challenge.Score = 0
-	challenge.EvaluatedAt = now
-	challenge.UpdatedAt = now
-	_ = challenge.UpdateKeys()
-	if err := s.store.DB.WithContext(ctx).Model(challenge).IfExists().Update("OptInStatus", "Status", "Result", "Score", "EvaluatedAt", "UpdatedAt"); err != nil {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to update opt-in status"}
-	}
-	return nil
 }
 
 // handleSoulCreateDispute creates a dispute record for an agent.
@@ -348,7 +320,7 @@ func (s *Server) handleSoulCreateDispute(ctx *apptheory.Context) (*apptheory.Res
 
 // handleSoulPublicGetDisputes returns paginated disputes for an agent.
 func (s *Server) handleSoulPublicGetDisputes(ctx *apptheory.Context) (*apptheory.Response, error) {
-	out, hasMore, nextCursor, appErr := listSoulPublicAgentItems[models.SoulAgentDispute](
+	items, hasMore, nextCursor, appErr := listSoulPublicAgentItems[models.SoulAgentDispute](
 		s,
 		ctx,
 		&models.SoulAgentDispute{},
@@ -357,6 +329,10 @@ func (s *Server) handleSoulPublicGetDisputes(ctx *apptheory.Context) (*apptheory
 	)
 	if appErr != nil {
 		return nil, appErr
+	}
+	out := make([]soulPublicDispute, 0, len(items))
+	for _, item := range items {
+		out = append(out, redactSoulPublicDispute(item))
 	}
 
 	resp, err := apptheory.JSON(http.StatusOK, soulListDisputesResponse{
@@ -371,6 +347,16 @@ func (s *Server) handleSoulPublicGetDisputes(ctx *apptheory.Context) (*apptheory
 	}
 	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
 	return resp, nil
+}
+
+func redactSoulPublicDispute(dispute models.SoulAgentDispute) soulPublicDispute {
+	return soulPublicDispute{
+		AgentID:    strings.ToLower(strings.TrimSpace(dispute.AgentID)),
+		DisputeID:  strings.TrimSpace(dispute.DisputeID),
+		Status:     strings.ToLower(strings.TrimSpace(dispute.Status)),
+		CreatedAt:  dispute.CreatedAt,
+		ResolvedAt: dispute.ResolvedAt,
+	}
 }
 
 func (s *Server) handleSoulPublicGetDispute(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -397,5 +383,10 @@ func (s *Server) handleSoulPublicGetDispute(ctx *apptheory.Context) (*apptheory.
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
-	return apptheory.JSON(http.StatusOK, dispute)
+	resp, jsonErr := apptheory.JSON(http.StatusOK, redactSoulPublicDispute(*dispute))
+	if jsonErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
+	return resp, nil
 }

--- a/internal/controlplane/handlers_soul_sovereignty_internal_test.go
+++ b/internal/controlplane/handlers_soul_sovereignty_internal_test.go
@@ -59,7 +59,7 @@ func newSoulSovereigntyTestDB() soulSovereigntyTestDB {
 	}
 }
 
-func TestHandleSoulValidationOptIn_DeclineCreatesZeroScoreRecord(t *testing.T) {
+func TestHandleSoulValidationOptIn_DeclineRecordsOptInOnly(t *testing.T) {
 	t.Parallel()
 
 	tdb := newSoulSovereigntyTestDB()
@@ -110,12 +110,6 @@ func TestHandleSoulValidationOptIn_DeclineCreatesZeroScoreRecord(t *testing.T) {
 		}
 	}).Once()
 
-	var createdRec *models.SoulAgentValidationRecord
-	tdb.db.On("Model", mock.AnythingOfType("*models.SoulAgentValidationRecord")).Return(tdb.qRec).Run(func(args mock.Arguments) {
-		rec := testutil.RequireMockArg[*models.SoulAgentValidationRecord](t, args, 0)
-		createdRec = rec
-	}).Once()
-
 	body, _ := json.Marshal(map[string]any{"accepted": false})
 	ctx := &apptheory.Context{
 		RequestID:    "r1",
@@ -132,18 +126,15 @@ func TestHandleSoulValidationOptIn_DeclineCreatesZeroScoreRecord(t *testing.T) {
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d (body=%q)", resp.Status, string(resp.Body))
 	}
-
-	if createdRec == nil {
-		t.Fatalf("expected validation record to be created")
+	var out models.SoulAgentValidationChallenge
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
 	}
-	if createdRec.Result != models.SoulValidationResultDeclined {
-		t.Fatalf("expected declined result, got %q", createdRec.Result)
+	if out.OptInStatus != models.SoulValidationOptInStatusDeclined {
+		t.Fatalf("expected optInStatus declined, got %q", out.OptInStatus)
 	}
-	if createdRec.Score != 0 {
-		t.Fatalf("expected score 0, got %v", createdRec.Score)
-	}
-	if createdRec.OptInStatus != models.SoulValidationOptInStatusDeclined {
-		t.Fatalf("expected optInStatus declined, got %q", createdRec.OptInStatus)
+	if out.Status == models.SoulValidationChallengeStatusEvaluated || out.Result != "" || out.Score != 0 || !out.EvaluatedAt.IsZero() {
+		t.Fatalf("declined opt-in should not finalize evaluation: %#v", out)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_sovereignty_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_sovereignty_more_internal_test.go
@@ -341,6 +341,9 @@ func TestHandleSoulCreateDispute_ValidationsAndSuccess(t *testing.T) {
 		if out.AgentID != agentID || out.DisputeID != "d-1" || out.Status != models.SoulDisputeStatusOpen {
 			t.Fatalf("unexpected dispute: %#v", out)
 		}
+		if out.SignalRef != "sig-1" || out.Evidence != "e" || out.Statement != "s" {
+			t.Fatalf("authenticated create response should retain raw dispute fields: %#v", out)
+		}
 	})
 
 	t.Run("conflict_when_create_fails", func(t *testing.T) {

--- a/internal/controlplane/handlers_soul_sovereignty_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_sovereignty_public_internal_test.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,8 +65,8 @@ func TestHandleSoulPublicGetDisputes_ReturnsDisputes(t *testing.T) {
 	if out.Disputes[0].DisputeID != "dispute-1" {
 		t.Fatalf("expected dispute_id %q, got %q", "dispute-1", out.Disputes[0].DisputeID)
 	}
-	if out.Disputes[0].SignalRef != "rep:signal:abc" {
-		t.Fatalf("expected signal_ref %q, got %q", "rep:signal:abc", out.Disputes[0].SignalRef)
+	if string(resp.Body) == "" || jsonContainsAny(resp.Body, "signal_ref", "evidence", "statement", "resolution", "rep:signal:abc", "s3://bucket/evidence.json", "This is incorrect.") {
+		t.Fatalf("public dispute list leaked raw evidence fields: %s", string(resp.Body))
 	}
 }
 
@@ -103,11 +104,24 @@ func TestHandleSoulPublicGetDispute_ReturnsDispute(t *testing.T) {
 		t.Fatalf("expected 200, got %d (body=%q)", resp.Status, string(resp.Body))
 	}
 
-	var out models.SoulAgentDispute
+	var out soulPublicDispute
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.DisputeID != "dispute-1" {
 		t.Fatalf("expected dispute_id %q, got %q", "dispute-1", out.DisputeID)
 	}
+	if jsonContainsAny(resp.Body, "signal_ref", "evidence", "statement", "resolution", "rep:signal:abc", "This is incorrect.") {
+		t.Fatalf("public dispute detail leaked raw evidence fields: %s", string(resp.Body))
+	}
+}
+
+func jsonContainsAny(body []byte, needles ...string) bool {
+	raw := string(body)
+	for _, needle := range needles {
+		if needle != "" && strings.Contains(raw, needle) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -479,21 +479,7 @@ func (s *Server) buildSoulV3ENSSync(agentIDHex string, identity *models.SoulAgen
 		Status:             models.SoulChannelStatusActive,
 		UpdatedAt:          now,
 	}
-	resolution := &models.SoulAgentENSResolution{
-		ENSName:             strings.TrimSpace(ens.Name),
-		AgentID:             agentIDHex,
-		Wallet:              strings.TrimSpace(identity.Wallet),
-		LocalID:             strings.TrimSpace(identity.LocalID),
-		Domain:              strings.TrimSpace(identity.Domain),
-		SoulRegistrationURI: s.soulMetaURI(agentIDHex),
-		MCPEndpoint:         strings.TrimSpace(regV3.Endpoints.MCP),
-		ActivityPubURI:      strings.TrimSpace(regV3.Endpoints.ActivityPub),
-		Email:               emailAddress,
-		Phone:               phoneNumber,
-		Status:              strings.TrimSpace(identity.LifecycleStatus),
-		UpdatedAt:           now,
-	}
-	return desired, resolution
+	return desired, nil
 }
 
 func buildSoulV3EmailSync(agentIDHex string, regV3 *soul.RegistrationFileV3, now time.Time) (*models.SoulAgentChannel, *models.SoulEmailAgentIndex) {
@@ -550,6 +536,9 @@ func (s *Server) syncSoulV3Channel(
 	if err != nil {
 		return err
 	}
+	if trustedManagedSoulChannelForIndex(existing) && !soulChannelsSameIdentifier(existing, desired) {
+		return &apptheory.AppError{Code: "app.conflict", Message: "managed channel must be deprovisioned before changing identifier"}
+	}
 	preserveManagedSoulChannelMetadata(desired, existing)
 	if appErr := s.cleanupSoulV3ChannelIndexes(ctx, agentIDHex, channelType, identity, existing, desired); appErr != nil {
 		return appErr
@@ -573,6 +562,9 @@ func preserveManagedSoulChannelMetadata(desired *models.SoulAgentChannel, existi
 	if desired == nil || existing == nil {
 		return
 	}
+	if !soulChannelsSameIdentifier(existing, desired) {
+		return
+	}
 	if strings.TrimSpace(desired.Provider) == "" {
 		desired.Provider = strings.TrimSpace(existing.Provider)
 	}
@@ -585,6 +577,12 @@ func preserveManagedSoulChannelMetadata(desired *models.SoulAgentChannel, existi
 	if desired.DeprovisionedAt.IsZero() && !existing.DeprovisionedAt.IsZero() {
 		desired.DeprovisionedAt = existing.DeprovisionedAt
 	}
+	if existing.Verified {
+		desired.Verified = true
+		if desired.VerifiedAt.IsZero() && !existing.VerifiedAt.IsZero() {
+			desired.VerifiedAt = existing.VerifiedAt
+		}
+	}
 }
 
 func (s *Server) cleanupSoulV3ChannelIndexes(ctx context.Context, agentIDHex string, channelType string, identity *models.SoulAgentIdentity, existing *models.SoulAgentChannel, desired *models.SoulAgentChannel) *apptheory.AppError {
@@ -595,15 +593,21 @@ func (s *Server) cleanupSoulV3ChannelIndexes(ctx context.Context, agentIDHex str
 	case models.SoulChannelTypeEmail:
 		old := &models.SoulEmailAgentIndex{Email: existing.Identifier, AgentID: agentIDHex}
 		_ = old.UpdateKeys()
-		_ = s.store.DB.WithContext(ctx).Model(old).Delete()
+		if err := s.deleteSoulEmailAgentIndexIfOwned(ctx, old); err != nil {
+			return &apptheory.AppError{Code: "app.internal", Message: "failed to delete email index"}
+		}
 	case models.SoulChannelTypePhone:
 		old := &models.SoulPhoneAgentIndex{Phone: existing.Identifier, AgentID: agentIDHex}
 		_ = old.UpdateKeys()
-		_ = s.store.DB.WithContext(ctx).Model(old).Delete()
+		if err := s.deleteSoulPhoneAgentIndexIfOwned(ctx, old); err != nil {
+			return &apptheory.AppError{Code: "app.internal", Message: "failed to delete phone index"}
+		}
 	case models.SoulChannelTypeENS:
 		old := &models.SoulAgentENSResolution{ENSName: existing.Identifier, AgentID: agentIDHex}
 		_ = old.UpdateKeys()
-		_ = s.store.DB.WithContext(ctx).Model(old).Delete()
+		if err := s.deleteSoulENSResolutionIfOwned(ctx, old); err != nil {
+			return &apptheory.AppError{Code: "app.internal", Message: "failed to delete ens resolution"}
+		}
 	}
 	if desired == nil {
 		return s.deleteSoulChannelAgentIndex(ctx, identity, channelType, agentIDHex)
@@ -649,7 +653,7 @@ func (s *Server) upsertSoulV3Channel(
 	if err := s.store.DB.WithContext(ctx).Model(desired).CreateOrUpdate(); err != nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to update channel"}
 	}
-	if appErr := s.upsertSoulV3ChannelIndexes(ctx, identity, channelType, desiredEmailIndex, desiredPhoneIndex, desiredENS); appErr != nil {
+	if appErr := s.upsertSoulV3ChannelIndexes(ctx, identity, channelType, desired, desiredEmailIndex, desiredPhoneIndex, desiredENS); appErr != nil {
 		return appErr
 	}
 	return nil
@@ -659,29 +663,38 @@ func (s *Server) upsertSoulV3ChannelIndexes(
 	ctx context.Context,
 	identity *models.SoulAgentIdentity,
 	channelType string,
+	desired *models.SoulAgentChannel,
 	desiredEmailIndex *models.SoulEmailAgentIndex,
 	desiredPhoneIndex *models.SoulPhoneAgentIndex,
 	desiredENS *models.SoulAgentENSResolution,
 ) *apptheory.AppError {
 	if desiredEmailIndex != nil {
-		_ = desiredEmailIndex.UpdateKeys()
-		if err := s.store.DB.WithContext(ctx).Model(desiredEmailIndex).CreateOrUpdate(); err != nil {
-			return &apptheory.AppError{Code: "app.internal", Message: "failed to update email index"}
+		if trustedManagedSoulChannelForIndex(desired) {
+			if appErr := s.ensureSoulEmailAgentIndex(ctx, desiredEmailIndex); appErr != nil {
+				return appErr
+			}
+		} else {
+			desiredEmailIndex = nil
 		}
 	}
 	if desiredPhoneIndex != nil {
-		_ = desiredPhoneIndex.UpdateKeys()
-		if err := s.store.DB.WithContext(ctx).Model(desiredPhoneIndex).CreateOrUpdate(); err != nil {
-			return &apptheory.AppError{Code: "app.internal", Message: "failed to update phone index"}
+		if trustedManagedSoulChannelForIndex(desired) {
+			if appErr := s.ensureSoulPhoneAgentIndex(ctx, desiredPhoneIndex); appErr != nil {
+				return appErr
+			}
+		} else {
+			desiredPhoneIndex = nil
 		}
 	}
 	if desiredENS != nil {
-		_ = desiredENS.UpdateKeys()
-		if err := s.store.DB.WithContext(ctx).Model(desiredENS).CreateOrUpdate(); err != nil {
-			return &apptheory.AppError{Code: "app.internal", Message: "failed to update ens resolution"}
+		if appErr := s.ensureSoulENSResolution(ctx, desiredENS); appErr != nil {
+			return appErr
 		}
 	}
 	if channelType != models.SoulChannelTypeEmail && channelType != models.SoulChannelTypePhone {
+		return nil
+	}
+	if !trustedManagedSoulChannelForIndex(desired) {
 		return nil
 	}
 	if strings.TrimSpace(identity.Domain) == "" || strings.TrimSpace(identity.LocalID) == "" {
@@ -698,6 +711,233 @@ func (s *Server) upsertSoulV3ChannelIndexes(
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to update channel index"}
 	}
 	return nil
+}
+
+func soulChannelsSameIdentifier(existing *models.SoulAgentChannel, desired *models.SoulAgentChannel) bool {
+	if existing == nil && desired == nil {
+		return true
+	}
+	if existing == nil || desired == nil {
+		return false
+	}
+	existingCopy := *existing
+	desiredCopy := *desired
+	_ = existingCopy.UpdateKeys()
+	_ = desiredCopy.UpdateKeys()
+	return strings.EqualFold(strings.TrimSpace(existingCopy.ChannelType), strings.TrimSpace(desiredCopy.ChannelType)) &&
+		strings.EqualFold(strings.TrimSpace(existingCopy.Identifier), strings.TrimSpace(desiredCopy.Identifier))
+}
+
+func trustedManagedSoulChannelForIndex(ch *models.SoulAgentChannel) bool {
+	if ch == nil {
+		return false
+	}
+	chCopy := *ch
+	_ = chCopy.UpdateKeys()
+	if !chCopy.Verified || chCopy.ProvisionedAt.IsZero() || !chCopy.DeprovisionedAt.IsZero() || chCopy.Status != models.SoulChannelStatusActive {
+		return false
+	}
+	switch chCopy.ChannelType {
+	case models.SoulChannelTypeEmail:
+		return chCopy.Provider == "migadu"
+	case models.SoulChannelTypePhone:
+		return chCopy.Provider == "telnyx"
+	default:
+		return false
+	}
+}
+
+func soulCanonicalENSName(localID string) string {
+	localID = strings.TrimSpace(localID)
+	if localID == "" {
+		return ""
+	}
+	return localID + ".lessersoul.eth"
+}
+
+func soulENSResolutionAllowedForIdentity(identity *models.SoulAgentIdentity, desired *models.SoulAgentChannel) bool {
+	if identity == nil || desired == nil {
+		return false
+	}
+	desiredCopy := *desired
+	_ = desiredCopy.UpdateKeys()
+	localID, err := soul.NormalizeLocalAgentID(strings.TrimSpace(identity.LocalID))
+	if err != nil {
+		return false
+	}
+	canonical := soulCanonicalENSName(localID)
+	return canonical != "" &&
+		desiredCopy.ChannelType == models.SoulChannelTypeENS &&
+		desiredCopy.Identifier == canonical &&
+		strings.TrimSpace(identity.AgentID) != ""
+}
+
+func (s *Server) ensureSoulEmailAgentIndex(ctx context.Context, idx *models.SoulEmailAgentIndex) *apptheory.AppError {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	if strings.TrimSpace(idx.Email) == "" || strings.TrimSpace(idx.AgentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "email index is invalid"}
+	}
+	var existing models.SoulEmailAgentIndex
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulEmailAgentIndex{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if err == nil {
+		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+			return nil
+		}
+		return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
+	}
+	if !theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate email mapping"}
+	}
+	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
+		if theoryErrors.IsConditionFailed(err) {
+			return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
+		}
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to update email index"}
+	}
+	return nil
+}
+
+func (s *Server) ensureSoulPhoneAgentIndex(ctx context.Context, idx *models.SoulPhoneAgentIndex) *apptheory.AppError {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	if strings.TrimSpace(idx.Phone) == "" || strings.TrimSpace(idx.AgentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "phone index is invalid"}
+	}
+	var existing models.SoulPhoneAgentIndex
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulPhoneAgentIndex{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if err == nil {
+		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+			return nil
+		}
+		return &apptheory.AppError{Code: "app.conflict", Message: "phone number is already provisioned"}
+	}
+	if !theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate phone mapping"}
+	}
+	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
+		if theoryErrors.IsConditionFailed(err) {
+			return &apptheory.AppError{Code: "app.conflict", Message: "phone number is already provisioned"}
+		}
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to update phone index"}
+	}
+	return nil
+}
+
+func (s *Server) ensureSoulENSResolution(ctx context.Context, idx *models.SoulAgentENSResolution) *apptheory.AppError {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	if strings.TrimSpace(idx.ENSName) == "" || strings.TrimSpace(idx.AgentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "ens resolution is invalid"}
+	}
+	var existing models.SoulAgentENSResolution
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulAgentENSResolution{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if err == nil {
+		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+			if err := s.store.DB.WithContext(ctx).Model(idx).CreateOrUpdate(); err != nil {
+				return &apptheory.AppError{Code: "app.internal", Message: "failed to update ens resolution"}
+			}
+			return nil
+		}
+		return &apptheory.AppError{Code: "app.conflict", Message: "ens name is already provisioned"}
+	}
+	if !theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate ens resolution"}
+	}
+	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
+		if theoryErrors.IsConditionFailed(err) {
+			return &apptheory.AppError{Code: "app.conflict", Message: "ens name is already provisioned"}
+		}
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to update ens resolution"}
+	}
+	return nil
+}
+
+func (s *Server) deleteSoulEmailAgentIndexIfOwned(ctx context.Context, idx *models.SoulEmailAgentIndex) error {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	var existing models.SoulEmailAgentIndex
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulEmailAgentIndex{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if theoryErrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+		return nil
+	}
+	return s.store.DB.WithContext(ctx).Model(idx).Delete()
+}
+
+func (s *Server) deleteSoulPhoneAgentIndexIfOwned(ctx context.Context, idx *models.SoulPhoneAgentIndex) error {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	var existing models.SoulPhoneAgentIndex
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulPhoneAgentIndex{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if theoryErrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+		return nil
+	}
+	return s.store.DB.WithContext(ctx).Model(idx).Delete()
+}
+
+func (s *Server) deleteSoulENSResolutionIfOwned(ctx context.Context, idx *models.SoulAgentENSResolution) error {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	var existing models.SoulAgentENSResolution
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulAgentENSResolution{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if theoryErrors.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+		return nil
+	}
+	return s.store.DB.WithContext(ctx).Model(idx).Delete()
 }
 
 func parseRFC3339Loose(raw string) (time.Time, bool) {

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -672,22 +672,10 @@ func (s *Server) upsertSoulV3ChannelIndexes(
 	desiredPhoneIndex *models.SoulPhoneAgentIndex,
 	desiredENS *models.SoulAgentENSResolution,
 ) *apptheory.AppError {
-	if desiredEmailIndex != nil {
-		if trustedManagedSoulChannelForIndex(desired) {
-			if appErr := s.ensureSoulEmailAgentIndex(ctx, desiredEmailIndex); appErr != nil {
-				return appErr
-			}
-		} else {
-			desiredEmailIndex = nil
-		}
-	}
-	if desiredPhoneIndex != nil {
-		if trustedManagedSoulChannelForIndex(desired) {
-			if appErr := s.ensureSoulPhoneAgentIndex(ctx, desiredPhoneIndex); appErr != nil {
-				return appErr
-			}
-		} else {
-			desiredPhoneIndex = nil
+	trustedManaged := trustedManagedSoulChannelForIndex(desired)
+	if trustedManaged {
+		if appErr := s.ensureTrustedSoulContactIndexes(ctx, desiredEmailIndex, desiredPhoneIndex); appErr != nil {
+			return appErr
 		}
 	}
 	if desiredENS != nil {
@@ -698,7 +686,7 @@ func (s *Server) upsertSoulV3ChannelIndexes(
 	if channelType != models.SoulChannelTypeEmail && channelType != models.SoulChannelTypePhone {
 		return nil
 	}
-	if !trustedManagedSoulChannelForIndex(desired) {
+	if !trustedManaged {
 		return nil
 	}
 	if strings.TrimSpace(identity.Domain) == "" || strings.TrimSpace(identity.LocalID) == "" {
@@ -713,6 +701,20 @@ func (s *Server) upsertSoulV3ChannelIndexes(
 	_ = idx.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx).Model(idx).CreateOrUpdate(); err != nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to update channel index"}
+	}
+	return nil
+}
+
+func (s *Server) ensureTrustedSoulContactIndexes(ctx context.Context, emailIdx *models.SoulEmailAgentIndex, phoneIdx *models.SoulPhoneAgentIndex) *apptheory.AppError {
+	if emailIdx != nil {
+		if appErr := s.ensureSoulEmailAgentIndex(ctx, emailIdx); appErr != nil {
+			return appErr
+		}
+	}
+	if phoneIdx != nil {
+		if appErr := s.ensureSoulPhoneAgentIndex(ctx, phoneIdx); appErr != nil {
+			return appErr
+		}
 	}
 	return nil
 }
@@ -759,53 +761,19 @@ func soulCanonicalENSName(localID string) string {
 	return localID + ".lessersoul.eth"
 }
 
-func soulENSResolutionAllowedForIdentity(identity *models.SoulAgentIdentity, desired *models.SoulAgentChannel) bool {
-	if identity == nil || desired == nil {
-		return false
-	}
-	desiredCopy := *desired
-	_ = desiredCopy.UpdateKeys()
-	localID, err := soul.NormalizeLocalAgentID(strings.TrimSpace(identity.LocalID))
-	if err != nil {
-		return false
-	}
-	canonical := soulCanonicalENSName(localID)
-	return canonical != "" &&
-		desiredCopy.ChannelType == models.SoulChannelTypeENS &&
-		desiredCopy.Identifier == canonical &&
-		strings.TrimSpace(identity.AgentID) != ""
-}
-
 func (s *Server) ensureSoulEmailAgentIndex(ctx context.Context, idx *models.SoulEmailAgentIndex) *apptheory.AppError {
 	if idx == nil {
 		return nil
 	}
 	_ = idx.UpdateKeys()
-	if strings.TrimSpace(idx.Email) == "" || strings.TrimSpace(idx.AgentID) == "" {
-		return &apptheory.AppError{Code: "app.bad_request", Message: "email index is invalid"}
-	}
-	var existing models.SoulEmailAgentIndex
-	err := s.store.DB.WithContext(ctx).
-		Model(&models.SoulEmailAgentIndex{}).
-		Where("PK", "=", idx.PK).
-		Where("SK", "=", idx.SK).
-		First(&existing)
-	if err == nil {
-		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
-			return nil
+	return s.ensureSoulContactAgentIndex(ctx, idx, idx.PK, idx.SK, idx.Email, idx.AgentID, "email index is invalid", "email address is already provisioned", "failed to validate email mapping", "failed to update email index", func() any {
+		return &models.SoulEmailAgentIndex{}
+	}, func(existing any) string {
+		if idx, ok := existing.(*models.SoulEmailAgentIndex); ok && idx != nil {
+			return idx.AgentID
 		}
-		return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
-	}
-	if !theoryErrors.IsNotFound(err) {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate email mapping"}
-	}
-	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
-		if theoryErrors.IsConditionFailed(err) {
-			return &apptheory.AppError{Code: "app.conflict", Message: "email address is already provisioned"}
-		}
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to update email index"}
-	}
-	return nil
+		return ""
+	})
 }
 
 func (s *Server) ensureSoulPhoneAgentIndex(ctx context.Context, idx *models.SoulPhoneAgentIndex) *apptheory.AppError {
@@ -813,29 +781,53 @@ func (s *Server) ensureSoulPhoneAgentIndex(ctx context.Context, idx *models.Soul
 		return nil
 	}
 	_ = idx.UpdateKeys()
-	if strings.TrimSpace(idx.Phone) == "" || strings.TrimSpace(idx.AgentID) == "" {
-		return &apptheory.AppError{Code: "app.bad_request", Message: "phone index is invalid"}
+	return s.ensureSoulContactAgentIndex(ctx, idx, idx.PK, idx.SK, idx.Phone, idx.AgentID, "phone index is invalid", "phone number is already provisioned", "failed to validate phone mapping", "failed to update phone index", func() any {
+		return &models.SoulPhoneAgentIndex{}
+	}, func(existing any) string {
+		if idx, ok := existing.(*models.SoulPhoneAgentIndex); ok && idx != nil {
+			return idx.AgentID
+		}
+		return ""
+	})
+}
+
+func (s *Server) ensureSoulContactAgentIndex(
+	ctx context.Context,
+	idx any,
+	pk string,
+	sk string,
+	identifier string,
+	agentID string,
+	invalidMessage string,
+	conflictMessage string,
+	validateMessage string,
+	updateMessage string,
+	newExisting func() any,
+	owner func(any) string,
+) *apptheory.AppError {
+	if strings.TrimSpace(identifier) == "" || strings.TrimSpace(agentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: invalidMessage}
 	}
-	var existing models.SoulPhoneAgentIndex
+	existing := newExisting()
 	err := s.store.DB.WithContext(ctx).
-		Model(&models.SoulPhoneAgentIndex{}).
-		Where("PK", "=", idx.PK).
-		Where("SK", "=", idx.SK).
-		First(&existing)
+		Model(idx).
+		Where("PK", "=", pk).
+		Where("SK", "=", sk).
+		First(existing)
 	if err == nil {
-		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
+		if strings.EqualFold(strings.TrimSpace(owner(existing)), strings.TrimSpace(agentID)) {
 			return nil
 		}
-		return &apptheory.AppError{Code: "app.conflict", Message: "phone number is already provisioned"}
+		return &apptheory.AppError{Code: "app.conflict", Message: conflictMessage}
 	}
 	if !theoryErrors.IsNotFound(err) {
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate phone mapping"}
+		return &apptheory.AppError{Code: "app.internal", Message: validateMessage}
 	}
-	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
-		if theoryErrors.IsConditionFailed(err) {
-			return &apptheory.AppError{Code: "app.conflict", Message: "phone number is already provisioned"}
+	if createErr := s.store.DB.WithContext(ctx).Model(idx).Create(); createErr != nil {
+		if theoryErrors.IsConditionFailed(createErr) {
+			return &apptheory.AppError{Code: "app.conflict", Message: conflictMessage}
 		}
-		return &apptheory.AppError{Code: "app.internal", Message: "failed to update phone index"}
+		return &apptheory.AppError{Code: "app.internal", Message: updateMessage}
 	}
 	return nil
 }
@@ -856,7 +848,7 @@ func (s *Server) ensureSoulENSResolution(ctx context.Context, idx *models.SoulAg
 		First(&existing)
 	if err == nil {
 		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) {
-			if err := s.store.DB.WithContext(ctx).Model(idx).CreateOrUpdate(); err != nil {
+			if updateErr := s.store.DB.WithContext(ctx).Model(idx).CreateOrUpdate(); updateErr != nil {
 				return &apptheory.AppError{Code: "app.internal", Message: "failed to update ens resolution"}
 			}
 			return nil

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -338,6 +338,10 @@ func (s *Server) publishLegacySoulRegistration(
 	if appErr != nil {
 		return 0, "", appErr
 	}
+	newCaps := normalizeSoulCapabilitiesLoose(capsNorm)
+	if appErr := s.validateCapabilityClaimLevelTransitions(ctx, identity, newCaps, claimLevels); appErr != nil {
+		return 0, "", appErr
+	}
 
 	s3Key := soulRegistrationS3Key(agentIDHex)
 	versionedKey := soulRegistrationVersionedS3Key(agentIDHex, nextVersion)
@@ -347,7 +351,7 @@ func (s *Server) publishLegacySoulRegistration(
 	if err := s.soulPacks.PutObject(ctx, s3Key, regBytes, "application/json", "private, max-age=0"); err != nil {
 		return 0, "", &apptheory.AppError{Code: "app.internal", Message: "failed to publish registration"}
 	}
-	if appErr := s.updateSoulAgentCapabilities(ctx, identity, capsNorm, claimLevels, now, false); appErr != nil {
+	if appErr := s.updateSoulAgentCapabilities(ctx, identity, capsNorm, claimLevels, now, true); appErr != nil {
 		return 0, "", appErr
 	}
 

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -777,6 +777,54 @@ func TestValidateCapabilityClaimLevelTransitions_DeprecatedAndInvalidRules(t *te
 	})
 }
 
+func TestPublishLegacySoulRegistration_RejectsClaimTransitionBeforeS3Write(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	packs := &fakeSoulPackStoreForPublish{}
+	s := &Server{
+		store:     store.New(tdb.db),
+		soulPacks: packs,
+		cfg: config.Config{
+			SoulEnabled:        true,
+			SoulPackBucketName: "soul-packs",
+		},
+	}
+	identity := &models.SoulAgentIdentity{
+		AgentID: "0xabc",
+		Domain:  "example.com",
+		LocalID: "agent-alice",
+	}
+	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = []*models.SoulAgentVersion{}
+	}).Once()
+	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulCapabilityAgentIndex](t, args, 0)
+		*dest = models.SoulCapabilityAgentIndex{ClaimLevel: soulClaimLevelPeerEndorsed}
+	}).Once()
+
+	regBytes := []byte(`{"capabilities":[{"capability":"social","claimLevel":"self-declared"}]}`)
+	_, _, appErr := s.publishLegacySoulRegistration(
+		context.Background(),
+		identity.AgentID,
+		identity,
+		regBytes,
+		regSHA256Hex(regBytes),
+		"self-sig",
+		"bad downgrade",
+		[]string{"social"},
+		map[string]string{"social": soulClaimLevelSelfDeclared},
+		time.Now().UTC(),
+	)
+	if appErr == nil || appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected claim-level rejection, got %v", appErr)
+	}
+	if len(packs.puts) != 0 {
+		t.Fatalf("rejected registration must not publish S3 metadata, got %d puts", len(packs.puts))
+	}
+}
+
 func TestUpdateSoulAgentCapabilities_UpdatesIdentityAndIndexModels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -549,8 +549,8 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}
 
 	summary := collectSyncV3StateModels(tdb.db.Calls, agentIDHex)
-	if !summary.ensNames["agent-alice.lessersoul.eth"] {
-		t.Fatalf("expected ENS resolution sync, got %v", summary.ensNames)
+	if len(summary.ensNames) != 0 {
+		t.Fatalf("expected self-asserted ENS resolution to remain unindexed, got %v", summary.ensNames)
 	}
 }
 
@@ -843,6 +843,10 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 			Identifier:  "old-agent.lessersoul.eth",
 		}
 	}).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
+		*dest = models.SoulAgentENSResolution{ENSName: "old-agent.lessersoul.eth", AgentID: identity.AgentID}
+	}).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
 		*dest = models.SoulAgentChannel{
@@ -850,6 +854,10 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 			ChannelType: models.SoulChannelTypeEmail,
 			Identifier:  "old-agent@example.com",
 		}
+	}).Once()
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{Email: "old-agent@example.com", AgentID: identity.AgentID}
 	}).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
@@ -865,6 +873,10 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 			ENSChain:           "",
 			ENSResolverAddress: "",
 		}
+	}).Once()
+	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulPhoneAgentIndex](t, args, 0)
+		*dest = models.SoulPhoneAgentIndex{Phone: "+15551234567", AgentID: identity.AgentID}
 	}).Once()
 
 	regV3 := &soul.RegistrationFileV3{
@@ -919,6 +931,63 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 	assertSyncV3PhoneModel(t, summary.phoneModel, now)
 	assertSyncV3PrefsModel(t, summary.prefsModel, rep)
 	assertSyncV3Indexes(t, summary)
+}
+
+func TestSyncSoulV3StateFromRegistration_RejectsManagedChannelIdentifierChange(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	now := time.Date(2026, time.March, 5, 13, 14, 15, 0, time.UTC)
+	identity := &models.SoulAgentIdentity{
+		AgentID:         soulLifecycleTestAgentIDHex,
+		Domain:          "example.com",
+		LocalID:         "agent-alice",
+		LifecycleStatus: models.SoulAgentStatusActive,
+	}
+
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:       identity.AgentID,
+			ChannelType:   models.SoulChannelTypePhone,
+			Identifier:    "+15551234567",
+			Provider:      "telnyx",
+			Verified:      true,
+			ProvisionedAt: now.Add(-time.Hour),
+			Status:        models.SoulChannelStatusActive,
+		}
+	}).Once()
+
+	appErr := s.syncSoulV3StateFromRegistration(context.Background(), identity.AgentID, identity, &soul.RegistrationFileV3{
+		Channels: &soul.ChannelsV3{
+			Phone: &soul.PhoneChannelV3{Number: "+15557654321", Verified: true},
+		},
+	}, now)
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "managed channel must be deprovisioned before changing identifier" {
+		t.Fatalf("expected managed channel conflict, got %v", appErr)
+	}
+}
+
+func TestEnsureSoulEmailAgentIndex_RejectsForeignOwner(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{Email: "agent@example.com", AgentID: "0xother"}
+	}).Once()
+
+	appErr := s.ensureSoulEmailAgentIndex(context.Background(), &models.SoulEmailAgentIndex{
+		Email:   "agent@example.com",
+		AgentID: soulLifecycleTestAgentIDHex,
+	})
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "email address is already provisioned" {
+		t.Fatalf("expected foreign owner conflict, got %v", appErr)
+	}
 }
 
 func TestSyncSoulV3StateFromRegistration_DeletesContactPreferencesWhenOmitted(t *testing.T) {
@@ -1077,17 +1146,17 @@ func assertSyncV3PhoneModel(t *testing.T, phoneModel *models.SoulAgentChannel, n
 	if phoneModel == nil {
 		t.Fatalf("expected updated phone channel model call")
 	}
-	if phoneModel.Provider != "twilio" {
-		t.Fatalf("expected host-managed provider to be preserved, got %q", phoneModel.Provider)
+	if phoneModel.Provider != "" {
+		t.Fatalf("expected self-asserted phone update not to inherit provider, got %q", phoneModel.Provider)
 	}
-	if phoneModel.SecretRef != "/ssm/phone" {
-		t.Fatalf("expected host-managed secret ref to be preserved, got %q", phoneModel.SecretRef)
+	if phoneModel.SecretRef != "" {
+		t.Fatalf("expected self-asserted phone update not to inherit secret ref, got %q", phoneModel.SecretRef)
 	}
-	if !phoneModel.ProvisionedAt.Equal(now.Add(-24 * time.Hour)) {
-		t.Fatalf("expected provisionedAt preservation, got %v", phoneModel.ProvisionedAt)
+	if !phoneModel.ProvisionedAt.IsZero() {
+		t.Fatalf("expected self-asserted phone update not to inherit provisionedAt, got %v", phoneModel.ProvisionedAt)
 	}
-	if !phoneModel.DeprovisionedAt.Equal(now.Add(-12 * time.Hour)) {
-		t.Fatalf("expected deprovisionedAt preservation, got %v", phoneModel.DeprovisionedAt)
+	if !phoneModel.DeprovisionedAt.IsZero() {
+		t.Fatalf("expected self-asserted phone update not to inherit deprovisionedAt, got %v", phoneModel.DeprovisionedAt)
 	}
 }
 
@@ -1109,16 +1178,16 @@ func assertSyncV3PrefsModel(t *testing.T, prefsModel *models.SoulAgentContactPre
 
 func assertSyncV3Indexes(t *testing.T, summary syncV3StateModels) {
 	t.Helper()
-	if !summary.ensNames["old-agent.lessersoul.eth"] || !summary.ensNames["agent-alice.lessersoul.eth"] {
-		t.Fatalf("expected old ENS cleanup and new ENS upsert, got %v", summary.ensNames)
+	if !summary.ensNames["old-agent.lessersoul.eth"] || summary.ensNames["agent-alice.lessersoul.eth"] {
+		t.Fatalf("expected old ENS cleanup without self-asserted ENS upsert, got %v", summary.ensNames)
 	}
 	if !summary.emailIndexSeen {
 		t.Fatalf("expected old email index cleanup")
 	}
-	if !summary.phoneIndexes["+15551234567"] || !summary.phoneIndexes["+15557654321"] {
-		t.Fatalf("expected old and new phone index models, got %v", summary.phoneIndexes)
+	if !summary.phoneIndexes["+15551234567"] || summary.phoneIndexes["+15557654321"] {
+		t.Fatalf("expected old phone index cleanup without self-asserted phone upsert, got %v", summary.phoneIndexes)
 	}
-	if !summary.channelIndexTypes[models.SoulChannelTypeEmail] || !summary.channelIndexTypes[models.SoulChannelTypePhone] {
-		t.Fatalf("expected email delete and phone upsert channel index models, got %v", summary.channelIndexTypes)
+	if !summary.channelIndexTypes[models.SoulChannelTypeEmail] || summary.channelIndexTypes[models.SoulChannelTypePhone] {
+		t.Fatalf("expected only removed email channel index cleanup, got %v", summary.channelIndexTypes)
 	}
 }

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -1038,6 +1038,234 @@ func TestEnsureSoulEmailAgentIndex_RejectsForeignOwner(t *testing.T) {
 	}
 }
 
+func TestEnsureSoulContactIndexes_CreatesMissingAndAcceptsSameOwner(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{Email: "agent@example.com", AgentID: soulLifecycleTestAgentIDHex}
+	}).Once()
+	if appErr := s.ensureSoulEmailAgentIndex(context.Background(), &models.SoulEmailAgentIndex{
+		Email:   "agent@example.com",
+		AgentID: soulLifecycleTestAgentIDHex,
+	}); appErr != nil {
+		t.Fatalf("expected same-owner email index to pass, got %v", appErr)
+	}
+
+	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	if appErr := s.ensureSoulPhoneAgentIndex(context.Background(), &models.SoulPhoneAgentIndex{
+		Phone:   "+15550142",
+		AgentID: soulLifecycleTestAgentIDHex,
+	}); appErr != nil {
+		t.Fatalf("expected missing phone index to be created, got %v", appErr)
+	}
+}
+
+func TestEnsureSoulContactIndexes_FailClosedOnInvalidAndRaces(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	if appErr := s.ensureSoulEmailAgentIndex(context.Background(), &models.SoulEmailAgentIndex{
+		AgentID: soulLifecycleTestAgentIDHex,
+	}); appErr == nil || appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected invalid email index to fail closed, got %v", appErr)
+	}
+
+	tdb.qEmailIdx.ExpectedCalls = nil
+	tdb.qEmailIdx.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(tdb.qEmailIdx).Maybe()
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qEmailIdx.On("Create").Return(theoryErrors.ErrConditionFailed).Once()
+	appErr := s.ensureSoulEmailAgentIndex(context.Background(), &models.SoulEmailAgentIndex{
+		Email:   "agent@example.com",
+		AgentID: soulLifecycleTestAgentIDHex,
+	})
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "email address is already provisioned" {
+		t.Fatalf("expected create race conflict, got %v", appErr)
+	}
+}
+
+func TestTrustedManagedSoulChannelForIndex(t *testing.T) {
+	t.Parallel()
+
+	activeAt := time.Date(2026, time.March, 5, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name string
+		ch   *models.SoulAgentChannel
+		want bool
+	}{
+		{name: "nil"},
+		{name: "unverified", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "agent@example.com", Provider: "migadu", ProvisionedAt: activeAt, Status: models.SoulChannelStatusActive}},
+		{name: "missing provisioned", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "agent@example.com", Provider: "migadu", Verified: true, Status: models.SoulChannelStatusActive}},
+		{name: "deprovisioned", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypePhone, Identifier: "+15550142", Provider: commDeliveryProviderTelnyx, Verified: true, ProvisionedAt: activeAt, DeprovisionedAt: activeAt.Add(time.Hour), Status: models.SoulChannelStatusActive}},
+		{name: "email unmanaged provider", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "agent@example.com", Provider: "other", Verified: true, ProvisionedAt: activeAt, Status: models.SoulChannelStatusActive}},
+		{name: "email managed", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "Agent@Example.com", Provider: "migadu", Verified: true, ProvisionedAt: activeAt, Status: models.SoulChannelStatusActive}, want: true},
+		{name: "phone managed", ch: &models.SoulAgentChannel{ChannelType: models.SoulChannelTypePhone, Identifier: "+1 (555) 0142", Provider: commDeliveryProviderTelnyx, Verified: true, ProvisionedAt: activeAt, Status: models.SoulChannelStatusActive}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := trustedManagedSoulChannelForIndex(tt.ch); got != tt.want {
+				t.Fatalf("trustedManagedSoulChannelForIndex()=%v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpsertSoulV3ChannelIndexes_CreatesTrustedManagedIndexes(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	identity := &models.SoulAgentIdentity{
+		AgentID: soulLifecycleTestAgentIDHex,
+		Domain:  "example.com",
+		LocalID: "agent-alice",
+	}
+	desired := &models.SoulAgentChannel{
+		AgentID:       identity.AgentID,
+		ChannelType:   models.SoulChannelTypeEmail,
+		Identifier:    "agent-alice@lessersoul.ai",
+		Provider:      "migadu",
+		Verified:      true,
+		ProvisionedAt: time.Date(2026, time.March, 5, 12, 0, 0, 0, time.UTC),
+		Status:        models.SoulChannelStatusActive,
+	}
+	emailIdx := &models.SoulEmailAgentIndex{Email: desired.Identifier, AgentID: identity.AgentID}
+	_ = emailIdx.UpdateKeys()
+
+	if appErr := s.upsertSoulV3ChannelIndexes(context.Background(), identity, models.SoulChannelTypeEmail, desired, emailIdx, nil, nil); appErr != nil {
+		t.Fatalf("expected trusted managed channel indexes to upsert, got %v", appErr)
+	}
+}
+
+func TestUpsertSoulV3ChannelIndexes_IgnoresUntrustedContactIndex(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	desired := &models.SoulAgentChannel{
+		AgentID:     soulLifecycleTestAgentIDHex,
+		ChannelType: models.SoulChannelTypeEmail,
+		Identifier:  "external@example.com",
+		Provider:    "external",
+		Verified:    true,
+		Status:      models.SoulChannelStatusActive,
+	}
+	identity := &models.SoulAgentIdentity{AgentID: desired.AgentID, Domain: "example.com", LocalID: "agent-alice"}
+
+	if appErr := s.upsertSoulV3ChannelIndexes(context.Background(), identity, models.SoulChannelTypeEmail, desired, &models.SoulEmailAgentIndex{Email: desired.Identifier, AgentID: desired.AgentID}, nil, nil); appErr != nil {
+		t.Fatalf("expected untrusted contact index to be ignored, got %v", appErr)
+	}
+}
+
+func TestUpsertSoulV3ChannelIndexes_HandlesENSAndMissingIdentityIndex(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	identity := &models.SoulAgentIdentity{AgentID: soulLifecycleTestAgentIDHex}
+	ensIdx := &models.SoulAgentENSResolution{ENSName: "agent-alice.lessersoul.eth", AgentID: soulLifecycleTestAgentIDHex}
+	if appErr := s.upsertSoulV3ChannelIndexes(context.Background(), identity, models.SoulChannelTypeENS, nil, nil, nil, ensIdx); appErr != nil {
+		t.Fatalf("expected ENS resolution to upsert without contact index, got %v", appErr)
+	}
+
+	activeAt := time.Date(2026, time.March, 5, 12, 0, 0, 0, time.UTC)
+	phoneIdx := &models.SoulPhoneAgentIndex{Phone: "+15550142", AgentID: soulLifecycleTestAgentIDHex}
+	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	if appErr := s.upsertSoulV3ChannelIndexes(context.Background(), identity, models.SoulChannelTypePhone, &models.SoulAgentChannel{
+		AgentID:       soulLifecycleTestAgentIDHex,
+		ChannelType:   models.SoulChannelTypePhone,
+		Identifier:    "+15550142",
+		Provider:      commDeliveryProviderTelnyx,
+		Verified:      true,
+		ProvisionedAt: activeAt,
+		Status:        models.SoulChannelStatusActive,
+	}, nil, phoneIdx, nil); appErr != nil {
+		t.Fatalf("expected missing domain/local id to skip aggregate contact index, got %v", appErr)
+	}
+}
+
+func TestPreserveManagedSoulChannelMetadata(t *testing.T) {
+	t.Parallel()
+
+	provisionedAt := time.Date(2026, time.March, 5, 12, 0, 0, 0, time.UTC)
+	verifiedAt := provisionedAt.Add(time.Minute)
+	deprovisionedAt := provisionedAt.Add(time.Hour)
+	existing := &models.SoulAgentChannel{
+		ChannelType:     models.SoulChannelTypeEmail,
+		Identifier:      "agent@example.com",
+		Provider:        "migadu",
+		SecretRef:       "ssm://secret",
+		ProvisionedAt:   provisionedAt,
+		DeprovisionedAt: deprovisionedAt,
+		Verified:        true,
+		VerifiedAt:      verifiedAt,
+	}
+	desired := &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "AGENT@example.com"}
+	preserveManagedSoulChannelMetadata(desired, existing)
+	if desired.Provider != existing.Provider || desired.SecretRef != existing.SecretRef || !desired.ProvisionedAt.Equal(provisionedAt) || !desired.DeprovisionedAt.Equal(deprovisionedAt) {
+		t.Fatalf("expected managed metadata to be preserved, got %#v", desired)
+	}
+	if !desired.Verified || !desired.VerifiedAt.Equal(verifiedAt) {
+		t.Fatalf("expected verification metadata to be preserved, got %#v", desired)
+	}
+
+	mismatched := &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeEmail, Identifier: "other@example.com"}
+	preserveManagedSoulChannelMetadata(mismatched, existing)
+	if mismatched.Provider != "" || mismatched.Verified {
+		t.Fatalf("did not expect metadata copy for different identifier, got %#v", mismatched)
+	}
+}
+
+func TestEnsureSoulENSResolution_CreatesAndPreservesOwnedIndex(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	ens := &models.SoulAgentENSResolution{ENSName: "agent-alice.lessersoul.eth", AgentID: soulLifecycleTestAgentIDHex}
+
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	if appErr := s.ensureSoulENSResolution(context.Background(), ens); appErr != nil {
+		t.Fatalf("expected missing ENS resolution to be created, got %v", appErr)
+	}
+
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
+		*dest = models.SoulAgentENSResolution{ENSName: ens.ENSName, AgentID: soulLifecycleTestAgentIDHex}
+	}).Once()
+	if appErr := s.ensureSoulENSResolution(context.Background(), ens); appErr != nil {
+		t.Fatalf("expected owned ENS resolution to update, got %v", appErr)
+	}
+}
+
+func TestEnsureSoulENSResolution_RejectsInvalidAndForeignOwner(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	if appErr := s.ensureSoulENSResolution(context.Background(), &models.SoulAgentENSResolution{AgentID: soulLifecycleTestAgentIDHex}); appErr == nil || appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected invalid ENS resolution to fail closed, got %v", appErr)
+	}
+
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
+		*dest = models.SoulAgentENSResolution{ENSName: "agent-alice.lessersoul.eth", AgentID: "0xother"}
+	}).Once()
+	appErr := s.ensureSoulENSResolution(context.Background(), &models.SoulAgentENSResolution{ENSName: "agent-alice.lessersoul.eth", AgentID: soulLifecycleTestAgentIDHex})
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "ens name is already provisioned" {
+		t.Fatalf("expected ENS ownership conflict, got %v", appErr)
+	}
+}
+
 func TestSyncSoulV3StateFromRegistration_DeletesContactPreferencesWhenOmitted(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_validation_internal_test.go
+++ b/internal/controlplane/handlers_soul_validation_internal_test.go
@@ -65,6 +65,7 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 
 	issueBody, _ := json.Marshal(soulIssueValidationChallengeRequest{
 		ChallengeType: "identity_verify",
+		Request:       "operator challenge material",
 		TTLSeconds:    -1,
 	})
 	issueCtx := &apptheory.Context{
@@ -99,14 +100,14 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 			ChallengeID:   chalID,
 			ChallengeType: "identity_verify",
 			ValidatorID:   soulValidatorSystem,
-			Request:       "req",
+			Request:       "operator challenge material",
 			Status:        models.SoulValidationChallengeStatusIssued,
 			IssuedAt:      time.Now().Add(-time.Minute).UTC(),
 			UpdatedAt:     time.Now().Add(-time.Minute).UTC(),
 		}
-	}).Times(2)
+	}).Once()
 
-	respBody, _ := json.Marshal(soulRecordValidationResponseRequest{Response: "ok"})
+	respBody, _ := json.Marshal(soulRecordValidationResponseRequest{Response: "agent response material"})
 	respCtx := &apptheory.Context{
 		RequestID:    "r2",
 		AuthIdentity: "op",
@@ -119,6 +120,22 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 	if err != nil || respResp.Status != 200 {
 		t.Fatalf("response: resp=%#v err=%v", respResp, err)
 	}
+
+	tdb.qChal.On("First", mock.AnythingOfType("*models.SoulAgentValidationChallenge")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentValidationChallenge](t, args, 0)
+		*dest = models.SoulAgentValidationChallenge{
+			AgentID:       agentID,
+			ChallengeID:   chalID,
+			ChallengeType: "identity_verify",
+			ValidatorID:   soulValidatorSystem,
+			Request:       "operator challenge material",
+			Response:      "agent response material",
+			Status:        models.SoulValidationChallengeStatusResponded,
+			IssuedAt:      time.Now().Add(-time.Minute).UTC(),
+			RespondedAt:   time.Now().Add(-30 * time.Second).UTC(),
+			UpdatedAt:     time.Now().Add(-30 * time.Second).UTC(),
+		}
+	}).Once()
 
 	evalBody, _ := json.Marshal(soulEvaluateValidationChallengeRequest{Result: models.SoulValidationResultPass})
 	evalCtx := &apptheory.Context{
@@ -139,6 +156,9 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 	}
 	if evalOut.Challenge.Status != models.SoulValidationChallengeStatusEvaluated || evalOut.Record.Result != models.SoulValidationResultPass {
 		t.Fatalf("unexpected evaluate output: %#v", evalOut)
+	}
+	if evalOut.Record.Request != "operator challenge material" || evalOut.Record.Response != "agent response material" {
+		t.Fatalf("operator evaluation response should retain raw transcript: %#v", evalOut.Record)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_validation_internal_test.go
+++ b/internal/controlplane/handlers_soul_validation_internal_test.go
@@ -55,28 +55,42 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 
 	tdb := newSoulValidationTestDB()
 	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
-
 	agentID := "0x" + strings.Repeat("11", 32)
 
-	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+	expectSoulValidationIdentity(t, tdb.qID, agentID)
+	issueOut := issueSoulValidationChallengeForTest(t, s, agentID)
+	chalID := issueOut.ChallengeID
+
+	expectSoulValidationChallengeLookup(t, tdb.qChal, issuedSoulValidationChallenge(agentID, chalID))
+	recordSoulValidationResponseForTest(t, s, agentID, chalID)
+
+	expectSoulValidationChallengeLookup(t, tdb.qChal, respondedSoulValidationChallenge(agentID, chalID))
+	evalOut := evaluateSoulValidationChallengeForTest(t, s, agentID, chalID)
+
+	if evalOut.Challenge.Status != models.SoulValidationChallengeStatusEvaluated || evalOut.Record.Result != models.SoulValidationResultPass {
+		t.Fatalf("unexpected evaluate output: %#v", evalOut)
+	}
+	if evalOut.Record.Request != "operator challenge material" || evalOut.Record.Response != "agent response material" {
+		t.Fatalf("operator evaluation response should retain raw transcript: %#v", evalOut.Record)
+	}
+}
+
+func expectSoulValidationIdentity(t *testing.T, q *ttmocks.MockQuery, agentID string) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
 	}).Once()
+}
 
+func issueSoulValidationChallengeForTest(t *testing.T, s *Server, agentID string) models.SoulAgentValidationChallenge {
+	t.Helper()
 	issueBody, _ := json.Marshal(soulIssueValidationChallengeRequest{
 		ChallengeType: "identity_verify",
 		Request:       "operator challenge material",
 		TTLSeconds:    -1,
 	})
-	issueCtx := &apptheory.Context{
-		RequestID:    "r1",
-		AuthIdentity: "op",
-		Params:       map[string]string{"agentId": agentID},
-		Request:      apptheory.Request{Body: issueBody},
-	}
-	issueCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
-
-	issueResp, err := s.handleSoulIssueValidationChallenge(issueCtx)
+	issueResp, err := s.handleSoulIssueValidationChallenge(newOperatorSoulValidationCtx("r1", agentID, "", issueBody))
 	if err != nil || issueResp.Status != 200 {
 		t.Fatalf("issue: resp=%#v err=%v", issueResp, err)
 	}
@@ -90,63 +104,53 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 	if issueOut.Challenge.ValidatorID != soulValidatorSystem {
 		t.Fatalf("expected default validator, got %#v", issueOut.Challenge.ValidatorID)
 	}
+	return issueOut.Challenge
+}
 
-	chalID := issueOut.Challenge.ChallengeID
-
-	tdb.qChal.On("First", mock.AnythingOfType("*models.SoulAgentValidationChallenge")).Return(nil).Run(func(args mock.Arguments) {
+func expectSoulValidationChallengeLookup(t *testing.T, q *ttmocks.MockQuery, challenge models.SoulAgentValidationChallenge) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.SoulAgentValidationChallenge")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentValidationChallenge](t, args, 0)
-		*dest = models.SoulAgentValidationChallenge{
-			AgentID:       agentID,
-			ChallengeID:   chalID,
-			ChallengeType: "identity_verify",
-			ValidatorID:   soulValidatorSystem,
-			Request:       "operator challenge material",
-			Status:        models.SoulValidationChallengeStatusIssued,
-			IssuedAt:      time.Now().Add(-time.Minute).UTC(),
-			UpdatedAt:     time.Now().Add(-time.Minute).UTC(),
-		}
+		*dest = challenge
 	}).Once()
+}
 
-	respBody, _ := json.Marshal(soulRecordValidationResponseRequest{Response: "agent response material"})
-	respCtx := &apptheory.Context{
-		RequestID:    "r2",
-		AuthIdentity: "op",
-		Params:       map[string]string{"agentId": agentID, "challengeId": chalID},
-		Request:      apptheory.Request{Body: respBody},
+func issuedSoulValidationChallenge(agentID string, chalID string) models.SoulAgentValidationChallenge {
+	issuedAt := time.Now().Add(-time.Minute).UTC()
+	return models.SoulAgentValidationChallenge{
+		AgentID:       agentID,
+		ChallengeID:   chalID,
+		ChallengeType: "identity_verify",
+		ValidatorID:   soulValidatorSystem,
+		Request:       "operator challenge material",
+		Status:        models.SoulValidationChallengeStatusIssued,
+		IssuedAt:      issuedAt,
+		UpdatedAt:     issuedAt,
 	}
-	respCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+}
 
-	respResp, err := s.handleSoulRecordValidationResponse(respCtx)
+func respondedSoulValidationChallenge(agentID string, chalID string) models.SoulAgentValidationChallenge {
+	chal := issuedSoulValidationChallenge(agentID, chalID)
+	chal.Response = "agent response material"
+	chal.Status = models.SoulValidationChallengeStatusResponded
+	chal.RespondedAt = time.Now().Add(-30 * time.Second).UTC()
+	chal.UpdatedAt = chal.RespondedAt
+	return chal
+}
+
+func recordSoulValidationResponseForTest(t *testing.T, s *Server, agentID string, chalID string) {
+	t.Helper()
+	respBody, _ := json.Marshal(soulRecordValidationResponseRequest{Response: "agent response material"})
+	respResp, err := s.handleSoulRecordValidationResponse(newOperatorSoulValidationCtx("r2", agentID, chalID, respBody))
 	if err != nil || respResp.Status != 200 {
 		t.Fatalf("response: resp=%#v err=%v", respResp, err)
 	}
+}
 
-	tdb.qChal.On("First", mock.AnythingOfType("*models.SoulAgentValidationChallenge")).Return(nil).Run(func(args mock.Arguments) {
-		dest := testutil.RequireMockArg[*models.SoulAgentValidationChallenge](t, args, 0)
-		*dest = models.SoulAgentValidationChallenge{
-			AgentID:       agentID,
-			ChallengeID:   chalID,
-			ChallengeType: "identity_verify",
-			ValidatorID:   soulValidatorSystem,
-			Request:       "operator challenge material",
-			Response:      "agent response material",
-			Status:        models.SoulValidationChallengeStatusResponded,
-			IssuedAt:      time.Now().Add(-time.Minute).UTC(),
-			RespondedAt:   time.Now().Add(-30 * time.Second).UTC(),
-			UpdatedAt:     time.Now().Add(-30 * time.Second).UTC(),
-		}
-	}).Once()
-
+func evaluateSoulValidationChallengeForTest(t *testing.T, s *Server, agentID string, chalID string) soulEvaluateValidationChallengeResponse {
+	t.Helper()
 	evalBody, _ := json.Marshal(soulEvaluateValidationChallengeRequest{Result: models.SoulValidationResultPass})
-	evalCtx := &apptheory.Context{
-		RequestID:    "r3",
-		AuthIdentity: "op",
-		Params:       map[string]string{"agentId": agentID, "challengeId": chalID},
-		Request:      apptheory.Request{Body: evalBody},
-	}
-	evalCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
-
-	evalResp, err := s.handleSoulEvaluateValidationChallenge(evalCtx)
+	evalResp, err := s.handleSoulEvaluateValidationChallenge(newOperatorSoulValidationCtx("r3", agentID, chalID, evalBody))
 	if err != nil || evalResp.Status != 200 {
 		t.Fatalf("evaluate: resp=%#v err=%v", evalResp, err)
 	}
@@ -154,12 +158,22 @@ func TestSoulValidationHandlers_IssueRespondEvaluate(t *testing.T) {
 	if err := json.Unmarshal(evalResp.Body, &evalOut); err != nil {
 		t.Fatalf("unmarshal eval: %v", err)
 	}
-	if evalOut.Challenge.Status != models.SoulValidationChallengeStatusEvaluated || evalOut.Record.Result != models.SoulValidationResultPass {
-		t.Fatalf("unexpected evaluate output: %#v", evalOut)
+	return evalOut
+}
+
+func newOperatorSoulValidationCtx(requestID string, agentID string, chalID string, body []byte) *apptheory.Context {
+	params := map[string]string{"agentId": agentID}
+	if strings.TrimSpace(chalID) != "" {
+		params["challengeId"] = chalID
 	}
-	if evalOut.Record.Request != "operator challenge material" || evalOut.Record.Response != "agent response material" {
-		t.Fatalf("operator evaluation response should retain raw transcript: %#v", evalOut.Record)
+	ctx := &apptheory.Context{
+		RequestID:    requestID,
+		AuthIdentity: "op",
+		Params:       params,
+		Request:      apptheory.Request{Body: body},
 	}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+	return ctx
 }
 
 func TestSoulValidationHandlers_NotFoundAndBadRequest(t *testing.T) {

--- a/internal/emailingress/server.go
+++ b/internal/emailingress/server.go
@@ -112,6 +112,10 @@ func (s *Server) handleRecord(ctx context.Context, record events.SimpleEmailReco
 	if messageID == "" {
 		return fmt.Errorf("ses message id is required")
 	}
+	if !sesReceiptVerdictsAccepted(record.SES.Receipt) {
+		s.logf("emailingress: rejecting unauthenticated or unsafe SES message %q", safeLogToken(messageID))
+		return nil
+	}
 	rawMessage, err := s.loadRawEmail(ctx, messageID)
 	if err != nil {
 		return err
@@ -157,6 +161,38 @@ func (s *Server) handleRecord(ctx context.Context, record events.SimpleEmailReco
 		}
 	}
 	return nil
+}
+
+func sesReceiptVerdictsAccepted(receipt events.SimpleEmailReceipt) bool {
+	if !sesVerdictPass(receipt.SpamVerdict) || !sesVerdictPass(receipt.VirusVerdict) {
+		return false
+	}
+	return sesVerdictPass(receipt.SPFVerdict) ||
+		sesVerdictPass(receipt.DKIMVerdict) ||
+		sesVerdictPass(receipt.DMARCVerdict)
+}
+
+func sesVerdictPass(verdict events.SimpleEmailVerdict) bool {
+	return strings.EqualFold(strings.TrimSpace(verdict.Status), "PASS")
+}
+
+func safeLogToken(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		default:
+			if r < 0x20 || r == 0x7f {
+				return -1
+			}
+			return r
+		}
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }
 
 func sesEnvelopeRecipients(record events.SimpleEmailRecord) []string {

--- a/internal/emailingress/server_internal_test.go
+++ b/internal/emailingress/server_internal_test.go
@@ -53,6 +53,17 @@ func (f *fakeSQS) SendMessage(_ context.Context, in *sqs.SendMessageInput, _ ...
 	return &sqs.SendMessageOutput{}, nil
 }
 
+func validSESReceipt(recipients ...string) events.SimpleEmailReceipt {
+	return events.SimpleEmailReceipt{
+		Recipients:   recipients,
+		SpamVerdict:  events.SimpleEmailVerdict{Status: "PASS"},
+		VirusVerdict: events.SimpleEmailVerdict{Status: "PASS"},
+		SPFVerdict:   events.SimpleEmailVerdict{Status: "PASS"},
+		DKIMVerdict:  events.SimpleEmailVerdict{Status: "PASS"},
+		DMARCVerdict: events.SimpleEmailVerdict{Status: "PASS"},
+	}
+}
+
 func TestNormalizeInboundRecipient(t *testing.T) {
 	t.Parallel()
 
@@ -306,6 +317,7 @@ func TestHandleSESEvent_SkipsNonBridgeRecipient(t *testing.T) {
 						MessageID:   "ses-msg-2",
 						Destination: []string{"medic@example.com"},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -346,7 +358,8 @@ func TestHandleSESEvent_PropagatesLoadError(t *testing.T) {
 		Records: []events.SimpleEmailRecord{
 			{
 				SES: events.SimpleEmailService{
-					Mail: events.SimpleEmailMessage{MessageID: "ses-msg-err"},
+					Mail:    events.SimpleEmailMessage{MessageID: "ses-msg-err"},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -355,6 +368,59 @@ func TestHandleSESEvent_PropagatesLoadError(t *testing.T) {
 	err := srv.HandleSESEvent(context.Background(), event)
 	if err == nil || !strings.Contains(err.Error(), `load inbound email "ses/inbound/ses-msg-err"`) {
 		t.Fatalf("expected load error, got %v", err)
+	}
+}
+
+func TestHandleSESEvent_RejectsUnauthenticatedSenderVerdicts(t *testing.T) {
+	t.Parallel()
+
+	s3Client := &fakeS3{bodyByKey: map[string]string{"ses/inbound/ses-msg-spoof": "From: Alice <alice@example.com>\r\n\r\nbody"}}
+	sqsClient := &fakeSQS{}
+	logs := make([]string, 0, 1)
+	srv := &Server{
+		cfg: config.Config{
+			CommQueueURL:           "queue",
+			SoulEmailInboundDomain: "inbound.lessersoul.ai",
+			InboundEmailBucketName: "bucket",
+			InboundEmailS3Prefix:   "ses/inbound/",
+		},
+		s3:  s3Client,
+		sqs: sqsClient,
+		now: time.Now,
+		logf: func(format string, args ...any) {
+			logs = append(logs, format)
+		},
+	}
+
+	event := events.SimpleEmailEvent{
+		Records: []events.SimpleEmailRecord{
+			{
+				SES: events.SimpleEmailService{
+					Mail: events.SimpleEmailMessage{
+						Source:      "alice@example.com",
+						MessageID:   "ses-msg-spoof",
+						Destination: []string{inboundBridgeAddress},
+					},
+					Receipt: events.SimpleEmailReceipt{
+						SpamVerdict:  events.SimpleEmailVerdict{Status: "PASS"},
+						VirusVerdict: events.SimpleEmailVerdict{Status: "PASS"},
+						SPFVerdict:   events.SimpleEmailVerdict{Status: "FAIL"},
+						DKIMVerdict:  events.SimpleEmailVerdict{Status: "FAIL"},
+						DMARCVerdict: events.SimpleEmailVerdict{Status: "FAIL"},
+					},
+				},
+			},
+		},
+	}
+
+	if err := srv.HandleSESEvent(context.Background(), event); err != nil {
+		t.Fatalf("HandleSESEvent: %v", err)
+	}
+	if len(sqsClient.bodies) != 0 {
+		t.Fatalf("expected no queued messages, got %d", len(sqsClient.bodies))
+	}
+	if len(logs) != 1 || !strings.Contains(logs[0], "rejecting unauthenticated") {
+		t.Fatalf("expected verdict reject log, got %#v", logs)
 	}
 }
 
@@ -397,6 +463,7 @@ func TestHandleSESEvent_PropagatesQueueError(t *testing.T) {
 						MessageID:   "ses-msg-queue",
 						Destination: []string{inboundBridgeAddress},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -453,6 +520,7 @@ func TestHandleSESEvent_EnqueuesEachBridgeRecipient(t *testing.T) {
 						MessageID:   "ses-msg-multi",
 						Destination: []string{"medic@inbound.lessersoul.ai", "surgeon@inbound.lessersoul.ai", "bad@example.com"},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -529,9 +597,7 @@ func TestHandleSESEvent_PrefersSESReceiptRecipientsForForwardedMail(t *testing.T
 						MessageID:   "ses-msg-forwarded",
 						Destination: []string{canonicalMedicAddress},
 					},
-					Receipt: events.SimpleEmailReceipt{
-						Recipients: []string{inboundBridgeAddress},
-					},
+					Receipt: validSESReceipt(inboundBridgeAddress),
 				},
 			},
 		},
@@ -605,6 +671,7 @@ func TestHandleSESEvent_RejectsOversizedInboundEmail(t *testing.T) {
 						MessageID:   "ses-msg-big",
 						Destination: []string{inboundBridgeAddress},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -659,6 +726,7 @@ func TestHandleSESEvent_UsesFallbackReceivedAtWhenTimestampMissing(t *testing.T)
 						MessageID:   "ses-msg-fallback",
 						Destination: []string{inboundBridgeAddress},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},
@@ -757,6 +825,7 @@ func TestHandleSESEvent_EnqueuesCanonicalEmailNotification(t *testing.T) {
 							Subject: "Hello",
 						},
 					},
+					Receipt: validSESReceipt(),
 				},
 			},
 		},

--- a/internal/store/models/soul_agent_channel_index_items.go
+++ b/internal/store/models/soul_agent_channel_index_items.go
@@ -25,7 +25,18 @@ type SoulEmailAgentIndex struct {
 func (SoulEmailAgentIndex) TableName() string { return MainTableName() }
 
 // BeforeCreate sets defaults and keys before creating SoulEmailAgentIndex.
-func (i *SoulEmailAgentIndex) BeforeCreate() error { return i.UpdateKeys() }
+func (i *SoulEmailAgentIndex) BeforeCreate() error {
+	if err := i.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("email", i.Email); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", i.AgentID); err != nil {
+		return err
+	}
+	return nil
+}
 
 // UpdateKeys updates the database keys for SoulEmailAgentIndex.
 func (i *SoulEmailAgentIndex) UpdateKeys() error {
@@ -63,7 +74,18 @@ type SoulPhoneAgentIndex struct {
 func (SoulPhoneAgentIndex) TableName() string { return MainTableName() }
 
 // BeforeCreate sets defaults and keys before creating SoulPhoneAgentIndex.
-func (i *SoulPhoneAgentIndex) BeforeCreate() error { return i.UpdateKeys() }
+func (i *SoulPhoneAgentIndex) BeforeCreate() error {
+	if err := i.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("phone", i.Phone); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", i.AgentID); err != nil {
+		return err
+	}
+	return nil
+}
 
 // UpdateKeys updates the database keys for SoulPhoneAgentIndex.
 func (i *SoulPhoneAgentIndex) UpdateKeys() error {

--- a/internal/store/models/soul_comm_mailbox.go
+++ b/internal/store/models/soul_comm_mailbox.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-	"unicode/utf8"
 
 	theorymodel "github.com/theory-cloud/tabletheory/pkg/model"
 )
@@ -477,17 +476,15 @@ func SoulCommMailboxEventID(eventType string, deliveryID string, status string, 
 	return "comm-mailbox-event-" + shortHash(root, 20)
 }
 
-// SoulCommMailboxPreview collapses message body text into a bounded redacted
-// preview for list responses. The full body remains in the explicit content
-// object, not in list-oriented fields.
+// SoulCommMailboxPreview returns a constant redacted marker for list responses.
+// The full body remains in the explicit content object, not in list-oriented
+// metadata. Avoid normalizing the full body here: even short messages can carry
+// private content, and unbounded normalization is an avoidable CPU/memory risk.
 func SoulCommMailboxPreview(body string) string {
-	body = strings.Join(strings.Fields(strings.TrimSpace(body)), " ")
-	const maxRunes = 160
-	if utf8.RuneCountInString(body) <= maxRunes {
-		return body
+	if strings.TrimSpace(body) == "" {
+		return ""
 	}
-	runes := []rune(body)
-	return string(runes[:maxRunes]) + "…"
+	return "[content available]"
 }
 
 func validateSoulCommMailboxStatus(status string) error {

--- a/internal/store/models/soul_comm_mailbox_test.go
+++ b/internal/store/models/soul_comm_mailbox_test.go
@@ -145,11 +145,8 @@ func assertMailboxMessageRetentionAndPreview(t *testing.T, msg *SoulCommMailboxM
 	if got, want := msg.TTL, created.Add(SoulCommMailboxRetentionDays*24*time.Hour).Unix(); got != want {
 		t.Fatalf("unexpected ttl: got %d want %d", got, want)
 	}
-	if len([]rune(msg.Preview)) > 161 {
-		t.Fatalf("expected bounded preview, got %q", msg.Preview)
-	}
-	if !strings.HasSuffix(msg.Preview, "…") {
-		t.Fatalf("expected truncated preview, got %q", msg.Preview)
+	if msg.Preview != "[content available]" {
+		t.Fatalf("expected redacted preview marker, got %q", msg.Preview)
 	}
 }
 

--- a/internal/store/models/soul_models_v3_test.go
+++ b/internal/store/models/soul_models_v3_test.go
@@ -54,6 +54,15 @@ func TestSoulPhoneAgentIndex_Keys(t *testing.T) {
 	require.Equal(t, "0xabc", i.AgentID)
 }
 
+func TestSoulContactAgentIndexes_RequireNonEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	require.Error(t, (&SoulEmailAgentIndex{AgentID: "0xabc"}).BeforeCreate())
+	require.Error(t, (&SoulEmailAgentIndex{Email: "agent@example.com"}).BeforeCreate())
+	require.Error(t, (&SoulPhoneAgentIndex{AgentID: "0xabc"}).BeforeCreate())
+	require.Error(t, (&SoulPhoneAgentIndex{Phone: "+15550123456"}).BeforeCreate())
+}
+
 func TestSoulChannelAgentIndex_Keys(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Milestone
M1 — Remediate P0 public ingress, comm, mailbox, and privacy blockers.

Closes #182
Closes #188
Closes #189
Closes #190
Closes #191
Closes #192
Closes #193

## Classification
security / trust-API-adjacent comm ingress / soul-registry off-chain state / privacy / operational-reliability / test-coverage

## Surfaces affected
- `internal/controlplane` comm mailbox capture/listing/previews
- control-plane comm webhooks for Migadu/SES-style email, Telnyx SMS, and Telnyx voice
- voice usage ledger idempotency
- soul email/phone/ENS channel provisioning and public channel resolution
- soul dispute and validation DTO redaction
- outbound soul comm first-contact and reply-boundary enforcement
- CDK SSM read grants for webhook signing configuration

## Specialist walks referenced
- Governance rubric: preserved; no verifier weakening; gov-infra PASS 29/0/0.
- Provisioning / managed-update / release verification: not touched.
- Soul registry: off-chain DynamoDB channel/index ownership only; no Solidity, no on-chain send, no Safe payload.
- Trust API / CSP / instance-auth: comm ingress/auth and public privacy surfaces hardened; no CSP loosening and no raw instance-key changes.
- Framework: idiomatic AppTheory/TableTheory usage; no framework patch.

## Multi-tenant isolation impact
Preserved. The changes continue to operate on host metadata/control-plane records only; no tenant content reads are added beyond the existing comm ingress/mailbox control-plane surface.

## On-chain impact
No Solidity, no Ethereum transaction construction, no Sepolia/mainnet deploy, no Safe-ready payload.

## Consumer impact
Managed operators and instances get stricter ingress/auth/privacy guarantees. Provider adapters must present configured webhook signatures/keys; public soul evidence responses no longer expose raw dispute/validation material.

## Tasks
- [x] #188 Harden mailbox content immutability, header safety, previews, and queue listing
- [x] #189 Authenticate comm webhooks and gate SES sender identity on authentication verdicts
- [x] #190 Make voice billing provider-bound and replay/idempotency safe
- [x] #191 Enforce email/phone/ENS channel ownership and uniqueness before index writes
- [x] #192 Redact or auth-gate dispute and validation public evidence surfaces
- [x] #193 Enforce comm first-contact and reply-boundary recipient correctness

## Validation
- [x] `test -z "$(git ls-files '*.go' | xargs gofmt -l)"`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `cd cdk && npm ci && npm run synth`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete, including comm webhook signature checks against configured lab secrets/keys
- [ ] Deployed to live with explicit operator authorization
- [ ] Post-deploy monitoring verified: control-plane 4xx/5xx, comm webhook failures, comm queue/DLQ depth, soul public resolve errors

## Cross-repo coordination
None required for this PR. Provider secret/key configuration must be present in SSM per stage before live rollout.

## Advisor-brief authorization
Not applicable.
