### PR TITLE
chore(deps): bump Theory Cloud frameworks

### DIFF
--- a/app-theory/app.json
+++ b/app-theory/app.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "apptheory": {
       "module": "github.com/theory-cloud/apptheory",
-      "version": "v1.1.0",
+      "version": "v1.3.0",
       "docs": [
         "docs/getting-started.md",
         "docs/migration/from-lift.md"
@@ -11,7 +11,7 @@
     },
     "tabletheory": {
       "module": "github.com/theory-cloud/tabletheory",
-      "version": "v1.7.0",
+      "version": "v1.8.0",
       "docs": [
         "docs/getting-started.md",
         "docs/api-reference.md",

--- a/go.mod
+++ b/go.mod
@@ -31,8 +31,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v79 v79.12.0
-	github.com/theory-cloud/apptheory v1.2.0
-	github.com/theory-cloud/tabletheory v1.7.1
+	github.com/theory-cloud/apptheory v1.3.0
+	github.com/theory-cloud/tabletheory v1.8.0
 	golang.org/x/net v0.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -273,10 +273,10 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theory-cloud/apptheory v1.2.0 h1:166njRE0GE+FfCVUlfIrPQe6fEoIpY2/slITb6SxknQ=
-github.com/theory-cloud/apptheory v1.2.0/go.mod h1:opIhZD4ipxAKa32+ELwHjfeXaHDRnd17tcVG5+H8134=
-github.com/theory-cloud/tabletheory v1.7.1 h1:pS0RoV6MpXtznL/z5tA4PLQ9vCoVo8Fo60FE1OgUTtY=
-github.com/theory-cloud/tabletheory v1.7.1/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
+github.com/theory-cloud/apptheory v1.3.0 h1:B/7CEv1N3+ymFehaQ7o7PB5XFQGcgD5tnFO4akKESKA=
+github.com/theory-cloud/apptheory v1.3.0/go.mod h1:V0j0LoaaTmRlRfkS8cxh0hWEZMyvniayixg4Hx+sA0g=
+github.com/theory-cloud/tabletheory v1.8.0 h1:IdbEfjjUbyYEj2tCkS/e1rjOHmWUCqZSiPuIcTf7oao=
+github.com/theory-cloud/tabletheory v1.8.0/go.mod h1:ZbXJkyBD2iTw/Ht3fec3BTECZaOD72D2ufAuTz6ZYrU=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=


### PR DESCRIPTION
## Milestone
Theory Cloud dependency maintenance — update host to AppTheory v1.3.0 and TableTheory v1.8.0.

## Classification
dependency-maintenance / framework-consumption

## Surfaces affected
- `go.mod` / `go.sum` Theory Cloud module pins
- `app-theory/app.json` framework manifest pins

## Specialist walks referenced
- Governance rubric: no rubric/verifier change
- Provisioning / managed-update / release verification: no managed provisioning path or consumer release verification change
- Soul registry: no on-chain, contract, mint-signer, or Safe-ready payload change
- Trust API / CSP / instance-auth: no trust API auth, attestation, or CSP change
- Framework: idiomatic consumption of published AppTheory/TableTheory releases; no local framework patches

## Multi-tenant isolation impact
None. Dependency pins only; no tenant data paths or cross-account boundaries changed.

## On-chain impact
None. No Solidity, on-chain-reaching code, or governance payload change.

## Consumer impact
Managed operators receive the updated framework runtime dependencies after normal `lab` soak and authorized `live` rollout.

## Tasks
- [x] Pin `github.com/theory-cloud/apptheory` to `v1.3.0`
- [x] Pin `github.com/theory-cloud/tabletheory` to `v1.8.0`
- [x] Align `app-theory/app.json` framework versions with the Go module graph

## Validation
- [x] `git diff --check`
- [x] `jq . app-theory/app.json >/dev/null`
- [x] `gofmt -l .` (empty)
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` (PASS 29/0/0)
- [x] `cd cdk && npm ci && npm run synth` (passed with existing CDK deprecation/feature-flag warnings)

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete
- [ ] Deployed to live
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required; this consumes published Theory Cloud releases without patching framework code.

## Advisor-brief authorization (if applicable)
Not applicable.
