### PR TITLE
docs(security): record M5 evidence and rollout checklist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,3 +35,11 @@ This directory contains maintainer documentation for `lesser-host` (the `lesser.
 - Moderation provider notes: `docs/moderation-provider.md`
 - Evidence policy v1: `docs/evidence-policy-v1.md`
 - Retention sweep: `docs/retention-sweep.md`
+
+## Security remediation records
+
+- Codex Security 2026-04-28 finding ledger: `docs/security/codex-findings-2026-04-28-ledger.md`
+- M0 evidence baseline: `docs/security/codex-security-m0-evidence-baseline-2026-04-28.md`
+- M5 evidence package: `docs/security/codex-security-m5-evidence-2026-04-29.md`
+- M5 rollout checklist: `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`
+- Release notes: `docs/security/codex-security-release-notes-2026-04-29.md`

--- a/docs/roadmap-codex-security-remediation-2026-04-28.md
+++ b/docs/roadmap-codex-security-remediation-2026-04-28.md
@@ -167,6 +167,10 @@ Security / tenant-isolation / on-chain-integrity / governance / provisioning / m
   - `gov-infra/evidence/` updated by verifiers where applicable.
   - Lab deployment and soak evidence.
   - Live deploy authorization checklist and post-deploy monitoring notes.
+- M5 repository-owned records:
+  - Evidence package: `docs/security/codex-security-m5-evidence-2026-04-29.md`
+  - Rollout checklist: `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`
+  - Release notes: `docs/security/codex-security-release-notes-2026-04-29.md`
 
 ## Stage rollout plan (host's own service)
 

--- a/docs/security/codex-security-m5-evidence-2026-04-29.md
+++ b/docs/security/codex-security-m5-evidence-2026-04-29.md
@@ -1,0 +1,74 @@
+# M5 Evidence Package — Codex Security 2026-04-28
+
+## Scope
+
+M5 covers the repository-owned closeout for GitHub Project
+[#26](https://github.com/orgs/equaltoai/projects/26), parent issue
+[#186](https://github.com/equaltoai/lesser-host/issues/186), and child issue
+[#209](https://github.com/equaltoai/lesser-host/issues/209). It does not run stage deploys: `theory app up` lab/live
+rollouts, on-chain deployments, and managed-instance canaries remain operator-run handoffs after this PR merges.
+
+This package records the regression/evidence baseline at synced `main` commit `81f4ee3` after M0-M4.5 merged.
+
+## Merged remediation PRs
+
+| Phase | PR | Merge time (UTC) | Merge commit | Primary evidence |
+|---|---|---:|---|---|
+| M0 | [#212](https://github.com/equaltoai/lesser-host/pull/212) `docs(security): baseline Codex finding ledger` | 2026-04-29T01:07:47Z | `4f42007` | Finding ledger and M0 evidence baseline |
+| M1 | [#213](https://github.com/equaltoai/lesser-host/pull/213) `fix(security): remediate M1 ingress privacy findings` | 2026-04-29T02:50:30Z | `634aeae` | Mailbox, comm webhook, SES verdict, channel ownership, privacy regressions |
+| M2 | [#214](https://github.com/equaltoai/lesser-host/pull/214) `fix(security): remediate M2 soul integrity findings` | 2026-04-29T04:10:06Z | `291aaf0` | Soul operation receipt binding, lifecycle/signature replay, contract tests/lint |
+| M3 | [#215](https://github.com/equaltoai/lesser-host/pull/215) `fix(security): remediate M3 provisioning release verification` | 2026-04-29T11:37:06Z | `5eae3e0` | Pinned release/version checks, checksum-preserving managed release gates, instance-key stage isolation |
+| M4 | [#216](https://github.com/equaltoai/lesser-host/pull/216) `fix(security): remediate M4 public reliability findings` | 2026-04-29T14:38:16Z | `988402f` | Public read bounds, CSP-safe markdown, CMP-4 semantics, trust-route/runtime registration, AppTheory deploy hardening |
+| M4.5 | [#222](https://github.com/equaltoai/lesser-host/pull/222) `fix(provision): align init-admin consent with lesser M9` | 2026-04-29T15:33:52Z | `81f4ee3` | Lesser M9 structured init-admin consent and exact-byte provisioning transport |
+
+## Local validation at M5 start
+
+Run from synced `main` on 2026-04-29 before opening the M5 evidence branch:
+
+| Command | Result | Notes |
+|---|---|---|
+| `gofmt -l .` | PASS | Empty output |
+| `go test ./...` | PASS | All Go packages passed |
+| `go vet ./...` | PASS | No findings |
+| `bash gov-infra/verifiers/gov-verify-rubric.sh` | PASS | `29` pass, `0` fail, `0` blocked |
+
+The local gov-rubric report was regenerated at `2026-04-29T15:36:32Z` with pack version `4221f0e715b1`. CI will rerun
+the same verifier for the M5 PR; `gov-infra` verifiers were not weakened.
+
+## Regression coverage by finding cluster
+
+| Cluster | Findings | Evidence status |
+|---|---|---|
+| M1 public ingress, comm, mailbox, and privacy | #1, #3, #4, #7-#11, #14, #19-#21, #23, #26, #29-#30, #39, #41, #43, #48-#49, #58-#62, #67 | PR #213 added focused Go regressions across control-plane, mailbox, comm-worker, email-ingress, and model paths; full Go validation passed locally and in CI. |
+| M2 soul registry and on-chain operation integrity | #6, #22, #28, #31-#34, #38, #40, #44-#45, #68 | PR #214 added receipt/effect validation, signature/canonicalization regressions, bounded relationship/endorsement tests, and Solidity tests/lint. Contract bytecode changes still require post-merge Sepolia evidence before any mainnet Safe-ready execution. |
+| M3 managed provisioning and release verification | #5, #12-#18, #47, #51-#55, #60, #63-#65 | PR #215 added release/version compatibility, certification/readiness, stage-isolated instance-key, trust verification, managed-update, and portal regressions. Consumer checksum verification remains mandatory. |
+| M4 public read scalability, web/CSP, governance, reputation, and model registration | #2, #24-#25, #27, #35-#37, #42, #46, #50, #56-#57, #66, #69 | PR #216 added bounded public read/search/version/ENS coverage, web markdown sanitization tests, gov-infra CMP-4 semantics, trust-route env/IAM coverage, and AppTheory deploy-contract hardening. |
+| M4.5 Lesser M9 provisioning alignment | Cross-repo handoff #217-#221 | PR #222 added structured consent and exact-byte transport regressions. M9 consumption remains blocked until lesser publishes exact M9 assets and host certifies them through checksum-verified managed-release/canary evidence. |
+
+## Open rollout gates
+
+These gates are intentionally not closed by repository implementation alone:
+
+1. **Lab deploy and soak** — run `theory app up --stage lab` only as an operator-run rollout step, then follow
+   `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`.
+2. **Live deploy authorization** — live deploy requires explicit operator authorization after lab soak.
+3. **On-chain contract rollout** — PR #214 included contract bytecode changes. Sepolia deploy/test evidence and any
+   mainnet Safe-ready payloads are separate on-chain operations; never single-signer deploy to mainnet.
+4. **Lesser M9 consumption** — PR #222 aligned host, but issue #221 remains blocked until lesser PR #901 merges and an
+   exact published M9 release is available for checksum-verified certification and canary evidence.
+5. **Managed-instance canary** — provisioning/update changes require a lab dry-run and a selected managed canary before
+   broader rollout; do not bypass consumer release verification.
+
+## Release note inputs
+
+Operator-facing release notes live in
+`docs/security/codex-security-release-notes-2026-04-29.md`. The live rollout checklist lives in
+`docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`.
+
+## Non-goals
+
+- No `theory app up` or CDK deploy was run by this implementation PR.
+- No live deployment was performed.
+- No Sepolia or mainnet on-chain transaction was sent.
+- No managed-instance rollout or M9 release certification was performed.
+- No gov-infra verifier, release-verification gate, trust-API instance-auth rule, or CSP posture was weakened.

--- a/docs/security/codex-security-m5-rollout-checklist-2026-04-29.md
+++ b/docs/security/codex-security-m5-rollout-checklist-2026-04-29.md
@@ -1,0 +1,169 @@
+# M5 rollout checklist — Codex Security 2026-04-29
+
+This checklist is the operator handoff for issue [#210](https://github.com/equaltoai/lesser-host/issues/210). It is
+intentionally explicit because M5 includes actions that `implement-milestone` does not perform: host stage deploys,
+on-chain deployments, and managed-instance canaries.
+
+## Hard rules
+
+- Do not run live deploys without explicit operator authorization.
+- Do not set timeouts on CDK/AppTheory deploy commands.
+- Do not delete CloudFormation stacks, Lambda versions, retained DynamoDB/S3/SSM/Secrets Manager resources, Route53 zones,
+  or CloudFront distributions during rollout.
+- Do not deploy on-chain contracts to mainnet single-signer.
+- Do not skip Slither, Hardhat tests, solhint, Sepolia evidence, or Safe-ready review for contract bytecode changes.
+- Do not bypass managed release checksum verification for lesser, lesser-body, or Lesser M9 assets.
+- Do not loosen trust-API instance auth or CSP to make rollout pass.
+
+## Pre-lab verification
+
+Record the exact commit deployed to lab:
+
+- Commit: `____________________________`
+- PR set included: #212, #213, #214, #215, #216, #222, and this M5 PR.
+- Local/CI validation evidence:
+  - [ ] `go test ./...`
+  - [ ] `go vet ./...`
+  - [ ] `gofmt -l .` empty
+  - [ ] web lint/typecheck/tests/build where web changed
+  - [ ] `cd cdk && npm run synth`
+  - [ ] `bash gov-infra/verifiers/gov-verify-rubric.sh`
+  - [ ] Slither / solhint / Hardhat evidence for contract changes
+
+## Lab deploy
+
+Command (operator-run, no timeout):
+
+```bash
+AWS_PROFILE=<lab-profile> theory app up --stage lab
+```
+
+Capture:
+
+- Start time (UTC): `____________________________`
+- End time (UTC): `____________________________`
+- CloudFormation stack events reviewed: `yes / no`
+- Deploy output artifact/log location: `____________________________`
+
+## Lab smoke checks
+
+### Control plane and portal
+
+- [ ] Wallet login challenge/login succeeds for an operator test account.
+- [ ] Portal customer wallet login works.
+- [ ] Portal instance list/details routes load without 5xx.
+- [ ] Portal managed-update version fields accept intended blank/config-only actions and reject invalid versions.
+- [ ] Portal self-service soul provisioning remains policy-gated.
+
+### Public soul and trust surfaces
+
+- [ ] Public soul lookup/search/version endpoints return bounded pages and usable cursors.
+- [ ] Public avatar enrichment does not trigger unbounded chain/RPC fanout.
+- [ ] Dispute and validation public responses are redacted or auth-gated as expected.
+- [ ] Trust API public routes still serve `/.well-known/jwks.json` and `/attestations*`.
+- [ ] Instance-authenticated trust routes still require bearer token hashes; raw keys are not logged.
+
+### Comm, mailbox, and provider webhooks
+
+- [ ] Valid SES/email ingress sample with passing verdict is accepted.
+- [ ] Failing SES verdict sample is rejected or avoids sender enrichment.
+- [ ] Valid Telnyx/Migadu webhook samples are accepted.
+- [ ] Invalid/replayed webhook samples are rejected and do not debit budgets or mutate delivery state.
+- [ ] Mailbox duplicate `Message-ID` sample cannot overwrite content.
+- [ ] Outbound voice status callback bills the originating soul-owned channel exactly once.
+
+### Web/CSP
+
+- [ ] Web app loads from the first-party origin.
+- [ ] Browser console has no CSP violations for normal portal paths.
+- [ ] Markdown content with unsafe HTML/URLs is sanitized, not rendered as executable content.
+
+### Managed provisioning / update dry-run
+
+- [ ] Managed update dry-run/test slug uses pinned lesser/body versions.
+- [ ] Release checksum mismatch test still fails closed.
+- [ ] Instance-key secret names include stage isolation.
+- [ ] Trust verification after update uses authenticated instance key flow.
+- [ ] Lesser M9 is not consumed unless exact M9 assets have passed certification/readiness.
+
+## On-chain rollout gate
+
+For contract bytecode changes from M2:
+
+- [ ] Hardhat tests passed for the exact artifact.
+- [ ] solhint completed; warnings/errors dispositioned.
+- [ ] Slither completed; findings fixed or documented.
+- [ ] Sepolia deploy executed.
+- [ ] Sepolia contract source/bytecode verified.
+- [ ] Sepolia behavior smoke tested.
+- [ ] Mainnet Safe-ready payload prepared only after Sepolia evidence.
+- [ ] Mainnet execution explicitly authorized by Safe signers.
+- [ ] `docs/deployments/` updated after any authorized deployment.
+
+## Lab soak
+
+Minimum soak: one business day unless Aron explicitly authorizes a compressed hotfix soak.
+
+Monitor during soak:
+
+- CloudWatch error rate per Lambda entrypoint.
+- CloudFront 4xx/5xx by path family.
+- `control-plane-api` errors for `/api/v1/soul/*`, `/api/v1/portal/*`, `/auth/*`, and `/setup/*`.
+- `trust-api` instance-auth failures and 5xx rate.
+- `email-ingress` SES verdict rejects and parse failures.
+- `comm-worker` queue depth and DLQ.
+- Provider webhook rejects by reason and replay/idempotency counters where available.
+- `provision-worker` SQS depth, CodeBuild failures, and managed-update failures.
+- `ai-worker` queue depth, LLM token/cost error rates, and fallback behavior.
+- `soul-reputation-worker` failures and suspended-agent reputation output.
+- eth_rpc latency/error rates and public read request latency.
+
+Lab soak result:
+
+- Start time (UTC): `____________________________`
+- End time (UTC): `____________________________`
+- Blocking regressions found: `yes / no`
+- Regression issue/PR links: `____________________________`
+- Operator who accepted lab soak: `____________________________`
+
+## Live authorization checklist
+
+Before live deploy:
+
+- [ ] Lab soak accepted.
+- [ ] M5 PR merged and CI green.
+- [ ] Sepolia/on-chain evidence captured if contract deployment is in scope.
+- [ ] Managed canary target selected if provisioning/update rollout is in scope.
+- [ ] Customer/operator communications prepared from release notes.
+- [ ] Rollback owner available.
+- [ ] Live deploy explicitly authorized by Aron/operator.
+
+Live command (operator-run, no timeout):
+
+```bash
+AWS_PROFILE=<live-profile> theory app up --stage live
+```
+
+## Post-live monitoring
+
+Watch for at least the first hour, then through the next business-day window:
+
+- CloudFront 4xx/5xx by route family.
+- Lambda error and duration p95/p99 by entrypoint.
+- DynamoDB throttles/conditional failures that indicate unexpected contention.
+- SQS queue age and DLQ depth for provision, comm, preview, safety, render, and AI queues.
+- Provider webhook authentication reject rates.
+- SES inbound verdict reject rates.
+- Public soul read/search/version latency and error rates.
+- trust-api instance-auth failure rates.
+- Billing/usage ledger idempotency errors.
+- Managed provisioning/update CodeBuild failures.
+- On-chain receipt validation rejects and successful validated operations.
+
+Post-live result:
+
+- Live deploy start (UTC): `____________________________`
+- Live deploy end (UTC): `____________________________`
+- First-hour monitor accepted by: `____________________________`
+- Next-business-day monitor accepted by: `____________________________`
+- Follow-up issues opened: `____________________________`

--- a/docs/security/codex-security-release-notes-2026-04-29.md
+++ b/docs/security/codex-security-release-notes-2026-04-29.md
@@ -1,0 +1,76 @@
+# Release notes — Codex Security remediation 2026-04-29
+
+These notes summarize the M0-M4.5 security hardening line for operators preparing a `lesser.host` lab/live rollout.
+They are not a deploy authorization by themselves.
+
+## Security fixes
+
+### Public ingress, comms, mailbox, and privacy
+
+- Comm provider webhooks are authenticated and replay/idempotency checked before state changes or billing effects.
+- SES-derived sender identity is gated on authentication verdicts before enrichment.
+- Mailbox content writes are reserved/immutable and previews are bounded.
+- Email, phone, ENS, and channel index writes enforce ownership/uniqueness before public mappings are updated.
+- Public dispute/validation/channel/search surfaces are redacted, bounded, or auth-gated where required.
+
+### Soul registry and on-chain operation integrity
+
+- Soul operation execution recording is bound to expected transaction target, calldata/value/effects, and agent-specific
+  state transitions before status or side effects are recorded.
+- Lifecycle, continuity, registration, and relationship signatures/canonicalization have replay and history-integrity
+  guardrails.
+- Public relationship/endorsement merges are bounded and cursor-safe.
+- Solidity contract fixes were tested and linted; any bytecode rollout still requires Sepolia evidence before mainnet
+  Safe-ready execution.
+
+### Managed provisioning, managed updates, and release verification
+
+- Managed provisioning/update release versions must be pinned or explicitly resolved; no silent `latest` default is used.
+- Release `git_sha` values and compatibility contracts are validated before source checkout or managed update execution.
+- lesser-body template certification/readiness evidence fails closed when evidence mismatches or deployment fails.
+- Managed-release canary routing is restricted to approved HTTPS host origins.
+- Instance-key secret names are stage-isolated, and trust verification remains authenticated.
+- Managed-update metadata handling, receipt semantics, and tip config validation were hardened.
+
+### Public read scalability, CSP/web, governance, and reliability
+
+- Public soul reads/search/version/ENS paths are bounded, cached, paginated, or rate/cost aware.
+- Markdown rendering remains mandatory-sanitized under strict single-origin CSP; no `unsafe-inline`, `unsafe-eval`, or
+  third-party script origin was added.
+- CMP-4 governance verification now checks semantics, not just keyword presence.
+- Trust-route runtime/IAM gaps and TableTheory soul model registration gaps were fixed.
+- AppTheory deploy command interpolation was hardened without patching AppTheory locally.
+
+### Lesser M9 provisioning alignment
+
+- Host emits Lesser M9 `lesser.init_admin_consent.v1` structured JSON for managed `init-admin` consent.
+- The exact signed consent bytes are preserved from browser wallet signing through `ProvisionJob`, CodeBuild
+  `CONSENT_MESSAGE_B64`, `provision.json`, and `lesser init-admin`.
+- Host will not consume/certify Lesser M9 until exact published release assets pass checksum verification,
+  managed-release certification/readiness, lab dry-run, and canary evidence.
+
+## Operator action required
+
+1. Review `docs/security/codex-security-m5-evidence-2026-04-29.md` and the merged PR validation sections.
+2. Deploy to lab via `theory app up --stage lab` without adding a timeout.
+3. Complete the lab soak checklist in `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`.
+4. Capture Sepolia evidence for contract bytecode changes before any mainnet Safe-ready execution.
+5. Select a managed-instance canary for provisioning/update changes.
+6. Seek explicit live deploy authorization after lab soak.
+
+## Backward compatibility and customer impact
+
+- Public APIs may return redacted/bounded responses where prior responses exposed dispute/validation/channel data or
+  performed unbounded reads.
+- Provider webhook calls without valid authentication or replay freshness are rejected.
+- Managed provisioning and managed updates now fail closed on unpinned, incompatible, or checksum-mismatched releases.
+- Portal/self-service paths enforce stricter policy around soul provisioning and update versions.
+- Existing Lesser releases remain usable when they pass the managed compatibility/release verification contract; Lesser M9
+  adds the structured `init-admin` consent expectation described in managed provisioning docs.
+
+## Rollback notes
+
+- Host service rollback is by reverting the offending commit and redeploying through AppTheory/CDK. Do not delete Lambda
+  versions, retained state resources, SSM parameters, Secrets Manager values, Route53 zones, or CloudFormation stacks.
+- On-chain rollback is not available; forward-fix through Sepolia-tested and Safe-ready governance paths.
+- Managed-instance rollback/remediation is per slug and must not bypass release checksum verification.


### PR DESCRIPTION
## Milestone
M5 — Evidence and rollout for Codex Security 2026-04-28 remediation.

## Classification
security / host docs / governance evidence / rollout handoff

## Surfaces affected
- `docs/security/codex-security-m5-evidence-2026-04-29.md`
- `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`
- `docs/security/codex-security-release-notes-2026-04-29.md`
- `docs/README.md`
- `docs/roadmap-codex-security-remediation-2026-04-28.md`

## Specialist walks referenced
- Governance rubric: no verifier or pack change; gov-infra verifier stayed green.
- Provisioning / managed-update / release verification: docs preserve the checksum-verification, lab dry-run, and canary gates; no provisioning code changed.
- Soul registry: no code or on-chain transaction in this PR; checklist preserves Slither/Hardhat/solhint, Sepolia, and Safe-ready requirements for M2 bytecode rollout.
- Trust API / CSP / instance-auth: no code change; release notes/checklist preserve strict instance-auth and CSP posture.
- Framework: no framework patch; AppTheory deploy behavior remains a rollout handoff.

## Multi-tenant isolation impact
None. This PR only adds operator-facing evidence and rollout documents, and does not introduce tenant data storage, cross-tenant reads, or credential movement.

## On-chain impact
None in this PR. The M5 evidence package explicitly keeps Sepolia evidence and any mainnet Safe-ready execution as separate operator-run gates.

## Consumer impact
Managed operators get a single evidence package, release notes, and lab/live rollout checklist for the M0-M4.5 security remediation line.

## Tasks
- [x] #209 Complete regression suite, docs, gov evidence, and release notes
- [x] #210 Prepare the lab/live rollout monitoring checklist

Closes #209
Refs #186
Refs #210

## Validation
Run locally on the M5 branch after docs were added:

- [x] `gofmt -l .`
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS `29` / FAIL `0` / BLOCKED `0`
- [x] `cd cdk && npm ci && npm run synth` — PASS with existing-style CDK warnings only

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Operator runs `theory app up --stage lab` without a timeout
- [ ] Lab smoke checks and one-business-day soak captured in the M5 checklist
- [ ] Sepolia evidence captured before any mainnet Safe-ready execution for contract bytecode changes
- [ ] Lesser M9 release assets certified through checksum-verified managed-release readiness before consumption
- [ ] Managed-instance canary selected and verified before broader provisioning/update rollout
- [ ] Live deploy explicitly authorized after lab soak
- [ ] Post-live monitoring verified

## Cross-repo coordination
Lesser M9 remains a referenced external gate through #221; this PR does not consume uncertified Lesser M9 assets.

## Advisor-brief authorization
Not applicable.
