### PR TITLE
chore(deps): pin latest Theory Cloud releases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v79 v79.12.0
-	github.com/theory-cloud/apptheory v1.1.0
-	github.com/theory-cloud/tabletheory v1.7.0
+	github.com/theory-cloud/apptheory v1.2.0
+	github.com/theory-cloud/tabletheory v1.7.1
 	golang.org/x/net v0.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -273,10 +273,10 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theory-cloud/apptheory v1.1.0 h1:xz0QAvBBQOWQ5n3Wo34l3lGR/ivaTktovzlgSJh5n90=
-github.com/theory-cloud/apptheory v1.1.0/go.mod h1:KoLO2fEjZPOXcOb8jepWlBf6wP1q3ZxaBrD2XEvrulc=
-github.com/theory-cloud/tabletheory v1.7.0 h1:FXUDnL1l2sSzUXTP6usfiwFlYZ5xfvIYnC3GzecuexY=
-github.com/theory-cloud/tabletheory v1.7.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/apptheory v1.2.0 h1:166njRE0GE+FfCVUlfIrPQe6fEoIpY2/slITb6SxknQ=
+github.com/theory-cloud/apptheory v1.2.0/go.mod h1:opIhZD4ipxAKa32+ELwHjfeXaHDRnd17tcVG5+H8134=
+github.com/theory-cloud/tabletheory v1.7.1 h1:pS0RoV6MpXtznL/z5tA4PLQ9vCoVo8Fo60FE1OgUTtY=
+github.com/theory-cloud/tabletheory v1.7.1/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
## Summary

Pins host's Theory Cloud Go dependencies to the latest verified upstream releases:

- `github.com/theory-cloud/apptheory`: `v1.1.0` → `v1.2.0`
- `github.com/theory-cloud/tabletheory`: `v1.7.0` → `v1.7.1`

## Source verification

Latest release metadata was checked before updating:

- AppTheory `v1.2.0`: https://github.com/theory-cloud/AppTheory/releases/tag/v1.2.0
- TableTheory `v1.7.1`: https://github.com/theory-cloud/TableTheory/releases/tag/v1.7.1
- `go list -m -json github.com/theory-cloud/apptheory@latest github.com/theory-cloud/tabletheory@latest`

## Stewardship notes

- No local AppTheory/TableTheory patches.
- No tenant data, trust API, CSP, release-verification, or on-chain behavior changes.
- This is dependency pinning only in `go.mod` / `go.sum`.

## Validation

- [x] `gofmt -l .`
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29 / FAIL 0 / BLOCKED 0
- [x] `cd cdk && npm ci && npm run synth` — PASS with existing CDK deprecation/feature-flag warnings

## Rollout

No deploy is run in this PR. Standard branch → PR → review → CI path only.
