### PR TITLE
fix(provision): replace legacy lab instance key secrets

### DIFF
--- a/internal/provisionworker/managed_instance_key_secrets.go
+++ b/internal/provisionworker/managed_instance_key_secrets.go
@@ -2,6 +2,7 @@ package provisionworker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,6 +12,8 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
+
+var errManagedInstanceKeySecretTags = errors.New("refusing unmanaged or cross-stage instance key secret")
 
 type managedInstanceSecretsInputs struct {
 	accountID string
@@ -125,12 +128,16 @@ func validateManagedInstanceKeySecretTags(tags []smtypes.Tag, slug string, contr
 	rawStageTag := secretsManagerTagValue(tags, managedInstanceKeySecretTagStage)
 	stageTag := managedInstanceKeySecretStage(rawStageTag)
 	if managedTag != "true" || slugTag != slug || stageTag != expectedStage {
-		return fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
+		return errManagedInstanceKeySecretTags
 	}
 	if strings.TrimSpace(rawStageTag) == "" {
-		return fmt.Errorf("refusing unmanaged or cross-stage instance key secret")
+		return errManagedInstanceKeySecretTags
 	}
 	return nil
+}
+
+func isManagedInstanceKeySecretTagError(err error) bool {
+	return errors.Is(err, errManagedInstanceKeySecretTags)
 }
 
 func resolveManagedInstanceKeySecretID(ctx context.Context, sm secretsManagerAPI, secretArn string, tags []smtypes.Tag) (string, error) {

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -1386,12 +1386,12 @@ func (s *Server) ensureManagedInstanceKeySecret(ctx context.Context, job *models
 		secretID = secretName
 	}
 
-	arn, describeErr := s.describeAndEnsureManagedInstanceKeySecret(ctx, sm, inputs.slug, secretID, s.cfg.Stage)
-	if describeErr == nil {
-		return arn, nil
+	arn, found, err := s.findManagedInstanceKeySecret(ctx, sm, inputs.slug, secretID, secretName)
+	if err != nil {
+		return "", err
 	}
-	if !isSecretsManagerNotFound(describeErr) {
-		return "", describeErr
+	if found {
+		return arn, nil
 	}
 
 	createdArn, keyID, createErr := s.createManagedInstanceKeySecret(ctx, sm, secretName, inputs.slug, s.cfg.Stage)
@@ -1411,6 +1411,41 @@ func (s *Server) ensureManagedInstanceKeySecret(ctx context.Context, job *models
 		return createdArn, nil
 	}
 	return s.describeAndEnsureManagedInstanceKeySecret(ctx, sm, inputs.slug, secretName, s.cfg.Stage)
+}
+
+func (s *Server) findManagedInstanceKeySecret(ctx context.Context, sm secretsManagerAPI, slug string, secretID string, secretName string) (string, bool, error) {
+	arn, err := s.describeAndEnsureManagedInstanceKeySecret(ctx, sm, slug, secretID, s.cfg.Stage)
+	if err == nil {
+		return arn, true, nil
+	}
+	if isSecretsManagerNotFound(err) {
+		return "", false, nil
+	}
+	if !s.canIgnoreLegacyInstanceKeySecret(secretID, secretName, err) {
+		return "", false, err
+	}
+	arn, err = s.describeAndEnsureManagedInstanceKeySecret(ctx, sm, slug, secretName, s.cfg.Stage)
+	if err == nil {
+		return arn, true, nil
+	}
+	if isSecretsManagerNotFound(err) {
+		return "", false, nil
+	}
+	return "", false, err
+}
+
+func (s *Server) canIgnoreLegacyInstanceKeySecret(secretID string, secretName string, err error) bool {
+	if !isManagedInstanceKeySecretTagError(err) {
+		return false
+	}
+	// Pre-M6 lab managed instances may point at tenant-account secrets that predate the
+	// managed/stage/slug tag contract. Do not adopt those secrets by tag-forgery-prone
+	// inference; in non-live stages only, ignore the legacy ARN and create/reuse the
+	// canonical managed secret instead. Live remains fail-closed.
+	if managedInstanceKeySecretStage(s.cfg.Stage) == "live" {
+		return false
+	}
+	return strings.TrimSpace(secretID) != "" && strings.TrimSpace(secretID) != strings.TrimSpace(secretName)
 }
 
 func (s *Server) rotateManagedInstanceKeySecret(ctx context.Context, job *models.ProvisionJob, secretArn string) (string, error) {

--- a/internal/provisionworker/state_machine_flow_internal_test.go
+++ b/internal/provisionworker/state_machine_flow_internal_test.go
@@ -128,14 +128,18 @@ func (f *fakeCodebuild) StartBuild(_ context.Context, in *codebuild.StartBuildIn
 }
 
 type fakeSecretsManager struct {
-	describeOut *secretsmanager.DescribeSecretOutput
-	describeErr error
+	describeOut     *secretsmanager.DescribeSecretOutput
+	describeErr     error
+	describeByID    map[string]*secretsmanager.DescribeSecretOutput
+	describeErrByID map[string]error
+	describeInputs  []string
 
 	getOut *secretsmanager.GetSecretValueOutput
 	getErr error
 
-	createOut *secretsmanager.CreateSecretOutput
-	createErr error
+	createOut    *secretsmanager.CreateSecretOutput
+	createErr    error
+	createInputs []*secretsmanager.CreateSecretInput
 
 	updateOut *secretsmanager.UpdateSecretOutput
 	updateErr error
@@ -147,14 +151,30 @@ type fakeSecretsManager struct {
 	untagErr error
 }
 
-func (f *fakeSecretsManager) CreateSecret(_ context.Context, _ *secretsmanager.CreateSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
+func (f *fakeSecretsManager) CreateSecret(_ context.Context, in *secretsmanager.CreateSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.CreateSecretOutput, error) {
+	f.createInputs = append(f.createInputs, in)
 	if f.createErr != nil {
 		return nil, f.createErr
 	}
-	return f.createOut, nil
+	if f.createOut != nil {
+		return f.createOut, nil
+	}
+	return &secretsmanager.CreateSecretOutput{ARN: in.Name}, nil
 }
 
-func (f *fakeSecretsManager) DescribeSecret(_ context.Context, _ *secretsmanager.DescribeSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+func (f *fakeSecretsManager) DescribeSecret(_ context.Context, in *secretsmanager.DescribeSecretInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.DescribeSecretOutput, error) {
+	secretID := strings.TrimSpace(aws.ToString(in.SecretId))
+	f.describeInputs = append(f.describeInputs, secretID)
+	if f.describeErrByID != nil {
+		if err, ok := f.describeErrByID[secretID]; ok {
+			return nil, err
+		}
+	}
+	if f.describeByID != nil {
+		if out, ok := f.describeByID[secretID]; ok {
+			return out, nil
+		}
+	}
 	if f.describeErr != nil {
 		return nil, f.describeErr
 	}

--- a/internal/provisionworker/update_jobs_more_internal_test.go
+++ b/internal/provisionworker/update_jobs_more_internal_test.go
@@ -634,6 +634,75 @@ func TestDescribeAndEnsureManagedInstanceKeySecret_RejectsTagOnlyKeyIDForgery(t 
 	require.ErrorContains(t, err, "mismatched key id tag")
 }
 
+func TestEnsureManagedInstanceKeySecret_NonLiveReplacesLegacyUntaggedARN(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qKey := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
+	qKey.On("IfNotExists").Return(qKey).Once()
+	qKey.On("Create").Return(nil).Once()
+
+	oldArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:legacy/instance-key"
+	newArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:lab/slug/instance-key"
+	canonicalName := managedInstanceKeySecretName("lab", "slug")
+	sm := &fakeSecretsManager{
+		describeByID: map[string]*secretsmanager.DescribeSecretOutput{
+			oldArn: {ARN: aws.String(oldArn), Tags: nil},
+		},
+		describeErrByID: map[string]error{
+			canonicalName: &smtypes.ResourceNotFoundException{},
+		},
+		createOut: &secretsmanager.CreateSecretOutput{ARN: aws.String(newArn)},
+	}
+
+	srv := &Server{
+		cfg:   config.Config{Stage: "lab"},
+		store: store.New(db),
+		smFactory: func(context.Context, string, string, string, string, string) (secretsManagerAPI, error) {
+			return sm, nil
+		},
+	}
+	job := &models.ProvisionJob{ID: "job1", InstanceSlug: "slug", AccountID: "123456789012", AccountRoleName: "role", Region: "us-east-1"}
+	inst := &models.Instance{Slug: "slug", LesserHostInstanceKeySecretARN: oldArn}
+
+	arn, err := srv.ensureManagedInstanceKeySecret(context.Background(), job, inst)
+	require.NoError(t, err)
+	require.Equal(t, newArn, arn)
+	require.Equal(t, []string{oldArn, canonicalName}, sm.describeInputs)
+	require.Len(t, sm.createInputs, 1)
+	require.Equal(t, canonicalName, aws.ToString(sm.createInputs[0].Name))
+	require.Equal(t, "slug", secretsManagerTagValue(sm.createInputs[0].Tags, managedInstanceKeySecretTagInstanceSlug))
+	require.Equal(t, "lab", secretsManagerTagValue(sm.createInputs[0].Tags, managedInstanceKeySecretTagStage))
+}
+
+func TestEnsureManagedInstanceKeySecret_LiveRefusesLegacyUntaggedARN(t *testing.T) {
+	t.Parallel()
+
+	oldArn := "arn:aws:secretsmanager:us-east-1:123456789012:secret:legacy/instance-key"
+	sm := &fakeSecretsManager{
+		describeByID: map[string]*secretsmanager.DescribeSecretOutput{
+			oldArn: {ARN: aws.String(oldArn), Tags: nil},
+		},
+	}
+
+	srv := &Server{
+		cfg:   config.Config{Stage: "live"},
+		store: store.New(ttmocks.NewMockExtendedDB()),
+		smFactory: func(context.Context, string, string, string, string, string) (secretsManagerAPI, error) {
+			return sm, nil
+		},
+	}
+	job := &models.ProvisionJob{ID: "job1", InstanceSlug: "slug", AccountID: "123456789012", AccountRoleName: "role", Region: "us-east-1"}
+	inst := &models.Instance{Slug: "slug", LesserHostInstanceKeySecretARN: oldArn}
+
+	_, err := srv.ensureManagedInstanceKeySecret(context.Background(), job, inst)
+	require.ErrorContains(t, err, "refusing unmanaged or cross-stage instance key secret")
+	require.Equal(t, []string{oldArn}, sm.describeInputs)
+	require.Empty(t, sm.createInputs)
+}
+
 func TestCreateManagedInstanceKeySecret_ValidatesAndPropagatesErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Investigation

Reported lab managed updates for `theory` and `simulacrum` failed after M6 with:

```text
Error: instance_key_secret_failed
failed to ensure instance key secret: refusing unmanaged or cross-stage instance key secret
```

Verified read-only in `lesser-host-lab-state`:
- `theory` update job `Nni2_8UTPdmysQlPz3xFaw` failed at `instance_key_secret_failed` and points at a pre-M6 tenant-account instance-key secret ARN.
- `simulacrum` update job `u_EbmcRgS_F-HtfQKNZ2Rg` failed at `instance_key_secret_failed` and points at a pre-M6 tenant-account instance-key secret ARN.

Root cause: these lab instances still point at pre-M6 tenant-account instance-key secrets that predate the new managed/stage/slug tag contract. M6 correctly made live adoption fail closed, but the lab migration path needed to ignore those legacy ARNs and create/reuse the canonical managed secret instead.

## Fix

- Preserve M6 fail-closed validation for live and for canonical managed secrets.
- In non-live stages only, when an existing instance record points at a legacy unmanaged/cross-stage ARN, do **not** adopt or retag that secret.
- Instead, ignore the legacy ARN and create/reuse the canonical `stage/slug/instance-key` managed secret with proper tags.
- Add regression tests covering non-live replacement and live refusal.

## Provisioning / managed-update audit

- Per-slug AWS account setup: unchanged.
- Tenant isolation: preserved; no cross-tenant read/write added.
- Secrets: old untagged lab secret is not adopted; a canonical per-slug secret is generated/reused.
- Live behavior: still fails closed on unmanaged/cross-stage tags.
- Consumer release verification: unchanged.
- CodeBuild runner: unchanged.
- Managed-update recovery: failed lab updates can be retried after this host deploy.

## Validation

- `gofmt -l $(git ls-files '*.go')`
- `git diff --check`
- `go test ./...`
- `go vet ./...`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

CI is green, including gov-rubric.

## Rollout

After merge:
- Deploy host lab with `AWS_PROFILE=Lesser theory app up --stage lab --execute`.
- Retry the `theory` and `simulacrum` managed Lesser updates.
- Confirm new/canonical instance key secret ARN is persisted and update jobs advance beyond `instance.config`.