### PR TITLE
fix(security): remediate M2 soul integrity findings

### DIFF
--- a/contracts/contracts/OffchainResolver.sol
+++ b/contracts/contracts/OffchainResolver.sol
@@ -132,6 +132,11 @@ contract OffchainResolver is IOffchainResolver, Ownable2Step {
         override
         returns (bytes memory)
     {
+        (, address sender) = abi.decode(extraData, (bytes, address));
+        if (sender != address(this)) {
+            revert("OffchainResolver: target mismatch");
+        }
+
         (address recovered, bytes memory result) = SignatureVerifier.verify(extraData, response);
         if (recovered != signer && recovered != previousSigner) {
             revert("OffchainResolver: invalid signature");

--- a/contracts/contracts/SoulRegistry.sol
+++ b/contracts/contracts/SoulRegistry.sol
@@ -36,6 +36,8 @@ contract SoulRegistry is ERC721, Ownable2Step, Pausable, EIP712 {
 
     // tokenId -> mint timestamp (seconds)
     mapping(uint256 => uint256) private _mintedAt;
+    // tokenId -> whether the ID has ever been minted.
+    mapping(uint256 => bool) private _everMinted;
 
     // agentId -> replay-protection nonce (used for rotations)
     /// @notice Replay-protection nonce used for wallet rotations (agentId => nonce).
@@ -213,10 +215,11 @@ contract SoulRegistry is ERC721, Ownable2Step, Pausable, EIP712 {
         if (bytes(metaURI).length == 0) {
             revert("SoulRegistry: metaURI required");
         }
-        if (_ownerOf(agentId) != address(0)) {
+        if (_ownerOf(agentId) != address(0) || _everMinted[agentId]) {
             revert("SoulRegistry: already minted");
         }
 
+        _everMinted[agentId] = true;
         _mintedAt[agentId] = block.timestamp;
         _metaURI[agentId] = metaURI;
         _avatarStyle[agentId] = avatarStyle;

--- a/contracts/contracts/TipSplitter.sol
+++ b/contracts/contracts/TipSplitter.sol
@@ -103,6 +103,8 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
     event TokenAllowedSet(address indexed token, bool allowed);
     /// @notice Emitted when the Lesser wallet is updated.
     event LesserWalletUpdated(address indexed oldWallet, address indexed newWallet);
+    /// @notice Emitted when pending balances are migrated during a wallet rotation.
+    event PendingMigrated(address indexed oldWallet, address indexed newWallet, uint256 ethAmount, uint256 tokenCount);
     /// @notice Emitted when a token's maximum tip amount is updated.
     event MaxTipAmountSet(address indexed token, uint256 amount);
     /// @notice Emitted when a token's minimum tip amount is updated.
@@ -363,8 +365,12 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
 
         address oldWallet = hosts[hostId].wallet;
         if (oldWallet != wallet) {
-            _hostWalletRefCount[oldWallet]--;
+            uint256 oldRefCount = _hostWalletRefCount[oldWallet];
+            _hostWalletRefCount[oldWallet] = oldRefCount - 1;
             _hostWalletRefCount[wallet]++;
+            if (oldRefCount == 1) {
+                _migratePending(oldWallet, wallet);
+            }
         }
         hosts[hostId].wallet = wallet;
         hosts[hostId].feeBps = feeBps;
@@ -421,6 +427,7 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
         require(_hostWalletRefCount[newWallet] == 0, "TipSplitter: wallet is a host wallet");
         address old = lesserWallet;
         lesserWallet = newWallet;
+        _migratePending(old, newWallet);
         emit LesserWalletUpdated(old, newWallet);
     }
 
@@ -543,6 +550,38 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
         }
         _recipientTokenList[recipient].pop();
         delete _recipientTokenIndex[recipient][token];
+    }
+
+    function _migratePending(address oldWallet, address newWallet) internal {
+        if (oldWallet == newWallet) {
+            return;
+        }
+
+        uint256 ethAmount = pendingETH[oldWallet];
+        if (ethAmount > 0) {
+            pendingETH[oldWallet] = 0;
+            pendingETH[newWallet] += ethAmount;
+        }
+
+        uint256 tokenCount = 0;
+        while (_recipientTokenList[oldWallet].length > 0) {
+            address token = _recipientTokenList[oldWallet][_recipientTokenList[oldWallet].length - 1];
+            uint256 amount = pendingToken[token][oldWallet];
+            pendingToken[token][oldWallet] = 0;
+            _removeRecipientToken(oldWallet, token);
+            if (amount > 0) {
+                if (_recipientTokenIndex[newWallet][token] == 0) {
+                    _recipientTokenList[newWallet].push(token);
+                    _recipientTokenIndex[newWallet][token] = _recipientTokenList[newWallet].length; // 1-based
+                }
+                pendingToken[token][newWallet] += amount;
+                tokenCount++;
+            }
+        }
+
+        if (ethAmount > 0 || tokenCount > 0) {
+            emit PendingMigrated(oldWallet, newWallet, ethAmount, tokenCount);
+        }
     }
 
     function _split(uint16 hostFeeBps, uint256 amount)

--- a/contracts/test/OffchainResolver.test.js
+++ b/contracts/test/OffchainResolver.test.js
@@ -192,6 +192,47 @@ describe("OffchainResolver — CCIP-Read contract", () => {
     assert.equal(await resolver.resolveWithProof(response2, extraData), result);
   });
 
+  it("resolveWithProof rejects proofs signed for a different target", async () => {
+    const signerWallet = ethersPkg.Wallet.createRandom();
+    const signingKey = new ethersPkg.SigningKey(signerWallet.privateKey);
+
+    const { resolver, other } = await deployOffchainResolver({
+      signer: signerWallet.address,
+    });
+
+    const resolverAddr = await resolver.getAddress();
+    const replayTarget = other.address;
+    const callData = "0xdeadbeef";
+    const result = "0x1234";
+    const expires =
+      BigInt((await ethers.provider.getBlock("latest")).timestamp) + 300n;
+
+    const replayHash = ethersPkg.solidityPackedKeccak256(
+      ["bytes", "address", "uint64", "bytes32", "bytes32"],
+      [
+        "0x1900",
+        replayTarget,
+        expires,
+        ethersPkg.keccak256(callData),
+        ethersPkg.keccak256(result),
+      ],
+    );
+    const response = ethersPkg.AbiCoder.defaultAbiCoder().encode(
+      ["bytes", "uint64", "bytes"],
+      [result, expires, signingKey.sign(replayHash).compactSerialized],
+    );
+    const extraData = ethersPkg.AbiCoder.defaultAbiCoder().encode(
+      ["bytes", "address"],
+      [callData, replayTarget],
+    );
+
+    await assert.rejects(
+      resolver.resolveWithProof(response, extraData),
+      /target mismatch/,
+    );
+    assert.notEqual(replayTarget, resolverAddr);
+  });
+
   it("owner-only setters enforce access control", async () => {
     const signerWallet = ethersPkg.Wallet.createRandom();
     const { resolver, owner, other } = await deployOffchainResolver({
@@ -214,4 +255,3 @@ describe("OffchainResolver — CCIP-Read contract", () => {
     );
   });
 });
-

--- a/contracts/test/SoulRegistry.test.js
+++ b/contracts/test/SoulRegistry.test.js
@@ -234,6 +234,19 @@ describe("SoulRegistry — Burn", () => {
     await assert.rejects(registry.ownerOf(agentId), /ERC721NonexistentToken/);
   });
 
+  it("burn tombstones the agentId so it cannot be reminted", async () => {
+    const { registry, owner, alice, bob } = await deployRegistry();
+    const agentId = 2002n;
+
+    await registry.connect(owner).mintSoulOwner(alice.address, agentId, "ipfs://m", 0);
+    await registry.connect(owner).burnSoul(agentId);
+
+    await assert.rejects(
+      registry.connect(owner).mintSoulOwner(bob.address, agentId, "ipfs://m2", 0),
+      /already minted/,
+    );
+  });
+
   it("burn works when token is soulbound", async () => {
     const { registry, owner, alice } = await deployRegistry({
       claimWindowSeconds: 1n,

--- a/contracts/test/TipSplitter.test.js
+++ b/contracts/test/TipSplitter.test.js
@@ -889,6 +889,48 @@ describe("TipSplitter — setLesserWallet", () => {
     assert.equal(await splitter.lesserWallet(), other.address);
   });
 
+  it("migrates pending ETH and token balances to the new lesser wallet", async () => {
+    const {
+      splitter,
+      token,
+      tokenAddr,
+      owner,
+      lesserWallet,
+      actor,
+      tipper,
+      other,
+      HOST_ID,
+      CONTENT_HASH,
+    } = await deploy();
+
+    const ethAmount = ethers.parseEther("1");
+    const tokenAmount = ethers.parseEther("2");
+    const ethSplit = expectedSplit(ethAmount);
+    const tokenSplit = expectedSplit(tokenAmount);
+
+    await splitter.connect(tipper).tipETH(HOST_ID, actor.address, CONTENT_HASH, {
+      value: ethAmount,
+    });
+    await splitter
+      .connect(tipper)
+      .tipToken(tokenAddr, HOST_ID, actor.address, tokenAmount, CONTENT_HASH);
+
+    await splitter.connect(owner).setLesserWallet(other.address);
+
+    assert.equal(await splitter.pendingETH(lesserWallet.address), 0n);
+    assert.equal(await splitter.pendingETH(other.address), ethSplit.lesserShare);
+    assert.equal(await splitter.pendingToken(tokenAddr, lesserWallet.address), 0n);
+    assert.equal(
+      await splitter.pendingToken(tokenAddr, other.address),
+      tokenSplit.lesserShare,
+    );
+    assert.equal(await splitter.totalPendingToken(tokenAddr), tokenAmount);
+
+    await splitter.connect(other).withdraw(ethers.ZeroAddress);
+    await splitter.connect(other).withdraw(tokenAddr);
+    assert.equal(await token.balanceOf(other.address), tokenSplit.lesserShare);
+  });
+
   it("rejects zero address", async () => {
     const { splitter, owner } = await deploy();
     await assert.rejects(
@@ -1255,6 +1297,24 @@ describe("TipSplitter — setLesserWallet host collision", () => {
     // Now hostWallet is no longer a host wallet
     await splitter.connect(owner).setLesserWallet(hostWallet.address);
     assert.equal(await splitter.lesserWallet(), hostWallet.address);
+  });
+});
+
+describe("TipSplitter — host wallet rotation pending migration", () => {
+  it("migrates pending host ETH when the last host reference rotates", async () => {
+    const { splitter, owner, hostWallet, actor, tipper, other, HOST_ID, CONTENT_HASH } =
+      await deploy();
+    const amount = ethers.parseEther("1");
+    const split = expectedSplit(amount);
+
+    await splitter.connect(tipper).tipETH(HOST_ID, actor.address, CONTENT_HASH, {
+      value: amount,
+    });
+
+    await splitter.connect(owner).updateHost(HOST_ID, other.address, HOST_FEE_BPS);
+
+    assert.equal(await splitter.pendingETH(hostWallet.address), 0n);
+    assert.equal(await splitter.pendingETH(other.address), split.hostShare);
   });
 });
 

--- a/internal/controlplane/eth_rpc.go
+++ b/internal/controlplane/eth_rpc.go
@@ -12,6 +12,7 @@ import (
 type ethRPCClient interface {
 	CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) ([]byte, error)
 	FilterLogs(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
+	TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error)
 	TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error)
 	Close()
 }

--- a/internal/controlplane/handlers_soul_agent_mint_operation_internal_test.go
+++ b/internal/controlplane/handlers_soul_agent_mint_operation_internal_test.go
@@ -3,12 +3,11 @@ package controlplane
 import (
 	"context"
 	"encoding/json"
-	"math/big"
 	"strings"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/common"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
@@ -63,6 +62,7 @@ func TestHandleSoulAgentGetMintOperation_Success(t *testing.T) {
 	stubSoulMintPortalAccess(t, tdb, identity)
 
 	opID := s.soulMintOperationID(&identity)
+	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, identity.Wallet, identity.PrincipalAddress)
 	tdb.base.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
 		*dest = models.SoulOperation{
@@ -70,7 +70,7 @@ func TestHandleSoulAgentGetMintOperation_Success(t *testing.T) {
 			Kind:            models.SoulOperationKindMint,
 			AgentID:         agentID,
 			Status:          models.SoulOperationStatusPending,
-			SafePayloadJSON: `{"safe_address":"0x00000000000000000000000000000000000000bb","to":"0x00000000000000000000000000000000000000cc","value":"0","data":"0x1234"}`,
+			SafePayloadJSON: soulTestPayloadJSON(t, payload),
 			CreatedAt:       time.Now().Add(-time.Minute).UTC(),
 			UpdatedAt:       time.Now().UTC(),
 		}
@@ -142,6 +142,7 @@ func TestHandleSoulAgentRecordMintOperationExecution_Success(t *testing.T) {
 	stubSoulMintPortalAccess(t, tdb, identity)
 
 	opID := s.soulMintOperationID(&identity)
+	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, identity.Wallet, identity.PrincipalAddress)
 	tdb.base.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
 		*dest = models.SoulOperation{
@@ -149,7 +150,7 @@ func TestHandleSoulAgentRecordMintOperationExecution_Success(t *testing.T) {
 			Kind:            models.SoulOperationKindMint,
 			AgentID:         agentID,
 			Status:          models.SoulOperationStatusPending,
-			SafePayloadJSON: `{"safe_address":"0x00000000000000000000000000000000000000bb","to":"0x00000000000000000000000000000000000000cc","value":"0","data":"0x1234"}`,
+			SafePayloadJSON: soulTestPayloadJSON(t, payload),
 			CreatedAt:       time.Now().Add(-time.Minute).UTC(),
 			UpdatedAt:       time.Now().UTC(),
 		}
@@ -157,12 +158,9 @@ func TestHandleSoulAgentRecordMintOperationExecution_Success(t *testing.T) {
 
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
 		return &fakeEthClient{
-			receipt: &types.Receipt{
-				Status:      1,
-				BlockNumber: big.NewInt(42),
-				GasUsed:     100,
-				Logs:        []*types.Log{},
-			},
+			tx:           soulTestTxFromPayload(t, payload),
+			receipt:      soulTestMintReceipt(common.HexToAddress(s.cfg.SoulRegistryContractAddress), agentID, identity.Wallet, identity.PrincipalAddress),
+			callContract: soulTestCallContractForWalletPrincipal(t, identity.Wallet, identity.PrincipalAddress),
 		}, nil
 	}
 

--- a/internal/controlplane/handlers_soul_agent_rotation_operation_internal_test.go
+++ b/internal/controlplane/handlers_soul_agent_rotation_operation_internal_test.go
@@ -86,6 +86,7 @@ func TestHandleSoulAgentRecordRotationOperationExecution_Success(t *testing.T) {
 	}).Once()
 
 	opID := soulRotationOpID(s.cfg.SoulChainID, "0x0000000000000000000000000000000000000001", agentID, "0x00000000000000000000000000000000000000aa", "0x00000000000000000000000000000000000000bb", "7", 1700000000)
+	payload := soulTestRotatePayload(t, s.cfg.SoulRegistryContractAddress, agentID, "0x00000000000000000000000000000000000000bb")
 	tdb.base.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
 		*dest = models.SoulOperation{
@@ -93,7 +94,7 @@ func TestHandleSoulAgentRecordRotationOperationExecution_Success(t *testing.T) {
 			Kind:            models.SoulOperationKindRotateWallet,
 			AgentID:         agentID,
 			Status:          models.SoulOperationStatusPending,
-			SafePayloadJSON: `{"to":"0x0000000000000000000000000000000000000001","value":"0","data":"0x1234"}`,
+			SafePayloadJSON: soulTestPayloadJSON(t, payload),
 			CreatedAt:       time.Now().Add(-time.Minute).UTC(),
 			UpdatedAt:       time.Now().UTC(),
 		}
@@ -101,6 +102,7 @@ func TestHandleSoulAgentRecordRotationOperationExecution_Success(t *testing.T) {
 
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
 		return &fakeEthClient{
+			tx: soulTestTxFromPayload(t, payload),
 			receipt: &types.Receipt{
 				Status:      0,
 				BlockNumber: big.NewInt(42),

--- a/internal/controlplane/handlers_soul_continuity.go
+++ b/internal/controlplane/handlers_soul_continuity.go
@@ -15,6 +15,11 @@ import (
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
+const (
+	soulSignedRequestMaxFutureSkew = 5 * time.Minute
+	soulSignedRequestMaxAge        = 15 * time.Minute
+)
+
 // --- Request / Response types ---
 
 type soulAppendContinuityRequest struct {
@@ -122,7 +127,7 @@ func parseSoulAppendContinuityData(req soulAppendContinuityRequest, now time.Tim
 		return soulAppendContinuityData{}, &apptheory.AppError{Code: "app.bad_request", Message: "invalid continuity entry type"}
 	}
 
-	parsedTS, appErr := parseSoulContinuityTimestamp(strings.TrimSpace(req.Timestamp), now)
+	parsedTS, timestampCanonical, appErr := parseSoulContinuityTimestamp(strings.TrimSpace(req.Timestamp), now)
 	if appErr != nil {
 		return soulAppendContinuityData{}, appErr
 	}
@@ -148,7 +153,7 @@ func parseSoulAppendContinuityData(req soulAppendContinuityRequest, now time.Tim
 	return soulAppendContinuityData{
 		entryType:          entryType,
 		parsedTS:           parsedTS,
-		timestampCanonical: parsedTS.UTC().Format(time.RFC3339Nano),
+		timestampCanonical: timestampCanonical,
 		summary:            summary,
 		recovery:           recovery,
 		references:         normalizeContinuityReferences(req.References),
@@ -157,26 +162,44 @@ func parseSoulAppendContinuityData(req soulAppendContinuityRequest, now time.Tim
 	}, nil
 }
 
-func parseSoulContinuityTimestamp(raw string, now time.Time) (time.Time, *apptheory.AppError) {
+func parseSoulContinuityTimestamp(raw string, now time.Time) (time.Time, string, *apptheory.AppError) {
+	return parseSoulSignedTimestamp(raw, now, "timestamp")
+}
+
+func parseSoulSignedTimestamp(raw string, now time.Time, field string) (time.Time, string, *apptheory.AppError) {
+	raw = strings.TrimSpace(raw)
+	field = strings.TrimSpace(field)
+	if field == "" {
+		field = "timestamp"
+	}
 	if raw == "" {
-		return time.Time{}, &apptheory.AppError{Code: "app.bad_request", Message: "timestamp is required"}
+		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: field + " is required"}
 	}
 	parsedTS, parseErr := time.Parse(time.RFC3339, raw)
 	if parseErr != nil {
 		var parsedNano time.Time
 		parsedNano, parseErr = time.Parse(time.RFC3339Nano, raw)
 		if parseErr != nil {
-			return time.Time{}, &apptheory.AppError{Code: "app.bad_request", Message: "timestamp must be RFC3339"}
+			return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: field + " must be RFC3339"}
 		}
 		parsedTS = parsedNano
 	}
-	if parsedTS.After(now.Add(5 * time.Minute)) {
-		return time.Time{}, &apptheory.AppError{Code: "app.bad_request", Message: "timestamp cannot be in the future"}
+	if now.IsZero() {
+		now = time.Now().UTC()
 	}
-	if parsedTS.Before(now.Add(-10 * 365 * 24 * time.Hour)) {
-		return time.Time{}, &apptheory.AppError{Code: "app.bad_request", Message: "timestamp is too far in the past"}
+	now = now.UTC()
+	parsedTS = parsedTS.UTC()
+	if parsedTS.After(now.Add(soulSignedRequestMaxFutureSkew)) {
+		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: field + " cannot be in the future"}
 	}
-	return parsedTS.UTC(), nil
+	if parsedTS.Before(now.Add(-soulSignedRequestMaxAge)) {
+		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: field + " is too far in the past"}
+	}
+	return parsedTS, canonicalSoulSignedTimestamp(parsedTS), nil
+}
+
+func canonicalSoulSignedTimestamp(ts time.Time) string {
+	return ts.UTC().Truncate(time.Millisecond).Format("2006-01-02T15:04:05.000Z")
 }
 
 func computeSoulContinuityEntryDigest(entryType string, timestamp string, summary string, recovery string, references []string) ([]byte, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_continuity_internal_test.go
+++ b/internal/controlplane/handlers_soul_continuity_internal_test.go
@@ -63,7 +63,7 @@ func TestHandleSoulAppendContinuity_VerifiesSignedEntry(t *testing.T) {
 	}).Once()
 
 	entryType := models.SoulContinuityEntryTypeModelChange
-	timestamp := "2026-03-01T00:00:00Z"
+	timestamp := canonicalSoulSignedTimestamp(time.Now().UTC())
 	summary := "Updated underlying model to claude-opus-4-6."
 	recovery := ""
 	references := []string{"boundary-001"}
@@ -109,10 +109,28 @@ func TestHandleSoulAppendContinuity_VerifiesSignedEntry(t *testing.T) {
 	if out.Entry.Type != entryType {
 		t.Fatalf("expected type %q, got %q", entryType, out.Entry.Type)
 	}
-	if out.Entry.Timestamp.IsZero() || out.Entry.Timestamp.UTC().Format(time.RFC3339) != timestamp {
+	if out.Entry.Timestamp.IsZero() || canonicalSoulSignedTimestamp(out.Entry.Timestamp) != timestamp {
 		t.Fatalf("expected timestamp %q, got %#v", timestamp, out.Entry.Timestamp)
 	}
 	if out.Entry.Signature != strings.ToLower(sigHex) {
 		t.Fatalf("expected signature %q, got %q", strings.ToLower(sigHex), out.Entry.Signature)
+	}
+}
+
+func TestParseSoulSignedTimestamp_CanonicalizesLikeJavaScriptISOString(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 4, 29, 3, 15, 0, 0, time.UTC)
+	_, canonical, appErr := parseSoulSignedTimestamp("2026-04-29T03:14:59.120Z", now, "timestamp")
+	if appErr != nil {
+		t.Fatalf("unexpected appErr: %#v", appErr)
+	}
+	if canonical != "2026-04-29T03:14:59.120Z" {
+		t.Fatalf("unexpected canonical timestamp: %q", canonical)
+	}
+
+	_, _, appErr = parseSoulSignedTimestamp("2026-04-29T02:59:59.999Z", now, "timestamp")
+	if appErr == nil || appErr.Message != "timestamp is too far in the past" {
+		t.Fatalf("expected stale timestamp rejection, got %#v", appErr)
 	}
 }

--- a/internal/controlplane/handlers_soul_lifecycle.go
+++ b/internal/controlplane/handlers_soul_lifecycle.go
@@ -90,7 +90,7 @@ func (s *Server) handleSoulArchiveAgentBegin(ctx *apptheory.Context) (*apptheory
 	}
 
 	now := time.Now().UTC()
-	timestamp := now.Format(time.RFC3339Nano)
+	timestamp := canonicalSoulSignedTimestamp(now)
 	summary := soulContinuitySummaryArchived
 	references := []string{fmt.Sprintf("agent:%s", agentIDHex)}
 
@@ -229,7 +229,7 @@ func (s *Server) handleSoulDesignateSuccessorBegin(ctx *apptheory.Context) (*app
 		return nil, successorErr
 	}
 
-	beginResp, appErr := buildSoulDesignateSuccessorBeginResponse(agentIDHex, successorIDHex, time.Now().UTC().Format(time.RFC3339Nano))
+	beginResp, appErr := buildSoulDesignateSuccessorBeginResponse(agentIDHex, successorIDHex, canonicalSoulSignedTimestamp(time.Now().UTC()))
 	if appErr != nil {
 		return nil, appErr
 	}
@@ -350,23 +350,7 @@ func (s *Server) handleSoulDesignateSuccessor(ctx *apptheory.Context) (*apptheor
 }
 
 func parseAndValidateSoulContinuityTimestamp(tsRaw string) (time.Time, string, *apptheory.AppError) {
-	tsRaw = strings.TrimSpace(tsRaw)
-	parsedTS, parseErr := time.Parse(time.RFC3339, tsRaw)
-	if parseErr != nil {
-		if parsedTS, parseErr = time.Parse(time.RFC3339Nano, tsRaw); parseErr != nil {
-			return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "timestamp must be RFC3339"}
-		}
-	}
-
-	now := time.Now().UTC()
-	if parsedTS.After(now.Add(5 * time.Minute)) {
-		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "timestamp cannot be in the future"}
-	}
-	if parsedTS.Before(now.Add(-10 * 365 * 24 * time.Hour)) {
-		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "timestamp is too far in the past"}
-	}
-
-	return parsedTS.UTC(), parsedTS.UTC().Format(time.RFC3339Nano), nil
+	return parseSoulSignedTimestamp(tsRaw, time.Now().UTC(), "timestamp")
 }
 
 func (s *Server) loadSoulLifecycleIdentity(ctx *apptheory.Context, agentIDHex string) (*models.SoulAgentIdentity, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_lifecycle_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_internal_test.go
@@ -47,6 +47,10 @@ func (f *fakeEVMClient) CallContract(ctx context.Context, msg ethereum.CallMsg, 
 	return f.callContract(ctx, msg)
 }
 
+func (f *fakeEVMClient) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	return nil, false, ethereum.NotFound
+}
+
 func (f *fakeEVMClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	return nil, ethereum.NotFound
 }

--- a/internal/controlplane/handlers_soul_lifecycle_transitions_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_transitions_internal_test.go
@@ -37,7 +37,7 @@ func TestHandleSoulArchiveAgent_ArchivesAndWritesAudit(t *testing.T) {
 	agentIDHex := soulLifecycleTestAgentIDHex
 	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, wallet)
 
-	timestamp := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	digest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeArchived,
 		timestamp,
@@ -108,7 +108,7 @@ func TestHandleSoulDesignateSuccessor_SucceedsAndCreatesEntries(t *testing.T) {
 	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, walletPred)
 	seedSoulSuccessorIdentity(t, tdb, successorIDHex, walletSucc)
 
-	timestamp := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	declaredDigest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeSuccessionDeclared,
 		timestamp,
@@ -256,8 +256,8 @@ func expectArchiveContinuityCreate(t *testing.T, tb *ttmocks.MockTransactionBuil
 		if entry.Signature != strings.ToLower(sigHex) {
 			t.Fatalf("expected signature %q, got %q", strings.ToLower(sigHex), entry.Signature)
 		}
-		if entry.Timestamp.UTC().Format(time.RFC3339) != timestamp {
-			t.Fatalf("expected timestamp %q, got %q", timestamp, entry.Timestamp.UTC().Format(time.RFC3339))
+		if canonicalSoulSignedTimestamp(entry.Timestamp.UTC()) != timestamp {
+			t.Fatalf("expected timestamp %q, got %q", timestamp, canonicalSoulSignedTimestamp(entry.Timestamp.UTC()))
 		}
 	})
 }
@@ -311,8 +311,8 @@ func expectSuccessorContinuityCreates(t *testing.T, tb *ttmocks.MockTransactionB
 		default:
 			t.Fatalf("unexpected continuity entry type %q", entry.Type)
 		}
-		if entry.Timestamp.UTC().Format(time.RFC3339) != timestamp {
-			t.Fatalf("expected timestamp %q, got %q", timestamp, entry.Timestamp.UTC().Format(time.RFC3339))
+		if canonicalSoulSignedTimestamp(entry.Timestamp.UTC()) != timestamp {
+			t.Fatalf("expected timestamp %q, got %q", timestamp, canonicalSoulSignedTimestamp(entry.Timestamp.UTC()))
 		}
 	})
 	return createKinds
@@ -468,7 +468,7 @@ func TestHandleSoulArchiveAgent_TransactionFailureReturnsInternalError(t *testin
 		}
 	}).Once()
 
-	timestamp := time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	digest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeArchived,
 		timestamp,

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -1129,8 +1129,8 @@ func (s *Server) handleSoulBeginFinalizeMintConversation(ctx *apptheory.Context)
 	if finalizeCtx.identity.SelfDescriptionVersion > 0 {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: soulMintConversationAlreadyPublishedMessage}
 	}
-	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
-		return nil, appErr
+	if activeErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); activeErr != nil {
+		return nil, activeErr
 	}
 	req, err := parseMintConversationFinalizeBeginRequestBody(ctx)
 	if err != nil {
@@ -1172,8 +1172,8 @@ func (s *Server) handleSoulAgentBeginFinalizeMintConversation(ctx *apptheory.Con
 	if agentCtx.identity.SelfDescriptionVersion > 0 {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: soulMintConversationAlreadyPublishedMessage}
 	}
-	if appErr := requireMintConversationFinalizeActiveIdentity(agentCtx.identity); appErr != nil {
-		return nil, appErr
+	if activeErr := requireMintConversationFinalizeActiveIdentity(agentCtx.identity); activeErr != nil {
+		return nil, activeErr
 	}
 	if strings.TrimSpace(agentCtx.identity.PrincipalAddress) == "" ||
 		strings.TrimSpace(agentCtx.identity.PrincipalSignature) == "" ||
@@ -1224,14 +1224,8 @@ func (s *Server) handleSoulFinalizeMintConversation(ctx *apptheory.Context) (*ap
 	}
 
 	nextVersion := *expectedVersion + 1
-	if finalizeCtx.identity.SelfDescriptionVersion > nextVersion {
-		return nil, &apptheory.AppError{Code: "app.conflict", Message: "agent has advanced beyond this version"}
-	}
-	if finalizeCtx.identity.SelfDescriptionVersion < *expectedVersion {
-		return nil, &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
-	}
-	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
-		return nil, appErr
+	if versionErr := requireMintConversationFinalizeVersionAndActive(finalizeCtx.identity, nextVersion, *expectedVersion); versionErr != nil {
+		return nil, versionErr
 	}
 	decl, appErr := parseAndValidateMintConversationDeclarations(finalizeCtx.conv.ProducedDeclarations)
 	if appErr != nil {
@@ -1286,14 +1280,8 @@ func (s *Server) handleSoulAgentFinalizeMintConversation(ctx *apptheory.Context)
 	}
 
 	nextVersion := *expectedVersion + 1
-	if finalizeCtx.identity.SelfDescriptionVersion > nextVersion {
-		return nil, &apptheory.AppError{Code: "app.conflict", Message: "agent has advanced beyond this version"}
-	}
-	if finalizeCtx.identity.SelfDescriptionVersion < *expectedVersion {
-		return nil, &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
-	}
-	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
-		return nil, appErr
+	if versionErr := requireMintConversationFinalizeVersionAndActive(finalizeCtx.identity, nextVersion, *expectedVersion); versionErr != nil {
+		return nil, versionErr
 	}
 
 	decl, appErr := parseAndValidateMintConversationDeclarations(finalizeCtx.conv.ProducedDeclarations)
@@ -1788,6 +1776,19 @@ func mintConversationFinalizeLifecycleStatus(identity *models.SoulAgentIdentity)
 		lifecycleStatus = strings.ToLower(strings.TrimSpace(identity.Status))
 	}
 	return lifecycleStatus
+}
+
+func requireMintConversationFinalizeVersionAndActive(identity *models.SoulAgentIdentity, nextVersion int, expectedVersion int) *apptheory.AppError {
+	if identity == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if identity.SelfDescriptionVersion > nextVersion {
+		return &apptheory.AppError{Code: "app.conflict", Message: "agent has advanced beyond this version"}
+	}
+	if identity.SelfDescriptionVersion < expectedVersion {
+		return &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
+	}
+	return requireMintConversationFinalizeActiveIdentity(identity)
 }
 
 func requireMintConversationFinalizeActiveIdentity(identity *models.SoulAgentIdentity) *apptheory.AppError {

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -1129,6 +1129,9 @@ func (s *Server) handleSoulBeginFinalizeMintConversation(ctx *apptheory.Context)
 	if finalizeCtx.identity.SelfDescriptionVersion > 0 {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: soulMintConversationAlreadyPublishedMessage}
 	}
+	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
+		return nil, appErr
+	}
 	req, err := parseMintConversationFinalizeBeginRequestBody(ctx)
 	if err != nil {
 		return nil, err
@@ -1168,6 +1171,9 @@ func (s *Server) handleSoulAgentBeginFinalizeMintConversation(ctx *apptheory.Con
 	}
 	if agentCtx.identity.SelfDescriptionVersion > 0 {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: soulMintConversationAlreadyPublishedMessage}
+	}
+	if appErr := requireMintConversationFinalizeActiveIdentity(agentCtx.identity); appErr != nil {
+		return nil, appErr
 	}
 	if strings.TrimSpace(agentCtx.identity.PrincipalAddress) == "" ||
 		strings.TrimSpace(agentCtx.identity.PrincipalSignature) == "" ||
@@ -1223,6 +1229,9 @@ func (s *Server) handleSoulFinalizeMintConversation(ctx *apptheory.Context) (*ap
 	}
 	if finalizeCtx.identity.SelfDescriptionVersion < *expectedVersion {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
+	}
+	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
+		return nil, appErr
 	}
 	decl, appErr := parseAndValidateMintConversationDeclarations(finalizeCtx.conv.ProducedDeclarations)
 	if appErr != nil {
@@ -1282,6 +1291,9 @@ func (s *Server) handleSoulAgentFinalizeMintConversation(ctx *apptheory.Context)
 	}
 	if finalizeCtx.identity.SelfDescriptionVersion < *expectedVersion {
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
+	}
+	if appErr := requireMintConversationFinalizeActiveIdentity(finalizeCtx.identity); appErr != nil {
+		return nil, appErr
 	}
 
 	decl, appErr := parseAndValidateMintConversationDeclarations(finalizeCtx.conv.ProducedDeclarations)
@@ -1775,10 +1787,21 @@ func mintConversationFinalizeLifecycleStatus(identity *models.SoulAgentIdentity)
 	if lifecycleStatus == "" {
 		lifecycleStatus = strings.ToLower(strings.TrimSpace(identity.Status))
 	}
-	if lifecycleStatus == models.SoulAgentStatusPending || lifecycleStatus == "" {
-		return models.SoulAgentStatusActive
-	}
 	return lifecycleStatus
+}
+
+func requireMintConversationFinalizeActiveIdentity(identity *models.SoulAgentIdentity) *apptheory.AppError {
+	lifecycleStatus := ""
+	if identity != nil {
+		lifecycleStatus = strings.ToLower(strings.TrimSpace(identity.LifecycleStatus))
+		if lifecycleStatus == "" {
+			lifecycleStatus = strings.ToLower(strings.TrimSpace(identity.Status))
+		}
+	}
+	if lifecycleStatus != models.SoulAgentStatusActive {
+		return &apptheory.AppError{Code: "app.conflict", Message: "agent must be active before publishing mint conversation registration"}
+	}
+	return nil
 }
 
 func buildMintConversationFinalizePrincipal(identity *models.SoulAgentIdentity) map[string]any {

--- a/internal/controlplane/handlers_soul_mint_conversation_coverage_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_coverage_internal_test.go
@@ -134,6 +134,8 @@ func beginFinalizeCoverageResponse(t *testing.T, usePreflightAlias bool) soulMin
 	s := newMintConversationServer(tdb)
 	identity, key := testMintConversationIdentityAndKey()
 	identity.AgentID = f.reg.AgentID
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	stubMintConversationRegistration(t, tdb, f.reg)
 	stubMintConversationDomainAccess(t, tdb, f.reg.DomainNormalized)
@@ -195,6 +197,8 @@ func testMintConversationBeginFinalizeRequiresBoundarySignatures(t *testing.T) {
 	s := newMintConversationServer(tdb)
 	identity := testMintConversationIdentity()
 	identity.AgentID = f.reg.AgentID
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	stubMintConversationRegistration(t, tdb, f.reg)
 	stubMintConversationDomainAccess(t, tdb, f.reg.DomainNormalized)
@@ -216,6 +220,8 @@ func testMintConversationFinalizeRequiresExpectedVersion(t *testing.T) {
 	s := newMintConversationServer(tdb)
 	identity := testMintConversationIdentity()
 	identity.AgentID = f.reg.AgentID
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	stubMintConversationRegistration(t, tdb, f.reg)
 	stubMintConversationDomainAccess(t, tdb, f.reg.DomainNormalized)
@@ -251,6 +257,8 @@ func testMintConversationFinalizeRejectsInvalidRegistrationSignature(t *testing.
 	s := newMintConversationServer(tdb)
 	identity, key := testMintConversationIdentityAndKey()
 	identity.AgentID = f.reg.AgentID
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	stubMintConversationRegistration(t, tdb, f.reg)
 	stubMintConversationDomainAccess(t, tdb, f.reg.DomainNormalized)
@@ -283,6 +291,8 @@ func assertMintConversationFinalizeIdentityVersionError(t *testing.T, identityVe
 	identity := testMintConversationIdentity()
 	identity.AgentID = f.reg.AgentID
 	identity.SelfDescriptionVersion = identityVersion
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	stubMintConversationRegistration(t, tdb, f.reg)
 	stubMintConversationDomainAccess(t, tdb, f.reg.DomainNormalized)

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -205,6 +205,22 @@ func testMintConversationIdentity() *models.SoulAgentIdentity {
 	return identity
 }
 
+func TestRequireMintConversationFinalizeActiveIdentityRejectsPending(t *testing.T) {
+	t.Parallel()
+
+	identity := testMintConversationIdentity()
+	appErr := requireMintConversationFinalizeActiveIdentity(identity)
+	if appErr == nil || appErr.Code != "app.conflict" {
+		t.Fatalf("expected pending identity conflict, got %#v", appErr)
+	}
+
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
+	if appErr := requireMintConversationFinalizeActiveIdentity(identity); appErr != nil {
+		t.Fatalf("expected active identity to pass, got %#v", appErr)
+	}
+}
+
 func TestMintConversationHelperCoverage(t *testing.T) {
 	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
 
@@ -397,8 +413,8 @@ func testMintConversationFinalizeRegistrationHelper(t *testing.T, now time.Time)
 	decl.SelfDescription.Constraints = "Stay within provided context."
 	decl.Capabilities[0].LastValidated = "2026-03-05T12:00:00Z"
 	decl.Boundaries[0].Rationale = "Prevent deception."
-	identity.Status = models.SoulAgentStatusPending
-	identity.LifecycleStatus = models.SoulAgentStatusPending
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 
 	reg, _, digest, capsNorm, claimLevels, appErr := s.buildMintConversationFinalizeV2Registration(identity.AgentID, identity, decl, map[string]string{"b1": "0x00"}, now, 2, "0x00")
 	assertMintConversationFinalizeRegistrationSuccess(t, identity, reg, digest, capsNorm, claimLevels, appErr)
@@ -1158,6 +1174,10 @@ func TestMintConversationBeginAndFinalize_Success(t *testing.T) {
 		addStandardMockQueryStubs(q)
 	}
 
+	qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = nil
+	}).Once()
 	qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 	tb.On("ConditionCheck", mock.AnythingOfType("*models.SoulAgentIdentity"), mock.Anything).Return(tb).Once()
@@ -1171,6 +1191,8 @@ func TestMintConversationBeginAndFinalize_Success(t *testing.T) {
 	tdb.qIdentity.On("Update", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	identity, key := testMintConversationIdentityAndKey()
+	identity.Status = models.SoulAgentStatusActive
+	identity.LifecycleStatus = models.SoulAgentStatusActive
 	reg := models.SoulAgentRegistration{
 		ID:               "reg-1",
 		Username:         "alice",

--- a/internal/controlplane/handlers_soul_operations.go
+++ b/internal/controlplane/handlers_soul_operations.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
@@ -130,6 +132,10 @@ func (s *Server) recordSoulOperationExecution(ctx context.Context, actor string,
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "exec_tx_hash is required"}
 	}
 
+	if terminal, appErr := terminalSoulOperationExecutionResult(op, txHash); terminal != nil || appErr != nil {
+		return terminal, appErr
+	}
+
 	client, appErr := s.dialSoulRPCClient(ctx)
 	if appErr != nil {
 		return nil, appErr
@@ -140,12 +146,13 @@ func (s *Server) recordSoulOperationExecution(ctx context.Context, actor string,
 	if appErr != nil {
 		return nil, appErr
 	}
-	if appErr := s.validateSoulOperationExecutionReceipt(ctx, client, op, txHash, receipt); appErr != nil {
+	validation, appErr := s.validateSoulOperationExecutionReceipt(ctx, client, op, txHash, receipt)
+	if appErr != nil {
 		return nil, appErr
 	}
 
 	now := time.Now().UTC()
-	success := receipt.Status == 1
+	success := validation.Success
 	blockNum := soulBlockNumber(receipt)
 	receiptJSON := soulReceiptSnapshotJSON(txHash, receipt)
 	snapshotJSON := strings.TrimSpace(op.SnapshotJSON)
@@ -176,17 +183,9 @@ func (s *Server) recordSoulOperationExecution(ctx context.Context, actor string,
 	}
 	_ = update.UpdateKeys()
 
-	if err := s.store.DB.WithContext(ctx).Model(update).IfExists().Update(
-		"ExecTxHash",
-		"ExecBlockNumber",
-		"ExecSuccess",
-		"ReceiptJSON",
-		"SnapshotJSON",
-		"Status",
-		"UpdatedAt",
-		"ExecutedAt",
-	); err != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to update operation"}
+	saved, recorded, appErr := s.saveSoulOperationExecutionRecord(ctx, update, txHash)
+	if appErr != nil || !recorded {
+		return saved, appErr
 	}
 
 	if success {
@@ -206,6 +205,69 @@ func (s *Server) recordSoulOperationExecution(ctx context.Context, actor string,
 	s.tryWriteAuditLogWithContext(ctx, audit)
 
 	return update, nil
+}
+
+func terminalSoulOperationExecutionResult(op *models.SoulOperation, txHash string) (*models.SoulOperation, *apptheory.AppError) {
+	if op == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if !isTerminalSoulOperationStatus(op.Status) {
+		return nil, nil
+	}
+	if strings.EqualFold(strings.TrimSpace(op.ExecTxHash), strings.TrimSpace(txHash)) && strings.TrimSpace(op.ExecTxHash) != "" {
+		return op, nil
+	}
+	return nil, &apptheory.AppError{Code: "app.conflict", Message: "operation execution already recorded"}
+}
+
+func isTerminalSoulOperationStatus(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case models.SoulOperationStatusExecuted, models.SoulOperationStatusFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Server) saveSoulOperationExecutionRecord(ctx context.Context, update *models.SoulOperation, txHash string) (*models.SoulOperation, bool, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil || update == nil {
+		return nil, false, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	fields := []string{
+		"ExecTxHash",
+		"ExecBlockNumber",
+		"ExecSuccess",
+		"ReceiptJSON",
+		"SnapshotJSON",
+		"Status",
+		"UpdatedAt",
+		"ExecutedAt",
+	}
+	err := s.store.DB.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+		tx.Update(
+			update,
+			fields,
+			tabletheory.IfExists(),
+			tabletheory.Condition("Status", "<>", models.SoulOperationStatusExecuted),
+			tabletheory.Condition("Status", "<>", models.SoulOperationStatusFailed),
+		)
+		return nil
+	})
+	if err == nil {
+		return update, true, nil
+	}
+	if !theoryErrors.IsConditionFailed(err) {
+		return nil, false, &apptheory.AppError{Code: "app.internal", Message: "failed to update operation"}
+	}
+
+	current, getErr := s.getSoulOperation(ctx, strings.TrimSpace(update.OperationID))
+	if getErr == nil {
+		if terminal, appErr := terminalSoulOperationExecutionResult(current, txHash); terminal != nil || appErr != nil {
+			return terminal, false, appErr
+		}
+	}
+	return nil, false, &apptheory.AppError{Code: "app.conflict", Message: "operation execution already recorded"}
 }
 
 func (s *Server) syncMintPromotionAfterOperationExecution(ctx context.Context, update *models.SoulOperation, requestID string, now time.Time, success bool) *apptheory.AppError {

--- a/internal/controlplane/handlers_soul_operations.go
+++ b/internal/controlplane/handlers_soul_operations.go
@@ -140,6 +140,9 @@ func (s *Server) recordSoulOperationExecution(ctx context.Context, actor string,
 	if appErr != nil {
 		return nil, appErr
 	}
+	if appErr := s.validateSoulOperationExecutionReceipt(ctx, client, op, txHash, receipt); appErr != nil {
+		return nil, appErr
+	}
 
 	now := time.Now().UTC()
 	success := receipt.Status == 1

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/soulattestations"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
@@ -332,7 +333,7 @@ func TestHandleRecordSoulOperationExecution_SuccessMint(t *testing.T) {
 	agentID := "0x" + strings.Repeat("11", 32)
 	txHash := "0x" + strings.Repeat("ab", 32)
 	wallet := "0x0000000000000000000000000000000000000002"
-	principal := "0x0000000000000000000000000000000000000003"
+	principal := testEthAddress3
 	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
 
 	op := &models.SoulOperation{
@@ -414,7 +415,7 @@ func TestRecordSoulOperationExecution_RejectsMismatchedTransactionPayload(t *tes
 	}
 	agentID := "0x" + strings.Repeat("11", 32)
 	wallet := "0x0000000000000000000000000000000000000002"
-	principal := "0x0000000000000000000000000000000000000003"
+	principal := testEthAddress3
 	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
 	wrongPayload := *payload
 	wrongPayload.Data = "0x1234"
@@ -447,7 +448,7 @@ func TestRecordSoulOperationExecution_RejectsMissingMintEvent(t *testing.T) {
 	}
 	agentID := "0x" + strings.Repeat("11", 32)
 	wallet := "0x0000000000000000000000000000000000000002"
-	principal := "0x0000000000000000000000000000000000000003"
+	principal := testEthAddress3
 	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
 	op := &models.SoulOperation{OperationID: "op-missing-event", Kind: models.SoulOperationKindMint, AgentID: agentID, Status: models.SoulOperationStatusPending, SafePayloadJSON: soulTestPayloadJSON(t, payload)}
 
@@ -467,6 +468,167 @@ func TestRecordSoulOperationExecution_RejectsMissingMintEvent(t *testing.T) {
 	_, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, "0x"+strings.Repeat("ab", 32))
 	if appErr == nil || appErr.Message != "execution receipt does not match operation" {
 		t.Fatalf("expected receipt mismatch, got %#v", appErr)
+	}
+}
+
+func TestValidateSoulExecutionTransactionMatchesPayload_DirectAndSafe(t *testing.T) {
+	t.Parallel()
+
+	agentID := "0x" + strings.Repeat("11", 32)
+	payload := soulTestMintPayload(t, testEthAddress1, agentID, testEthAddress2, testEthAddress3)
+	expect := soulOperationReceiptExpectation{Payload: payload, To: common.HexToAddress(payload.To)}
+	expect.Value, _ = parseSoulOperationPayloadValue(payload.Value)
+	expect.Data, _ = hexutil.Decode(payload.Data)
+
+	if appErr := validateSoulExecutionTransactionMatchesPayload(soulTestTxFromPayload(t, payload), expect); appErr != nil {
+		t.Fatalf("expected direct payload to match, got %#v", appErr)
+	}
+
+	safePayload := *payload
+	safePayload.SafeAddress = "0x0000000000000000000000000000000000000004"
+	safeTx := soulTestSafeExecTx(t, &safePayload, 0)
+	expect.Payload = &safePayload
+	if appErr := validateSoulExecutionTransactionMatchesPayload(safeTx, expect); appErr != nil {
+		t.Fatalf("expected safe payload to match, got %#v", appErr)
+	}
+
+	delegateCallTx := soulTestSafeExecTx(t, &safePayload, 1)
+	if appErr := validateSoulExecutionTransactionMatchesPayload(delegateCallTx, expect); appErr == nil {
+		t.Fatalf("expected delegatecall operation mismatch")
+	}
+}
+
+func soulTestSafeExecTx(t *testing.T, payload *safeTxPayload, operation uint8) *types.Transaction {
+	t.Helper()
+	to := common.HexToAddress(payload.To)
+	value, ok := parseSoulOperationPayloadValue(payload.Value)
+	if !ok {
+		t.Fatalf("invalid value %q", payload.Value)
+	}
+	innerData, err := hexutil.Decode(payload.Data)
+	if err != nil {
+		t.Fatalf("decode payload data: %v", err)
+	}
+	data, err := safeExecReceiptABI.Pack(
+		"execTransaction",
+		to,
+		value,
+		innerData,
+		operation,
+		big.NewInt(0),
+		big.NewInt(0),
+		big.NewInt(0),
+		common.Address{},
+		common.Address{},
+		[]byte{0x01},
+	)
+	if err != nil {
+		t.Fatalf("pack safe exec: %v", err)
+	}
+	safeAddress := common.HexToAddress(payload.SafeAddress)
+	return types.NewTx(&types.LegacyTx{To: &safeAddress, Value: big.NewInt(0), Data: data})
+}
+
+func TestValidateSoulRotateWalletExecutionEffect_Success(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	agentIDHex := "0x" + strings.Repeat("11", 32)
+	newWallet := testEthAddress3
+	payload := soulTestRotatePayload(t, testEthAddress1, agentIDHex, newWallet)
+	agentID, _ := new(big.Int).SetString(strings.TrimPrefix(agentIDHex, "0x"), 16)
+	receipt := &types.Receipt{
+		Status:      1,
+		BlockNumber: big.NewInt(456),
+		GasUsed:     100,
+		Logs: []*types.Log{{
+			Address: common.HexToAddress(payload.To),
+			Topics:  []common.Hash{walletRotatedTopic, topicBig(agentID), topicAddress(common.HexToAddress(testEthAddress2)), topicAddress(common.HexToAddress(newWallet))},
+		}},
+	}
+	client := &fakeEthClient{callContract: soulTestCallContractForWalletPrincipal(t, newWallet, common.Address{}.Hex())}
+	data, _ := hexutil.Decode(payload.Data)
+	expect := soulOperationReceiptExpectation{Payload: payload, To: common.HexToAddress(payload.To), Value: big.NewInt(0), Data: data}
+	op := &models.SoulOperation{Kind: models.SoulOperationKindRotateWallet, AgentID: agentIDHex}
+
+	if appErr := s.validateSoulRotateWalletExecutionEffect(context.Background(), client, op, expect, receipt); appErr != nil {
+		t.Fatalf("expected rotate effect to validate, got %#v", appErr)
+	}
+}
+
+func TestValidateSoulBurnExecutionEffect_Success(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	agentIDHex := "0x" + strings.Repeat("11", 32)
+	agentID, _ := new(big.Int).SetString(strings.TrimPrefix(agentIDHex, "0x"), 16)
+	data, err := soul.EncodeBurnSoulCall(agentID)
+	if err != nil {
+		t.Fatalf("EncodeBurnSoulCall: %v", err)
+	}
+	payload := &safeTxPayload{To: testEthAddress1, Value: "0", Data: hexutil.Encode(data)}
+	expect := soulOperationReceiptExpectation{Payload: payload, To: common.HexToAddress(payload.To), Value: big.NewInt(0), Data: data}
+	receipt := &types.Receipt{Status: 1, Logs: []*types.Log{{Address: common.HexToAddress(payload.To), Topics: []common.Hash{soulBurnedTopic, topicBig(agentID), topicAddress(common.HexToAddress(testEthAddress2))}}}}
+
+	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
+	if err != nil {
+		t.Fatalf("parse abi: %v", err)
+	}
+	walletRet, _ := parsedABI.Methods["getAgentWallet"].Outputs.Pack(common.Address{})
+	client := &fakeEthClient{callContract: func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+		if bytes.HasPrefix(msg.Data, parsedABI.Methods["getAgentWallet"].ID) {
+			return walletRet, nil
+		}
+		return nil, ethereum.NotFound
+	}}
+	op := &models.SoulOperation{Kind: models.SoulOperationKindBurn, AgentID: agentIDHex}
+	if appErr := s.validateSoulOperationSuccessEffect(context.Background(), client, op, expect, receipt); appErr != nil {
+		t.Fatalf("expected burn effect to validate, got %#v", appErr)
+	}
+}
+
+func TestSoulOperationReceiptHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	if _, ok := parseSoulOperationPayloadValue("not-a-number"); ok {
+		t.Fatalf("expected invalid payload value")
+	}
+	if _, appErr := parseSoulOperationReceiptExpectation(&models.SoulOperation{}); appErr == nil {
+		t.Fatalf("expected missing payload mismatch")
+	}
+	if receiptLogs(nil) != nil {
+		t.Fatalf("expected nil receipt logs")
+	}
+	if topicBig(nil) != (common.Hash{}) {
+		t.Fatalf("expected nil big topic to be zero")
+	}
+	if !bigIntsEqual(nil, big.NewInt(0)) || bigIntsEqual(big.NewInt(1), nil) {
+		t.Fatalf("unexpected big int equality")
+	}
+	if !abiOperationIsCall(uint8(0)) || abiOperationIsCall(uint8(1)) || !abiOperationIsCall(big.NewInt(0)) || abiOperationIsCall(big.NewInt(1)) || abiOperationIsCall("0") {
+		t.Fatalf("unexpected Safe operation handling")
+	}
+}
+
+func TestValidateSoulPublishRootExecutionEffect_SuccessAndMismatch(t *testing.T) {
+	t.Parallel()
+
+	root := common.HexToHash("0x" + strings.Repeat("aa", 32))
+	data, err := soulattestations.EncodePublishRootCall(root, 123, 2)
+	if err != nil {
+		t.Fatalf("EncodePublishRootCall: %v", err)
+	}
+	payload := &safeTxPayload{To: testEthAddress1, Value: "0", Data: hexutil.Encode(data)}
+	expect := soulOperationReceiptExpectation{Payload: payload, To: common.HexToAddress(payload.To), Value: big.NewInt(0), Data: data}
+	op := &models.SoulOperation{Kind: models.SoulOperationKindPublishValidationRoot}
+	receipt := &types.Receipt{Status: 1, Logs: []*types.Log{{Address: common.HexToAddress(payload.To), Topics: []common.Hash{rootPublishedTopic, root}}}}
+
+	if appErr := validateSoulPublishRootExecutionEffect(op, expect, receipt); appErr != nil {
+		t.Fatalf("expected publish root receipt to validate, got %#v", appErr)
+	}
+	receipt.Logs[0].Topics[1] = common.HexToHash("0x" + strings.Repeat("bb", 32))
+	if appErr := validateSoulPublishRootExecutionEffect(op, expect, receipt); appErr == nil {
+		t.Fatalf("expected root mismatch")
 	}
 }
 

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -471,6 +471,137 @@ func TestRecordSoulOperationExecution_RejectsMissingMintEvent(t *testing.T) {
 	}
 }
 
+func TestRecordSoulOperationExecution_TerminalIdempotentAndImmutable(t *testing.T) {
+	t.Parallel()
+
+	txHash := "0x" + strings.Repeat("ab", 32)
+	op := &models.SoulOperation{
+		OperationID: "op-terminal",
+		Kind:        models.SoulOperationKindRotateWallet,
+		Status:      models.SoulOperationStatusExecuted,
+		ExecTxHash:  strings.ToLower(txHash),
+	}
+
+	s := &Server{}
+	got, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, txHash)
+	if appErr != nil {
+		t.Fatalf("expected idempotent terminal record, got %#v", appErr)
+	}
+	if got != op {
+		t.Fatalf("expected original terminal operation")
+	}
+
+	_, appErr = s.recordSoulOperationExecution(context.Background(), "op", "rid", op, "0x"+strings.Repeat("cd", 32))
+	if appErr == nil || appErr.Code != "app.conflict" {
+		t.Fatalf("expected conflict for different terminal tx hash, got %#v", appErr)
+	}
+}
+
+func TestRecordSoulOperationExecution_ConditionalRaceIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulOperationsTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulRegistryContractAddress: testEthAddress1,
+			SoulRPCURL:                  "http://rpc",
+		},
+	}
+
+	agentID := "0x" + strings.Repeat("11", 32)
+	txHash := "0x" + strings.Repeat("ab", 32)
+	payload := soulTestRotatePayload(t, testEthAddress1, agentID, testEthAddress2)
+	op := &models.SoulOperation{
+		OperationID:     "op-race",
+		Kind:            models.SoulOperationKindRotateWallet,
+		AgentID:         agentID,
+		Status:          models.SoulOperationStatusPending,
+		SafePayloadJSON: soulTestPayloadJSON(t, payload),
+	}
+	terminal := *op
+	terminal.Status = models.SoulOperationStatusFailed
+	terminal.ExecTxHash = strings.ToLower(txHash)
+	failed := false
+	terminal.ExecSuccess = &failed
+
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(theoryErrors.ErrConditionFailed).Once()
+	tdb.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulOperation](t, args, 0)
+		*dest = terminal
+	}).Once()
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeEthClient{
+			tx: soulTestTxFromPayload(t, payload),
+			receipt: &types.Receipt{
+				Status:      0,
+				BlockNumber: big.NewInt(77),
+				GasUsed:     100,
+			},
+		}, nil
+	}
+
+	got, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, txHash)
+	if appErr != nil {
+		t.Fatalf("expected idempotent condition-failed race, got %#v", appErr)
+	}
+	if got == nil || got.Status != models.SoulOperationStatusFailed || !strings.EqualFold(got.ExecTxHash, txHash) {
+		t.Fatalf("unexpected raced operation: %#v", got)
+	}
+}
+
+func TestRecordSoulOperationExecution_SafeInnerFailureRecordsFailed(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulOperationsTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulRegistryContractAddress: testEthAddress1,
+			SoulRPCURL:                  "http://rpc",
+		},
+	}
+
+	agentID := "0x" + strings.Repeat("11", 32)
+	txHash := "0x" + strings.Repeat("ab", 32)
+	payload := soulTestRotatePayload(t, testEthAddress1, agentID, testEthAddress2)
+	payload.SafeAddress = testEthAddress3
+	op := &models.SoulOperation{
+		OperationID:     "op-safe-failure",
+		Kind:            models.SoulOperationKindRotateWallet,
+		AgentID:         agentID,
+		Status:          models.SoulOperationStatusPending,
+		SafePayloadJSON: soulTestPayloadJSON(t, payload),
+	}
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeEthClient{
+			tx: soulTestSafeExecTx(t, payload, 0),
+			receipt: &types.Receipt{
+				Status:      1,
+				BlockNumber: big.NewInt(88),
+				GasUsed:     100,
+				Logs: []*types.Log{{
+					Address: common.HexToAddress(payload.SafeAddress),
+					Topics:  []common.Hash{safeExecutionFailureTopic},
+				}},
+			},
+		}, nil
+	}
+
+	got, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, txHash)
+	if appErr != nil {
+		t.Fatalf("expected Safe inner failure to record failed operation, got %#v", appErr)
+	}
+	if got.Status != models.SoulOperationStatusFailed || got.ExecSuccess == nil || *got.ExecSuccess {
+		t.Fatalf("expected failed operation from Safe ExecutionFailure, got %#v", got)
+	}
+	if got.ExecBlockNumber != 88 || !strings.EqualFold(got.ExecTxHash, txHash) {
+		t.Fatalf("unexpected execution metadata: %#v", got)
+	}
+}
+
 func TestValidateSoulExecutionTransactionMatchesPayload_DirectAndSafe(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -30,6 +31,9 @@ import (
 type fakeEthClient struct {
 	receipt *types.Receipt
 	err     error
+	tx      *types.Transaction
+	pending bool
+	txErr   error
 
 	callContract func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error)
 	filterLogs   func(ctx context.Context, q ethereum.FilterQuery) ([]types.Log, error)
@@ -40,6 +44,10 @@ func (f *fakeEthClient) CallContract(ctx context.Context, msg ethereum.CallMsg, 
 		return f.callContract(ctx, msg)
 	}
 	return nil, errors.New("not implemented")
+}
+
+func (f *fakeEthClient) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	return f.tx, f.pending, f.txErr
 }
 
 func (f *fakeEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
@@ -135,6 +143,91 @@ func latestPromotionLifecycleEventModelCall(t *testing.T, db *ttmocks.MockExtend
 	}
 	t.Fatalf("expected lifecycle event model call")
 	return nil
+}
+
+func soulTestMintPayload(t *testing.T, contract string, agentIDHex string, wallet string, principal string) *safeTxPayload {
+	t.Helper()
+	agentID, ok := new(big.Int).SetString(strings.TrimPrefix(agentIDHex, "0x"), 16)
+	if !ok {
+		t.Fatalf("invalid agent id %q", agentIDHex)
+	}
+	walletAddr := common.HexToAddress(wallet)
+	principalAddr := common.HexToAddress(principal)
+	data, err := soul.EncodeSelfMintSoulCall(walletAddr, agentID, "https://example.com/meta.json", 0, principalAddr, big.NewInt(time.Now().Add(time.Hour).Unix()), []byte{0x01, 0x02})
+	if err != nil {
+		t.Fatalf("EncodeSelfMintSoulCall: %v", err)
+	}
+	return &safeTxPayload{To: contract, Value: "500000000000000", Data: hexutil.Encode(data)}
+}
+
+func soulTestRotatePayload(t *testing.T, contract string, agentIDHex string, newWallet string) *safeTxPayload {
+	t.Helper()
+	agentID, ok := new(big.Int).SetString(strings.TrimPrefix(agentIDHex, "0x"), 16)
+	if !ok {
+		t.Fatalf("invalid agent id %q", agentIDHex)
+	}
+	data, err := soul.EncodeRotateWalletCall(agentID, common.HexToAddress(newWallet), big.NewInt(7), big.NewInt(time.Now().Add(time.Hour).Unix()), []byte{0x01}, []byte{0x02})
+	if err != nil {
+		t.Fatalf("EncodeRotateWalletCall: %v", err)
+	}
+	return &safeTxPayload{To: contract, Value: "0", Data: hexutil.Encode(data)}
+}
+
+func soulTestPayloadJSON(t *testing.T, payload *safeTxPayload) string {
+	t.Helper()
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return string(b)
+}
+
+func soulTestTxFromPayload(t *testing.T, payload *safeTxPayload) *types.Transaction {
+	t.Helper()
+	to := common.HexToAddress(payload.To)
+	value, ok := parseSoulOperationPayloadValue(payload.Value)
+	if !ok {
+		t.Fatalf("invalid value %q", payload.Value)
+	}
+	data, err := hexutil.Decode(payload.Data)
+	if err != nil {
+		t.Fatalf("decode payload data: %v", err)
+	}
+	return types.NewTx(&types.LegacyTx{To: &to, Value: value, Data: data})
+}
+
+func soulTestMintReceipt(contract common.Address, agentIDHex string, wallet string, principal string) *types.Receipt {
+	agentID, _ := new(big.Int).SetString(strings.TrimPrefix(agentIDHex, "0x"), 16)
+	walletAddr := common.HexToAddress(wallet)
+	principalAddr := common.HexToAddress(principal)
+	return &types.Receipt{
+		Status:      1,
+		BlockNumber: big.NewInt(123),
+		GasUsed:     100,
+		Logs: []*types.Log{
+			{Address: contract, Topics: []common.Hash{soulMintedTopic, topicBig(agentID), topicAddress(walletAddr)}},
+			{Address: contract, Topics: []common.Hash{principalDeclaredTopic, topicBig(agentID), topicAddress(principalAddr)}},
+		},
+	}
+}
+
+func soulTestCallContractForWalletPrincipal(t *testing.T, wallet string, principal string) func(context.Context, ethereum.CallMsg) ([]byte, error) {
+	t.Helper()
+	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
+	if err != nil {
+		t.Fatalf("parse abi: %v", err)
+	}
+	walletRet, _ := parsedABI.Methods["getAgentWallet"].Outputs.Pack(common.HexToAddress(wallet))
+	principalRet, _ := parsedABI.Methods["principalOf"].Outputs.Pack(common.HexToAddress(principal))
+	return func(ctx context.Context, msg ethereum.CallMsg) ([]byte, error) {
+		if bytes.HasPrefix(msg.Data, parsedABI.Methods["getAgentWallet"].ID) {
+			return walletRet, nil
+		}
+		if bytes.HasPrefix(msg.Data, parsedABI.Methods["principalOf"].ID) {
+			return principalRet, nil
+		}
+		return nil, ethereum.NotFound
+	}
 }
 
 func TestHandleListSoulOperations_DefaultStatusAndInvalidStatus(t *testing.T) {
@@ -238,15 +331,19 @@ func TestHandleRecordSoulOperationExecution_SuccessMint(t *testing.T) {
 
 	agentID := "0x" + strings.Repeat("11", 32)
 	txHash := "0x" + strings.Repeat("ab", 32)
+	wallet := "0x0000000000000000000000000000000000000002"
+	principal := "0x0000000000000000000000000000000000000003"
+	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
 
 	op := &models.SoulOperation{
-		OperationID:  "op1",
-		Kind:         models.SoulOperationKindMint,
-		AgentID:      agentID,
-		Status:       models.SoulOperationStatusPending,
-		SnapshotJSON: `{"k":"v"}`,
-		CreatedAt:    time.Now().Add(-time.Minute).UTC(),
-		UpdatedAt:    time.Now().Add(-time.Minute).UTC(),
+		OperationID:     "op1",
+		Kind:            models.SoulOperationKindMint,
+		AgentID:         agentID,
+		Status:          models.SoulOperationStatusPending,
+		SafePayloadJSON: soulTestPayloadJSON(t, payload),
+		SnapshotJSON:    `{"k":"v"}`,
+		CreatedAt:       time.Now().Add(-time.Minute).UTC(),
+		UpdatedAt:       time.Now().Add(-time.Minute).UTC(),
 	}
 
 	tdb.qOp.On("First", mock.AnythingOfType("*models.SoulOperation")).Return(nil).Run(func(args mock.Arguments) {
@@ -256,7 +353,7 @@ func TestHandleRecordSoulOperationExecution_SuccessMint(t *testing.T) {
 
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive, Wallet: "0x0000000000000000000000000000000000000002"}
+		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive, Wallet: wallet}
 	}).Once()
 	tdb.qPromotion.On("First", mock.AnythingOfType("*models.SoulAgentPromotion")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentPromotion](t, args, 0)
@@ -276,12 +373,9 @@ func TestHandleRecordSoulOperationExecution_SuccessMint(t *testing.T) {
 
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
 		return &fakeEthClient{
-			receipt: &types.Receipt{
-				Status:      1,
-				BlockNumber: big.NewInt(123),
-				GasUsed:     100,
-				Logs:        []*types.Log{},
-			},
+			tx:           soulTestTxFromPayload(t, payload),
+			receipt:      soulTestMintReceipt(common.HexToAddress(s.cfg.SoulRegistryContractAddress), agentID, wallet, principal),
+			callContract: soulTestCallContractForWalletPrincipal(t, wallet, principal),
 		}, nil
 	}
 
@@ -304,6 +398,75 @@ func TestHandleRecordSoulOperationExecution_SuccessMint(t *testing.T) {
 	}
 	if out.ExecSuccess == nil || !*out.ExecSuccess {
 		t.Fatalf("expected ExecSuccess true, got %#v", out.ExecSuccess)
+	}
+}
+
+func TestRecordSoulOperationExecution_RejectsMismatchedTransactionPayload(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulOperationsTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
+			SoulRPCURL:                  "http://rpc",
+		},
+	}
+	agentID := "0x" + strings.Repeat("11", 32)
+	wallet := "0x0000000000000000000000000000000000000002"
+	principal := "0x0000000000000000000000000000000000000003"
+	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
+	wrongPayload := *payload
+	wrongPayload.Data = "0x1234"
+	op := &models.SoulOperation{OperationID: "op-mismatch", Kind: models.SoulOperationKindMint, AgentID: agentID, Status: models.SoulOperationStatusPending, SafePayloadJSON: soulTestPayloadJSON(t, payload)}
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeEthClient{
+			tx:           soulTestTxFromPayload(t, &wrongPayload),
+			receipt:      soulTestMintReceipt(common.HexToAddress(s.cfg.SoulRegistryContractAddress), agentID, wallet, principal),
+			callContract: soulTestCallContractForWalletPrincipal(t, wallet, principal),
+		}, nil
+	}
+
+	_, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, "0x"+strings.Repeat("ab", 32))
+	if appErr == nil || appErr.Message != "execution receipt does not match operation" {
+		t.Fatalf("expected receipt mismatch, got %#v", appErr)
+	}
+}
+
+func TestRecordSoulOperationExecution_RejectsMissingMintEvent(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulOperationsTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
+			SoulRPCURL:                  "http://rpc",
+		},
+	}
+	agentID := "0x" + strings.Repeat("11", 32)
+	wallet := "0x0000000000000000000000000000000000000002"
+	principal := "0x0000000000000000000000000000000000000003"
+	payload := soulTestMintPayload(t, s.cfg.SoulRegistryContractAddress, agentID, wallet, principal)
+	op := &models.SoulOperation{OperationID: "op-missing-event", Kind: models.SoulOperationKindMint, AgentID: agentID, Status: models.SoulOperationStatusPending, SafePayloadJSON: soulTestPayloadJSON(t, payload)}
+
+	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) {
+		return &fakeEthClient{
+			tx: soulTestTxFromPayload(t, payload),
+			receipt: &types.Receipt{
+				Status:      1,
+				BlockNumber: big.NewInt(123),
+				GasUsed:     100,
+				Logs:        []*types.Log{},
+			},
+			callContract: soulTestCallContractForWalletPrincipal(t, wallet, principal),
+		}, nil
+	}
+
+	_, appErr := s.recordSoulOperationExecution(context.Background(), "op", "rid", op, "0x"+strings.Repeat("ab", 32))
+	if appErr == nil || appErr.Message != "execution receipt does not match operation" {
+		t.Fatalf("expected receipt mismatch, got %#v", appErr)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_operations_receipts.go
+++ b/internal/controlplane/handlers_soul_operations_receipts.go
@@ -28,11 +28,13 @@ var (
 	rootAttestationReceiptABI = mustControlPlaneABI(soulattestations.RootAttestationABI)
 	safeExecReceiptABI        = mustControlPlaneABI(safeExecTransactionABI)
 
-	soulMintedTopic        = crypto.Keccak256Hash([]byte("SoulMinted(uint256,address,string)"))
-	principalDeclaredTopic = crypto.Keccak256Hash([]byte("PrincipalDeclared(uint256,address)"))
-	walletRotatedTopic     = crypto.Keccak256Hash([]byte("WalletRotated(uint256,address,address,uint256)"))
-	soulBurnedTopic        = crypto.Keccak256Hash([]byte("SoulBurned(uint256,address)"))
-	rootPublishedTopic     = crypto.Keccak256Hash([]byte("RootPublished(bytes32,bytes32,uint256,uint256,uint256)"))
+	soulMintedTopic           = crypto.Keccak256Hash([]byte("SoulMinted(uint256,address,string)"))
+	principalDeclaredTopic    = crypto.Keccak256Hash([]byte("PrincipalDeclared(uint256,address)"))
+	walletRotatedTopic        = crypto.Keccak256Hash([]byte("WalletRotated(uint256,address,address,uint256)"))
+	soulBurnedTopic           = crypto.Keccak256Hash([]byte("SoulBurned(uint256,address)"))
+	rootPublishedTopic        = crypto.Keccak256Hash([]byte("RootPublished(bytes32,bytes32,uint256,uint256,uint256)"))
+	safeExecutionSuccessTopic = crypto.Keccak256Hash([]byte("ExecutionSuccess(bytes32,uint256)"))
+	safeExecutionFailureTopic = crypto.Keccak256Hash([]byte("ExecutionFailure(bytes32,uint256)"))
 )
 
 type soulOperationReceiptExpectation struct {
@@ -40,6 +42,10 @@ type soulOperationReceiptExpectation struct {
 	To      common.Address
 	Value   *big.Int
 	Data    []byte
+}
+
+type soulOperationExecutionValidation struct {
+	Success bool
 }
 
 func mustControlPlaneABI(raw string) abi.ABI {
@@ -50,25 +56,72 @@ func mustControlPlaneABI(raw string) abi.ABI {
 	return parsed
 }
 
-func (s *Server) validateSoulOperationExecutionReceipt(ctx context.Context, client ethRPCClient, op *models.SoulOperation, txHash string, receipt *types.Receipt) *apptheory.AppError {
+func (s *Server) validateSoulOperationExecutionReceipt(ctx context.Context, client ethRPCClient, op *models.SoulOperation, txHash string, receipt *types.Receipt) (soulOperationExecutionValidation, *apptheory.AppError) {
 	if s == nil || client == nil || op == nil || receipt == nil {
-		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+		return soulOperationExecutionValidation{}, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	expect, appErr := parseSoulOperationReceiptExpectation(op)
 	if appErr != nil {
-		return appErr
+		return soulOperationExecutionValidation{}, appErr
 	}
 	tx, pending, err := client.TransactionByHash(ctx, common.HexToHash(txHash))
 	if err != nil || tx == nil || pending {
-		return soulOperationReceiptMismatch()
+		return soulOperationExecutionValidation{}, soulOperationReceiptMismatch()
 	}
-	if appErr := validateSoulExecutionTransactionMatchesPayload(tx, expect); appErr != nil {
-		return appErr
+	appErr = validateSoulExecutionTransactionMatchesPayload(tx, expect)
+	if appErr != nil {
+		return soulOperationExecutionValidation{}, appErr
+	}
+
+	success, appErr := soulExecutionReceiptSuccess(receipt, expect)
+	if appErr != nil {
+		return soulOperationExecutionValidation{}, appErr
+	}
+	if !success {
+		return soulOperationExecutionValidation{Success: false}, nil
+	}
+	appErr = s.validateSoulOperationSuccessEffect(ctx, client, op, expect, receipt)
+	if appErr != nil {
+		return soulOperationExecutionValidation{}, appErr
+	}
+	return soulOperationExecutionValidation{Success: true}, nil
+}
+
+func soulExecutionReceiptSuccess(receipt *types.Receipt, expect soulOperationReceiptExpectation) (bool, *apptheory.AppError) {
+	if receipt == nil || expect.Payload == nil {
+		return false, soulOperationReceiptMismatch()
 	}
 	if receipt.Status != 1 {
-		return nil
+		return false, nil
 	}
-	return s.validateSoulOperationSuccessEffect(ctx, client, op, expect, receipt)
+	safeAddress := strings.TrimSpace(expect.Payload.SafeAddress)
+	if safeAddress == "" {
+		return true, nil
+	}
+	if !common.IsHexAddress(safeAddress) {
+		return false, soulOperationReceiptMismatch()
+	}
+	return safeExecutionReceiptSuccess(receipt, common.HexToAddress(safeAddress))
+}
+
+func safeExecutionReceiptSuccess(receipt *types.Receipt, safeAddress common.Address) (bool, *apptheory.AppError) {
+	hasSuccess := false
+	hasFailure := false
+	for _, lg := range receiptLogs(receipt) {
+		if lg == nil || !addressesEqual(lg.Address, safeAddress) || len(lg.Topics) == 0 {
+			continue
+		}
+		switch lg.Topics[0] {
+		case safeExecutionSuccessTopic:
+			hasSuccess = true
+		case safeExecutionFailureTopic:
+			hasFailure = true
+		}
+	}
+	if hasSuccess == hasFailure {
+		return false, soulOperationReceiptMismatch()
+	}
+	return hasSuccess, nil
 }
 
 func parseSoulOperationReceiptExpectation(op *models.SoulOperation) (soulOperationReceiptExpectation, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_operations_receipts.go
+++ b/internal/controlplane/handlers_soul_operations_receipts.go
@@ -104,55 +104,55 @@ func parseSoulOperationPayloadValue(raw string) (*big.Int, bool) {
 }
 
 func validateSoulExecutionTransactionMatchesPayload(tx *types.Transaction, expect soulOperationReceiptExpectation) *apptheory.AppError {
-	if tx == nil || expect.Value == nil || expect.Payload == nil {
-		return soulOperationReceiptMismatch()
-	}
-	txTo := tx.To()
-	if txTo == nil {
+	if tx == nil || expect.Value == nil || expect.Payload == nil || tx.To() == nil {
 		return soulOperationReceiptMismatch()
 	}
 	safeAddress := strings.TrimSpace(expect.Payload.SafeAddress)
 	if safeAddress == "" {
-		if !addressesEqual(*txTo, expect.To) || !bigIntsEqual(tx.Value(), expect.Value) || !bytes.Equal(tx.Data(), expect.Data) {
-			return soulOperationReceiptMismatch()
-		}
-		return nil
+		return validateDirectSoulExecutionTransaction(tx, expect)
 	}
-	if !common.IsHexAddress(safeAddress) || !addressesEqual(*txTo, common.HexToAddress(safeAddress)) {
-		return soulOperationReceiptMismatch()
-	}
-	innerTo, innerValue, innerData, operation, appErr := decodeSafeExecTransaction(tx.Data())
-	if appErr != nil {
-		return appErr
-	}
-	if operation != 0 || !addressesEqual(innerTo, expect.To) || !bigIntsEqual(innerValue, expect.Value) || !bytes.Equal(innerData, expect.Data) {
+	return validateSafeSoulExecutionTransaction(tx, safeAddress, expect)
+}
+
+func validateDirectSoulExecutionTransaction(tx *types.Transaction, expect soulOperationReceiptExpectation) *apptheory.AppError {
+	if !addressesEqual(*tx.To(), expect.To) || !bigIntsEqual(tx.Value(), expect.Value) || !bytes.Equal(tx.Data(), expect.Data) {
 		return soulOperationReceiptMismatch()
 	}
 	return nil
 }
 
-func decodeSafeExecTransaction(data []byte) (common.Address, *big.Int, []byte, uint8, *apptheory.AppError) {
+func validateSafeSoulExecutionTransaction(tx *types.Transaction, safeAddress string, expect soulOperationReceiptExpectation) *apptheory.AppError {
+	if !common.IsHexAddress(safeAddress) || !addressesEqual(*tx.To(), common.HexToAddress(safeAddress)) {
+		return soulOperationReceiptMismatch()
+	}
+	innerTo, innerValue, innerData, appErr := decodeSafeExecTransaction(tx.Data())
+	if appErr != nil {
+		return appErr
+	}
+	if !addressesEqual(innerTo, expect.To) || !bigIntsEqual(innerValue, expect.Value) || !bytes.Equal(innerData, expect.Data) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+func decodeSafeExecTransaction(data []byte) (common.Address, *big.Int, []byte, *apptheory.AppError) {
 	method, args, ok := unpackCallData(safeExecReceiptABI, data)
 	if !ok || method.Name != "execTransaction" || len(args) < 4 {
-		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+		return common.Address{}, nil, nil, soulOperationReceiptMismatch()
 	}
 	to, ok := args[0].(common.Address)
 	if !ok {
-		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+		return common.Address{}, nil, nil, soulOperationReceiptMismatch()
 	}
 	value, ok := args[1].(*big.Int)
 	if !ok || value == nil {
-		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+		return common.Address{}, nil, nil, soulOperationReceiptMismatch()
 	}
 	innerData, ok := args[2].([]byte)
-	if !ok {
-		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	if !ok || !abiOperationIsCall(args[3]) {
+		return common.Address{}, nil, nil, soulOperationReceiptMismatch()
 	}
-	operation, ok := abiUint8(args[3])
-	if !ok {
-		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
-	}
-	return to, value, innerData, operation, nil
+	return to, value, innerData, nil
 }
 
 func (s *Server) validateSoulOperationSuccessEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
@@ -171,45 +171,68 @@ func (s *Server) validateSoulOperationSuccessEffect(ctx context.Context, client 
 }
 
 func (s *Server) validateSoulMintExecutionEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
-	method, args, ok := unpackCallData(soulRegistryReceiptABI, expect.Data)
-	if !ok || !isSoulMintMethod(method.Name) || len(args) < 3 {
+	mint, appErr := decodeSoulMintEffect(op, expect.Data)
+	if appErr != nil {
+		return appErr
+	}
+	if !receiptHasIndexedLog(receipt, expect.To, soulMintedTopic, topicBig(mint.agentID), topicAddress(mint.to)) {
 		return soulOperationReceiptMismatch()
+	}
+	wallet, err := s.soulRegistryGetAgentWallet(ctx, client, expect.To, mint.agentID)
+	if err != nil || !addressesEqual(wallet, mint.to) {
+		return soulOperationReceiptMismatch()
+	}
+	if mint.principal == (common.Address{}) {
+		return nil
+	}
+	if !receiptHasIndexedLog(receipt, expect.To, principalDeclaredTopic, topicBig(mint.agentID), topicAddress(mint.principal)) {
+		return soulOperationReceiptMismatch()
+	}
+	onChainPrincipal, err := s.soulRegistryPrincipalOf(ctx, client, expect.To, mint.agentID)
+	if err != nil || !addressesEqual(onChainPrincipal, mint.principal) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+type soulMintExecutionEffect struct {
+	to        common.Address
+	agentID   *big.Int
+	principal common.Address
+}
+
+func decodeSoulMintEffect(op *models.SoulOperation, data []byte) (soulMintExecutionEffect, *apptheory.AppError) {
+	method, args, ok := unpackCallData(soulRegistryReceiptABI, data)
+	if !ok || !isSoulMintMethod(method.Name) || len(args) < 3 {
+		return soulMintExecutionEffect{}, soulOperationReceiptMismatch()
 	}
 	to, ok := args[0].(common.Address)
 	if !ok {
-		return soulOperationReceiptMismatch()
+		return soulMintExecutionEffect{}, soulOperationReceiptMismatch()
 	}
 	agentID, ok := args[1].(*big.Int)
 	if !ok || !soulOperationAgentMatches(op, agentID) {
-		return soulOperationReceiptMismatch()
+		return soulMintExecutionEffect{}, soulOperationReceiptMismatch()
 	}
-	principal := common.Address{}
-	if method.Name == "selfMintSoul" {
-		if len(args) < 5 {
-			return soulOperationReceiptMismatch()
-		}
-		principal, ok = args[4].(common.Address)
-		if !ok {
-			return soulOperationReceiptMismatch()
-		}
+	principal, appErr := decodeSelfMintPrincipal(method.Name, args)
+	if appErr != nil {
+		return soulMintExecutionEffect{}, appErr
 	}
-	if !receiptHasIndexedLog(receipt, expect.To, soulMintedTopic, topicBig(agentID), topicAddress(to)) {
-		return soulOperationReceiptMismatch()
+	return soulMintExecutionEffect{to: to, agentID: agentID, principal: principal}, nil
+}
+
+func decodeSelfMintPrincipal(methodName string, args []any) (common.Address, *apptheory.AppError) {
+	if methodName != "selfMintSoul" {
+		return common.Address{}, nil
 	}
-	wallet, err := s.soulRegistryGetAgentWallet(ctx, client, expect.To, agentID)
-	if err != nil || !addressesEqual(wallet, to) {
-		return soulOperationReceiptMismatch()
+	if len(args) < 5 {
+		return common.Address{}, soulOperationReceiptMismatch()
 	}
-	if principal != (common.Address{}) {
-		if !receiptHasIndexedLog(receipt, expect.To, principalDeclaredTopic, topicBig(agentID), topicAddress(principal)) {
-			return soulOperationReceiptMismatch()
-		}
-		onChainPrincipal, err := s.soulRegistryPrincipalOf(ctx, client, expect.To, agentID)
-		if err != nil || !addressesEqual(onChainPrincipal, principal) {
-			return soulOperationReceiptMismatch()
-		}
+	principal, ok := args[4].(common.Address)
+	if !ok {
+		return common.Address{}, soulOperationReceiptMismatch()
 	}
-	return nil
+	return principal, nil
 }
 
 func (s *Server) validateSoulRotateWalletExecutionEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
@@ -376,16 +399,15 @@ func bigIntsEqual(a *big.Int, b *big.Int) bool {
 	return a.Cmp(b) == 0
 }
 
-func abiUint8(v any) (uint8, bool) {
+func abiOperationIsCall(v any) bool {
 	switch n := v.(type) {
 	case uint8:
-		return n, true
+		return n == 0
 	case *big.Int:
-		if n != nil && n.Sign() >= 0 && n.BitLen() <= 8 {
-			return uint8(n.Uint64()), true
-		}
+		return n != nil && n.Sign() == 0
+	default:
+		return false
 	}
-	return 0, false
 }
 
 func soulOperationReceiptMismatch() *apptheory.AppError {

--- a/internal/controlplane/handlers_soul_operations_receipts.go
+++ b/internal/controlplane/handlers_soul_operations_receipts.go
@@ -1,0 +1,393 @@
+package controlplane
+
+import (
+	"bytes"
+	"context"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/soulattestations"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const safeExecTransactionABI = `[
+  {"type":"function","name":"execTransaction","stateMutability":"payable","inputs":[{"name":"to","type":"address"},{"name":"value","type":"uint256"},{"name":"data","type":"bytes"},{"name":"operation","type":"uint8"},{"name":"safeTxGas","type":"uint256"},{"name":"baseGas","type":"uint256"},{"name":"gasPrice","type":"uint256"},{"name":"gasToken","type":"address"},{"name":"refundReceiver","type":"address"},{"name":"signatures","type":"bytes"}],"outputs":[{"name":"success","type":"bool"}]}
+]`
+
+var (
+	soulRegistryReceiptABI    = mustControlPlaneABI(soul.SoulRegistryABI)
+	rootAttestationReceiptABI = mustControlPlaneABI(soulattestations.RootAttestationABI)
+	safeExecReceiptABI        = mustControlPlaneABI(safeExecTransactionABI)
+
+	soulMintedTopic        = crypto.Keccak256Hash([]byte("SoulMinted(uint256,address,string)"))
+	principalDeclaredTopic = crypto.Keccak256Hash([]byte("PrincipalDeclared(uint256,address)"))
+	walletRotatedTopic     = crypto.Keccak256Hash([]byte("WalletRotated(uint256,address,address,uint256)"))
+	soulBurnedTopic        = crypto.Keccak256Hash([]byte("SoulBurned(uint256,address)"))
+	rootPublishedTopic     = crypto.Keccak256Hash([]byte("RootPublished(bytes32,bytes32,uint256,uint256,uint256)"))
+)
+
+type soulOperationReceiptExpectation struct {
+	Payload *safeTxPayload
+	To      common.Address
+	Value   *big.Int
+	Data    []byte
+}
+
+func mustControlPlaneABI(raw string) abi.ABI {
+	parsed, err := abi.JSON(strings.NewReader(raw))
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+func (s *Server) validateSoulOperationExecutionReceipt(ctx context.Context, client ethRPCClient, op *models.SoulOperation, txHash string, receipt *types.Receipt) *apptheory.AppError {
+	if s == nil || client == nil || op == nil || receipt == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	expect, appErr := parseSoulOperationReceiptExpectation(op)
+	if appErr != nil {
+		return appErr
+	}
+	tx, pending, err := client.TransactionByHash(ctx, common.HexToHash(txHash))
+	if err != nil || tx == nil || pending {
+		return soulOperationReceiptMismatch()
+	}
+	if appErr := validateSoulExecutionTransactionMatchesPayload(tx, expect); appErr != nil {
+		return appErr
+	}
+	if receipt.Status != 1 {
+		return nil
+	}
+	return s.validateSoulOperationSuccessEffect(ctx, client, op, expect, receipt)
+}
+
+func parseSoulOperationReceiptExpectation(op *models.SoulOperation) (soulOperationReceiptExpectation, *apptheory.AppError) {
+	payload := parseSafeTxPayload(op.SafePayloadJSON)
+	if payload == nil {
+		return soulOperationReceiptExpectation{}, soulOperationReceiptMismatch()
+	}
+	toRaw := strings.TrimSpace(payload.To)
+	if !common.IsHexAddress(toRaw) {
+		return soulOperationReceiptExpectation{}, soulOperationReceiptMismatch()
+	}
+	value, ok := parseSoulOperationPayloadValue(payload.Value)
+	if !ok {
+		return soulOperationReceiptExpectation{}, soulOperationReceiptMismatch()
+	}
+	data, err := hexutil.Decode(strings.TrimSpace(payload.Data))
+	if err != nil {
+		return soulOperationReceiptExpectation{}, soulOperationReceiptMismatch()
+	}
+	return soulOperationReceiptExpectation{Payload: payload, To: common.HexToAddress(toRaw), Value: value, Data: data}, nil
+}
+
+func parseSoulOperationPayloadValue(raw string) (*big.Int, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return new(big.Int), true
+	}
+	value, ok := new(big.Int).SetString(raw, 10)
+	if !ok || value.Sign() < 0 {
+		return nil, false
+	}
+	return value, true
+}
+
+func validateSoulExecutionTransactionMatchesPayload(tx *types.Transaction, expect soulOperationReceiptExpectation) *apptheory.AppError {
+	if tx == nil || expect.Value == nil || expect.Payload == nil {
+		return soulOperationReceiptMismatch()
+	}
+	txTo := tx.To()
+	if txTo == nil {
+		return soulOperationReceiptMismatch()
+	}
+	safeAddress := strings.TrimSpace(expect.Payload.SafeAddress)
+	if safeAddress == "" {
+		if !addressesEqual(*txTo, expect.To) || !bigIntsEqual(tx.Value(), expect.Value) || !bytes.Equal(tx.Data(), expect.Data) {
+			return soulOperationReceiptMismatch()
+		}
+		return nil
+	}
+	if !common.IsHexAddress(safeAddress) || !addressesEqual(*txTo, common.HexToAddress(safeAddress)) {
+		return soulOperationReceiptMismatch()
+	}
+	innerTo, innerValue, innerData, operation, appErr := decodeSafeExecTransaction(tx.Data())
+	if appErr != nil {
+		return appErr
+	}
+	if operation != 0 || !addressesEqual(innerTo, expect.To) || !bigIntsEqual(innerValue, expect.Value) || !bytes.Equal(innerData, expect.Data) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+func decodeSafeExecTransaction(data []byte) (common.Address, *big.Int, []byte, uint8, *apptheory.AppError) {
+	method, args, ok := unpackCallData(safeExecReceiptABI, data)
+	if !ok || method.Name != "execTransaction" || len(args) < 4 {
+		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	}
+	to, ok := args[0].(common.Address)
+	if !ok {
+		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	}
+	value, ok := args[1].(*big.Int)
+	if !ok || value == nil {
+		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	}
+	innerData, ok := args[2].([]byte)
+	if !ok {
+		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	}
+	operation, ok := abiUint8(args[3])
+	if !ok {
+		return common.Address{}, nil, nil, 0, soulOperationReceiptMismatch()
+	}
+	return to, value, innerData, operation, nil
+}
+
+func (s *Server) validateSoulOperationSuccessEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
+	switch strings.ToLower(strings.TrimSpace(op.Kind)) {
+	case models.SoulOperationKindMint:
+		return s.validateSoulMintExecutionEffect(ctx, client, op, expect, receipt)
+	case models.SoulOperationKindRotateWallet:
+		return s.validateSoulRotateWalletExecutionEffect(ctx, client, op, expect, receipt)
+	case models.SoulOperationKindBurn:
+		return s.validateSoulBurnExecutionEffect(ctx, client, op, expect, receipt)
+	case models.SoulOperationKindPublishReputationRoot, models.SoulOperationKindPublishValidationRoot:
+		return validateSoulPublishRootExecutionEffect(op, expect, receipt)
+	default:
+		return nil
+	}
+}
+
+func (s *Server) validateSoulMintExecutionEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
+	method, args, ok := unpackCallData(soulRegistryReceiptABI, expect.Data)
+	if !ok || !isSoulMintMethod(method.Name) || len(args) < 3 {
+		return soulOperationReceiptMismatch()
+	}
+	to, ok := args[0].(common.Address)
+	if !ok {
+		return soulOperationReceiptMismatch()
+	}
+	agentID, ok := args[1].(*big.Int)
+	if !ok || !soulOperationAgentMatches(op, agentID) {
+		return soulOperationReceiptMismatch()
+	}
+	principal := common.Address{}
+	if method.Name == "selfMintSoul" {
+		if len(args) < 5 {
+			return soulOperationReceiptMismatch()
+		}
+		principal, ok = args[4].(common.Address)
+		if !ok {
+			return soulOperationReceiptMismatch()
+		}
+	}
+	if !receiptHasIndexedLog(receipt, expect.To, soulMintedTopic, topicBig(agentID), topicAddress(to)) {
+		return soulOperationReceiptMismatch()
+	}
+	wallet, err := s.soulRegistryGetAgentWallet(ctx, client, expect.To, agentID)
+	if err != nil || !addressesEqual(wallet, to) {
+		return soulOperationReceiptMismatch()
+	}
+	if principal != (common.Address{}) {
+		if !receiptHasIndexedLog(receipt, expect.To, principalDeclaredTopic, topicBig(agentID), topicAddress(principal)) {
+			return soulOperationReceiptMismatch()
+		}
+		onChainPrincipal, err := s.soulRegistryPrincipalOf(ctx, client, expect.To, agentID)
+		if err != nil || !addressesEqual(onChainPrincipal, principal) {
+			return soulOperationReceiptMismatch()
+		}
+	}
+	return nil
+}
+
+func (s *Server) validateSoulRotateWalletExecutionEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
+	method, args, ok := unpackCallData(soulRegistryReceiptABI, expect.Data)
+	if !ok || method.Name != "rotateWallet" || len(args) < 2 {
+		return soulOperationReceiptMismatch()
+	}
+	agentID, ok := args[0].(*big.Int)
+	if !ok || !soulOperationAgentMatches(op, agentID) {
+		return soulOperationReceiptMismatch()
+	}
+	newWallet, ok := args[1].(common.Address)
+	if !ok {
+		return soulOperationReceiptMismatch()
+	}
+	if !receiptHasLogWithTopic(receipt, expect.To, walletRotatedTopic, 1, topicBig(agentID)) || !receiptHasLogWithTopic(receipt, expect.To, walletRotatedTopic, 3, topicAddress(newWallet)) {
+		return soulOperationReceiptMismatch()
+	}
+	onChainWallet, err := s.soulRegistryGetAgentWallet(ctx, client, expect.To, agentID)
+	if err != nil || !addressesEqual(onChainWallet, newWallet) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+func (s *Server) validateSoulBurnExecutionEffect(ctx context.Context, client ethRPCClient, op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
+	method, args, ok := unpackCallData(soulRegistryReceiptABI, expect.Data)
+	if !ok || method.Name != "burnSoul" || len(args) < 1 {
+		return soulOperationReceiptMismatch()
+	}
+	agentID, ok := args[0].(*big.Int)
+	if !ok || !soulOperationAgentMatches(op, agentID) {
+		return soulOperationReceiptMismatch()
+	}
+	if !receiptHasLogWithTopic(receipt, expect.To, soulBurnedTopic, 1, topicBig(agentID)) {
+		return soulOperationReceiptMismatch()
+	}
+	onChainWallet, err := s.soulRegistryGetAgentWallet(ctx, client, expect.To, agentID)
+	if err != nil || onChainWallet != (common.Address{}) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+func (s *Server) soulRegistryPrincipalOf(ctx context.Context, client ethRPCClient, contract common.Address, agentID *big.Int) (common.Address, error) {
+	data, err := soul.EncodePrincipalOfCall(agentID)
+	if err != nil {
+		return common.Address{}, err
+	}
+	ret, err := client.CallContract(ctx, ethereum.CallMsg{To: &contract, Data: data}, nil)
+	if err != nil {
+		return common.Address{}, err
+	}
+	return soul.DecodePrincipalOfResult(ret)
+}
+
+func validateSoulPublishRootExecutionEffect(op *models.SoulOperation, expect soulOperationReceiptExpectation, receipt *types.Receipt) *apptheory.AppError {
+	method, args, ok := unpackCallData(rootAttestationReceiptABI, expect.Data)
+	if !ok || method.Name != "publishRoot" || len(args) < 1 {
+		return soulOperationReceiptMismatch()
+	}
+	root, ok := args[0].([32]byte)
+	if !ok {
+		return soulOperationReceiptMismatch()
+	}
+	if !receiptHasLogWithTopic(receipt, expect.To, rootPublishedTopic, 1, common.BytesToHash(root[:])) {
+		return soulOperationReceiptMismatch()
+	}
+	return nil
+}
+
+func unpackCallData(parsed abi.ABI, data []byte) (*abi.Method, []any, bool) {
+	if len(data) < 4 {
+		return nil, nil, false
+	}
+	method, err := parsed.MethodById(data[:4])
+	if err != nil || method == nil {
+		return nil, nil, false
+	}
+	args, err := method.Inputs.Unpack(data[4:])
+	if err != nil {
+		return nil, nil, false
+	}
+	return method, args, true
+}
+
+func isSoulMintMethod(name string) bool {
+	switch name {
+	case "mintSoul", "mintSoulOwner", "selfMintSoul":
+		return true
+	default:
+		return false
+	}
+}
+
+func soulOperationAgentMatches(op *models.SoulOperation, agentID *big.Int) bool {
+	if op == nil || agentID == nil {
+		return false
+	}
+	expected, ok := new(big.Int).SetString(strings.TrimPrefix(strings.TrimSpace(op.AgentID), "0x"), 16)
+	return ok && expected.Cmp(agentID) == 0
+}
+
+func receiptHasIndexedLog(receipt *types.Receipt, address common.Address, topic0 common.Hash, indexed ...common.Hash) bool {
+	for _, lg := range receiptLogs(receipt) {
+		if !addressesEqual(lg.Address, address) || len(lg.Topics) < 1+len(indexed) || lg.Topics[0] != topic0 {
+			continue
+		}
+		matched := true
+		for i, want := range indexed {
+			if lg.Topics[i+1] != want {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+func receiptHasLogWithTopic(receipt *types.Receipt, address common.Address, topic0 common.Hash, topicIndex int, topic common.Hash) bool {
+	for _, lg := range receiptLogs(receipt) {
+		if !addressesEqual(lg.Address, address) || len(lg.Topics) <= topicIndex || lg.Topics[0] != topic0 {
+			continue
+		}
+		if lg.Topics[topicIndex] == topic {
+			return true
+		}
+	}
+	return false
+}
+
+func receiptLogs(receipt *types.Receipt) []*types.Log {
+	if receipt == nil {
+		return nil
+	}
+	return receipt.Logs
+}
+
+func topicBig(v *big.Int) common.Hash {
+	if v == nil {
+		return common.Hash{}
+	}
+	return common.BigToHash(v)
+}
+
+func topicAddress(v common.Address) common.Hash {
+	return common.BytesToHash(v.Bytes())
+}
+
+func addressesEqual(a common.Address, b common.Address) bool {
+	return bytes.Equal(a.Bytes(), b.Bytes())
+}
+
+func bigIntsEqual(a *big.Int, b *big.Int) bool {
+	if a == nil {
+		a = new(big.Int)
+	}
+	if b == nil {
+		b = new(big.Int)
+	}
+	return a.Cmp(b) == 0
+}
+
+func abiUint8(v any) (uint8, bool) {
+	switch n := v.(type) {
+	case uint8:
+		return n, true
+	case *big.Int:
+		if n != nil && n.Sign() >= 0 && n.BitLen() <= 8 {
+			return uint8(n.Uint64()), true
+		}
+	}
+	return 0, false
+}
+
+func soulOperationReceiptMismatch() *apptheory.AppError {
+	return &apptheory.AppError{Code: "app.bad_request", Message: "execution receipt does not match operation"}
+}

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -69,6 +69,10 @@ func (f *fakeSoulPublicEthClient) FilterLogs(ctx context.Context, q ethereum.Fil
 	return nil, errors.New("unexpected FilterLogs")
 }
 
+func (f *fakeSoulPublicEthClient) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	return nil, false, ethereum.NotFound
+}
+
 func (f *fakeSoulPublicEthClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	return nil, ethereum.NotFound
 }

--- a/internal/controlplane/handlers_soul_registry.go
+++ b/internal/controlplane/handlers_soul_registry.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -851,6 +852,7 @@ func (s *Server) handleSoulAgentRegistrationVerify(ctx *apptheory.Context) (*app
 
 	principalAddr, principalDeclaration, principalSig, declaredAt, appErr := s.validateSoulRegistrationVerifyPrincipalInputs(
 		ctx.Context(),
+		reg,
 		principalAddrRaw,
 		principalDeclarationRaw,
 		principalSigRaw,
@@ -1101,6 +1103,7 @@ func needsSoulPendingIdentityPrincipalUpdate(existing *models.SoulAgentIdentity,
 
 func (s *Server) validateSoulRegistrationVerifyPrincipalInputs(
 	ctx context.Context,
+	reg *models.SoulAgentRegistration,
 	principalAddrRaw string,
 	principalDeclarationRaw string,
 	principalSigRaw string,
@@ -1121,20 +1124,56 @@ func (s *Server) validateSoulRegistrationVerifyPrincipalInputs(
 	if declaredAt == "" {
 		return "", "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "declared_at is required"}
 	}
-	if _, err := time.Parse(time.RFC3339, declaredAt); err != nil {
-		if _, err2 := time.Parse(time.RFC3339Nano, declaredAt); err2 != nil {
-			return "", "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "declared_at must be an RFC3339 timestamp"}
+	_, declaredAtCanonical, tsErr := parseSoulSignedTimestamp(declaredAt, time.Now().UTC(), "declared_at")
+	if tsErr != nil {
+		if tsErr.Message == "declared_at must be RFC3339" {
+			tsErr.Message = "declared_at must be an RFC3339 timestamp"
 		}
+		return "", "", "", "", tsErr
 	}
 	principalSig := strings.TrimSpace(principalSigRaw)
 	if principalSig == "" {
 		return "", "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "principal_signature is required"}
 	}
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(reg, principalAddr, principalDeclaration, declaredAtCanonical)
+	if appErr != nil {
+		return "", "", "", "", appErr
+	}
 	if err := verifyEthereumSignatureBytes(principalAddr, principalDigest, principalSig); err != nil {
 		return "", "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "invalid principal_signature"}
 	}
-	return principalAddr, principalDeclaration, principalSig, declaredAt, nil
+	return principalAddr, principalDeclaration, principalSig, declaredAtCanonical, nil
+}
+
+func (s *Server) computeSoulPrincipalDeclarationDigest(reg *models.SoulAgentRegistration, principalAddr string, principalDeclaration string, declaredAt string) ([]byte, *apptheory.AppError) {
+	if s == nil || reg == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if s.cfg.SoulChainID <= 0 || strings.TrimSpace(s.cfg.SoulRegistryContractAddress) == "" {
+		return nil, &apptheory.AppError{Code: "app.conflict", Message: "soul registry is not configured"}
+	}
+	unsigned := map[string]any{
+		"kind":             "soul_principal_declaration",
+		"version":          "1",
+		"agentId":          strings.ToLower(strings.TrimSpace(reg.AgentID)),
+		"wallet":           strings.ToLower(strings.TrimSpace(reg.Wallet)),
+		"domain":           strings.ToLower(strings.TrimSpace(reg.DomainNormalized)),
+		"localId":          strings.TrimSpace(reg.LocalID),
+		"chainId":          strconv.FormatInt(s.cfg.SoulChainID, 10),
+		"contract":         strings.ToLower(strings.TrimSpace(s.cfg.SoulRegistryContractAddress)),
+		"principalAddress": strings.ToLower(strings.TrimSpace(principalAddr)),
+		"declaration":      strings.TrimSpace(principalDeclaration),
+		"declaredAt":       strings.TrimSpace(declaredAt),
+	}
+	unsignedBytes, err := json.Marshal(unsigned)
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid principal declaration JSON"}
+	}
+	jcsBytes, err := jsoncanonicalizer.Transform(unsignedBytes)
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid principal declaration JSON"}
+	}
+	return crypto.Keccak256(jcsBytes), nil
 }
 
 func (s *Server) upsertSoulAgentIndexes(ctx context.Context, reg *models.SoulAgentRegistration) {

--- a/internal/controlplane/handlers_soul_registry_branch_internal_test.go
+++ b/internal/controlplane/handlers_soul_registry_branch_internal_test.go
@@ -83,14 +83,16 @@ func newSoulRegistryVerifyHarness(t *testing.T, mutateCfg func(*config.Config)) 
 	return s, tdb, reg, key
 }
 
-func newSoulRegistryVerifyContext(t *testing.T, reg *models.SoulAgentRegistration, key *ecdsa.PrivateKey, mutate func(*soulAgentRegistrationVerifyRequest)) *apptheory.Context {
+func newSoulRegistryVerifyContext(t *testing.T, s *Server, reg *models.SoulAgentRegistration, key *ecdsa.PrivateKey, mutate func(*soulAgentRegistrationVerifyRequest)) *apptheory.Context {
 	t.Helper()
 
 	walletSig, err := crypto.Sign(accounts.TextHash([]byte(reg.WalletMessage)), key)
 	require.NoError(t, err)
 
 	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
+	declaredAt := canonicalSoulSignedTimestamp(time.Now().UTC())
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(reg, reg.Wallet, principalDeclaration, declaredAt)
+	require.Nil(t, appErr)
 	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
 	require.NoError(t, err)
 
@@ -99,7 +101,7 @@ func newSoulRegistryVerifyContext(t *testing.T, reg *models.SoulAgentRegistratio
 		PrincipalAddress:     reg.Wallet,
 		PrincipalDeclaration: principalDeclaration,
 		PrincipalSignature:   "0x" + hex.EncodeToString(principalSig),
-		DeclaredAt:           reg.CreatedAt.Add(1 * time.Minute).Format(time.RFC3339),
+		DeclaredAt:           declaredAt,
 	}
 	if mutate != nil {
 		mutate(&req)
@@ -358,7 +360,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 
 	t.Run("invalid principal address", func(t *testing.T) {
 		s, _, reg, key := newSoulRegistryVerifyHarness(t, nil)
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.PrincipalAddress = "not-a-wallet"
 		})
 
@@ -371,7 +373,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("principal declaration required", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.PrincipalDeclaration = " "
 		})
 
@@ -384,7 +386,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("principal declaration too long", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.PrincipalDeclaration = strings.Repeat("x", 8193)
 		})
 
@@ -397,7 +399,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("declared_at required", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.DeclaredAt = " "
 		})
 
@@ -410,7 +412,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("declared_at must be rfc3339", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.DeclaredAt = "yesterday"
 		})
 
@@ -423,7 +425,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("principal signature required", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.PrincipalSignature = " "
 		})
 
@@ -436,8 +438,27 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 	t.Run("invalid principal signature", func(t *testing.T) {
 		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
 			req.PrincipalSignature = "0x1234"
+		})
+
+		_, err := s.handleSoulAgentRegistrationVerify(ctx)
+		var appErr *apptheory.AppError
+		require.ErrorAs(t, err, &appErr)
+		require.Equal(t, "invalid principal_signature", appErr.Message)
+	})
+
+	t.Run("principal signature is agent-bound", func(t *testing.T) {
+		s, tdb, reg, key := newSoulRegistryVerifyHarness(t, nil)
+		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, func(req *soulAgentRegistrationVerifyRequest) {
+			otherReg := *reg
+			otherReg.AgentID = "0x" + strings.Repeat("66", 32)
+			digest, appErr := s.computeSoulPrincipalDeclarationDigest(&otherReg, req.PrincipalAddress, req.PrincipalDeclaration, req.DeclaredAt)
+			require.Nil(t, appErr)
+			sig, err := crypto.Sign(accounts.TextHash(digest), key)
+			require.NoError(t, err)
+			req.PrincipalSignature = "0x" + hex.EncodeToString(sig)
 		})
 
 		_, err := s.handleSoulAgentRegistrationVerify(ctx)
@@ -451,7 +472,7 @@ func TestHandleSoulAgentRegistrationVerify_ValidationBranches(t *testing.T) {
 			cfg.SoulMintSignerKey = ""
 		})
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
-		ctx := newSoulRegistryVerifyContext(t, reg, key, nil)
+		ctx := newSoulRegistryVerifyContext(t, s, reg, key, nil)
 
 		_, err := s.handleSoulAgentRegistrationVerify(ctx)
 		var appErr *apptheory.AppError

--- a/internal/controlplane/handlers_soul_registry_internal_test.go
+++ b/internal/controlplane/handlers_soul_registry_internal_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
 	"net/http"
@@ -531,20 +532,12 @@ func TestHandleSoulAgentRegistrationVerify_UsesExistingProofFlagsAndCreatesOpera
 
 	principalDeclaration := boundaryTestPrincipalDeclaration
 	declaredAt := canonicalSoulSignedTimestamp(time.Now().UTC())
-	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(&models.SoulAgentRegistration{
+	principalSigHex := signSoulRegistrationVerifyPrincipalForTest(t, s, key, &models.SoulAgentRegistration{
 		DomainNormalized: "example.com",
 		LocalID:          "agent-alice",
 		AgentID:          "0x8db124b1d48e366002db4e61cc1501eeb8561e1ef06fd6f9abf9f984501d13ab",
 		Wallet:           addr,
 	}, addr, principalDeclaration, declaredAt)
-	if appErr != nil {
-		t.Fatalf("principal digest: %#v", appErr)
-	}
-	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
-	if err != nil {
-		t.Fatalf("principal Sign: %v", err)
-	}
-	principalSigHex := "0x" + hex.EncodeToString(principalSig)
 
 	body, _ := json.Marshal(soulAgentRegistrationVerifyRequest{
 		Signature:            sigHex,
@@ -792,6 +785,19 @@ func TestHandleSoulAgentPromotionVerify_UsesPromotionRegistrationID(t *testing.T
 	if out.Registration.ID != "reg1" || out.Promotion == nil || out.Promotion.RegistrationID != "reg1" {
 		t.Fatalf("unexpected promotion verify response: %#v", out)
 	}
+}
+
+func signSoulRegistrationVerifyPrincipalForTest(t *testing.T, s *Server, key *ecdsa.PrivateKey, reg *models.SoulAgentRegistration, principalAddr string, principalDeclaration string, declaredAt string) string {
+	t.Helper()
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(reg, principalAddr, principalDeclaration, declaredAt)
+	if appErr != nil {
+		t.Fatalf("principal digest: %#v", appErr)
+	}
+	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
+	if err != nil {
+		t.Fatalf("principal Sign: %v", err)
+	}
+	return "0x" + hex.EncodeToString(principalSig)
 }
 
 func TestNormalizeSoulCapabilitiesLoose_NormalizesWithoutAllowlist(t *testing.T) {

--- a/internal/controlplane/handlers_soul_registry_internal_test.go
+++ b/internal/controlplane/handlers_soul_registry_internal_test.go
@@ -530,7 +530,16 @@ func TestHandleSoulAgentRegistrationVerify_UsesExistingProofFlagsAndCreatesOpera
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
+	declaredAt := canonicalSoulSignedTimestamp(time.Now().UTC())
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(&models.SoulAgentRegistration{
+		DomainNormalized: "example.com",
+		LocalID:          "agent-alice",
+		AgentID:          "0x8db124b1d48e366002db4e61cc1501eeb8561e1ef06fd6f9abf9f984501d13ab",
+		Wallet:           addr,
+	}, addr, principalDeclaration, declaredAt)
+	if appErr != nil {
+		t.Fatalf("principal digest: %#v", appErr)
+	}
 	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
 	if err != nil {
 		t.Fatalf("principal Sign: %v", err)
@@ -542,7 +551,7 @@ func TestHandleSoulAgentRegistrationVerify_UsesExistingProofFlagsAndCreatesOpera
 		PrincipalAddress:     addr,
 		PrincipalDeclaration: principalDeclaration,
 		PrincipalSignature:   principalSigHex,
-		DeclaredAt:           time.Now().UTC().Format(time.RFC3339),
+		DeclaredAt:           declaredAt,
 	})
 	ctx := &apptheory.Context{
 		RequestID:    "r2",
@@ -738,7 +747,16 @@ func TestHandleSoulAgentPromotionVerify_UsesPromotionRegistrationID(t *testing.T
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
+	declaredAt := canonicalSoulSignedTimestamp(time.Now().UTC())
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(&models.SoulAgentRegistration{
+		DomainNormalized: "example.com",
+		LocalID:          "agent-alice",
+		AgentID:          "0x8db124b1d48e366002db4e61cc1501eeb8561e1ef06fd6f9abf9f984501d13ab",
+		Wallet:           addr,
+	}, addr, principalDeclaration, declaredAt)
+	if appErr != nil {
+		t.Fatalf("principal digest: %#v", appErr)
+	}
 	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
 	if err != nil {
 		t.Fatalf("principal Sign: %v", err)
@@ -750,7 +768,7 @@ func TestHandleSoulAgentPromotionVerify_UsesPromotionRegistrationID(t *testing.T
 		PrincipalAddress:     addr,
 		PrincipalDeclaration: principalDeclaration,
 		PrincipalSignature:   principalSigHex,
-		DeclaredAt:           time.Now().UTC().Format(time.RFC3339),
+		DeclaredAt:           declaredAt,
 	})
 	ctx := &apptheory.Context{
 		RequestID:    "r-promo-verify",

--- a/internal/controlplane/handlers_soul_relationships.go
+++ b/internal/controlplane/handlers_soul_relationships.go
@@ -208,23 +208,7 @@ func parseSoulCreateRelationshipInput(ctx *apptheory.Context) (soulCreateRelatio
 }
 
 func parseSoulRelationshipCreatedAt(raw string, now time.Time) (time.Time, string, *apptheory.AppError) {
-	if raw == "" {
-		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "created_at is required"}
-	}
-	parsedTS, parseErr := time.Parse(time.RFC3339, raw)
-	if parseErr != nil {
-		if parsedTS, parseErr = time.Parse(time.RFC3339Nano, raw); parseErr != nil {
-			return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "created_at must be RFC3339"}
-		}
-	}
-	if parsedTS.After(now.Add(5 * time.Minute)) {
-		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "created_at cannot be in the future"}
-	}
-	if parsedTS.Before(now.Add(-10 * 365 * 24 * time.Hour)) {
-		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "created_at is too far in the past"}
-	}
-	createdAt := parsedTS.UTC()
-	return createdAt, createdAt.Format(time.RFC3339Nano), nil
+	return parseSoulSignedTimestamp(raw, now, "created_at")
 }
 
 func (s *Server) requireSoulRelationshipTarget(ctx context.Context, toAgentIDHex string) *apptheory.AppError {

--- a/internal/controlplane/handlers_soul_relationships.go
+++ b/internal/controlplane/handlers_soul_relationships.go
@@ -20,6 +20,8 @@ import (
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
+const soulRelationshipCursorLegacyEndorsementPrefix = "legacy_endorsements:"
+
 // --- Request / Response types ---
 
 type soulCreateRelationshipRequest struct {
@@ -323,6 +325,13 @@ func parseSoulRelationshipListParams(ctx *apptheory.Context) soulRelationshipLis
 }
 
 func (s *Server) listSoulPublicRelationships(ctx context.Context, agentIDHex string, params soulRelationshipListParams) ([]models.SoulAgentRelationship, bool, string, *apptheory.AppError) {
+	if legacyCursor, ok := legacyRelationshipEndorsementCursor(params.cursor); ok {
+		if !canUseLegacyRelationshipEndorsementCursor(params) {
+			return nil, false, "", &apptheory.AppError{Code: "app.bad_request", Message: "invalid cursor"}
+		}
+		return s.listLegacyRelationshipEndorsementCursorPage(ctx, agentIDHex, legacyCursor, params.limit)
+	}
+
 	out := make([]models.SoulAgentRelationship, 0, params.limit)
 	pageCursor := params.cursor
 	nextCursor := ""
@@ -348,19 +357,33 @@ func (s *Server) listSoulPublicRelationships(ctx context.Context, agentIDHex str
 	}
 
 	if shouldMergeLegacyRelationshipEndorsements(params) {
-		remaining := params.limit - len(out)
-		if remaining > 0 {
-			endorsements, endorsementsHaveMore, appErr := s.loadLegacyRelationshipEndorsements(ctx, agentIDHex, remaining)
-			if appErr != nil {
-				return nil, false, "", appErr
-			}
-			out = append(out, endorsements...)
-			if endorsementsHaveMore {
-				hasMore = true
-			}
-		}
+		return s.appendLegacyRelationshipEndorsements(ctx, agentIDHex, params.limit, out, hasMore, nextCursor)
 	}
 
+	return out, hasMore, nextCursor, nil
+}
+
+func (s *Server) appendLegacyRelationshipEndorsements(
+	ctx context.Context,
+	agentIDHex string,
+	limit int,
+	out []models.SoulAgentRelationship,
+	hasMore bool,
+	nextCursor string,
+) ([]models.SoulAgentRelationship, bool, string, *apptheory.AppError) {
+	remaining := limit - len(out)
+	if remaining <= 0 {
+		return out, hasMore, nextCursor, nil
+	}
+	endorsements, endorsementsHaveMore, endorsementCursor, appErr := s.loadLegacyRelationshipEndorsements(ctx, agentIDHex, "", remaining)
+	if appErr != nil {
+		return nil, false, "", appErr
+	}
+	out = append(out, endorsements...)
+	if endorsementsHaveMore && strings.TrimSpace(endorsementCursor) != "" {
+		hasMore = true
+		nextCursor = encodeLegacyRelationshipEndorsementCursor(endorsementCursor)
+	}
 	return out, hasMore, nextCursor, nil
 }
 
@@ -440,24 +463,61 @@ func resolveRelationshipPageCursor(items []*models.SoulAgentRelationship, idx in
 }
 
 func shouldMergeLegacyRelationshipEndorsements(params soulRelationshipListParams) bool {
-	return params.cursor == "" &&
-		params.taskTypeFilter == "" &&
+	return params.cursor == "" && canUseLegacyRelationshipEndorsementCursor(params)
+}
+
+func canUseLegacyRelationshipEndorsementCursor(params soulRelationshipListParams) bool {
+	return params.taskTypeFilter == "" &&
 		(params.typeFilter == "" || params.typeFilter == models.SoulRelationshipTypeEndorsement)
 }
 
-func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentIDHex string, limit int) ([]models.SoulAgentRelationship, bool, *apptheory.AppError) {
+func legacyRelationshipEndorsementCursor(cursor string) (string, bool) {
+	cursor = strings.TrimSpace(cursor)
+	if !strings.HasPrefix(cursor, soulRelationshipCursorLegacyEndorsementPrefix) {
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimPrefix(cursor, soulRelationshipCursorLegacyEndorsementPrefix)), true
+}
+
+func encodeLegacyRelationshipEndorsementCursor(cursor string) string {
+	cursor = strings.TrimSpace(cursor)
+	if cursor == "" {
+		return ""
+	}
+	return soulRelationshipCursorLegacyEndorsementPrefix + cursor
+}
+
+func (s *Server) listLegacyRelationshipEndorsementCursorPage(ctx context.Context, agentIDHex string, legacyCursor string, limit int) ([]models.SoulAgentRelationship, bool, string, *apptheory.AppError) {
+	if strings.TrimSpace(legacyCursor) == "" {
+		return nil, false, "", &apptheory.AppError{Code: "app.bad_request", Message: "invalid cursor"}
+	}
+	endorsements, hasMore, nextCursor, appErr := s.loadLegacyRelationshipEndorsements(ctx, agentIDHex, legacyCursor, limit)
+	if appErr != nil {
+		return nil, false, "", appErr
+	}
+	encodedNextCursor := ""
+	if hasMore && strings.TrimSpace(nextCursor) != "" {
+		encodedNextCursor = encodeLegacyRelationshipEndorsementCursor(nextCursor)
+	}
+	return endorsements, encodedNextCursor != "", encodedNextCursor, nil
+}
+
+func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentIDHex string, cursor string, limit int) ([]models.SoulAgentRelationship, bool, string, *apptheory.AppError) {
 	if limit <= 0 {
-		return nil, false, nil
+		return nil, false, "", nil
 	}
 	var endorsements []*models.SoulAgentPeerEndorsement
-	paged, err := s.store.DB.WithContext(ctx).
+	qb := s.store.DB.WithContext(ctx).
 		Model(&models.SoulAgentPeerEndorsement{}).
 		Where("PK", "=", fmt.Sprintf("SOUL#AGENT#%s", agentIDHex)).
 		Where("SK", "BEGINS_WITH", "ENDORSEMENT#").
-		Limit(limit).
-		AllPaginated(&endorsements)
+		Limit(limit)
+	if strings.TrimSpace(cursor) != "" {
+		qb = qb.Cursor(strings.TrimSpace(cursor))
+	}
+	paged, err := qb.AllPaginated(&endorsements)
 	if err != nil {
-		return nil, false, &apptheory.AppError{Code: "app.internal", Message: "failed to list endorsements"}
+		return nil, false, "", &apptheory.AppError{Code: "app.internal", Message: "failed to list endorsements"}
 	}
 
 	out := make([]models.SoulAgentRelationship, 0, len(endorsements))
@@ -474,7 +534,11 @@ func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentID
 			CreatedAt:   e.CreatedAt,
 		})
 	}
-	return out, paged != nil && strings.TrimSpace(paged.NextCursor) != "", nil
+	nextCursor := ""
+	if paged != nil {
+		nextCursor = strings.TrimSpace(paged.NextCursor)
+	}
+	return out, nextCursor != "", nextCursor, nil
 }
 
 func isValidRelationshipType(relType string) bool {

--- a/internal/controlplane/handlers_soul_relationships.go
+++ b/internal/controlplane/handlers_soul_relationships.go
@@ -364,11 +364,17 @@ func (s *Server) listSoulPublicRelationships(ctx context.Context, agentIDHex str
 	}
 
 	if shouldMergeLegacyRelationshipEndorsements(params) {
-		endorsements, appErr := s.loadLegacyRelationshipEndorsements(ctx, agentIDHex)
-		if appErr != nil {
-			return nil, false, "", appErr
+		remaining := params.limit - len(out)
+		if remaining > 0 {
+			endorsements, endorsementsHaveMore, appErr := s.loadLegacyRelationshipEndorsements(ctx, agentIDHex, remaining)
+			if appErr != nil {
+				return nil, false, "", appErr
+			}
+			out = append(out, endorsements...)
+			if endorsementsHaveMore {
+				hasMore = true
+			}
 		}
-		out = append(out, endorsements...)
 	}
 
 	return out, hasMore, nextCursor, nil
@@ -455,14 +461,19 @@ func shouldMergeLegacyRelationshipEndorsements(params soulRelationshipListParams
 		(params.typeFilter == "" || params.typeFilter == models.SoulRelationshipTypeEndorsement)
 }
 
-func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentIDHex string) ([]models.SoulAgentRelationship, *apptheory.AppError) {
+func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentIDHex string, limit int) ([]models.SoulAgentRelationship, bool, *apptheory.AppError) {
+	if limit <= 0 {
+		return nil, false, nil
+	}
 	var endorsements []*models.SoulAgentPeerEndorsement
-	if err := s.store.DB.WithContext(ctx).
+	paged, err := s.store.DB.WithContext(ctx).
 		Model(&models.SoulAgentPeerEndorsement{}).
 		Where("PK", "=", fmt.Sprintf("SOUL#AGENT#%s", agentIDHex)).
 		Where("SK", "BEGINS_WITH", "ENDORSEMENT#").
-		All(&endorsements); err != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list endorsements"}
+		Limit(limit).
+		AllPaginated(&endorsements)
+	if err != nil {
+		return nil, false, &apptheory.AppError{Code: "app.internal", Message: "failed to list endorsements"}
 	}
 
 	out := make([]models.SoulAgentRelationship, 0, len(endorsements))
@@ -479,7 +490,7 @@ func (s *Server) loadLegacyRelationshipEndorsements(ctx context.Context, agentID
 			CreatedAt:   e.CreatedAt,
 		})
 	}
-	return out, nil
+	return out, paged != nil && strings.TrimSpace(paged.NextCursor) != "", nil
 }
 
 func isValidRelationshipType(relType string) bool {

--- a/internal/controlplane/handlers_soul_relationships_create_internal_test.go
+++ b/internal/controlplane/handlers_soul_relationships_create_internal_test.go
@@ -147,6 +147,7 @@ type strictRelationshipFixture struct {
 func newStrictRelationshipFixture(t *testing.T) *strictRelationshipFixture {
 	t.Helper()
 
+	createdAt := time.Now().UTC()
 	fixture := &strictRelationshipFixture{
 		tdb:               newSoulLifecycleTestDB(),
 		tx:                new(ttmocks.MockTransactionBuilder),
@@ -154,8 +155,8 @@ func newStrictRelationshipFixture(t *testing.T) *strictRelationshipFixture {
 		fromAgentIDHex:    "0x" + strings.Repeat("11", 32),
 		message:           "delegation for summaries",
 		contextJSON:       `{"taskType":"summarization"}`,
-		createdAtRaw:      "2026-03-01T00:00:00Z",
-		expectedCreatedAt: time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		createdAtRaw:      canonicalSoulSignedTimestamp(createdAt),
+		expectedCreatedAt: createdAt.Truncate(time.Millisecond),
 		createKinds:       map[string]bool{},
 	}
 

--- a/internal/controlplane/handlers_soul_relationships_internal_test.go
+++ b/internal/controlplane/handlers_soul_relationships_internal_test.go
@@ -123,7 +123,7 @@ func TestHandleSoulPublicGetRelationships_IncludesV1Endorsements(t *testing.T) {
 		*dest = nil
 	}).Once()
 
-	tdb.qEnd.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+	tdb.qEnd.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
 		*dest = []*models.SoulAgentPeerEndorsement{
 			{
@@ -162,5 +162,59 @@ func TestHandleSoulPublicGetRelationships_IncludesV1Endorsements(t *testing.T) {
 	}
 	if out.Relationships[0].FromAgentID != "0xendorser" {
 		t.Fatalf("unexpected from agent id: %q", out.Relationships[0].FromAgentID)
+	}
+}
+
+func TestHandleSoulPublicGetRelationships_BoundsV1EndorsementMerge(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulRelationshipsTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+
+	agentIDHex := "0x" + strings.Repeat("11", 32)
+
+	tdb.qRel.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentRelationship](t, args, 0)
+		*dest = nil
+	}).Once()
+	tdb.qEnd.On("Limit", 1).Return(tdb.qEnd).Once()
+	tdb.qEnd.On("AllPaginated", mock.Anything).Return(&core.PaginatedResult{NextCursor: "more-endorsements"}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{
+			{
+				AgentID:         agentIDHex,
+				EndorserAgentID: "0xendorser1",
+				Message:         "good agent",
+				Signature:       "0xsig",
+				CreatedAt:       time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+			},
+		}
+	}).Once()
+
+	ctx := &apptheory.Context{
+		RequestID: "r1",
+		Params:    map[string]string{"agentId": agentIDHex},
+		Request: apptheory.Request{Query: map[string][]string{
+			"limit": {"1"},
+		}},
+	}
+
+	resp, err := s.handleSoulPublicGetRelationships(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", resp.Status, string(resp.Body))
+	}
+
+	var out soulListRelationshipsResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Relationships) != 1 {
+		t.Fatalf("expected bounded single relationship, got %d", len(out.Relationships))
+	}
+	if !out.HasMore {
+		t.Fatalf("expected has_more when endorsement page has more results")
 	}
 }

--- a/internal/controlplane/handlers_soul_relationships_internal_test.go
+++ b/internal/controlplane/handlers_soul_relationships_internal_test.go
@@ -217,4 +217,57 @@ func TestHandleSoulPublicGetRelationships_BoundsV1EndorsementMerge(t *testing.T)
 	if !out.HasMore {
 		t.Fatalf("expected has_more when endorsement page has more results")
 	}
+	if !strings.HasPrefix(out.NextCursor, soulRelationshipCursorLegacyEndorsementPrefix) {
+		t.Fatalf("expected usable legacy endorsement cursor, got %q", out.NextCursor)
+	}
+}
+
+func TestHandleSoulPublicGetRelationships_UsesV1EndorsementCursor(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulRelationshipsTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+
+	agentIDHex := "0x" + strings.Repeat("11", 32)
+
+	tdb.qEnd.On("Limit", 1).Return(tdb.qEnd).Once()
+	tdb.qEnd.On("Cursor", "legacy-cursor").Return(tdb.qEnd).Once()
+	tdb.qEnd.On("AllPaginated", mock.Anything).Return((*core.PaginatedResult)(nil), nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{{
+			AgentID:         agentIDHex,
+			EndorserAgentID: "0xendorser2",
+			Message:         "second page",
+			Signature:       "0xsig2",
+			CreatedAt:       time.Date(2026, 3, 1, 1, 0, 0, 0, time.UTC),
+		}}
+	}).Once()
+
+	ctx := &apptheory.Context{
+		RequestID: "r1",
+		Params:    map[string]string{"agentId": agentIDHex},
+		Request: apptheory.Request{Query: map[string][]string{
+			"limit":  {"1"},
+			"cursor": {soulRelationshipCursorLegacyEndorsementPrefix + "legacy-cursor"},
+		}},
+	}
+
+	resp, err := s.handleSoulPublicGetRelationships(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", resp.Status, string(resp.Body))
+	}
+
+	var out soulListRelationshipsResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.HasMore || out.NextCursor != "" {
+		t.Fatalf("expected final legacy endorsement page, got has_more=%v cursor=%q", out.HasMore, out.NextCursor)
+	}
+	if len(out.Relationships) != 1 || out.Relationships[0].FromAgentID != "0xendorser2" {
+		t.Fatalf("unexpected relationships: %#v", out.Relationships)
+	}
 }

--- a/internal/controlplane/handlers_soul_rotation_internal_test.go
+++ b/internal/controlplane/handlers_soul_rotation_internal_test.go
@@ -43,6 +43,11 @@ func (c *stubEthRPCClient) CallContract(ctx context.Context, msg ethereum.CallMs
 	return c.callContract(ctx, msg, blockNumber)
 }
 
+func (c *stubEthRPCClient) TransactionByHash(ctx context.Context, txHash common.Hash) (*types.Transaction, bool, error) {
+	c.t.Fatalf("unexpected TransactionByHash(%s)", txHash.Hex())
+	return nil, false, nil
+}
+
 func (c *stubEthRPCClient) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
 	c.t.Fatalf("unexpected TransactionReceipt(%s)", txHash.Hex())
 	return nil, nil

--- a/internal/controlplane/handlers_soul_update_registration_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_internal_test.go
@@ -74,6 +74,10 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 		}
 	}).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = nil
+	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
@@ -253,6 +257,10 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 		}
 	}).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = nil
+	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	// v3 sync reads existing channel records by SK.
@@ -616,6 +624,24 @@ func TestGetNextSoulAgentVersion_IgnoresLexicographicSKOrder(t *testing.T) {
 	}
 	if n != 11 {
 		t.Fatalf("expected 11, got %d", n)
+	}
+}
+
+func TestEnsureNoSoulRegistrationVersionHistory_RejectsMissingPreviousURIWithExistingHistory(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = []*models.SoulAgentVersion{
+			{AgentID: soulLifecycleTestAgentIDHex, VersionNumber: 2},
+		}
+	}).Once()
+
+	appErr := s.ensureNoSoulRegistrationVersionHistory(context.Background(), soulLifecycleTestAgentIDHex)
+	if appErr == nil || appErr.Message != "previousVersionUri is required for existing version history" {
+		t.Fatalf("expected existing history conflict, got %#v", appErr)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -409,6 +409,10 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}).Once()
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentVersion](t, args, 0)
+		*dest = nil
+	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
 

--- a/internal/controlplane/soul_registration_publish_helpers.go
+++ b/internal/controlplane/soul_registration_publish_helpers.go
@@ -206,6 +206,11 @@ func (s *Server) prepareSoulRegistrationPublish(
 	if validateErr := validatePrevious(nextVersion); validateErr != nil {
 		return soulRegistrationPublishPlan{}, validateErr
 	}
+	if prevVersionFromURI == 0 && nextVersion == 1 {
+		if historyErr := s.ensureNoSoulRegistrationVersionHistory(ctx, agentIDHex); historyErr != nil {
+			return soulRegistrationPublishPlan{}, historyErr
+		}
+	}
 	if identity.SelfDescriptionVersion > nextVersion {
 		return soulRegistrationPublishPlan{}, &apptheory.AppError{Code: "app.conflict", Message: "agent has advanced beyond this version"}
 	}
@@ -239,4 +244,16 @@ func (s *Server) prepareSoulRegistrationPublish(
 		nextVersion:        nextVersion,
 		versionRecord:      versionRecord,
 	}, nil
+}
+
+func (s *Server) ensureNoSoulRegistrationVersionHistory(ctx context.Context, agentIDHex string) *apptheory.AppError {
+	nextExisting, _, appErr := s.getNextSoulAgentVersion(ctx, agentIDHex)
+	if appErr != nil {
+		return appErr
+	}
+	if nextExisting > 2 {
+		log.Printf("controlplane: soul_integrity version_chain_violation agent=%s reason=missing_prev_uri_with_existing_history next_existing=%d", agentIDHex, nextExisting)
+		return &apptheory.AppError{Code: "app.conflict", Message: "previousVersionUri is required for existing version history"}
+	}
+	return nil
 }

--- a/internal/controlplane/test_consts_internal_test.go
+++ b/internal/controlplane/test_consts_internal_test.go
@@ -8,5 +8,7 @@ const (
 	testNope         = "nope"
 	testNotAnAddress = "not-an-address"
 
+	testEthAddress1 = "0x0000000000000000000000000000000000000001"
+	testEthAddress2 = "0x0000000000000000000000000000000000000002"
 	testEthAddress3 = "0x0000000000000000000000000000000000000003"
 )

--- a/scripts/managed-release-certification/main.go
+++ b/scripts/managed-release-certification/main.go
@@ -1205,7 +1205,7 @@ func (c *certificationClient) createUpdate(ctx context.Context, slug string, req
 	if err != nil {
 		return updateJobResponse{}, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint("/api/v1/portal/instances/"+slug+"/updates"), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint("/api/v1/portal/instances/"+slug+"/updates"), bytes.NewReader(body)) //nolint:gosec // Target host is an explicitly provided certification endpoint validated by parseCLI.
 	if err != nil {
 		return updateJobResponse{}, err
 	}
@@ -1267,7 +1267,7 @@ func (c *certificationClient) waitForJob(ctx context.Context, slug string, jobID
 }
 
 func (c *certificationClient) listUpdates(ctx context.Context, slug string) ([]updateJobResponse, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint("/api/v1/portal/instances/"+slug+"/updates"), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint("/api/v1/portal/instances/"+slug+"/updates"), nil) //nolint:gosec // Target host is an explicitly provided certification endpoint validated by parseCLI.
 	if err != nil {
 		return nil, err
 	}

--- a/web/src/pages/portal/SoulRegister.svelte
+++ b/web/src/pages/portal/SoulRegister.svelte
@@ -37,6 +37,7 @@
 		switchEthereumChain,
 		waitForEthereumTransactionReceipt,
 	} from 'src/lib/wallet/ethereum';
+	import { jcsCanonicalize } from 'src/lib/wallet/jcs';
 	import { keccak256Utf8Hex } from 'src/lib/wallet/keccak';
 	import {
 		Alert,
@@ -840,6 +841,14 @@
 			principalSignError = 'Declaration is required.';
 			return;
 		}
+		if (!beginResult?.registration) {
+			principalSignError = 'Generate a registration challenge first.';
+			return;
+		}
+		if (!soulConfig?.chain_id || !soulConfig?.registry_contract_address) {
+			principalSignError = 'Soul registry configuration is unavailable.';
+			return;
+		}
 
 		principalSignLoading = true;
 		try {
@@ -850,9 +859,24 @@
 				return;
 			}
 
-			const digestHex = keccak256Utf8Hex(decl);
+			const declaredAt = new Date().toISOString();
+			const reg = beginResult.registration;
+			const unsigned = {
+				kind: 'soul_principal_declaration',
+				version: '1',
+				agentId: reg.agent_id.trim().toLowerCase(),
+				wallet: reg.wallet_address.trim().toLowerCase(),
+				domain: reg.domain_normalized.trim().toLowerCase(),
+				localId: reg.local_id.trim(),
+				chainId: String(soulConfig.chain_id),
+				contract: soulConfig.registry_contract_address.trim().toLowerCase(),
+				principalAddress: addr.toLowerCase(),
+				declaration: decl,
+				declaredAt,
+			};
+			const digestHex = keccak256Utf8Hex(jcsCanonicalize(unsigned));
 			principalSignature = await personalSign(provider, digestHex, addr);
-			principalDeclaredAt = new Date().toISOString();
+			principalDeclaredAt = declaredAt;
 		} catch (err) {
 			principalSignError = formatError(err);
 		} finally {


### PR DESCRIPTION
## Milestone
M2 — remediate soul registry and on-chain operation integrity findings from the 2026-04-28 Codex Security report.

## Classification
Security / soul-registry / on-chain-integrity / host hardening / contract hardening / web signing correctness / governance-gated quality.

## Surfaces affected
- Solidity contracts: `OffchainResolver`, `SoulRegistry`, `TipSplitter`
- Soul operation execution recording and receipt validation
- Soul registration principal signing and portal signing digest
- Soul lifecycle / continuity / relationship timestamp canonicalization and replay windows
- Mint-conversation registration finalization lifecycle checks
- Public relationship endorsement merge bounds
- Managed-release-certification lint false-positive annotation required by governance gates

## Specialist walks referenced
- Soul registry: `evolve-soul-registry` applied; on-chain-reaching code and Solidity changes received elevated scrutiny.
- Governance rubric: local gov-infra verifier PASS 29/0/0.
- Provisioning / managed-update / release verification: no provisioning behavior changed; one certification-client lint annotation preserves the existing explicit-endpoint rationale.
- Trust API / CSP / instance-auth: no trust API or CSP loosening.
- Framework: idiomatic local consumption; no framework patches.

## Multi-tenant isolation impact
No tenant content is introduced into host storage or logs. Changes stay within host control-plane metadata and soul-registry operation state.

## On-chain impact
Elevated. Contract bytecode changes are included and require post-merge Sepolia deployment/test evidence before any mainnet Safe-ready execution. Go-side operation execution now validates transaction target/value/calldata plus success logs/state before side effects.

## Consumer impact
Managed operators and soul-registry users get stricter signature replay protection, registration history integrity, bounded public relationship reads, and safer on-chain operation reconciliation. Existing pending operations must have stored payloads matching the submitted execution transaction before status can be recorded.

## Tasks
- [x] #197 Resolve contract findings with tests, Slither, and solhint; Sepolia evidence remains in rollout checklist
- [x] #196 Bound public relationship and endorsement merge behavior
- [x] #195 Fix soul lifecycle signature replay and timestamp canonicalization
- [x] #194 Bind soul operation execution receipts to expected contract effects

## Validation
- `gofmt -l .` (empty)
- `go test ./...`
- `go vet ./...`
- `golangci-lint run --timeout=10m`
- `cd web && npm ci && npm run lint && npm run typecheck && npm test`
- `cd web && npm run build -- --outDir /tmp/lesser-host-web-build-m2 --emptyOutDir`
  - Note: direct `npm run build` initially hit a local stale root-owned `web/dist` artifact; temp outDir build passed, and `cd cdk && npm ci && npm run synth` also completed the web build in its synthesis flow.
- `cd contracts && npm ci && npm test && npm run lint` (solhint warnings only, no errors)
- `cd cdk && npm ci && npm run synth` (existing CDK deprecation warnings only)
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete
- [ ] Deployed to live with explicit operator authorization
- [ ] Post-deploy monitoring verified
- [ ] Sepolia deploy/test evidence captured for contract bytecode changes
- [ ] Mainnet Safe-ready payload prepared and reviewed if production contract migration proceeds
- [ ] Mainnet multisig execution complete, if authorized

## Cross-repo coordination
No sibling-repo code changes required. Contract deployment coordination remains an operator/on-chain release step after merge.

## Advisor-brief authorization
Not applicable; this work was directly requested by Aron.