### PR TITLE
M6 pre-live provisioning hardening

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -687,15 +687,6 @@ export class LesserHostStack extends cdk.Stack {
 				resources: [`arn:aws:iam::*:role/${managedInstanceRoleName.trim() || defaultManagedInstanceRoleName}`],
 			}),
 		);
-		if (managedOrgVendingRoleArn.trim()) {
-			provisionRunnerProject.addToRolePolicy(
-				new iam.PolicyStatement({
-					actions: ['sts:AssumeRole'],
-					resources: [managedOrgVendingRoleArn.trim()],
-				}),
-			);
-		}
-
 		provisionWorkerFn.addToRolePolicy(
 			new iam.PolicyStatement({
 				actions: [

--- a/cdk/lib/provision-runner/prebuild.sh
+++ b/cdk/lib/provision-runner/prebuild.sh
@@ -2,15 +2,8 @@
 # Pre-build phase: assume IAM roles into the target managed account.
 set -euo pipefail
 
-echo "Assuming role into target account..."
-if [ -n "${MANAGED_ORG_VENDING_ROLE_ARN:-}" ]; then
-  echo "Assuming org vending role..."
-  ORG_CREDS=$(aws sts assume-role --role-arn "$MANAGED_ORG_VENDING_ROLE_ARN" --role-session-name "lesser-host-org-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text)
-  read ORG_AK ORG_SK ORG_TOKEN <<< "$ORG_CREDS"
-  CREDS=$(AWS_ACCESS_KEY_ID=$ORG_AK AWS_SECRET_ACCESS_KEY=$ORG_SK AWS_SESSION_TOKEN=$ORG_TOKEN aws sts assume-role --role-arn "arn:aws:iam::$TARGET_ACCOUNT_ID:role/$TARGET_ROLE_NAME" --role-session-name "lesser-host-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text)
-else
-  CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::$TARGET_ACCOUNT_ID:role/$TARGET_ROLE_NAME" --role-session-name "lesser-host-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text)
-fi
+echo "Assuming managed-instance role in target account..."
+CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::$TARGET_ACCOUNT_ID:role/$TARGET_ROLE_NAME" --role-session-name "lesser-host-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text)
 read MANAGED_AK MANAGED_SK MANAGED_TOKEN <<< "$CREDS"
 mkdir -p ~/.aws
 printf "[managed]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s\n" "$MANAGED_AK" "$MANAGED_SK" "$MANAGED_TOKEN" > ~/.aws/credentials

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -27,6 +27,14 @@ function synthTemplate(): SynthesizedTemplate {
 	return synthesizedTemplate;
 }
 
+function synthTemplateWithContext(context: Record<string, unknown>): SynthesizedTemplate {
+	const app = new cdk.App({ context });
+	const stack = new LesserHostStack(app, 'TestLesserHostStackWithContext', { stage: 'lab' });
+	const assembly = app.synth();
+	const artifact = assembly.getStackArtifact(stack.artifactId);
+	return JSON.parse(readFileSync(artifact.templateFullPath, 'utf8')) as SynthesizedTemplate;
+}
+
 function findResources(template: SynthesizedTemplate, type: string): Array<Record<string, unknown>> {
 	return Object.values(template.Resources ?? {})
 		.filter((resource) => resource?.Type === type)
@@ -102,5 +110,69 @@ test('trust api receives soul registration runtime configuration', () => {
 		'SOUL_PACK_BUCKET_NAME',
 	]) {
 		assert.ok(key in env, `expected trust-api environment to include ${key}`);
+	}
+});
+
+test('provision runner cannot assume the organization vending role', () => {
+	const orgVendingRoleArn = 'arn:aws:iam::123456789012:role/lesser-host-org-vending';
+	const template = synthTemplateWithContext({ managedOrgVendingRoleArn: orgVendingRoleArn });
+	const resources = template.Resources ?? {};
+
+	const codeBuildRoleIds = new Set(
+		Object.entries(resources)
+			.filter(([, resource]) => {
+				if (resource.Type !== 'AWS::IAM::Role') {
+					return false;
+				}
+				const policy = resource.Properties?.AssumeRolePolicyDocument;
+				const statements = policy && typeof policy === 'object'
+					? (policy as { Statement?: unknown }).Statement
+					: undefined;
+				if (!Array.isArray(statements)) {
+					return false;
+				}
+				return statements.some((statement) => {
+					const principal = statement && typeof statement === 'object'
+						? (statement as { Principal?: unknown }).Principal
+						: undefined;
+					const service = principal && typeof principal === 'object'
+						? (principal as { Service?: unknown }).Service
+						: undefined;
+					return service === 'codebuild.amazonaws.com';
+				});
+			})
+			.map(([logicalId]) => logicalId),
+	);
+	assert.ok(codeBuildRoleIds.size > 0, 'expected a CodeBuild service role');
+
+	for (const [logicalId, resource] of Object.entries(resources)) {
+		if (resource.Type !== 'AWS::IAM::Policy') {
+			continue;
+		}
+		const roles = resource.Properties?.Roles;
+		const attachedToCodeBuild = Array.isArray(roles) && roles.some((role) => {
+			return role && typeof role === 'object' &&
+				'Ref' in role &&
+				codeBuildRoleIds.has((role as { Ref?: string }).Ref ?? '');
+		});
+		if (!attachedToCodeBuild) {
+			continue;
+		}
+
+		const doc = resource.Properties?.PolicyDocument;
+		const statements = doc && typeof doc === 'object'
+			? (doc as { Statement?: unknown }).Statement
+			: undefined;
+		assert.ok(Array.isArray(statements), `expected ${logicalId} to have policy statements`);
+		for (const statement of statements) {
+			const resourceValue = statement && typeof statement === 'object'
+				? (statement as { Resource?: unknown }).Resource
+				: undefined;
+			const resourcesValue = Array.isArray(resourceValue) ? resourceValue : [resourceValue];
+			assert.ok(
+				!resourcesValue.includes(orgVendingRoleArn),
+				`expected ${logicalId} to omit org vending role from CodeBuild policies`,
+			);
+		}
 	}
 });

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,8 @@ This directory contains maintainer documentation for `lesser-host` (the `lesser.
 ## Security remediation records
 
 - Codex Security 2026-04-28 finding ledger: `docs/security/codex-findings-2026-04-28-ledger.md`
+- Codex Security 2026-04-30 round-2 ledger: `docs/security/codex-findings-2026-04-30-round2-ledger.md`
+- Host Security round-2 pre-live rollout notes: `docs/security/host-security-round2-prelive-rollout.md`
 - M0 evidence baseline: `docs/security/codex-security-m0-evidence-baseline-2026-04-28.md`
 - M5 evidence package: `docs/security/codex-security-m5-evidence-2026-04-29.md`
 - M5 rollout checklist: `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`

--- a/docs/security/codex-findings-2026-04-30-round2-ledger.md
+++ b/docs/security/codex-findings-2026-04-30-round2-ledger.md
@@ -1,0 +1,37 @@
+# Codex Security round 2 ledger — 2026-04-30
+
+This repository-safe ledger records the second Codex Security review for host. The source CSV remains local at
+`.theory/codex-security-findings-2026-04-30T13-51-20.970Z.csv`; do not copy exploit-ready finding text into public
+documentation.
+
+## Review baseline
+
+- Reviewed against host `main` commit `f613299716b442c3bb82466dfa293bdc8a0c73da`.
+- Deployment assumption for this remediation line: host is pre-live, with active validation limited to lab and Sepolia.
+- There are no live users, live data, or live tipping events to preserve.
+- Existing lab data may be migrated, denied, or reset where that simplifies secure pre-live state.
+- `theory` is the internal validation stage; `simulacrum` is the host-lab canary.
+- Parallel Lesser security remediation is coordinated before host consumes or canaries relevant Lesser release artifacts.
+
+## Triage counts
+
+| Classification | Count | Rows |
+| --- | ---: | --- |
+| Fixed or stale after the prior merged work | 37 | `1-6`, `22-39`, `59-65`, `67-69`, `71-73` |
+| Confirmed outstanding | 37 | Tracked through M6-M9 below |
+| Partial / residual / policy | 3 | Tracked through M6-M9 below |
+
+## Remediation tracking
+
+| Milestone | GitHub issue | Scope | Rows |
+| --- | --- | --- | --- |
+| M6 | #226 | Pre-live isolation and provisioning hardening | `7-12`, `43`, `45`, `51`, `76`, plus partial/policy `20`, `48` |
+| M7 | #227 | Trust, AI, managed-update, and billing hardening | `13-16`, `40-42`, `52-58`, `77`, plus residual `57` |
+| M8 | #228 | Comms, operator surface, web, and test reliability | `18`, `19`, `21`, `44`, `49`, `50`, `66`, `70`, `74`, `75` |
+| M9 | #229 | Sepolia TipSplitter hardening | `17`, `47` |
+
+## Disclosure discipline
+
+This ledger intentionally records row numbers, counts, assumptions, and milestone ownership only. Detailed finding text
+stays in the local scan artifact and the private triage context until the corresponding fix lands. Public release notes
+should summarize fixed classes of risk after merge rather than advertise unresolved exploit paths before remediation.

--- a/docs/security/host-security-round2-prelive-rollout.md
+++ b/docs/security/host-security-round2-prelive-rollout.md
@@ -1,0 +1,27 @@
+# Host Security round 2 pre-live rollout notes
+
+This note accompanies the M6-M9 round-2 hardening work. It is intentionally operational and does not duplicate detailed
+finding text from the local Codex Security CSV.
+
+## Current deployment posture
+
+- Host validation is lab/Sepolia only for this line of work.
+- No live users, live data, or live tipping events are in scope.
+- Existing lab data can be migrated, denied, or reset if the stricter security model requires it.
+
+## Stage order
+
+1. Merge each milestone through PR review with gov-infra verifiers green.
+2. Deploy host lab through the AppTheory deploy contract.
+3. Validate the `theory` dev stage first.
+4. Use `simulacrum` as the host-lab canary for managed provisioning and managed-release consumption.
+5. Defer any live deployment until Aron explicitly authorizes a future live-readiness rollout.
+
+## Lesser coordination gate
+
+Parallel Lesser remediation must be consumed through host's normal managed-release discipline:
+
+- Host does not sign off from Lesser source review or fixtures alone.
+- The exact published Lesser release artifacts must be downloaded and checksum-verified through host's real consumer path.
+- `theory` validation precedes `simulacrum` canary for relevant producer/consumer contract changes.
+- Any interface drift is coordinated through Aron with the Lesser steward before host canary signoff.

--- a/docs/security/host-security-round2-prelive-rollout.md
+++ b/docs/security/host-security-round2-prelive-rollout.md
@@ -25,3 +25,13 @@ Parallel Lesser remediation must be consumed through host's normal managed-relea
 - The exact published Lesser release artifacts must be downloaded and checksum-verified through host's real consumer path.
 - `theory` validation precedes `simulacrum` canary for relevant producer/consumer contract changes.
 - Any interface drift is coordinated through Aron with the Lesser steward before host canary signoff.
+
+## M6 canary checklist
+
+M6 is considered ready for broader lab soak only after all of the following are true:
+
+- Host lab deploy includes the M6 control-plane, CDK, and provisioning-worker changes.
+- `theory` validates account adoption, consent one-time use, provisioning leases, and managed-update runner dispatch.
+- Host consumes a published Lesser artifact through managed-release certification; no source-only signoff.
+- `simulacrum` runs as the host-lab canary after `theory` passes, using the same verified Lesser artifact line.
+- Any Lesser-side rollout blocker is recorded on the M6 tracking issue/PR before canary signoff.

--- a/gov-infra/pack.json
+++ b/gov-infra/pack.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://gov.pai.dev/schemas/pack.schema.json",
   "schemaVersion": 1,
-  "packVersion": "5ff40b430fd8",
-  "packDigest": "5ff40b430fd800229f21baaa2f3e38fa43ce5332185f953a07380d7e46b2e25e",
+  "packVersion": "2026.04.30-m6",
+  "packDigest": "506c5bee3285c5d902ea39f0070bd8bfe753a51a91147c06d2e0d658be963d8d",
   "domain": "custom",
   "projectSlug": "lesser-host",
-  "generatedAt": "2026-04-29T12:16:47Z",
+  "generatedAt": "2026-04-30T15:30:00Z",
   "source": {
     "commitSha": "UNKNOWN",
-    "branch": "codex/security-m4-public-web-governance-reliability"
+    "branch": "codex/host-security-m6-prelive-hardening"
   },
   "artifacts": {
     "planning": [

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -446,22 +446,57 @@ scan_python_supply_chain() {
 }
 
 check_supply_chain_actions_pinned() {
-  # Enforces integrity pinning for GitHub Actions (reject floating tags like @v4).
+  # Enforces integrity pinning for GitHub Actions. External actions must pin
+  # either a full 40-character commit SHA or a full SemVer release tag
+  # (vX.Y.Z). Floating refs such as @v4, @v4.1, @main, @master, and branch
+  # names are rejected.
   local wf_dir="${REPO_ROOT}/.github/workflows"
   if [[ ! -d "${wf_dir}" ]]; then
     echo "GitHub Actions pin check: no workflows detected; skipping."
     return 0
   fi
 
-  local matches=""
-  matches="$(grep -R --include='*.yml' --include='*.yaml' -nE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]].*@v[0-9]+' "${wf_dir}" 2>/dev/null || true)"
-  if [[ -n "${matches}" ]]; then
-    echo "FAIL: unpinned GitHub Action detected (uses @vN; pin by commit SHA)"
-    echo "${matches}"
+  local failures=""
+  local line file lineno value action ref
+  while IFS= read -r line; do
+    file="${line%%:*}"
+    local rest="${line#*:}"
+    lineno="${rest%%:*}"
+    value="${rest#*:}"
+    value="$(printf '%s' "${value}" | sed -E 's/^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*//; s/[[:space:]]+#.*$//; s/^[\"'\\'' ]+//; s/[\"'\\'' ]+$//')"
+    [[ -n "${value}" ]] || continue
+
+    # Local reusable actions and docker image actions do not use owner/repo@ref.
+    if [[ "${value}" == ./* ]] || [[ "${value}" == docker://* ]]; then
+      continue
+    fi
+
+    if [[ "${value}" != *@* ]]; then
+      failures+="${file}:${lineno}: ${value} (missing @ref)"$'\n'
+      continue
+    fi
+
+    action="${value%@*}"
+    ref="${value##*@}"
+    if [[ -z "${action}" || -z "${ref}" ]]; then
+      failures+="${file}:${lineno}: ${value} (malformed uses ref)"$'\n'
+      continue
+    fi
+
+    if [[ "${ref}" =~ ^[0-9a-fA-F]{40}$ ]] || [[ "${ref}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+      continue
+    fi
+
+    failures+="${file}:${lineno}: ${value} (ref must be 40-char SHA or vX.Y.Z)"$'\n'
+  done < <(grep -R --include='*.yml' --include='*.yaml' -nE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*' "${wf_dir}" 2>/dev/null || true)
+
+  if [[ -n "${failures}" ]]; then
+    echo "FAIL: unpinned GitHub Action detected"
+    printf '%s' "${failures}"
     return 1
   fi
 
-  echo "GitHub Actions pin check: PASS (no uses @vN detected)"
+  echo "GitHub Actions pin check: PASS (all external uses refs are 40-char SHA or vX.Y.Z)"
   return 0
 }
 
@@ -864,7 +899,7 @@ scan_node_project_supply_chain() {
 
 check_supply_chain() {
   # SEC-3: Supply-chain verification gate.
-  # - Enforces GitHub Actions SHA pinning (no uses: ...@vN).
+  # - Enforces GitHub Actions ref pinning (40-char SHA or vX.Y.Z; no floating refs).
   # - Scans Node dependencies for subprojects (web/, cdk/, contracts/) with scripts disabled.
   # - Runs lightweight Go and Python metadata scans.
 

--- a/internal/controlplane/handlers_operator_provisioning.go
+++ b/internal/controlplane/handlers_operator_provisioning.go
@@ -383,7 +383,8 @@ func (s *Server) handleGetOperatorProvisionJob(ctx *apptheory.Context) (*apptheo
 	}
 
 	if status := strings.ToLower(strings.TrimSpace(job.Status)); status == models.ProvisionJobStatusQueued || status == models.ProvisionJobStatusRunning {
-		if shouldNudgeAsyncJob(time.Now().UTC(), job.UpdatedAt) {
+		now := time.Now().UTC()
+		if shouldNudgeAsyncJob(now, job.UpdatedAt) && !job.HasActiveLease(now) {
 			s.enqueueProvisionJobBestEffort(ctx, id)
 		}
 	}
@@ -480,6 +481,9 @@ func (s *Server) handleRetryOperatorProvisionJob(ctx *apptheory.Context) (*appth
 			return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to retry job"}
 		}
 	} else {
+		if !shouldNudgeAsyncJob(now, job.UpdatedAt) || job.HasActiveLease(now) {
+			return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(job))
+		}
 		audit := &models.AuditLogEntry{
 			Actor:     actor,
 			Action:    auditAction,

--- a/internal/controlplane/handlers_operator_provisioning.go
+++ b/internal/controlplane/handlers_operator_provisioning.go
@@ -171,10 +171,13 @@ func parseAdoptProvisionJobAccountRequest(ctx *apptheory.Context) (adoptProvisio
 		return req, &apptheory.AppError{Code: "app.bad_request", Message: "invalid request"}
 	}
 	req.AccountID = strings.TrimSpace(req.AccountID)
-	req.AccountEmail = strings.TrimSpace(req.AccountEmail)
+	req.AccountEmail = strings.ToLower(strings.TrimSpace(req.AccountEmail))
 	req.Note = strings.TrimSpace(req.Note)
 	if !isAWSAccountID(req.AccountID) {
 		return req, &apptheory.AppError{Code: "app.bad_request", Message: "account_id must be a 12-digit AWS account id"}
+	}
+	if req.AccountEmail == "" {
+		return req, &apptheory.AppError{Code: "app.bad_request", Message: "account_email is required for adoption validation"}
 	}
 	return req, nil
 }
@@ -193,6 +196,23 @@ func validateAdoptableProvisionJob(job *models.ProvisionJob) *apptheory.AppError
 	mode := strings.ToLower(strings.TrimSpace(job.Mode))
 	if mode != "" && mode != "managed" {
 		return &apptheory.AppError{Code: "app.conflict", Message: "job is not a managed provisioning job"}
+	}
+	return nil
+}
+
+func (s *Server) validateAdoptProvisionJobAccountRequest(job *models.ProvisionJob, req adoptProvisionJobAccountRequest) *apptheory.AppError {
+	if job == nil {
+		return &apptheory.AppError{Code: "app.not_found", Message: "job not found"}
+	}
+	expectedEmail := strings.ToLower(strings.TrimSpace(expandManagedAccountEmailTemplate(s.cfg.ManagedAccountEmailTemplate, job.InstanceSlug)))
+	if expectedEmail == "" {
+		return &apptheory.AppError{Code: "app.conflict", Message: "managed account email template is required for account adoption"}
+	}
+	if strings.ToLower(strings.TrimSpace(req.AccountEmail)) != expectedEmail {
+		return &apptheory.AppError{Code: "app.forbidden", Message: "account_email does not match expected managed account email"}
+	}
+	if existingAccountID := strings.TrimSpace(job.AccountID); existingAccountID != "" && existingAccountID != strings.TrimSpace(req.AccountID) {
+		return &apptheory.AppError{Code: "app.conflict", Message: "job already references a different account_id"}
 	}
 	return nil
 }
@@ -503,6 +523,9 @@ func (s *Server) handleAdoptOperatorProvisionJobAccount(ctx *apptheory.Context) 
 		return nil, appErr
 	}
 	if appErr := validateAdoptableProvisionJob(job); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.validateAdoptProvisionJobAccountRequest(job, req); appErr != nil {
 		return nil, appErr
 	}
 

--- a/internal/controlplane/handlers_operator_provisioning_internal_test.go
+++ b/internal/controlplane/handlers_operator_provisioning_internal_test.go
@@ -226,7 +226,11 @@ func TestHandleAdoptOperatorProvisionJobAccount(t *testing.T) {
 	s := &Server{
 		store:  store.New(tdb.db),
 		queues: &queueClient{},
-		cfg:    config.Config{ProvisionQueueURL: "url"},
+		cfg: config.Config{
+			ProvisionQueueURL:           "url",
+			ManagedAccountEmailTemplate: "ops+{slug}@example.com",
+			ManagedAccountNamePrefix:    "lesser-",
+		},
 	}
 
 	ctx := operatorCtx()
@@ -238,7 +242,7 @@ func TestHandleAdoptOperatorProvisionJobAccount(t *testing.T) {
 
 	ctx = operatorCtx()
 	ctx.Params = map[string]string{"id": "missing"}
-	ctx.Request.Body = []byte(`{"account_id":"123456789012"}`)
+	ctx.Request.Body = []byte(`{"account_id":"123456789012","account_email":"ops+inst@example.com"}`)
 	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(theoryErrors.ErrItemNotFound).Once()
 	if _, err := s.handleAdoptOperatorProvisionJobAccount(ctx); err == nil {
 		t.Fatalf("expected not found")
@@ -246,7 +250,7 @@ func TestHandleAdoptOperatorProvisionJobAccount(t *testing.T) {
 
 	ctx = operatorCtx()
 	ctx.Params = map[string]string{"id": "ok"}
-	ctx.Request.Body = []byte(`{"account_id":"123456789012"}`)
+	ctx.Request.Body = []byte(`{"account_id":"123456789012","account_email":"ops+inst@example.com"}`)
 	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
 		*dest = models.ProvisionJob{ID: "ok", InstanceSlug: "inst", Status: models.ProvisionJobStatusOK}
@@ -257,8 +261,20 @@ func TestHandleAdoptOperatorProvisionJobAccount(t *testing.T) {
 	}
 
 	ctx = operatorCtx()
+	ctx.Params = map[string]string{"id": "wrong-email"}
+	ctx.Request.Body = []byte(`{"account_id":"123456789012","account_email":"ops+other@example.com"}`)
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{ID: "wrong-email", InstanceSlug: "inst", Status: models.ProvisionJobStatusError}
+		_ = dest.UpdateKeys()
+	}).Once()
+	if _, err := s.handleAdoptOperatorProvisionJobAccount(ctx); err == nil {
+		t.Fatalf("expected forbidden for mismatched adoption email")
+	}
+
+	ctx = operatorCtx()
 	ctx.Params = map[string]string{"id": "e1"}
-	ctx.Request.Body = []byte(`{"account_id":"123456789012","account_email":"ops+demo@example.com","note":"recover"}`)
+	ctx.Request.Body = []byte(`{"account_id":"123456789012","account_email":"ops+inst@example.com","note":"recover"}`)
 	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
 		*dest = models.ProvisionJob{ID: "e1", InstanceSlug: "inst", Status: models.ProvisionJobStatusError, CreatedAt: time.Unix(1, 0).UTC()}

--- a/internal/controlplane/handlers_portal_instances.go
+++ b/internal/controlplane/handlers_portal_instances.go
@@ -580,6 +580,10 @@ func (s *Server) handlePortalGetInstanceBudgetMonth(ctx *apptheory.Context) (*ap
 }
 
 func (s *Server) handlePortalSetInstanceBudgetMonth(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if err := requireAdmin(ctx); err != nil {
+		return nil, err
+	}
+
 	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
 	if err != nil {
 		return nil, err

--- a/internal/controlplane/handlers_portal_instances.go
+++ b/internal/controlplane/handlers_portal_instances.go
@@ -405,16 +405,17 @@ func (s *Server) verifyPortalStartProvisionConsent(ctx *apptheory.Context, slug 
 	if appErr := validateProvisionConsentChallenge(ctx, chall, slug, stage, consentMessage); appErr != nil {
 		return req, appErr
 	}
+	if reqAdmin := strings.ToLower(strings.TrimSpace(req.AdminUsername)); reqAdmin != "" && reqAdmin != strings.ToLower(strings.TrimSpace(chall.AdminUsername)) {
+		return req, &apptheory.AppError{Code: "app.bad_request", Message: "admin_username does not match consent challenge"}
+	}
 	if reservedErr := validateNotReservedWalletAddress(strings.TrimSpace(chall.WalletAddr), "wallet"); reservedErr != nil {
 		return req, reservedErr
 	}
+	if appErr := s.consumeProvisionConsentChallenge(ctx, chall, consentMessage, time.Now().UTC()); appErr != nil {
+		return req, appErr
+	}
 	if verifyErr := verifyEthereumSignature(strings.TrimSpace(chall.WalletAddr), strings.TrimSpace(chall.Message), consentSignature); verifyErr != nil {
 		return req, &apptheory.AppError{Code: "app.forbidden", Message: "invalid signature"}
-	}
-	_ = s.deleteProvisionConsentChallenge(ctx, chall)
-
-	if reqAdmin := strings.ToLower(strings.TrimSpace(req.AdminUsername)); reqAdmin != "" && reqAdmin != strings.ToLower(strings.TrimSpace(chall.AdminUsername)) {
-		return req, &apptheory.AppError{Code: "app.bad_request", Message: "admin_username does not match consent challenge"}
 	}
 
 	// Canonicalize consent artifacts from the stored challenge message.
@@ -498,7 +499,8 @@ func (s *Server) handlePortalGetInstanceProvisioning(ctx *apptheory.Context) (*a
 	}
 
 	if status := strings.ToLower(strings.TrimSpace(job.Status)); status == models.ProvisionJobStatusQueued || status == models.ProvisionJobStatusRunning {
-		if shouldNudgeAsyncJob(time.Now().UTC(), job.UpdatedAt) {
+		now := time.Now().UTC()
+		if shouldNudgeAsyncJob(now, job.UpdatedAt) && !job.HasActiveLease(now) {
 			s.enqueueProvisionJobBestEffort(ctx, jobID)
 		}
 	}

--- a/internal/controlplane/handlers_portal_instances_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_internal_test.go
@@ -429,9 +429,22 @@ func TestHandlePortalSetInstanceBudgetMonth_SuccessPreservesUsedCredits(t *testi
 
 	body, _ := json.Marshal(setBudgetMonthRequest{IncludedCredits: 10})
 	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo", "month": "2026-01"}, Request: apptheory.Request{Body: body}}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
 	resp, err := s.handlePortalSetInstanceBudgetMonth(ctx)
 	if err != nil || resp == nil || resp.Status != 200 {
 		t.Fatalf("unexpected set budget resp: %#v err=%v", resp, err)
+	}
+}
+
+func TestHandlePortalSetInstanceBudgetMonth_RejectsCustomerSelfGrant(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	body, _ := json.Marshal(setBudgetMonthRequest{IncludedCredits: 10})
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo", "month": "2026-01"}, Request: apptheory.Request{Body: body}}
+
+	if _, err := s.handlePortalSetInstanceBudgetMonth(ctx); err == nil {
+		t.Fatalf("expected forbidden for customer budget grant")
 	}
 }
 
@@ -607,6 +620,7 @@ func TestHandlePortalSetInstanceBudgetMonth_RejectsIncludedLessThanUsed(t *testi
 
 	body, _ := json.Marshal(setBudgetMonthRequest{IncludedCredits: 3})
 	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo", "month": "2026-01"}, Request: apptheory.Request{Body: body}}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
 	if _, err := s.handlePortalSetInstanceBudgetMonth(ctx); err == nil {
 		t.Fatalf("expected conflict error")
 	}

--- a/internal/controlplane/handlers_portal_instances_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_internal_test.go
@@ -68,6 +68,7 @@ func newPortalTestDB() portalTestDB {
 		q.On("Limit", mock.Anything).Return(q).Maybe()
 		q.On("IfExists").Return(q).Maybe()
 		q.On("IfNotExists").Return(q).Maybe()
+		q.On("WithConditionExpression", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("Create").Return(nil).Maybe()
 		q.On("CreateOrUpdate").Return(nil).Maybe()

--- a/internal/controlplane/handlers_portal_instances_more_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_more_internal_test.go
@@ -339,13 +339,29 @@ func TestHandlePortalSetInstanceBudgetMonth_ErrorBranches(t *testing.T) {
 	t.Parallel()
 
 	makeCtx := func(body []byte) *apptheory.Context {
-		return &apptheory.Context{
+		ctx := &apptheory.Context{
 			AuthIdentity: "alice",
 			Params:       map[string]string{"slug": "demo", "month": "2026-01"},
 			Request:      apptheory.Request{Body: body},
 			RequestID:    "rid",
 		}
+		ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+		return ctx
 	}
+
+	t.Run("customer cannot self grant credits", func(t *testing.T) {
+		srv := &Server{}
+
+		body, _ := json.Marshal(setBudgetMonthRequest{IncludedCredits: 10})
+		ctx := &apptheory.Context{
+			AuthIdentity: "alice",
+			Params:       map[string]string{"slug": "demo", "month": "2026-01"},
+			Request:      apptheory.Request{Body: body},
+			RequestID:    "rid",
+		}
+		_, err := srv.handlePortalSetInstanceBudgetMonth(ctx)
+		requirePortalAppErrorCode(t, err, "app.forbidden")
+	})
 
 	t.Run("included credits must be non negative", func(t *testing.T) {
 		tdb := newPortalHandlerDB()

--- a/internal/controlplane/handlers_provisioning.go
+++ b/internal/controlplane/handlers_provisioning.go
@@ -65,7 +65,6 @@ type provisionJobResponse struct {
 	AdminUsername     string    `json:"admin_username,omitempty"`
 
 	ConsentMessageHash string `json:"consent_message_hash,omitempty"`
-	ConsentSignature   string `json:"consent_signature,omitempty"`
 
 	AccountRequestID string `json:"account_request_id,omitempty"`
 	AccountID        string `json:"account_id,omitempty"`
@@ -107,7 +106,6 @@ func provisionJobResponseFromModel(j *models.ProvisionJob) provisionJobResponse 
 		McpWiredAt:         j.McpWiredAt,
 		AdminUsername:      strings.TrimSpace(j.AdminUsername),
 		ConsentMessageHash: strings.TrimSpace(j.ConsentMessageHash),
-		ConsentSignature:   strings.TrimSpace(j.ConsentSignature),
 		AccountRequestID:   strings.TrimSpace(j.AccountRequestID),
 		AccountID:          strings.TrimSpace(j.AccountID),
 		ParentHostedZoneID: strings.TrimSpace(j.ParentHostedZoneID),
@@ -212,7 +210,10 @@ func (s *Server) getExistingProvisionJobAndNudge(ctx *apptheory.Context, inst *m
 		return nil, false
 	}
 
-	s.enqueueProvisionJobBestEffort(ctx, jobID)
+	now := time.Now().UTC()
+	if shouldNudgeAsyncJob(now, job.UpdatedAt) && !job.HasActiveLease(now) {
+		s.enqueueProvisionJobBestEffort(ctx, jobID)
+	}
 	return job, true
 }
 
@@ -418,7 +419,8 @@ func (s *Server) handleGetInstanceProvisioning(ctx *apptheory.Context) (*apptheo
 	}
 
 	if status := strings.ToLower(strings.TrimSpace(job.Status)); status == models.ProvisionJobStatusQueued || status == models.ProvisionJobStatusRunning {
-		if shouldNudgeAsyncJob(time.Now().UTC(), job.UpdatedAt) {
+		now := time.Now().UTC()
+		if shouldNudgeAsyncJob(now, job.UpdatedAt) && !job.HasActiveLease(now) {
 			s.enqueueProvisionJobBestEffort(ctx, jobID)
 		}
 	}

--- a/internal/controlplane/handlers_provisioning_consent.go
+++ b/internal/controlplane/handlers_provisioning_consent.go
@@ -172,6 +172,7 @@ func (s *Server) handlePortalProvisionConsentChallenge(ctx *apptheory.Context) (
 		ChainID:       cred.ChainID,
 		Nonce:         nonce,
 		Message:       msg,
+		MessageHash:   sha256Hex(msg),
 		IssuedAt:      now,
 		ExpiresAt:     expiresAt,
 	}
@@ -244,9 +245,55 @@ func (s *Server) deleteProvisionConsentChallenge(ctx *apptheory.Context, chall *
 		Delete()
 }
 
+func (s *Server) consumeProvisionConsentChallenge(ctx *apptheory.Context, chall *models.ProvisionConsentChallenge, message string, now time.Time) *apptheory.AppError {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if chall == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if strings.TrimSpace(message) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "consent_message is required"}
+	}
+
+	update := &models.ProvisionConsentChallenge{
+		ID:          strings.TrimSpace(chall.ID),
+		ExpiresAt:   chall.ExpiresAt,
+		Message:     "",
+		MessageHash: sha256Hex(message),
+		Consumed:    true,
+		ConsumedAt:  now,
+	}
+	_ = update.UpdateKeys()
+
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(update).
+		IfExists().
+		WithConditionExpression("attribute_not_exists(consumed) OR consumed = :false", map[string]any{":false": false}).
+		Update("Consumed", "ConsumedAt", "Message", "MessageHash")
+	if theoryErrors.IsConditionFailed(err) || theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+	if err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to consume consent challenge"}
+	}
+
+	chall.Consumed = true
+	chall.ConsumedAt = now
+	chall.MessageHash = sha256Hex(message)
+	return nil
+}
+
 func validateProvisionConsentChallenge(ctx *apptheory.Context, chall *models.ProvisionConsentChallenge, slug string, stage string, message string) *apptheory.AppError {
 	if ctx == nil || chall == nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	if chall.Consumed {
+		return &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
 	}
 
 	if !chall.ExpiresAt.IsZero() && time.Now().After(chall.ExpiresAt) {
@@ -267,6 +314,9 @@ func validateProvisionConsentChallenge(ctx *apptheory.Context, chall *models.Pro
 
 	if strings.TrimSpace(message) == "" || strings.TrimSpace(chall.Message) == "" || message != chall.Message {
 		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge message mismatch"}
+	}
+	if msgHash := strings.TrimSpace(chall.MessageHash); msgHash != "" && msgHash != sha256Hex(message) {
+		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge message hash mismatch"}
 	}
 
 	return nil

--- a/internal/controlplane/handlers_provisioning_consent.go
+++ b/internal/controlplane/handlers_provisioning_consent.go
@@ -221,30 +221,6 @@ func (s *Server) getProvisionConsentChallenge(ctx *apptheory.Context, id string)
 	return &chall, nil
 }
 
-func (s *Server) deleteProvisionConsentChallenge(ctx *apptheory.Context, chall *models.ProvisionConsentChallenge) error {
-	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
-		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-	if chall == nil {
-		return nil
-	}
-	pk := strings.TrimSpace(chall.PK)
-	sk := strings.TrimSpace(chall.SK)
-	if pk == "" || sk == "" {
-		_ = chall.UpdateKeys()
-		pk = strings.TrimSpace(chall.PK)
-		sk = strings.TrimSpace(chall.SK)
-	}
-	if pk == "" || sk == "" {
-		return nil
-	}
-	return s.store.DB.WithContext(ctx.Context()).
-		Model(&models.ProvisionConsentChallenge{}).
-		Where("PK", "=", pk).
-		Where("SK", "=", sk).
-		Delete()
-}
-
 func (s *Server) consumeProvisionConsentChallenge(ctx *apptheory.Context, chall *models.ProvisionConsentChallenge, message string, now time.Time) *apptheory.AppError {
 	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
@@ -291,27 +267,32 @@ func validateProvisionConsentChallenge(ctx *apptheory.Context, chall *models.Pro
 	if ctx == nil || chall == nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
-
 	if chall.Consumed {
 		return &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
 	}
-
 	if !chall.ExpiresAt.IsZero() && time.Now().After(chall.ExpiresAt) {
 		return &apptheory.AppError{Code: "app.bad_request", Message: "consent challenge expired"}
 	}
+	if appErr := validateProvisionConsentChallengeScope(ctx, chall, slug, stage); appErr != nil {
+		return appErr
+	}
+	return validateProvisionConsentChallengeMessage(chall, message)
+}
 
+func validateProvisionConsentChallengeScope(ctx *apptheory.Context, chall *models.ProvisionConsentChallenge, slug string, stage string) *apptheory.AppError {
 	if strings.TrimSpace(chall.Username) == "" || strings.TrimSpace(ctx.AuthIdentity) == "" || strings.TrimSpace(chall.Username) != strings.TrimSpace(ctx.AuthIdentity) {
 		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge user mismatch"}
 	}
-
 	if strings.TrimSpace(chall.InstanceSlug) != strings.TrimSpace(slug) {
 		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge slug mismatch"}
 	}
-
 	if strings.TrimSpace(chall.Stage) != strings.TrimSpace(stage) {
 		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge stage mismatch"}
 	}
+	return nil
+}
 
+func validateProvisionConsentChallengeMessage(chall *models.ProvisionConsentChallenge, message string) *apptheory.AppError {
 	if strings.TrimSpace(message) == "" || strings.TrimSpace(chall.Message) == "" || message != chall.Message {
 		return &apptheory.AppError{Code: "app.forbidden", Message: "consent challenge message mismatch"}
 	}

--- a/internal/controlplane/handlers_provisioning_consent_internal_test.go
+++ b/internal/controlplane/handlers_provisioning_consent_internal_test.go
@@ -273,6 +273,30 @@ func TestConsumeProvisionConsentChallenge_MarksConsumedAndClearsMessage(t *testi
 	}
 }
 
+func TestConsumeProvisionConsentChallenge_RejectsAlreadyConsumed(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qConsent := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Once()
+	db.On("Model", mock.AnythingOfType("*models.ProvisionConsentChallenge")).Return(qConsent).Once()
+	qConsent.On("IfExists").Return(qConsent).Once()
+	qConsent.On("WithConditionExpression", mock.Anything, mock.Anything).Return(qConsent).Once()
+	qConsent.On("Update", []string{"Consumed", "ConsumedAt", "Message", "MessageHash"}).Return(theoryErrors.ErrConditionFailed).Once()
+
+	s := &Server{store: store.New(db)}
+	now := time.Unix(100, 0).UTC()
+	msg := buildProvisionConsentMessage(testProvisionConsentStageLab, testProvisionConsentBaseDomainDemoGreater, testProvisionConsentSlugDemo, testProvisionConsentNonce16, now.Add(time.Minute))
+	chall := &models.ProvisionConsentChallenge{ID: "c1", Message: msg, ExpiresAt: now.Add(time.Minute)}
+	_ = chall.UpdateKeys()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice"}
+	appErr := s.consumeProvisionConsentChallenge(ctx, chall, msg, now)
+	if appErr == nil || appErr.Code != testProvisionConsentCodeUnauthorized {
+		t.Fatalf("expected unauthorized, got %#v", appErr)
+	}
+}
+
 func TestValidateProvisionConsentChallenge_RequiresExactMessageBytes(t *testing.T) {
 	t.Parallel()
 
@@ -363,6 +387,16 @@ func TestValidateProvisionConsentChallenge_RejectsMismatchedOrExpiredChallenge(t
 			slug:  testProvisionConsentSlugDemo,
 			stage: testProvisionConsentStageLab,
 			code:  testProvisionConsentCodeUnauthorized,
+		},
+		{
+			name: "message hash mismatch",
+			ctx:  &apptheory.Context{AuthIdentity: "alice"},
+			mut: func(chall *models.ProvisionConsentChallenge) {
+				chall.MessageHash = strings.Repeat("0", 64)
+			},
+			slug:  testProvisionConsentSlugDemo,
+			stage: testProvisionConsentStageLab,
+			code:  appErrCodeForbidden,
 		},
 	}
 

--- a/internal/controlplane/handlers_provisioning_consent_internal_test.go
+++ b/internal/controlplane/handlers_provisioning_consent_internal_test.go
@@ -8,6 +8,7 @@ import (
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/stretchr/testify/mock"
 
@@ -238,6 +239,40 @@ func TestGetProvisionConsentChallenge_NormalizesNotFoundToUnauthorized(t *testin
 	}
 }
 
+func TestConsumeProvisionConsentChallenge_MarksConsumedAndClearsMessage(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qConsent := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Once()
+
+	var captured *models.ProvisionConsentChallenge
+	db.On("Model", mock.MatchedBy(func(ch *models.ProvisionConsentChallenge) bool {
+		captured = ch
+		return ch != nil
+	})).Return(qConsent).Once()
+	qConsent.On("IfExists").Return(qConsent).Once()
+	qConsent.On("WithConditionExpression", mock.Anything, mock.Anything).Return(qConsent).Once()
+	qConsent.On("Update", []string{"Consumed", "ConsumedAt", "Message", "MessageHash"}).Return(nil).Once()
+
+	s := &Server{store: store.New(db)}
+	now := time.Unix(100, 0).UTC()
+	msg := buildProvisionConsentMessage(testProvisionConsentStageLab, testProvisionConsentBaseDomainDemoGreater, testProvisionConsentSlugDemo, testProvisionConsentNonce16, now.Add(time.Minute))
+	chall := &models.ProvisionConsentChallenge{ID: "c1", Message: msg, ExpiresAt: now.Add(time.Minute)}
+	_ = chall.UpdateKeys()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice"}
+	if appErr := s.consumeProvisionConsentChallenge(ctx, chall, msg, now); appErr != nil {
+		t.Fatalf("consumeProvisionConsentChallenge: %#v", appErr)
+	}
+	if captured == nil || captured.Message != "" || captured.MessageHash != sha256Hex(msg) || !captured.Consumed || !captured.ConsumedAt.Equal(now) {
+		t.Fatalf("unexpected consumed update: %#v", captured)
+	}
+	if !chall.Consumed || chall.MessageHash != sha256Hex(msg) || !chall.ConsumedAt.Equal(now) {
+		t.Fatalf("expected in-memory challenge to reflect consumption: %#v", chall)
+	}
+}
+
 func TestValidateProvisionConsentChallenge_RequiresExactMessageBytes(t *testing.T) {
 	t.Parallel()
 
@@ -318,6 +353,16 @@ func TestValidateProvisionConsentChallenge_RejectsMismatchedOrExpiredChallenge(t
 			slug:  testProvisionConsentSlugDemo,
 			stage: testProvisionConsentStageLab,
 			code:  appErrCodeBadRequest,
+		},
+		{
+			name: "already consumed",
+			ctx:  &apptheory.Context{AuthIdentity: "alice"},
+			mut: func(chall *models.ProvisionConsentChallenge) {
+				chall.Consumed = true
+			},
+			slug:  testProvisionConsentSlugDemo,
+			stage: testProvisionConsentStageLab,
+			code:  testProvisionConsentCodeUnauthorized,
 		},
 	}
 

--- a/internal/controlplane/testdb_helpers_internal_test.go
+++ b/internal/controlplane/testdb_helpers_internal_test.go
@@ -30,6 +30,7 @@ func addStandardMockQueryStubs(q *ttmocks.MockQuery) {
 	q.On("Limit", mock.Anything).Return(q).Maybe()
 	q.On("IfExists").Return(q).Maybe()
 	q.On("IfNotExists").Return(q).Maybe()
+	q.On("WithConditionExpression", mock.Anything, mock.Anything).Return(q).Maybe()
 	q.On("ConsistentRead").Return(q).Maybe()
 	q.On("Create").Return(nil).Maybe()
 	q.On("CreateOrUpdate").Return(nil).Maybe()

--- a/internal/provisionworker/account_create_branches_internal_test.go
+++ b/internal/provisionworker/account_create_branches_internal_test.go
@@ -65,7 +65,7 @@ func TestHandleProvisionAccountCreateStatus_Branches(t *testing.T) {
 	require.False(t, done)
 	require.Zero(t, delay)
 	require.Equal(t, provisionStepFailed, job.Step)
-	require.Equal(t, "account_create_failed", job.ErrorCode)
+	require.Equal(t, "account_email_exists_adoption_required", job.ErrorCode)
 
 	// Succeeded but missing account id.
 	job.Step = provisionStepAccountCreatePoll
@@ -160,16 +160,10 @@ func TestStartProvisionAccountCreate_ErrorBranches(t *testing.T) {
 		require.Equal(t, "create_account_failed", job.ErrorCode)
 	})
 
-	t.Run("reuse_existing_account_by_email", func(t *testing.T) {
+	t.Run("does_not_reuse_existing_account_by_email", func(t *testing.T) {
 		s := makeServer(&fakeOrg{
-			createErr: errors.New("should not create"),
-			listOut: &organizations.ListAccountsOutput{
-				Accounts: []orgtypes.Account{{
-					Id:     aws.String("123456789012"),
-					Email:  aws.String("ops+slug@example.com"),
-					Name:   aws.String("lesser-slug"),
-					Status: orgtypes.AccountStatusActive,
-				}},
+			createOut: &organizations.CreateAccountOutput{
+				CreateAccountStatus: &orgtypes.CreateAccountStatus{Id: aws.String("car-123")},
 			},
 		})
 		job := &models.ProvisionJob{ID: "j4", InstanceSlug: "slug", Status: models.ProvisionJobStatusRunning, Step: provisionStepAccountCreate, MaxAttempts: 3}
@@ -177,10 +171,10 @@ func TestStartProvisionAccountCreate_ErrorBranches(t *testing.T) {
 		delay, done, err := s.startProvisionAccountCreate(context.Background(), job, "req", now)
 		require.NoError(t, err)
 		require.False(t, done)
-		require.Zero(t, delay)
-		require.Equal(t, provisionStepAccountMove, job.Step)
-		require.Equal(t, "123456789012", job.AccountID)
-		require.Contains(t, job.Note, "reusing")
+		require.Equal(t, provisionDefaultPollDelay, delay)
+		require.Equal(t, provisionStepAccountCreatePoll, job.Step)
+		require.Equal(t, "car-123", job.AccountRequestID)
+		require.Empty(t, job.AccountID)
 	})
 }
 
@@ -206,6 +200,75 @@ func TestAdvanceProvisionAccountCreate_Branches(t *testing.T) {
 	if err != nil || done || delay != provisionDefaultPollDelay || job2.Step != provisionStepAccountCreatePoll {
 		t.Fatalf("unexpected request id branch: delay=%v done=%v job=%#v err=%v", delay, done, job2, err)
 	}
+}
+
+func TestValidateAdoptedProvisionAccount_RequiresMatchingOrgAccount(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	makeServer := func(accounts []orgtypes.Account) *Server {
+		db := ttmocks.NewMockExtendedDB()
+		st := store.New(db)
+		return &Server{
+			cfg: config.Config{
+				ManagedAccountEmailTemplate: "ops+{slug}@example.com",
+				ManagedAccountNamePrefix:    "lesser-",
+			},
+			store: st,
+			org: &fakeOrg{listOut: &organizations.ListAccountsOutput{
+				Accounts: accounts,
+			}},
+		}
+	}
+
+	t.Run("matches", func(t *testing.T) {
+		s := makeServer([]orgtypes.Account{{
+			Id:     aws.String("123456789012"),
+			Email:  aws.String("ops+slug@example.com"),
+			Name:   aws.String("lesser-slug"),
+			Status: orgtypes.AccountStatusActive,
+		}})
+		job := &models.ProvisionJob{
+			ID:           "j",
+			InstanceSlug: "slug",
+			Status:       models.ProvisionJobStatusRunning,
+			Step:         provisionStepAccountMove,
+			AccountID:    "123456789012",
+			AccountEmail: "ops+slug@example.com",
+			MaxAttempts:  3,
+		}
+
+		delay, done, err := s.validateAdoptedProvisionAccount(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Zero(t, delay)
+		require.NotEqual(t, provisionStepFailed, job.Step)
+	})
+
+	t.Run("mismatched email fails", func(t *testing.T) {
+		s := makeServer([]orgtypes.Account{{
+			Id:     aws.String("123456789012"),
+			Email:  aws.String("ops+other@example.com"),
+			Name:   aws.String("lesser-slug"),
+			Status: orgtypes.AccountStatusActive,
+		}})
+		job := &models.ProvisionJob{
+			ID:           "j",
+			InstanceSlug: "slug",
+			Status:       models.ProvisionJobStatusRunning,
+			Step:         provisionStepAccountMove,
+			AccountID:    "123456789012",
+			AccountEmail: "ops+slug@example.com",
+			MaxAttempts:  3,
+		}
+
+		delay, done, err := s.validateAdoptedProvisionAccount(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Zero(t, delay)
+		require.Equal(t, provisionStepFailed, job.Step)
+		require.Equal(t, "account_adoption_invalid", job.ErrorCode)
+	})
 }
 
 func TestAdvanceProvisionAccountCreatePoll_RestartTimeoutAndDescribeError(t *testing.T) {

--- a/internal/provisionworker/env_overrides_internal_test.go
+++ b/internal/provisionworker/env_overrides_internal_test.go
@@ -88,6 +88,7 @@ func TestStartDeployRunner_AppendsTipAndAIEnv(t *testing.T) {
 			ManagedLesserGitHubOwner:          "o",
 			ManagedLesserGitHubRepo:           "r",
 			ArtifactBucketName:                "bucket",
+			ManagedOrgVendingRoleARN:          "arn:aws:iam::123456789012:role/lesser-host-org-vending",
 		},
 		store: st,
 		cb:    cb,
@@ -110,6 +111,7 @@ func TestStartDeployRunner_AppendsTipAndAIEnv(t *testing.T) {
 	)
 
 	env := envOverrideMap(cb.lastStart.EnvironmentVariablesOverride)
+	require.NotContains(t, env, "MANAGED_ORG_VENDING_ROLE_ARN")
 	require.Equal(t, "true", env["TIP_ENABLED"])
 	require.Equal(t, "8453", env["TIP_CHAIN_ID"])
 	require.Equal(t, "0xabc", env["TIP_CONTRACT_ADDRESS"])
@@ -202,6 +204,7 @@ func TestStartUpdateDeployRunner_AppendsTipAndAIEnv(t *testing.T) {
 			ManagedLesserGitHubOwner:          "o",
 			ManagedLesserGitHubRepo:           "r",
 			ArtifactBucketName:                "bucket",
+			ManagedOrgVendingRoleARN:          "arn:aws:iam::123456789012:role/lesser-host-org-vending",
 		},
 		cb: cb,
 	}
@@ -242,6 +245,7 @@ func TestStartUpdateDeployRunner_AppendsTipAndAIEnv(t *testing.T) {
 	)
 
 	env := envOverrideMap(cb.lastStart.EnvironmentVariablesOverride)
+	require.NotContains(t, env, "MANAGED_ORG_VENDING_ROLE_ARN")
 	require.Equal(t, "true", env["TIP_ENABLED"])
 	require.Equal(t, "10", env["TIP_CHAIN_ID"])
 	require.Equal(t, "0xdef", env["TIP_CONTRACT_ADDRESS"])

--- a/internal/provisionworker/managed_instance_key_secrets.go
+++ b/internal/provisionworker/managed_instance_key_secrets.go
@@ -114,16 +114,19 @@ func (s *Server) describeAndEnsureManagedInstanceKeySecret(ctx context.Context, 
 	if strings.TrimSpace(rawStageTag) == "" {
 		return "", fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
 	}
-	if keyID == "" {
-		plaintext, err := getSecretsManagerSecretPlaintext(ctx, sm, secretArn)
-		if err != nil {
-			return "", err
-		}
-		keyID = secretValueToKeyID(plaintext)
+
+	plaintext, err := getSecretsManagerSecretPlaintext(ctx, sm, secretArn)
+	if err != nil {
+		return "", err
 	}
-	if keyID == "" {
+	derivedKeyID := secretValueToKeyID(plaintext)
+	if derivedKeyID == "" {
 		return "", fmt.Errorf("unable to resolve instance key id from secret")
 	}
+	if keyID != "" && keyID != derivedKeyID {
+		return "", fmt.Errorf("refusing instance key secret with mismatched key id tag")
+	}
+	keyID = derivedKeyID
 
 	if err := s.ensureInstanceKeyRecord(ctx, slug, keyID); err != nil {
 		return "", fmt.Errorf("ensure instance key record: %w", err)

--- a/internal/provisionworker/managed_instance_key_secrets.go
+++ b/internal/provisionworker/managed_instance_key_secrets.go
@@ -102,19 +102,39 @@ func (s *Server) describeAndEnsureManagedInstanceKeySecret(ctx context.Context, 
 		secretArn = secretID
 	}
 
-	keyID := secretsManagerTagValue(desc.Tags, managedInstanceKeySecretTagKeyID)
-	expectedStage := managedInstanceKeySecretStage(controlPlaneStage)
-	managedTag := strings.ToLower(secretsManagerTagValue(desc.Tags, managedInstanceKeySecretTagManaged))
-	slugTag := strings.ToLower(secretsManagerTagValue(desc.Tags, managedInstanceKeySecretTagInstanceSlug))
-	rawStageTag := secretsManagerTagValue(desc.Tags, managedInstanceKeySecretTagStage)
-	stageTag := managedInstanceKeySecretStage(rawStageTag)
-	if managedTag != "true" || slugTag != slug || stageTag != expectedStage {
-		return "", fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
-	}
-	if strings.TrimSpace(rawStageTag) == "" {
-		return "", fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
+	if err := validateManagedInstanceKeySecretTags(desc.Tags, slug, controlPlaneStage); err != nil {
+		return "", err
 	}
 
+	keyID, err := resolveManagedInstanceKeySecretID(ctx, sm, secretArn, desc.Tags)
+	if err != nil {
+		return "", err
+	}
+
+	if err := s.ensureInstanceKeyRecord(ctx, slug, keyID); err != nil {
+		return "", fmt.Errorf("ensure instance key record: %w", err)
+	}
+
+	return secretArn, nil
+}
+
+func validateManagedInstanceKeySecretTags(tags []smtypes.Tag, slug string, controlPlaneStage string) error {
+	expectedStage := managedInstanceKeySecretStage(controlPlaneStage)
+	managedTag := strings.ToLower(secretsManagerTagValue(tags, managedInstanceKeySecretTagManaged))
+	slugTag := strings.ToLower(secretsManagerTagValue(tags, managedInstanceKeySecretTagInstanceSlug))
+	rawStageTag := secretsManagerTagValue(tags, managedInstanceKeySecretTagStage)
+	stageTag := managedInstanceKeySecretStage(rawStageTag)
+	if managedTag != "true" || slugTag != slug || stageTag != expectedStage {
+		return fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
+	}
+	if strings.TrimSpace(rawStageTag) == "" {
+		return fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
+	}
+	return nil
+}
+
+func resolveManagedInstanceKeySecretID(ctx context.Context, sm secretsManagerAPI, secretArn string, tags []smtypes.Tag) (string, error) {
+	taggedKeyID := secretsManagerTagValue(tags, managedInstanceKeySecretTagKeyID)
 	plaintext, err := getSecretsManagerSecretPlaintext(ctx, sm, secretArn)
 	if err != nil {
 		return "", err
@@ -123,16 +143,10 @@ func (s *Server) describeAndEnsureManagedInstanceKeySecret(ctx context.Context, 
 	if derivedKeyID == "" {
 		return "", fmt.Errorf("unable to resolve instance key id from secret")
 	}
-	if keyID != "" && keyID != derivedKeyID {
+	if taggedKeyID != "" && taggedKeyID != derivedKeyID {
 		return "", fmt.Errorf("refusing instance key secret with mismatched key id tag")
 	}
-	keyID = derivedKeyID
-
-	if err := s.ensureInstanceKeyRecord(ctx, slug, keyID); err != nil {
-		return "", fmt.Errorf("ensure instance key record: %w", err)
-	}
-
-	return secretArn, nil
+	return derivedKeyID, nil
 }
 
 func (s *Server) createManagedInstanceKeySecret(ctx context.Context, sm secretsManagerAPI, secretName, slug string, controlPlaneStage string) (string, string, error) {

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -203,6 +203,58 @@ func (s *Server) processActiveProvisionSweep(ctx context.Context, requestID stri
 		}, nil
 	}
 
+	items, err := s.listProvisionSweepJobs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := provisionSweepCounts{}
+	for _, item := range items {
+		if item == nil || !provisionJobProcessable(item) {
+			continue
+		}
+		counts.activeJobs++
+		processed, err := s.processProvisionSweepJob(ctx, item, requestID, now)
+		counts.record(processed, err)
+	}
+
+	result := counts.result(now)
+	if counts.firstErr != nil {
+		return result, fmt.Errorf("provisioning sweep encountered %d errors: %w", counts.errorCount, counts.firstErr)
+	}
+	return result, nil
+}
+
+type provisionSweepCounts struct {
+	activeJobs int
+	processed  int
+	errorCount int
+	firstErr   error
+}
+
+func (c *provisionSweepCounts) record(processed bool, err error) {
+	if err != nil {
+		c.errorCount++
+		if c.firstErr == nil {
+			c.firstErr = err
+		}
+		return
+	}
+	if processed {
+		c.processed++
+	}
+}
+
+func (c provisionSweepCounts) result(now time.Time) map[string]any {
+	return map[string]any{
+		"active_jobs": c.activeJobs,
+		"processed":   c.processed,
+		"errors":      c.errorCount,
+		"swept_at":    now.UTC().Format(time.RFC3339),
+	}
+}
+
+func (s *Server) listProvisionSweepJobs(ctx context.Context) ([]*models.ProvisionJob, error) {
 	var items []*models.ProvisionJob
 	err := s.store.DB.WithContext(ctx).
 		Model(&models.ProvisionJob{}).
@@ -212,57 +264,28 @@ func (s *Server) processActiveProvisionSweep(ctx context.Context, requestID stri
 	if err != nil && !theoryErrors.IsNotFound(err) {
 		return nil, err
 	}
+	return items, nil
+}
 
-	activeJobs := 0
-	processed := 0
-	errorCount := 0
-	var firstErr error
+func (s *Server) processProvisionSweepJob(ctx context.Context, item *models.ProvisionJob, requestID string, now time.Time) (bool, error) {
+	if !item.ExpiresAt.IsZero() && item.ExpiresAt.Before(now) {
+		return true, s.failJob(ctx, item, requestID, now, "expired", "provisioning job has expired")
+	}
+	if item.HasActiveLease(now) || !provisionJobStaleForSweep(item, now) {
+		return false, nil
+	}
+	return true, s.requeueProvisionJob(ctx, strings.TrimSpace(item.ID), 0)
+}
 
-	for _, item := range items {
-		if item == nil || !provisionJobProcessable(item) {
-			continue
-		}
-		activeJobs++
-		if !item.ExpiresAt.IsZero() && item.ExpiresAt.Before(now) {
-			if err := s.failJob(ctx, item, requestID, now, "expired", "provisioning job has expired"); err != nil {
-				errorCount++
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
-			}
-			processed++
-			continue
-		}
-		if item.HasActiveLease(now) {
-			continue
-		}
-		lastSeen := item.UpdatedAt
-		if lastSeen.IsZero() {
-			lastSeen = item.CreatedAt
-		}
-		if lastSeen.IsZero() || now.Sub(lastSeen) >= provisionSweepStaleAfter {
-			if err := s.requeueProvisionJob(ctx, strings.TrimSpace(item.ID), 0); err != nil {
-				errorCount++
-				if firstErr == nil {
-					firstErr = err
-				}
-				continue
-			}
-			processed++
-		}
+func provisionJobStaleForSweep(item *models.ProvisionJob, now time.Time) bool {
+	if item == nil {
+		return false
 	}
-
-	result := map[string]any{
-		"active_jobs": activeJobs,
-		"processed":   processed,
-		"errors":      errorCount,
-		"swept_at":    now.UTC().Format(time.RFC3339),
+	lastSeen := item.UpdatedAt
+	if lastSeen.IsZero() {
+		lastSeen = item.CreatedAt
 	}
-	if firstErr != nil {
-		return result, fmt.Errorf("provisioning sweep encountered %d errors: %w", errorCount, firstErr)
-	}
-	return result, nil
+	return lastSeen.IsZero() || now.Sub(lastSeen) >= provisionSweepStaleAfter
 }
 
 func (s *Server) processProvisionJob(ctx context.Context, requestID string, jobID string) error {

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -548,40 +548,7 @@ func (s *Server) startProvisionAccountCreate(ctx context.Context, job *models.Pr
 	accountName := managedAccountName(s.cfg.ManagedAccountNamePrefix, job.InstanceSlug)
 	roleName := managedAccountRoleName(job.AccountRoleName, s.cfg.ManagedInstanceRoleName)
 
-	handled, delay, done, err := s.tryReuseAccountByEmail(ctx, job, requestID, now, email, accountName)
-	if handled {
-		return delay, done, err
-	}
-
 	return s.requestAccountCreate(ctx, job, requestID, now, email, accountName, roleName)
-}
-
-func (s *Server) tryReuseAccountByEmail(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time, email string, accountName string) (bool, time.Duration, bool, error) {
-	if strings.TrimSpace(email) == "" {
-		return false, 0, false, nil
-	}
-
-	acct, err := s.findAccountByEmail(ctx, email)
-	if err != nil {
-		if isOrgAccessDenied(err) {
-			return true, 0, false, s.failOrgPermissions(ctx, job, requestID, now, "ListAccounts", err)
-		}
-		delay, done, retryErr := s.retryProvisionJobOrFail(ctx, job, requestID, now, "account_lookup_failed", "account lookup failed: "+err.Error(), provisionDefaultShortRetryDelay, 5*time.Minute)
-		return true, delay, done, retryErr
-	}
-	if acct == nil {
-		return false, 0, false, nil
-	}
-
-	if matchErr := ensureAccountMatchesExpected(acct, accountName); matchErr != nil {
-		return true, 0, false, s.failJob(ctx, job, requestID, now, "account_email_conflict", matchErr.Error())
-	}
-	if strings.TrimSpace(job.AccountID) == "" {
-		job.AccountID = strings.TrimSpace(aws.ToString(acct.Id))
-	}
-	job.Note = "AWS account already exists; reusing"
-	delay, done, err := s.advanceToAccountMove(ctx, job, requestID, now, job.Note)
-	return true, delay, done, err
 }
 
 func (s *Server) requestAccountCreate(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time, email string, accountName string, roleName string) (time.Duration, bool, error) {
@@ -768,36 +735,19 @@ func (s *Server) handleAccountCreateEmailExists(
 	requestID string,
 	now time.Time,
 ) (time.Duration, bool, error, bool) {
-	email := strings.TrimSpace(job.AccountEmail)
-	if email == "" {
-		email = strings.TrimSpace(expandManagedAccountEmailTemplate(s.cfg.ManagedAccountEmailTemplate, job.InstanceSlug))
-		job.AccountEmail = email
+	email := ensureProvisionAccountEmail(job, s.cfg.ManagedAccountEmailTemplate)
+	msg := "AWS Organizations reports the managed account email already exists; explicit validated account adoption is required"
+	if strings.TrimSpace(email) != "" {
+		msg += " for " + strings.TrimSpace(email)
 	}
-	accountName := strings.TrimSpace(strings.TrimSpace(s.cfg.ManagedAccountNamePrefix) + strings.TrimSpace(job.InstanceSlug))
-	if len(accountName) > 50 {
-		accountName = accountName[:50]
-	}
-	acct, err := s.findAccountByEmail(ctx, email)
-	if err != nil {
-		if isOrgAccessDenied(err) {
-			return 0, false, s.failOrgPermissions(ctx, job, requestID, now, "ListAccounts", err), true
-		}
-		delay, done, retryErr := s.retryProvisionJobOrFail(ctx, job, requestID, now, "account_lookup_failed", "account lookup failed after email exists: "+err.Error(), provisionDefaultShortRetryDelay, 5*time.Minute)
-		return delay, done, retryErr, true
-	}
-	if acct == nil {
-		return 0, false, nil, false
-	}
-	if matchErr := ensureAccountMatchesExpected(acct, accountName); matchErr != nil {
-		return 0, false, s.failJob(ctx, job, requestID, now, "account_email_conflict", matchErr.Error()), true
-	}
-	job.AccountID = strings.TrimSpace(aws.ToString(acct.Id))
-	job.Note = "AWS account already exists; reusing"
-	delay, done, err := s.advanceToAccountMove(ctx, job, requestID, now, job.Note)
-	return delay, done, err, true
+	return 0, false, s.failJob(ctx, job, requestID, now, "account_email_exists_adoption_required", msg), true
 }
 
 func (s *Server) advanceProvisionAccountMove(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time) (time.Duration, bool, error) {
+	if delay, done, err := s.validateAdoptedProvisionAccount(ctx, job, requestID, now); err != nil || done || delay > 0 {
+		return delay, done, err
+	}
+
 	targetOu := strings.TrimSpace(s.cfg.ManagedTargetOrganizationalUnitID)
 	if targetOu != "" {
 		requeueDelay, done, err := s.moveProvisionAccountToTargetOU(ctx, job, requestID, now, targetOu)
@@ -1717,12 +1667,31 @@ func ensureAccountMatchesExpected(acct *orgtypes.Account, expectedName string) e
 	return nil
 }
 
-func (s *Server) findAccountByEmail(ctx context.Context, email string) (*orgtypes.Account, error) {
+func ensureAdoptedAccountMatchesExpected(acct *orgtypes.Account, accountID string, expectedEmail string, expectedName string) error {
+	if acct == nil {
+		return fmt.Errorf("account lookup returned nil")
+	}
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" || strings.TrimSpace(aws.ToString(acct.Id)) != accountID {
+		return fmt.Errorf("adopted account id does not match Organizations account")
+	}
+	expectedEmail = strings.ToLower(strings.TrimSpace(expectedEmail))
+	if expectedEmail == "" {
+		return fmt.Errorf("expected account email is required for account adoption")
+	}
+	actualEmail := strings.ToLower(strings.TrimSpace(aws.ToString(acct.Email)))
+	if actualEmail == "" || actualEmail != expectedEmail {
+		return fmt.Errorf("adopted account email does not match expected managed account email")
+	}
+	return ensureAccountMatchesExpected(acct, expectedName)
+}
+
+func (s *Server) findAccountByID(ctx context.Context, accountID string) (*orgtypes.Account, error) {
 	if s == nil || s.org == nil {
 		return nil, fmt.Errorf("org client not initialized")
 	}
-	email = strings.TrimSpace(strings.ToLower(email))
-	if email == "" {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
 		return nil, nil
 	}
 
@@ -1734,7 +1703,7 @@ func (s *Server) findAccountByEmail(ctx context.Context, email string) (*orgtype
 		}
 		if out != nil {
 			for _, acct := range out.Accounts {
-				if strings.EqualFold(strings.TrimSpace(aws.ToString(acct.Email)), email) {
+				if strings.TrimSpace(aws.ToString(acct.Id)) == accountID {
 					return &acct, nil
 				}
 			}
@@ -1747,6 +1716,40 @@ func (s *Server) findAccountByEmail(ctx context.Context, email string) (*orgtype
 		break
 	}
 	return nil, nil
+}
+
+func (s *Server) validateAdoptedProvisionAccount(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time) (time.Duration, bool, error) {
+	if s == nil || job == nil {
+		return 0, false, nil
+	}
+	accountID := strings.TrimSpace(job.AccountID)
+	if accountID == "" || strings.TrimSpace(job.AccountRequestID) != "" {
+		return 0, false, nil
+	}
+
+	expectedEmail := strings.TrimSpace(job.AccountEmail)
+	if expectedEmail == "" {
+		expectedEmail = strings.TrimSpace(expandManagedAccountEmailTemplate(s.cfg.ManagedAccountEmailTemplate, job.InstanceSlug))
+	}
+	expectedName := managedAccountName(s.cfg.ManagedAccountNamePrefix, job.InstanceSlug)
+
+	acct, err := s.findAccountByID(ctx, accountID)
+	if err != nil {
+		if isOrgAccessDenied(err) {
+			return 0, false, s.failOrgPermissions(ctx, job, requestID, now, "ListAccounts", err)
+		}
+		return s.retryProvisionJobOrFail(ctx, job, requestID, now, "account_lookup_failed", "account lookup failed for adopted account: "+err.Error(), provisionDefaultShortRetryDelay, 5*time.Minute)
+	}
+	if acct == nil {
+		return 0, false, s.failJob(ctx, job, requestID, now, "account_adoption_invalid", "adopted AWS account is not visible in the managed organization")
+	}
+	if matchErr := ensureAdoptedAccountMatchesExpected(acct, accountID, expectedEmail, expectedName); matchErr != nil {
+		return 0, false, s.failJob(ctx, job, requestID, now, "account_adoption_invalid", matchErr.Error())
+	}
+	if strings.TrimSpace(job.AccountEmail) == "" {
+		job.AccountEmail = expectedEmail
+	}
+	return 0, false, nil
 }
 
 var errAssumeRoleNotReady = errors.New("assume role not ready")

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -2115,12 +2115,6 @@ func (s *Server) buildDeployRunnerEnv(job *models.ProvisionJob, stage, receiptKe
 		{Name: aws.String("LESSER_BODY_GITHUB_REPO"), Value: aws.String(strings.TrimSpace(s.cfg.ManagedLesserBodyGitHubRepo))},
 		{Name: aws.String("LESSER_BODY_VERSION"), Value: aws.String(strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion))},
 	}
-	if strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN) != "" {
-		env = append(env, cbtypes.EnvironmentVariable{
-			Name:  aws.String("MANAGED_ORG_VENDING_ROLE_ARN"),
-			Value: aws.String(strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN)),
-		})
-	}
 
 	return env
 }

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -165,7 +165,104 @@ func (s *Server) handleUpdateSweep(ctx *apptheory.EventContext, _ events.EventBr
 	if ctx == nil {
 		return nil, fmt.Errorf("event context is nil")
 	}
-	return s.processActiveUpdateSweep(ctx.Context(), ctx.RequestID, time.Now().UTC())
+	now := time.Now().UTC()
+	updateResult, updateErr := s.processActiveUpdateSweep(ctx.Context(), ctx.RequestID, now)
+	if updateResult == nil {
+		updateResult = map[string]any{}
+	}
+
+	provisionResult, provisionErr := s.processActiveProvisionSweep(ctx.Context(), ctx.RequestID, now)
+	updateResult["provisioning"] = provisionResult
+
+	if updateErr != nil && provisionErr != nil {
+		return updateResult, fmt.Errorf("update sweep failed: %v; provisioning sweep failed: %w", updateErr, provisionErr)
+	}
+	if updateErr != nil {
+		return updateResult, updateErr
+	}
+	if provisionErr != nil {
+		return updateResult, provisionErr
+	}
+	return updateResult, nil
+}
+
+func (s *Server) processActiveProvisionSweep(ctx context.Context, requestID string, now time.Time) (map[string]any, error) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return nil, fmt.Errorf("store not initialized")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if s.sqs == nil {
+		return map[string]any{
+			"active_jobs": 0,
+			"processed":   0,
+			"errors":      0,
+			"skipped":     "sqs not initialized",
+			"swept_at":    now.UTC().Format(time.RFC3339),
+		}, nil
+	}
+
+	var items []*models.ProvisionJob
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.ProvisionJob{}).
+		Where("SK", "=", models.SKJob).
+		Limit(provisionSweepLimit).
+		All(&items)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	activeJobs := 0
+	processed := 0
+	errorCount := 0
+	var firstErr error
+
+	for _, item := range items {
+		if item == nil || !provisionJobProcessable(item) {
+			continue
+		}
+		activeJobs++
+		if !item.ExpiresAt.IsZero() && item.ExpiresAt.Before(now) {
+			if err := s.failJob(ctx, item, requestID, now, "expired", "provisioning job has expired"); err != nil {
+				errorCount++
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			processed++
+			continue
+		}
+		if item.HasActiveLease(now) {
+			continue
+		}
+		lastSeen := item.UpdatedAt
+		if lastSeen.IsZero() {
+			lastSeen = item.CreatedAt
+		}
+		if lastSeen.IsZero() || now.Sub(lastSeen) >= provisionSweepStaleAfter {
+			if err := s.requeueProvisionJob(ctx, strings.TrimSpace(item.ID), 0); err != nil {
+				errorCount++
+				if firstErr == nil {
+					firstErr = err
+				}
+				continue
+			}
+			processed++
+		}
+	}
+
+	result := map[string]any{
+		"active_jobs": activeJobs,
+		"processed":   processed,
+		"errors":      errorCount,
+		"swept_at":    now.UTC().Format(time.RFC3339),
+	}
+	if firstErr != nil {
+		return result, fmt.Errorf("provisioning sweep encountered %d errors: %w", errorCount, firstErr)
+	}
+	return result, nil
 }
 
 func (s *Server) processProvisionJob(ctx context.Context, requestID string, jobID string) error {
@@ -191,7 +288,84 @@ func (s *Server) processProvisionJob(ctx context.Context, requestID string, jobI
 		return s.failJob(ctx, job, requestID, now, "missing_config", "missing required config: "+strings.Join(missing, ", "))
 	}
 
+	leased, err := s.tryAcquireProvisionJobLease(ctx, job, requestID, now)
+	if err != nil {
+		return err
+	}
+	if !leased {
+		return nil
+	}
+
 	return s.runManagedProvisioningStateMachine(ctx, job, requestID, now)
+}
+
+func provisionJobLeaseOwner(requestID string, jobID string) string {
+	owner := strings.TrimSpace(requestID)
+	if owner == "" {
+		owner = "worker"
+	}
+	jobID = strings.TrimSpace(jobID)
+	if jobID != "" {
+		owner += ":" + jobID
+	}
+	if len(owner) > 128 {
+		return owner[:128]
+	}
+	return owner
+}
+
+func (s *Server) tryAcquireProvisionJobLease(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time) (bool, error) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return false, fmt.Errorf("store not initialized")
+	}
+	if job == nil {
+		return false, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	owner := provisionJobLeaseOwner(requestID, job.ID)
+	expiresAt := now.Add(provisionJobLeaseDuration)
+	jobExpiresAt := job.ExpiresAt
+	if jobExpiresAt.IsZero() {
+		jobExpiresAt = now.Add(30 * 24 * time.Hour)
+	}
+	update := &models.ProvisionJob{
+		ID:             strings.TrimSpace(job.ID),
+		InstanceSlug:   strings.TrimSpace(job.InstanceSlug),
+		CreatedAt:      job.CreatedAt,
+		ExpiresAt:      jobExpiresAt,
+		LeaseOwner:     owner,
+		LeaseExpiresAt: expiresAt,
+		RequestID:      strings.TrimSpace(requestID),
+		UpdatedAt:      now,
+	}
+	_ = update.UpdateKeys()
+
+	err := s.store.DB.WithContext(ctx).
+		Model(update).
+		IfExists().
+		WithConditionExpression(
+			"attribute_not_exists(leaseExpiresAt) OR leaseExpiresAt <= :now OR leaseOwner = :owner OR attribute_not_exists(leaseOwner) OR leaseOwner = :empty",
+			map[string]any{":now": now, ":owner": owner, ":empty": ""},
+		).
+		Update("LeaseOwner", "LeaseExpiresAt", "RequestID", "UpdatedAt")
+	if theoryErrors.IsConditionFailed(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	job.LeaseOwner = owner
+	job.LeaseExpiresAt = expiresAt
+	if job.ExpiresAt.IsZero() {
+		job.ExpiresAt = jobExpiresAt
+	}
+	job.RequestID = strings.TrimSpace(requestID)
+	job.UpdatedAt = now
+	return true, nil
 }
 
 func (s *Server) loadProvisionJob(ctx context.Context, jobID string) (*models.ProvisionJob, error) {
@@ -320,6 +494,9 @@ const (
 	provisionMaxDeployAge           = 3 * time.Hour
 	provisionDefaultPollDelay       = 45 * time.Second
 	provisionDefaultShortRetryDelay = 20 * time.Second
+	provisionJobLeaseDuration       = 10 * time.Second
+	provisionSweepLimit             = 200
+	provisionSweepStaleAfter        = 2 * time.Minute
 
 	noteMissingAccountIDRestart = "missing account id; restarting account allocation"
 
@@ -1260,6 +1437,7 @@ func (s *Server) advanceProvisionDeployStart(ctx context.Context, job *models.Pr
 	if strings.TrimSpace(job.RunID) != "" {
 		job.Step = provisionStepDeployWait
 		job.Note = "deploy runner already started"
+		clearProvisionJobConsentArtifacts(job)
 		if err := s.persistJobAndInstance(ctx, job, requestID, now, nil); err != nil {
 			return 0, false, err
 		}
@@ -1297,10 +1475,23 @@ func (s *Server) advanceProvisionDeployStart(ctx context.Context, job *models.Pr
 	job.RunID = strings.TrimSpace(runID)
 	job.Step = provisionStepDeployWait
 	job.Note = noteDeployRunnerInProgress
+	clearProvisionJobConsentArtifacts(job)
 	if err := s.persistJobAndInstance(ctx, job, requestID, now, nil); err != nil {
 		return 0, false, err
 	}
 	return provisionDefaultPollDelay, false, nil
+}
+
+func clearProvisionJobConsentArtifacts(job *models.ProvisionJob) {
+	if job == nil {
+		return
+	}
+	if strings.TrimSpace(job.ConsentMessageHash) == "" && job.ConsentMessage != "" {
+		sum := sha256.Sum256([]byte(job.ConsentMessage))
+		job.ConsentMessageHash = hex.EncodeToString(sum[:])
+	}
+	job.ConsentMessage = ""
+	job.ConsentSignature = ""
 }
 
 func (s *Server) advanceProvisionDeployWait(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time) (time.Duration, bool, error) {

--- a/internal/provisionworker/server_helpers_internal_test.go
+++ b/internal/provisionworker/server_helpers_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	cbtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	smtypes "github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
@@ -94,6 +95,111 @@ func TestProvisionWorker_HelperFunctions(t *testing.T) {
 	}
 	if isRetryableAssumeRoleErr(nil) {
 		t.Fatalf("expected false for nil")
+	}
+}
+
+func TestProvisionWorker_InstanceKeySecretNameAndStageHelpers(t *testing.T) {
+	t.Parallel()
+
+	if got := managedInstanceKeySecretName(" lab ", " Demo "); got != "lab/demo/instance-key" {
+		t.Fatalf("unexpected secret name: %q", got)
+	}
+	if got := managedInstanceKeySecretName("lab", " "); got != "" {
+		t.Fatalf("expected empty name for missing slug, got %q", got)
+	}
+	if got := managedInstanceKeySecretStage(""); got != defaultControlPlaneStage {
+		t.Fatalf("expected default stage, got %q", got)
+	}
+	if got := managedInstanceKeySecretStage("..LAB@@stage__"); got != "labstage" {
+		t.Fatalf("unexpected sanitized stage: %q", got)
+	}
+	if got := managedInstanceKeySecretStage("!!!"); got != defaultControlPlaneStage {
+		t.Fatalf("expected default for all-invalid stage, got %q", got)
+	}
+}
+
+func TestProvisionWorker_InstanceKeySecretTagAndKeyIDHelpers(t *testing.T) {
+	t.Parallel()
+
+	tags := []smtypes.Tag{
+		{Key: aws.String(" key "), Value: aws.String(" value ")},
+	}
+	if got := secretsManagerTagValue(tags, ""); got != "" {
+		t.Fatalf("expected empty lookup for empty key, got %q", got)
+	}
+	if got := secretsManagerTagValue(tags, "key"); got != "value" {
+		t.Fatalf("unexpected tag value: %q", got)
+	}
+	if got := secretsManagerTagValue(tags, "missing"); got != "" {
+		t.Fatalf("expected missing tag lookup to be empty, got %q", got)
+	}
+
+	if got := secretValueToKeyID(" "); got != "" {
+		t.Fatalf("expected empty key id for empty secret, got %q", got)
+	}
+	if got := secretValueToKeyID("  lhk_value  "); got == "" {
+		t.Fatalf("expected key id")
+	}
+}
+
+func TestProvisionWorker_InstanceKeySecretStringHelpers(t *testing.T) {
+	t.Parallel()
+
+	if _, err := unwrapSecretsManagerSecretString(" "); err == nil {
+		t.Fatalf("expected empty secret unwrap error")
+	}
+	if _, err := unwrapSecretsManagerSecretString("{"); err == nil {
+		t.Fatalf("expected invalid json unwrap error")
+	}
+	if _, err := unwrapSecretsManagerSecretString(`{"secret":" "}`); err == nil {
+		t.Fatalf("expected missing secret key error")
+	}
+	if got, err := unwrapSecretsManagerSecretString(" raw-secret "); err != nil || got != "raw-secret" {
+		t.Fatalf("unexpected raw unwrap: got=%q err=%v", got, err)
+	}
+	wrapped, err := wrapSecretsManagerSecretString(" raw-secret ")
+	if err != nil || !strings.Contains(wrapped, "raw-secret") {
+		t.Fatalf("unexpected wrapped secret: %q err=%v", wrapped, err)
+	}
+	if _, err := wrapSecretsManagerSecretString(" "); err == nil {
+		t.Fatalf("expected empty secret wrap error")
+	}
+}
+
+func TestProvisionWorker_SweepHelperAccounting(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(1_000, 0).UTC()
+	if provisionJobStaleForSweep(nil, now) {
+		t.Fatalf("nil job should not be stale")
+	}
+	if !provisionJobStaleForSweep(&models.ProvisionJob{}, now) {
+		t.Fatalf("zero timestamps should be stale")
+	}
+	if !provisionJobStaleForSweep(&models.ProvisionJob{CreatedAt: now.Add(-provisionSweepStaleAfter)}, now) {
+		t.Fatalf("old created timestamp should be stale")
+	}
+	if provisionJobStaleForSweep(&models.ProvisionJob{UpdatedAt: now.Add(-time.Second)}, now) {
+		t.Fatalf("recent update should not be stale")
+	}
+
+	counts := provisionSweepCounts{}
+	counts.record(false, nil)
+	counts.record(true, nil)
+	counts.record(false, errors.New("first"))
+	counts.record(false, errors.New("second"))
+	out := counts.result(now)
+	if counts.processed != 1 || counts.errorCount != 2 || counts.firstErr == nil {
+		t.Fatalf("unexpected counts: %#v", counts)
+	}
+	if out["processed"] != 1 || out["errors"] != 2 {
+		t.Fatalf("unexpected result map: %#v", out)
+	}
+
+	leased := &models.ProvisionJob{Status: models.ProvisionJobStatusRunning, UpdatedAt: now.Add(-time.Hour), LeaseOwner: "worker", LeaseExpiresAt: now.Add(time.Minute)}
+	processed, err := (&Server{}).processProvisionSweepJob(context.Background(), leased, "req", now)
+	if err != nil || processed {
+		t.Fatalf("active lease should skip processing, processed=%v err=%v", processed, err)
 	}
 }
 
@@ -181,6 +287,37 @@ func TestTryAcquireProvisionJobLease_SetsBoundedLease(t *testing.T) {
 	}
 	if !job.HasActiveLease(now) {
 		t.Fatalf("expected in-memory job to have active lease: %#v", job)
+	}
+}
+
+func TestTryAcquireProvisionJobLease_ValidationAndConditionFailed(t *testing.T) {
+	t.Parallel()
+
+	if _, err := (&Server{}).tryAcquireProvisionJobLease(context.Background(), &models.ProvisionJob{ID: "job"}, "req", time.Now()); err == nil {
+		t.Fatalf("expected store validation error")
+	}
+
+	db := ttmocks.NewMockExtendedDB()
+	srv := &Server{store: store.New(db)}
+	leased, err := srv.tryAcquireProvisionJobLease(context.Background(), nil, "req", time.Now())
+	if err != nil || leased {
+		t.Fatalf("nil job should not lease: leased=%v err=%v", leased, err)
+	}
+
+	qJob := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Once()
+	db.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qJob).Once()
+	qJob.On("IfExists").Return(qJob).Once()
+	qJob.On("WithConditionExpression", mock.Anything, mock.Anything).Return(qJob).Once()
+	qJob.On("Update", []string{"LeaseOwner", "LeaseExpiresAt", "RequestID", "UpdatedAt"}).Return(theoryErrors.ErrConditionFailed).Once()
+
+	job := &models.ProvisionJob{ID: "job1", InstanceSlug: "slug", Status: models.ProvisionJobStatusQueued}
+	leased, err = srv.tryAcquireProvisionJobLease(context.Background(), job, "", time.Time{})
+	if err != nil || leased {
+		t.Fatalf("condition failure should skip lease without error: leased=%v err=%v", leased, err)
+	}
+	if job.LeaseOwner != "" || !job.LeaseExpiresAt.IsZero() {
+		t.Fatalf("condition failure should not mutate original job lease: %#v", job)
 	}
 }
 

--- a/internal/provisionworker/server_helpers_internal_test.go
+++ b/internal/provisionworker/server_helpers_internal_test.go
@@ -133,6 +133,57 @@ func TestBuildDeployRunnerEnv_PreservesConsentMessageBytes(t *testing.T) {
 	}
 }
 
+func TestClearProvisionJobConsentArtifacts_PreservesHashOnly(t *testing.T) {
+	t.Parallel()
+
+	job := &models.ProvisionJob{
+		ConsentMessage:   "signed message",
+		ConsentSignature: "0xsignature",
+	}
+	clearProvisionJobConsentArtifacts(job)
+
+	if job.ConsentMessage != "" || job.ConsentSignature != "" {
+		t.Fatalf("expected replayable consent artifacts cleared: %#v", job)
+	}
+	if job.ConsentMessageHash == "" {
+		t.Fatalf("expected consent message hash retained")
+	}
+}
+
+func TestTryAcquireProvisionJobLease_SetsBoundedLease(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qJob := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Once()
+
+	var captured *models.ProvisionJob
+	db.On("Model", mock.MatchedBy(func(job *models.ProvisionJob) bool {
+		captured = job
+		return job != nil
+	})).Return(qJob).Once()
+	qJob.On("IfExists").Return(qJob).Once()
+	qJob.On("WithConditionExpression", mock.Anything, mock.Anything).Return(qJob).Once()
+	qJob.On("Update", []string{"LeaseOwner", "LeaseExpiresAt", "RequestID", "UpdatedAt"}).Return(nil).Once()
+
+	srv := &Server{store: store.New(db)}
+	now := time.Unix(100, 0).UTC()
+	job := &models.ProvisionJob{ID: "job1", InstanceSlug: "slug", Status: models.ProvisionJobStatusQueued, CreatedAt: now, ExpiresAt: now.Add(time.Hour)}
+	leased, err := srv.tryAcquireProvisionJobLease(context.Background(), job, "req1", now)
+	if err != nil {
+		t.Fatalf("tryAcquireProvisionJobLease: %v", err)
+	}
+	if !leased {
+		t.Fatalf("expected lease acquired")
+	}
+	if captured == nil || captured.LeaseOwner == "" || !captured.LeaseExpiresAt.Equal(now.Add(provisionJobLeaseDuration)) {
+		t.Fatalf("unexpected lease update: %#v", captured)
+	}
+	if !job.HasActiveLease(now) {
+		t.Fatalf("expected in-memory job to have active lease: %#v", job)
+	}
+}
+
 func TestAssumeInstanceRole_ValidationAndRetryableError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/provisionworker/server_test.go
+++ b/internal/provisionworker/server_test.go
@@ -307,3 +307,52 @@ func TestUpdateSweepEventBridge_ReconcilesActiveBodyJob(t *testing.T) {
 	require.Contains(t, loaded.ErrorMessage, "CodeBuild: https://logs.example/body")
 	require.NotContains(t, loaded.ErrorMessage, "--stack-name")
 }
+
+func TestProcessActiveProvisionSweep_RequeuesOnlyStaleUnleasedJobs(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qJob := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qJob).Maybe()
+	qJob.On("Where", "SK", "=", models.SKJob).Return(qJob).Once()
+	qJob.On("Limit", provisionSweepLimit).Return(qJob).Once()
+
+	now := time.Unix(1_000, 0).UTC()
+	qJob.On("All", mock.AnythingOfType("*[]*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.ProvisionJob](t, args, 0)
+		*dest = []*models.ProvisionJob{
+			{
+				ID:           "stale",
+				InstanceSlug: "slug",
+				Status:       models.ProvisionJobStatusQueued,
+				UpdatedAt:    now.Add(-provisionSweepStaleAfter - time.Second),
+				ExpiresAt:    now.Add(time.Hour),
+			},
+			{
+				ID:             "leased",
+				InstanceSlug:   "slug",
+				Status:         models.ProvisionJobStatusRunning,
+				UpdatedAt:      now.Add(-provisionSweepStaleAfter - time.Second),
+				LeaseOwner:     "worker",
+				LeaseExpiresAt: now.Add(time.Minute),
+				ExpiresAt:      now.Add(time.Hour),
+			},
+		}
+	}).Once()
+
+	sqsClient := &fakeSQS{}
+	srv := &Server{
+		cfg:   config.Config{ProvisionQueueURL: "https://sqs.us-east-1.amazonaws.com/123/provision"},
+		store: store.New(db),
+		sqs:   sqsClient,
+	}
+
+	out, err := srv.processActiveProvisionSweep(context.Background(), "req-sweep", now)
+	require.NoError(t, err)
+	require.EqualValues(t, 2, out["active_jobs"])
+	require.EqualValues(t, 1, out["processed"])
+	require.EqualValues(t, 0, out["errors"])
+	require.Len(t, sqsClient.inputs, 1)
+	require.Contains(t, aws.ToString(sqsClient.inputs[0].MessageBody), `"job_id":"stale"`)
+}

--- a/internal/provisionworker/server_test.go
+++ b/internal/provisionworker/server_test.go
@@ -356,3 +356,90 @@ func TestProcessActiveProvisionSweep_RequeuesOnlyStaleUnleasedJobs(t *testing.T)
 	require.Len(t, sqsClient.inputs, 1)
 	require.Contains(t, aws.ToString(sqsClient.inputs[0].MessageBody), `"job_id":"stale"`)
 }
+
+func TestProcessActiveProvisionSweep_FailsExpiredJobs(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qJob := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qJob).Maybe()
+	qJob.On("Where", "SK", "=", models.SKJob).Return(qJob).Once()
+	qJob.On("Limit", provisionSweepLimit).Return(qJob).Once()
+
+	now := time.Unix(1_000, 0).UTC()
+	expired := &models.ProvisionJob{
+		ID:           "expired",
+		InstanceSlug: "slug",
+		Status:       models.ProvisionJobStatusRunning,
+		UpdatedAt:    now.Add(-time.Hour),
+		ExpiresAt:    now.Add(-time.Minute),
+	}
+	qJob.On("All", mock.AnythingOfType("*[]*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.ProvisionJob](t, args, 0)
+		*dest = []*models.ProvisionJob{expired}
+	}).Once()
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+
+	srv := &Server{
+		cfg:   config.Config{ProvisionQueueURL: "https://sqs.us-east-1.amazonaws.com/123/provision"},
+		store: store.New(db),
+		sqs:   &fakeSQS{},
+	}
+
+	out, err := srv.processActiveProvisionSweep(context.Background(), "req-sweep", now)
+	require.NoError(t, err)
+	require.EqualValues(t, 1, out["active_jobs"])
+	require.EqualValues(t, 1, out["processed"])
+	require.Equal(t, models.ProvisionJobStatusError, expired.Status)
+	require.Equal(t, "expired", expired.ErrorCode)
+}
+
+func TestProcessActiveProvisionSweep_ValidationAndErrorAccounting(t *testing.T) {
+	t.Parallel()
+
+	now := time.Unix(2_000, 0).UTC()
+	var nilServer *Server
+	_, err := nilServer.processActiveProvisionSweep(context.Background(), "req", now)
+	require.ErrorContains(t, err, "store not initialized")
+
+	out, err := (&Server{store: store.New(ttmocks.NewMockExtendedDB())}).processActiveProvisionSweep(context.Background(), "req", now)
+	require.NoError(t, err)
+	require.Equal(t, "sqs not initialized", out["skipped"])
+
+	dbListErr := ttmocks.NewMockExtendedDB()
+	qListErr := new(ttmocks.MockQuery)
+	dbListErr.On("WithContext", mock.Anything).Return(dbListErr).Once()
+	dbListErr.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qListErr).Once()
+	qListErr.On("Where", "SK", "=", models.SKJob).Return(qListErr).Once()
+	qListErr.On("Limit", provisionSweepLimit).Return(qListErr).Once()
+	qListErr.On("All", mock.AnythingOfType("*[]*models.ProvisionJob")).Return(fmt.Errorf("db down")).Once()
+
+	_, err = (&Server{store: store.New(dbListErr), sqs: &fakeSQS{}}).processActiveProvisionSweep(context.Background(), "req", now)
+	require.ErrorContains(t, err, "db down")
+
+	dbProcessErr := ttmocks.NewMockExtendedDB()
+	qProcessErr := new(ttmocks.MockQuery)
+	dbProcessErr.On("WithContext", mock.Anything).Return(dbProcessErr).Once()
+	dbProcessErr.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qProcessErr).Once()
+	qProcessErr.On("Where", "SK", "=", models.SKJob).Return(qProcessErr).Once()
+	qProcessErr.On("Limit", provisionSweepLimit).Return(qProcessErr).Once()
+	qProcessErr.On("All", mock.AnythingOfType("*[]*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.ProvisionJob](t, args, 0)
+		*dest = []*models.ProvisionJob{
+			nil,
+			{ID: "done", Status: models.ProvisionJobStatusOK},
+			{ID: "stale", Status: models.ProvisionJobStatusRunning, UpdatedAt: now.Add(-time.Hour)},
+		}
+	}).Once()
+
+	out, err = (&Server{
+		cfg:   config.Config{ProvisionQueueURL: "https://sqs.us-east-1.amazonaws.com/123/provision"},
+		store: store.New(dbProcessErr),
+		sqs:   &fakeSQS{err: fmt.Errorf("sqs down")},
+	}).processActiveProvisionSweep(context.Background(), "req", now)
+	require.ErrorContains(t, err, "sqs down")
+	require.EqualValues(t, 1, out["active_jobs"])
+	require.EqualValues(t, 0, out["processed"])
+	require.EqualValues(t, 1, out["errors"])
+}

--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -1109,7 +1109,6 @@ func (s *Server) buildUpdateDeployRunnerEnv(job *models.UpdateJob, inputs update
 		)
 	}
 
-
 	return env
 }
 

--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -1109,12 +1109,6 @@ func (s *Server) buildUpdateDeployRunnerEnv(job *models.UpdateJob, inputs update
 		)
 	}
 
-	if strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN) != "" {
-		env = append(env, cbtypes.EnvironmentVariable{
-			Name:  aws.String("MANAGED_ORG_VENDING_ROLE_ARN"),
-			Value: aws.String(strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN)),
-		})
-	}
 
 	return env
 }

--- a/internal/provisionworker/update_jobs_more_internal_test.go
+++ b/internal/provisionworker/update_jobs_more_internal_test.go
@@ -592,6 +592,7 @@ func TestDescribeAndEnsureManagedInstanceKeySecret_RequiresManagedStageTags(t *t
 
 	sm.describeOut.Tags = []smtypes.Tag{
 		{Key: aws.String(managedInstanceKeySecretTagInstanceSlug), Value: aws.String("slug")},
+		{Key: aws.String(managedInstanceKeySecretTagKeyID), Value: aws.String(secretValueToKeyID("lhk_test"))},
 		{Key: aws.String(managedInstanceKeySecretTagManaged), Value: aws.String("true")},
 		{Key: aws.String(managedInstanceKeySecretTagStage), Value: aws.String("lab")},
 	}
@@ -601,6 +602,36 @@ func TestDescribeAndEnsureManagedInstanceKeySecret_RequiresManagedStageTags(t *t
 
 	_, err = srv.describeAndEnsureManagedInstanceKeySecret(context.Background(), sm, " slug ", " secret ", "live")
 	require.ErrorContains(t, err, "refusing unmanaged")
+}
+
+func TestDescribeAndEnsureManagedInstanceKeySecret_RejectsTagOnlyKeyIDForgery(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qKey := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
+	qKey.On("IfNotExists").Return(qKey).Maybe()
+	qKey.On("Create").Return(nil).Maybe()
+
+	srv := &Server{store: store.New(db)}
+	sm := &fakeSecretsManager{
+		describeOut: &secretsmanager.DescribeSecretOutput{
+			ARN: aws.String("arn:secret"),
+			Tags: []smtypes.Tag{
+				{Key: aws.String(managedInstanceKeySecretTagInstanceSlug), Value: aws.String("slug")},
+				{Key: aws.String(managedInstanceKeySecretTagKeyID), Value: aws.String(secretValueToKeyID("lhk_attacker"))},
+				{Key: aws.String(managedInstanceKeySecretTagManaged), Value: aws.String("true")},
+				{Key: aws.String(managedInstanceKeySecretTagStage), Value: aws.String("lab")},
+			},
+		},
+		getOut: &secretsmanager.GetSecretValueOutput{
+			SecretString: aws.String(`{"secret":"lhk_real"}`),
+		},
+	}
+
+	_, err := srv.describeAndEnsureManagedInstanceKeySecret(context.Background(), sm, "slug", "arn:secret", "lab")
+	require.ErrorContains(t, err, "mismatched key id tag")
 }
 
 func TestCreateManagedInstanceKeySecret_ValidatesAndPropagatesErrors(t *testing.T) {

--- a/internal/store/models/provision_consent_challenge.go
+++ b/internal/store/models/provision_consent_challenge.go
@@ -24,10 +24,13 @@ type ProvisionConsentChallenge struct {
 	WalletAddr string `theorydb:"attr:walletAddress" json:"wallet_address"`
 	ChainID    int    `theorydb:"attr:chainID" json:"chain_id"`
 
-	Nonce     string    `theorydb:"attr:nonce" json:"nonce"`
-	Message   string    `theorydb:"attr:message" json:"message"`
-	IssuedAt  time.Time `theorydb:"attr:issuedAt" json:"issued_at"`
-	ExpiresAt time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
+	Nonce       string    `theorydb:"attr:nonce" json:"nonce"`
+	Message     string    `theorydb:"attr:message" json:"message"`
+	MessageHash string    `theorydb:"attr:messageHash" json:"message_hash,omitempty"`
+	Consumed    bool      `theorydb:"attr:consumed" json:"consumed,omitempty"`
+	ConsumedAt  time.Time `theorydb:"attr:consumedAt" json:"consumed_at,omitempty"`
+	IssuedAt    time.Time `theorydb:"attr:issuedAt" json:"issued_at"`
+	ExpiresAt   time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
 }
 
 // TableName returns the database table name for ProvisionConsentChallenge.
@@ -62,6 +65,7 @@ func (c *ProvisionConsentChallenge) UpdateKeys() error {
 	c.WalletType = strings.TrimSpace(c.WalletType)
 	c.WalletAddr = strings.ToLower(strings.TrimSpace(c.WalletAddr))
 	c.Nonce = strings.TrimSpace(c.Nonce)
+	c.MessageHash = strings.TrimSpace(c.MessageHash)
 
 	c.PK = fmt.Sprintf("PROVISION_CONSENT#%s", c.ID)
 	c.SK = "CHALLENGE"

--- a/internal/store/models/provision_job.go
+++ b/internal/store/models/provision_job.go
@@ -72,6 +72,9 @@ type ProvisionJob struct {
 	Attempts    int64 `theorydb:"attr:attempts" json:"attempts"`
 	MaxAttempts int64 `theorydb:"attr:maxAttempts" json:"max_attempts,omitempty"`
 
+	LeaseOwner     string    `theorydb:"attr:leaseOwner" json:"lease_owner,omitempty"`
+	LeaseExpiresAt time.Time `theorydb:"attr:leaseExpiresAt" json:"lease_expires_at,omitempty"`
+
 	ErrorCode    string `theorydb:"attr:errorCode" json:"error_code,omitempty"`
 	ErrorMessage string `theorydb:"attr:errorMessage" json:"error_message,omitempty"`
 
@@ -143,6 +146,7 @@ func (j *ProvisionJob) UpdateKeys() error {
 	j.ChildHostedZoneID = strings.TrimSpace(j.ChildHostedZoneID)
 	j.ReceiptJSON = strings.TrimSpace(j.ReceiptJSON)
 	j.SoulReceiptJSON = strings.TrimSpace(j.SoulReceiptJSON)
+	j.LeaseOwner = strings.TrimSpace(j.LeaseOwner)
 	j.ErrorCode = strings.TrimSpace(j.ErrorCode)
 	j.ErrorMessage = strings.TrimSpace(j.ErrorMessage)
 	j.RequestID = strings.TrimSpace(j.RequestID)
@@ -163,6 +167,17 @@ func (j *ProvisionJob) GetPK() string { return j.PK }
 
 // GetSK returns the sort key for ProvisionJob.
 func (j *ProvisionJob) GetSK() string { return j.SK }
+
+// HasActiveLease reports whether a worker lease should suppress duplicate provisioning work.
+func (j *ProvisionJob) HasActiveLease(now time.Time) bool {
+	if j == nil {
+		return false
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return strings.TrimSpace(j.LeaseOwner) != "" && j.LeaseExpiresAt.After(now)
+}
 
 func (j *ProvisionJob) updateGSI1() {
 	if j == nil {


### PR DESCRIPTION
## Milestone
M6 — Critical pre-live isolation and provisioning hardening for host security round 2.

Closes #226
Closes #230
Closes #231
Closes #232
Closes #233
Closes #234
Closes #235
Closes #236

## Classification
security / tenant-isolation / provisioning / managed-update / governance / billing-guardrail / operational-reliability / docs

## Surfaces affected
- gov-infra action-pin verifier and pack metadata
- Round-2 Codex Security ledger and pre-live rollout docs
- Managed instance key secret discovery and instance-key hash persistence
- AWS Organizations account creation/adoption path
- CodeBuild provisioning runner IAM/env surface
- Portal budget endpoint authorization
- Provisioning consent challenge persistence/consumption
- Provision worker queue lease and active-job sweep recovery
- Lesser host-lab + simulacrum canary coordination checklist

## Specialist walks referenced
- Governance rubric: explicit SEC-3 verifier tightening with pack metadata bump; no silent weakening.
- Provisioning / managed-update / release verification: provisioning-worker changes keep per-slug account isolation and preserve checksum-based consumer release verification.
- Soul registry: none; no contracts/on-chain changes in this milestone.
- Trust API / CSP / instance-auth: instance API key storage remains `sha256(raw_key)` only; no CSP changes.
- Framework: idiomatic AppTheory/TableTheory consumption; no local framework patches.

## Multi-tenant isolation impact
Elevated scrutiny. This PR tightens managed-instance isolation by refusing tag-only instance key adoption, requiring explicit validated AWS account adoption, and removing org vending-role access from the deploy runner.

## On-chain impact
None. Lab/Sepolia assumptions are documented; no Solidity, Sepolia deploy, mainnet deploy, or Safe payload changes are included in M6.

## Consumer impact
Managed operators and future customers. This is pre-live hardening for lab/Sepolia before any live customer data/tips exist. Existing lab data may be migrated/reset; simulacrum remains the host-lab canary.

## Tasks
- [x] #230 Record round-2 Codex Security ledger and sanitize unresolved disclosure
- [x] #231 Verify managed instance key secrets from secret values
- [x] #232 Require explicit validated AWS account adoption and disable email reuse
- [x] #233 Remove org vending role access from deploy runner
- [x] #234 Prevent portal credit self-grants
- [x] #235 Make provisioning consent and queue processing one-time and leased
- [x] #236 Coordinate Lesser security rollout with host lab and simulacrum canary

## Validation
- [x] `gofmt -l $(git ls-files '*.go')` (empty)
- [x] `git diff --check`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `cd cdk && npm ci && npm test && npm run synth`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

Notes: CDK validation still emits existing deprecation warnings for `S3Origin`/`DnsValidatedCertificate` and existing Vite/lightningcss `:global` warnings from greater component CSS; tests/synth completed successfully.

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deploy host lab (`theory app up --stage lab`) — operator-run, no timeout
- [ ] Exercise `theory` dev stage provisioning/update paths
- [ ] Coordinate Lesser security branch/release artifact readiness
- [ ] Run simulacrum as host-lab canary after Lesser coordination
- [ ] Lab soak complete
- [ ] Live deployment explicitly authorized later; no live deploy in this PR

## Cross-repo coordination
Required with Lesser before canary rollout. This PR documents the host-side canary gates; Lesser-side fixes and release artifact verification remain coordinated outside this repo.

## Advisor-brief authorization
Not applicable; this was Aron-directed work, not an advisor-dispatched brief.
