### PR TITLE
fix(provision): repair deploy runner tenant trust

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -586,6 +586,7 @@ export class LesserHostStack extends cdk.Stack {
 				MANAGED_DEFAULT_REGION: managedDefaultRegion,
 				MANAGED_LESSER_DEFAULT_VERSION: managedLesserDefaultVersion,
 				MANAGED_PROVISION_RUNNER_PROJECT_NAME: provisionRunnerProjectName,
+				MANAGED_PROVISION_RUNNER_ROLE_ARN: provisionRunnerProject.role?.roleArn ?? '',
 				MANAGED_LESSER_GITHUB_OWNER: lesserGitHubOwner,
 				MANAGED_LESSER_GITHUB_REPO: lesserGitHubRepo,
 				MANAGED_LESSER_GITHUB_TOKEN_SSM_PARAM: managedLesserGitHubTokenSsmParam.trim(),

--- a/cdk/lib/provision-runner/prebuild.sh
+++ b/cdk/lib/provision-runner/prebuild.sh
@@ -3,7 +3,22 @@
 set -euo pipefail
 
 echo "Assuming managed-instance role in target account..."
-CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::$TARGET_ACCOUNT_ID:role/$TARGET_ROLE_NAME" --role-session-name "lesser-host-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text)
+ASSUME_ERR=$(mktemp)
+CREDS=""
+for attempt in $(seq 1 12); do
+  if CREDS=$(aws sts assume-role --role-arn "arn:aws:iam::$TARGET_ACCOUNT_ID:role/$TARGET_ROLE_NAME" --role-session-name "lesser-host-$APP_SLUG" --duration-seconds 3600 --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" --output text 2>"$ASSUME_ERR"); then
+    break
+  fi
+  status=$?
+  if [ "$attempt" -ge 12 ]; then
+    cat "$ASSUME_ERR" >&2
+    rm -f "$ASSUME_ERR"
+    exit "$status"
+  fi
+  echo "Managed-instance role not assumable yet (attempt $attempt/12); retrying..."
+  sleep 5
+done
+rm -f "$ASSUME_ERR"
 read MANAGED_AK MANAGED_SK MANAGED_TOKEN <<< "$CREDS"
 mkdir -p ~/.aws
 printf "[managed]\naws_access_key_id=%s\naws_secret_access_key=%s\naws_session_token=%s\n" "$MANAGED_AK" "$MANAGED_SK" "$MANAGED_TOKEN" > ~/.aws/credentials

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -176,3 +176,18 @@ test('provision runner cannot assume the organization vending role', () => {
 		}
 	}
 });
+
+test('provision worker receives deploy runner role arn for tenant trust repair', () => {
+	const template = synthTemplate();
+	const provisionWorker = findLambdaByFunctionName(template, 'provision-worker');
+	const env = lambdaEnvironment(provisionWorker);
+
+	assert.ok(
+		'MANAGED_PROVISION_RUNNER_ROLE_ARN' in env,
+		'expected provision worker to receive CodeBuild service role ARN',
+	);
+	assert.ok(
+		env.MANAGED_PROVISION_RUNNER_ROLE_ARN,
+		'expected provision worker CodeBuild service role ARN to be non-empty',
+	);
+});

--- a/docs/managed-instance-provisioning.md
+++ b/docs/managed-instance-provisioning.md
@@ -176,6 +176,8 @@ The control plane needs (at minimum):
 - `MANAGED_DEFAULT_REGION` (default: `AWS_REGION` or `us-east-1`)
 - `MANAGED_LESSER_DEFAULT_VERSION` (optional release tag or `latest`; used when the request doesn’t specify one)
 - `MANAGED_PROVISION_RUNNER_PROJECT_NAME` (CodeBuild project name used to run `lesser up`)
+- `MANAGED_PROVISION_RUNNER_ROLE_ARN` (CodeBuild service role ARN; provision worker ensures the per-instance role trust
+  policy allows this principal before invoking the runner)
 - `ARTIFACT_BUCKET_NAME` (S3 bucket where the runner writes receipts)
 - `MANAGED_LESSER_GITHUB_OWNER` (default: `equaltoai`)
 - `MANAGED_LESSER_GITHUB_REPO` (default: `lesser`)

--- a/docs/security/host-security-round2-prelive-rollout.md
+++ b/docs/security/host-security-round2-prelive-rollout.md
@@ -35,3 +35,11 @@ M6 is considered ready for broader lab soak only after all of the following are 
 - Host consumes a published Lesser artifact through managed-release certification; no source-only signoff.
 - `simulacrum` runs as the host-lab canary after `theory` passes, using the same verified Lesser artifact line.
 - Any Lesser-side rollout blocker is recorded on the M6 tracking issue/PR before canary signoff.
+
+### Lab canary trust-policy remediation
+
+M6 intentionally keeps the Organizations vending role scoped to host-side orchestration; the CodeBuild deploy runner must
+not receive that high-privilege role. Before a managed provisioning or managed-update runner starts, the provision worker
+now ensures the per-instance `MANAGED_INSTANCE_ROLE_NAME` trust policy includes the concrete
+`MANAGED_PROVISION_RUNNER_ROLE_ARN`. Existing lab tenant accounts (`theory` first, `simulacrum` canary second) should be
+migrated by the normal managed-update path; do not restore org-vending-role access to the deploy runner as a shortcut.

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,13 @@ require (
 	github.com/andybalholm/brotli v1.2.0
 	github.com/anthropics/anthropic-sdk-go v1.26.0
 	github.com/aws/aws-lambda-go v1.54.0
-	github.com/aws/aws-sdk-go-v2 v1.41.5
+	github.com/aws/aws-sdk-go-v2 v1.41.7
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2
+	github.com/aws/aws-sdk-go-v2/service/iam v1.53.9
 	github.com/aws/aws-sdk-go-v2/service/kms v1.50.3
 	github.com/aws/aws-sdk-go-v2/service/organizations v1.50.5
 	github.com/aws/aws-sdk-go-v2/service/rekognition v1.51.19
@@ -21,7 +22,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.42.24
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.68.3
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
-	github.com/aws/smithy-go v1.24.2
+	github.com/aws/smithy-go v1.25.1
 	github.com/chromedp/cdproto v0.0.0-20250803210736-d308e07a266d
 	github.com/chromedp/chromedp v0.14.2
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
@@ -41,8 +42,8 @@ require (
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20260218040609-6f1c0c95351b // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/apigatewaymanagementapi v1.29.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,8 +12,8 @@ github.com/anthropics/anthropic-sdk-go v1.26.0 h1:oUTzFaUpAevfuELAP1sjL6CQJ9HHAf
 github.com/anthropics/anthropic-sdk-go v1.26.0/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/aws/aws-lambda-go v1.54.0 h1:EGYpdyRGF88xszqlGcBewz811mJeRS+maNlLZXFheII=
 github.com/aws/aws-lambda-go v1.54.0/go.mod h1:dpMpZgvWx5vuQJfBt0zqBha60q7Dd7RfgJv23DymV8A=
-github.com/aws/aws-sdk-go-v2 v1.41.5 h1:dj5kopbwUsVUVFgO4Fi5BIT3t4WyqIDjGKCangnV/yY=
-github.com/aws/aws-sdk-go-v2 v1.41.5/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
+github.com/aws/aws-sdk-go-v2 v1.41.7 h1:DWpAJt66FmnnaRIOT/8ASTucrvuDPZASqhhLey6tLY8=
+github.com/aws/aws-sdk-go-v2 v1.41.7/go.mod h1:4LAfZOPHNVNQEckOACQx60Y8pSRjIkNZQz1w92xpMJc=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.12 h1:O3csC7HUGn2895eNrLytOJQdoL2xyJy0iYXhoZ1OmP0=
@@ -22,10 +22,10 @@ github.com/aws/aws-sdk-go-v2/credentials v1.19.12 h1:oqtA6v+y5fZg//tcTWahyN9PEn5
 github.com/aws/aws-sdk-go-v2/credentials v1.19.12/go.mod h1:U3R1RtSHx6NB0DvEQFGyf/0sbrpJrluENHdPy1j/3TE=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 h1:zOgq3uezl5nznfoK3ODuqbhVg1JzAGDUhXOsU0IDCAo=
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20/go.mod h1:z/MVwUARehy6GAg/yQ1GO2IMl0k++cu1ohP9zo887wE=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21 h1:Rgg6wvjjtX8bNHcvi9OnXWwcE0a2vGpbwmtICOsvcf4=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.21/go.mod h1:A/kJFst/nm//cyqonihbdpQZwiUhhzpqTsdbhDdRF9c=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21 h1:PEgGVtPoB6NTpPrBgqSE5hE/o47Ij9qk/SEZFbUOe9A=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.21/go.mod h1:p+hz+PRAYlY3zcpJhPwXlLC4C+kqn70WIHwnzAfs6ps=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23 h1:GpT/TrnBYuE5gan2cZbTtvP+JlHsutdmlV2YfEyNde0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.23/go.mod h1:xYWD6BS9ywC5bS3sz9Xh04whO/hzK2plt2Zkyrp4JuA=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23 h1:bpd8vxhlQi2r1hiueOw02f/duEPTMK59Q4QMAoTTtTo=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.23/go.mod h1:15DfR2nw+CRHIk0tqNyifu3G1YdAOy68RftkhMDDwYk=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20 h1:AFxiBqfeAwybIkTFP2cV
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20/go.mod h1:0ZcEjoeeMH4Mji0ZrwiKgTnQiv7uoNG9DoQS2crnhX8=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2 h1:xi/ECwajy2mixviBD7bKAlGGSwzEaFKX2wIhrZt9NGw=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2/go.mod h1:dLREOeW66eVaaGIOi2ZlLHDgkR3nuJ02rd00j0YSlBE=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.9 h1:slEs4iUvSt/YOiQQajtXkYBZTMrsEeplSnaB928p4l0=
+github.com/aws/aws-sdk-go-v2/service/iam v1.53.9/go.mod h1:1vkJzjCYC3byO0kIrBqLPzvZpuvYhPXkuyARs6E7tM4=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 h1:5EniKhLZe4xzL7a+fU3C2tfUN4nWIqlLesfrjkuPFTY=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7/go.mod h1:x0nZssQ3qZSnIcePWLvcoFisRXJzcTVvYpAAdYX8+GI=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.13 h1:JRaIgADQS/U6uXDqlPiefP32yXTda7Kqfx+LgspooZM=
@@ -74,8 +76,8 @@ github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 h1:jzKAXIlhZhJbnYwHbvUQZEB
 github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17/go.mod h1:Al9fFsXjv4KfbzQHGe6V4NZSZQXecFcvaIF4e70FoRA=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9 h1:Cng+OOwCHmFljXIxpEVXAGMnBia8MSU6Ch5i9PgBkcU=
 github.com/aws/aws-sdk-go-v2/service/sts v1.41.9/go.mod h1:LrlIndBDdjA/EeXeyNBle+gyCwTlizzW5ycgWnvIxkk=
-github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
-github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.25.1 h1:J8ERsGSU7d+aCmdQur5Txg6bVoYelvQJgtZehD12GkI=
+github.com/aws/smithy-go v1.25.1/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -119,6 +119,7 @@ type Config struct {
 	ManagedDefaultRegion              string // e.g. us-east-1
 	ManagedLesserDefaultVersion       string // release tag or "latest", optional
 	ManagedProvisionRunnerProjectName string // CodeBuild project name used to run lesser up
+	ManagedProvisionRunnerRoleARN     string // CodeBuild service role allowed in per-instance assume-role trust
 	ManagedLesserGitHubOwner          string // GitHub org/user for the lesser repo
 	ManagedLesserGitHubRepo           string // GitHub repo name for lesser
 	ManagedLesserGitHubTokenSSMParam  string // optional SSM param name for a GitHub token (CodeBuild)
@@ -284,6 +285,7 @@ func Load() Config {
 		ManagedDefaultRegion:              managedDefaultRegion,
 		ManagedLesserDefaultVersion:       envString("MANAGED_LESSER_DEFAULT_VERSION"),
 		ManagedProvisionRunnerProjectName: managedProvisionRunnerProjectName,
+		ManagedProvisionRunnerRoleARN:     envString("MANAGED_PROVISION_RUNNER_ROLE_ARN"),
 		ManagedLesserGitHubOwner:          managedLesserGitHubOwner,
 		ManagedLesserGitHubRepo:           managedLesserGitHubRepo,
 		ManagedLesserGitHubTokenSSMParam:  envString("MANAGED_LESSER_GITHUB_TOKEN_SSM_PARAM"),

--- a/internal/provisionworker/deploy_runner_trust.go
+++ b/internal/provisionworker/deploy_runner_trust.go
@@ -1,0 +1,238 @@
+package provisionworker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/arn"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+)
+
+type iamAPI interface {
+	GetRole(ctx context.Context, params *iam.GetRoleInput, optFns ...func(*iam.Options)) (*iam.GetRoleOutput, error)
+	UpdateAssumeRolePolicy(ctx context.Context, params *iam.UpdateAssumeRolePolicyInput, optFns ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error)
+}
+
+type iamClientFactory func(ctx context.Context, accountID string, roleName string, region string, slug string, jobID string) (iamAPI, error)
+
+func (s *Server) ensureDeployRunnerAssumeRoleTrust(ctx context.Context, accountID string, roleName string, region string, slug string, jobID string) error {
+	if s == nil {
+		return fmt.Errorf("server not initialized")
+	}
+	runnerRoleARN := strings.TrimSpace(s.cfg.ManagedProvisionRunnerRoleARN)
+	if runnerRoleARN == "" {
+		return nil
+	}
+	if err := validateIAMRoleARN(runnerRoleARN); err != nil {
+		return fmt.Errorf("invalid managed provision runner role arn: %w", err)
+	}
+
+	accountID = strings.TrimSpace(accountID)
+	roleName = strings.TrimSpace(roleName)
+	if accountID == "" || roleName == "" {
+		return fmt.Errorf("account id and role name are required")
+	}
+
+	childIAM, err := s.childIAMClient(ctx, accountID, roleName, region, slug, jobID)
+	if err != nil {
+		return err
+	}
+
+	out, err := childIAM.GetRole(ctx, &iam.GetRoleInput{RoleName: aws.String(roleName)})
+	if err != nil {
+		return fmt.Errorf("get managed instance role trust policy: %w", err)
+	}
+	if out == nil || out.Role == nil || strings.TrimSpace(aws.ToString(out.Role.AssumeRolePolicyDocument)) == "" {
+		return fmt.Errorf("managed instance role trust policy is empty")
+	}
+
+	updated, changed, err := ensureAssumeRolePolicyAllowsPrincipal(aws.ToString(out.Role.AssumeRolePolicyDocument), runnerRoleARN)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		return nil
+	}
+
+	if _, err := childIAM.UpdateAssumeRolePolicy(ctx, &iam.UpdateAssumeRolePolicyInput{
+		RoleName:       aws.String(roleName),
+		PolicyDocument: aws.String(updated),
+	}); err != nil {
+		return fmt.Errorf("update managed instance role trust policy: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) childIAMClient(ctx context.Context, accountID string, roleName string, region string, slug string, jobID string) (iamAPI, error) {
+	if s == nil {
+		return nil, fmt.Errorf("server not initialized")
+	}
+	if s.iamFactory != nil {
+		return s.iamFactory(ctx, accountID, roleName, region, slug, jobID)
+	}
+
+	assumed, _, err := s.assumeInstanceRole(ctx, accountID, roleName, slug, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("assume instance role: %w", err)
+	}
+	if assumed == nil || assumed.Credentials == nil {
+		return nil, fmt.Errorf("assume role returned empty credentials")
+	}
+
+	region = strings.TrimSpace(region)
+	if region == "" {
+		region = strings.TrimSpace(s.cfg.ManagedDefaultRegion)
+	}
+	if region == "" {
+		region = defaultManagedAWSRegion
+	}
+
+	creds := credentials.NewStaticCredentialsProvider(
+		aws.ToString(assumed.Credentials.AccessKeyId),
+		aws.ToString(assumed.Credentials.SecretAccessKey),
+		aws.ToString(assumed.Credentials.SessionToken),
+	)
+	return iam.New(iam.Options{
+		Region:      region,
+		Credentials: aws.NewCredentialsCache(creds),
+	}), nil
+}
+
+func validateIAMRoleARN(value string) error {
+	parsed, err := arn.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return err
+	}
+	if parsed.Service != "iam" || parsed.AccountID == "" || !strings.HasPrefix(parsed.Resource, "role/") {
+		return fmt.Errorf("expected iam role arn")
+	}
+	return nil
+}
+
+func ensureAssumeRolePolicyAllowsPrincipal(rawPolicy string, principalARN string) (string, bool, error) {
+	principalARN = strings.TrimSpace(principalARN)
+	if principalARN == "" {
+		return "", false, fmt.Errorf("principal arn is required")
+	}
+
+	policyJSON, err := decodeAssumeRolePolicyDocument(rawPolicy)
+	if err != nil {
+		return "", false, err
+	}
+
+	var doc map[string]any
+	if unmarshalErr := json.Unmarshal([]byte(policyJSON), &doc); unmarshalErr != nil {
+		return "", false, fmt.Errorf("parse managed instance role trust policy: %w", unmarshalErr)
+	}
+	if strings.TrimSpace(fmt.Sprint(doc["Version"])) == "" {
+		doc["Version"] = "2012-10-17"
+	}
+
+	statements, err := normalizedPolicyStatements(doc["Statement"])
+	if err != nil {
+		return "", false, err
+	}
+	for _, statement := range statements {
+		if assumeRoleStatementAllowsPrincipal(statement, principalARN) {
+			return policyJSON, false, nil
+		}
+	}
+
+	statements = append(statements, map[string]any{
+		"Effect": "Allow",
+		"Principal": map[string]any{
+			"AWS": principalARN,
+		},
+		"Action": "sts:AssumeRole",
+	})
+	doc["Statement"] = statements
+
+	updated, err := json.Marshal(doc)
+	if err != nil {
+		return "", false, fmt.Errorf("marshal managed instance role trust policy: %w", err)
+	}
+	return string(updated), true, nil
+}
+
+func decodeAssumeRolePolicyDocument(rawPolicy string) (string, error) {
+	rawPolicy = strings.TrimSpace(rawPolicy)
+	if rawPolicy == "" {
+		return "", fmt.Errorf("managed instance role trust policy is empty")
+	}
+	if strings.HasPrefix(rawPolicy, "{") {
+		return rawPolicy, nil
+	}
+	decoded, err := url.QueryUnescape(rawPolicy)
+	if err == nil && strings.HasPrefix(strings.TrimSpace(decoded), "{") {
+		return strings.TrimSpace(decoded), nil
+	}
+	decoded, err = url.PathUnescape(rawPolicy)
+	if err == nil && strings.HasPrefix(strings.TrimSpace(decoded), "{") {
+		return strings.TrimSpace(decoded), nil
+	}
+	return "", fmt.Errorf("managed instance role trust policy is not JSON")
+}
+
+func normalizedPolicyStatements(value any) ([]any, error) {
+	switch v := value.(type) {
+	case nil:
+		return []any{}, nil
+	case []any:
+		return v, nil
+	case map[string]any:
+		return []any{v}, nil
+	default:
+		return nil, fmt.Errorf("managed instance role trust policy Statement has unexpected shape")
+	}
+}
+
+func assumeRoleStatementAllowsPrincipal(statement any, principalARN string) bool {
+	stmt, ok := statement.(map[string]any)
+	if !ok {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(fmt.Sprint(stmt["Effect"])), "Allow") {
+		return false
+	}
+	if !policyValueContains(stmt["Action"], "sts:AssumeRole") && !policyValueContains(stmt["Action"], "sts:*") && !policyValueContains(stmt["Action"], "*") {
+		return false
+	}
+	return principalAllowsARN(stmt["Principal"], principalARN)
+}
+
+func principalAllowsARN(value any, principalARN string) bool {
+	if policyValueContains(value, "*") || policyValueContains(value, principalARN) {
+		return true
+	}
+	principal, ok := value.(map[string]any)
+	if !ok {
+		return false
+	}
+	return policyValueContains(principal["AWS"], principalARN) || policyValueContains(principal["AWS"], "*")
+}
+
+func policyValueContains(value any, want string) bool {
+	want = strings.TrimSpace(want)
+	switch v := value.(type) {
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), want)
+	case []any:
+		for _, item := range v {
+			if policyValueContains(item, want) {
+				return true
+			}
+		}
+	case []string:
+		for _, item := range v {
+			if strings.EqualFold(strings.TrimSpace(item), want) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/provisionworker/deploy_runner_trust_internal_test.go
+++ b/internal/provisionworker/deploy_runner_trust_internal_test.go
@@ -1,0 +1,198 @@
+package provisionworker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/url"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamtypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	ststypes "github.com/aws/aws-sdk-go-v2/service/sts/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+)
+
+const (
+	testDeployRunnerRoleARN = "arn:aws:iam::111122223333:role/lesser-host-lab-ProvisionRunnerProjectRole"
+)
+
+type fakeIAM struct {
+	getOut *iam.GetRoleOutput
+	getErr error
+	updErr error
+
+	getInputs    []*iam.GetRoleInput
+	updateInputs []*iam.UpdateAssumeRolePolicyInput
+}
+
+func (f *fakeIAM) GetRole(_ context.Context, in *iam.GetRoleInput, _ ...func(*iam.Options)) (*iam.GetRoleOutput, error) {
+	f.getInputs = append(f.getInputs, in)
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return f.getOut, nil
+}
+
+func (f *fakeIAM) UpdateAssumeRolePolicy(_ context.Context, in *iam.UpdateAssumeRolePolicyInput, _ ...func(*iam.Options)) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	f.updateInputs = append(f.updateInputs, in)
+	if f.updErr != nil {
+		return nil, f.updErr
+	}
+	return &iam.UpdateAssumeRolePolicyOutput{}, nil
+}
+
+func TestEnsureAssumeRolePolicyAllowsPrincipalAddsDeployRunner(t *testing.T) {
+	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::902552026581:root"},"Action":"sts:AssumeRole"}]}`
+
+	updated, changed, err := ensureAssumeRolePolicyAllowsPrincipal(policy, testDeployRunnerRoleARN)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	var doc map[string]any
+	require.NoError(t, json.Unmarshal([]byte(updated), &doc))
+	statements, err := normalizedPolicyStatements(doc["Statement"])
+	require.NoError(t, err)
+	require.Len(t, statements, 2)
+	require.True(t, assumeRoleStatementAllowsPrincipal(statements[1], testDeployRunnerRoleARN))
+}
+
+func TestEnsureAssumeRolePolicyAllowsPrincipalNoopsForExistingEncodedTrust(t *testing.T) {
+	policy := `{"Version":"2012-10-17","Statement":{"Effect":"Allow","Principal":{"AWS":["` + testDeployRunnerRoleARN + `"]},"Action":["sts:AssumeRole"]}}`
+
+	updated, changed, err := ensureAssumeRolePolicyAllowsPrincipal(url.QueryEscape(policy), testDeployRunnerRoleARN)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.JSONEq(t, policy, updated)
+}
+
+func TestEnsureDeployRunnerAssumeRoleTrustUpdatesTenantRole(t *testing.T) {
+	t.Parallel()
+
+	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"arn:aws:iam::902552026581:root"},"Action":"sts:AssumeRole"}]}`
+	fake := &fakeIAM{getOut: &iam.GetRoleOutput{Role: &iamtypes.Role{AssumeRolePolicyDocument: aws.String(policy)}}}
+
+	srv := &Server{
+		cfg: config.Config{ManagedProvisionRunnerRoleARN: testDeployRunnerRoleARN},
+		iamFactory: func(_ context.Context, accountID string, roleName string, region string, slug string, jobID string) (iamAPI, error) {
+			require.Equal(t, "123456789012", accountID)
+			require.Equal(t, "OrganizationAccountAccessRole", roleName)
+			require.Equal(t, defaultManagedAWSRegion, region)
+			require.Equal(t, "simulacrum", slug)
+			require.Equal(t, "job1", jobID)
+			return fake, nil
+		},
+	}
+
+	err := srv.ensureDeployRunnerAssumeRoleTrust(context.Background(), "123456789012", "OrganizationAccountAccessRole", defaultManagedAWSRegion, "simulacrum", "job1")
+	require.NoError(t, err)
+	require.Len(t, fake.getInputs, 1)
+	require.Equal(t, "OrganizationAccountAccessRole", aws.ToString(fake.getInputs[0].RoleName))
+	require.Len(t, fake.updateInputs, 1)
+	require.Equal(t, "OrganizationAccountAccessRole", aws.ToString(fake.updateInputs[0].RoleName))
+	require.Contains(t, aws.ToString(fake.updateInputs[0].PolicyDocument), testDeployRunnerRoleARN)
+}
+
+func TestEnsureDeployRunnerAssumeRoleTrustNoopsWhenRunnerRoleUnset(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	srv := &Server{iamFactory: func(context.Context, string, string, string, string, string) (iamAPI, error) {
+		called = true
+		return nil, nil
+	}}
+
+	err := srv.ensureDeployRunnerAssumeRoleTrust(context.Background(), "123456789012", "OrganizationAccountAccessRole", defaultManagedAWSRegion, "demo", "job1")
+	require.NoError(t, err)
+	require.False(t, called)
+}
+
+func TestEnsureDeployRunnerAssumeRoleTrustNoopsWhenAlreadyAllowed(t *testing.T) {
+	t.Parallel()
+
+	policy := `{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"AWS":"` + testDeployRunnerRoleARN + `"},"Action":"sts:AssumeRole"}]}`
+	fake := &fakeIAM{getOut: &iam.GetRoleOutput{Role: &iamtypes.Role{AssumeRolePolicyDocument: aws.String(policy)}}}
+	srv := &Server{
+		cfg:        config.Config{ManagedProvisionRunnerRoleARN: testDeployRunnerRoleARN},
+		iamFactory: func(context.Context, string, string, string, string, string) (iamAPI, error) { return fake, nil },
+	}
+
+	err := srv.ensureDeployRunnerAssumeRoleTrust(context.Background(), "123456789012", "OrganizationAccountAccessRole", defaultManagedAWSRegion, "demo", "job1")
+	require.NoError(t, err)
+	require.Len(t, fake.getInputs, 1)
+	require.Empty(t, fake.updateInputs)
+}
+
+func TestEnsureDeployRunnerAssumeRoleTrustRejectsInvalidRunnerRoleARN(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{cfg: config.Config{ManagedProvisionRunnerRoleARN: "not-an-arn"}}
+	err := srv.ensureDeployRunnerAssumeRoleTrust(context.Background(), "123456789012", "OrganizationAccountAccessRole", defaultManagedAWSRegion, "demo", "job1")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid managed provision runner role arn")
+}
+
+func TestEnsureDeployRunnerAssumeRoleTrustPropagatesIAMFactoryError(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("iam factory failed")
+	srv := &Server{
+		cfg:        config.Config{ManagedProvisionRunnerRoleARN: testDeployRunnerRoleARN},
+		iamFactory: func(context.Context, string, string, string, string, string) (iamAPI, error) { return nil, expectedErr },
+	}
+
+	err := srv.ensureDeployRunnerAssumeRoleTrust(context.Background(), "123456789012", "OrganizationAccountAccessRole", defaultManagedAWSRegion, "demo", "job1")
+	require.ErrorIs(t, err, expectedErr)
+}
+
+func TestChildIAMClientUsesAssumedInstanceCredentials(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{
+		cfg: config.Config{ManagedDefaultRegion: defaultManagedAWSRegion},
+		sts: &fakeSTS{out: &sts.AssumeRoleOutput{Credentials: &ststypes.Credentials{
+			AccessKeyId:     aws.String("AKIAIOSFODNN7EXAMPLE"),
+			SecretAccessKey: aws.String("secret"), // #nosec G101 -- synthetic unit-test credential
+			SessionToken:    aws.String("token"),  // #nosec G101 -- synthetic unit-test credential
+		}}},
+	}
+
+	client, err := srv.childIAMClient(context.Background(), "123456789012", "OrganizationAccountAccessRole", "", "demo", "job1")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestAssumeRolePolicyHelperBranches(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, validateIAMRoleARN(testDeployRunnerRoleARN))
+	require.Error(t, validateIAMRoleARN("arn:aws:s3:::bucket"))
+
+	pathEscaped := url.PathEscape(`{"Statement":{"Effect":"Allow","Principal":"*","Action":"*"}}`)
+	decoded, err := decodeAssumeRolePolicyDocument(pathEscaped)
+	require.NoError(t, err)
+	require.Contains(t, decoded, `"Principal":"*"`)
+	_, err = decodeAssumeRolePolicyDocument("not-json")
+	require.Error(t, err)
+
+	statements, err := normalizedPolicyStatements(map[string]any{"Effect": "Allow"})
+	require.NoError(t, err)
+	require.Len(t, statements, 1)
+	_, err = normalizedPolicyStatements("bad")
+	require.Error(t, err)
+
+	require.True(t, assumeRoleStatementAllowsPrincipal(map[string]any{
+		"Effect":    "Allow",
+		"Principal": "*",
+		"Action":    []any{"sts:*"},
+	}, testDeployRunnerRoleARN))
+	require.False(t, assumeRoleStatementAllowsPrincipal(map[string]any{
+		"Effect":    "Deny",
+		"Principal": "*",
+		"Action":    "sts:AssumeRole",
+	}, testDeployRunnerRoleARN))
+}

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -98,7 +98,8 @@ type Server struct {
 	cb  codebuildAPI
 	s3  s3API
 
-	smFactory secretsManagerClientFactory
+	smFactory  secretsManagerClientFactory
+	iamFactory iamClientFactory
 }
 
 // NewServer constructs a Server with AWS service clients and a store.
@@ -520,6 +521,7 @@ const (
 	provisionJobLeaseDuration       = 10 * time.Second
 	provisionSweepLimit             = 200
 	provisionSweepStaleAfter        = 2 * time.Minute
+	defaultManagedAWSRegion         = "us-east-1"
 
 	noteMissingAccountIDRestart = "missing account id; restarting account allocation"
 
@@ -2100,7 +2102,7 @@ func (s *Server) childSecretsManagerClient(ctx context.Context, accountID string
 		region = strings.TrimSpace(s.cfg.ManagedDefaultRegion)
 	}
 	if region == "" {
-		region = "us-east-1"
+		region = defaultManagedAWSRegion
 	}
 
 	assumed, _, err := s.assumeInstanceRole(ctx, accountID, roleName, slug, jobID)

--- a/internal/provisionworker/server_helpers.go
+++ b/internal/provisionworker/server_helpers.go
@@ -60,6 +60,14 @@ func (s *Server) startDeployRunner(ctx context.Context, job *models.ProvisionJob
 	return s.startDeployRunnerWithMode(ctx, job, deployRunnerModeLesser, s.receiptS3Key(job))
 }
 
+func normalizeDeployRunnerMode(mode string) string {
+	mode = strings.ToLower(strings.TrimSpace(mode))
+	if mode == "" {
+		return deployRunnerModeLesser
+	}
+	return mode
+}
+
 func (s *Server) startDeployRunnerWithMode(ctx context.Context, job *models.ProvisionJob, mode string, receiptKey string) (string, error) {
 	if s == nil || s.cb == nil {
 		return "", fmt.Errorf("codebuild client not initialized")
@@ -95,14 +103,22 @@ func (s *Server) startDeployRunnerWithMode(ctx context.Context, job *models.Prov
 	if lesserHostURL == "" {
 		return "", fmt.Errorf("lesser host base url is missing")
 	}
+	trustErr := s.ensureDeployRunnerAssumeRoleTrust(
+		ctx,
+		strings.TrimSpace(job.AccountID),
+		strings.TrimSpace(job.AccountRoleName),
+		strings.TrimSpace(job.Region),
+		strings.TrimSpace(job.InstanceSlug),
+		strings.TrimSpace(job.ID),
+	)
+	if trustErr != nil {
+		return "", trustErr
+	}
 
 	bootstrapKey := s.bootstrapS3Key(job)
 	stage := s.deployRunnerStage(job)
 	env := s.buildDeployRunnerEnv(job, stage, receiptKey, bootstrapKey)
-	mode = strings.ToLower(strings.TrimSpace(mode))
-	if mode == "" {
-		mode = deployRunnerModeLesser
-	}
+	mode = normalizeDeployRunnerMode(mode)
 	env = append(env, cbtypes.EnvironmentVariable{Name: aws.String("RUN_MODE"), Value: aws.String(mode)})
 	tipEnabled := effectiveTipEnabled(inst.TipEnabled)
 	env = append(env,

--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -1135,6 +1135,17 @@ func (s *Server) startUpdateDeployRunnerWithMode(ctx context.Context, job *model
 	if strings.TrimSpace(receiptKey) != "" {
 		inputs.receiptKey = strings.TrimSpace(receiptKey)
 	}
+	trustErr := s.ensureDeployRunnerAssumeRoleTrust(
+		ctx,
+		inputs.accountID,
+		inputs.roleName,
+		inputs.region,
+		strings.TrimSpace(job.InstanceSlug),
+		strings.TrimSpace(job.ID),
+	)
+	if trustErr != nil {
+		return "", trustErr
+	}
 	env := s.buildUpdateDeployRunnerEnv(job, inputs)
 
 	mode = strings.ToLower(strings.TrimSpace(mode))


### PR DESCRIPTION
## Summary
- keep the M6 org-vending-role hardening intact: CodeBuild deploy runner still does **not** receive `MANAGED_ORG_VENDING_ROLE_ARN`
- pass the concrete CodeBuild service role ARN to `provision-worker`
- before starting managed provisioning/update CodeBuild runs, have `provision-worker` ensure the tenant `MANAGED_INSTANCE_ROLE_NAME` trust policy allows that exact runner role
- add a short retry loop in the runner pre-build assume-role step to tolerate IAM trust propagation
- document the lab/canary remediation path for `theory` then `simulacrum`

## Investigation
The lab retry advanced past `instance.config` after #252, but both `theory` and the `simulacrum` canary failed in CodeBuild `PRE_BUILD` while assuming the managed-instance role. The tenant role trust policies still trusted only the Organizations management account root. After M6 removed org-vending credentials from the deploy runner, the runner had a host-side identity policy for `sts:AssumeRole` but no tenant-side trust.

This patch fixes the tenant-side trust gap without restoring the high-privilege org-vending role to CodeBuild.

## Validation
- `go test ./internal/provisionworker`
- `go test ./...`
- `go vet ./...`
- `cd cdk && npm ci && npm test`
- `cd cdk && npm ci && npm run synth`
- `gofmt -l ...` clean
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS 29 / 0 / 0
