### PR TITLE
fix(security): harden M7 trust AI billing flows

### DIFF
--- a/docs/ai-evidence.md
+++ b/docs/ai-evidence.md
@@ -1,0 +1,27 @@
+# AI evidence endpoints
+
+The trust API exposes instance-authenticated AI evidence endpoints for managed instances.
+
+## `POST /api/v1/ai/evidence/image`
+
+The image evidence endpoint runs bounded Rekognition evidence extraction for an image already present in the host artifact bucket.
+
+Request shape:
+
+```json
+{
+  "object_key": "evidence/<instanceSlug>/<object-id>"
+}
+```
+
+Ownership requirements:
+
+- The bearer token authenticates the caller as an instance slug.
+- `object_key` **must** be under an instance-owned prefix:
+  - `evidence/<instanceSlug>/...`, or
+  - `moderation/<instanceSlug>/...` when reusing a moderation image object.
+- Keys from other instances, render artifacts (`renders/...`), provisioning receipts, or arbitrary shared-bucket locations are rejected before any S3 `HeadObject` or provider call.
+
+This keeps the shared artifact bucket from becoming a cross-tenant processing/read boundary: one instance cannot cause host AI tooling to process another instance's image object and then read derived labels/text/face counts through its own AI job.
+
+Render artifacts are not accepted by raw `object_key`; use a dedicated `render_id` flow only after host verifies `RenderArtifact.RequestedBy == <instanceSlug>`.

--- a/docs/attestations.md
+++ b/docs/attestations.md
@@ -10,7 +10,9 @@
 
 - Fetch by id: `GET /attestations/{id}`
 
-- Lookup by tuple: `GET /attestations?actor_uri=...&object_uri=...&content_hash=...&module=...&policy_version=...`
+- Lookup by tuple:
+  `GET /attestations?instance_slug=...&actor_uri=...&object_uri=...&content_hash=...&module=...&policy_version=...`
+  - `instance_slug` is required so lookup ids are bound to the managed instance that produced the attestation.
 
 ## Response format
 
@@ -25,15 +27,17 @@ Attestation responses return:
 
 The signed payload is `type=lesser.host/attestation/v1` and binds:
 
+- `instance_slug`
 - `actor_uri`, `object_uri`, `content_hash`
 - `module`, `policy_version`, `model_set`
 - `created_at`, `expires_at`
 - module-specific `result` (and optional `evidence`)
 
-This binding is why attestations **do not apply to quote posts** unless `(actor_uri, object_uri, content_hash)` matches
-exactly.
+This binding is why attestations **do not apply to quote posts** or other tenants unless
+`(instance_slug, actor_uri, object_uri, content_hash)` matches exactly. Attestation-producing endpoints additionally
+require the authenticated instance to own the `actor_uri` and `object_uri` HTTP(S) hosts before issuing public
+attestations.
 
 ## Caching behavior
 
 `GET /attestations/{id}` is served with `Cache-Control: public, max-age=<seconds-until-expires_at>, immutable`.
-

--- a/internal/ai/service.go
+++ b/internal/ai/service.go
@@ -223,7 +223,7 @@ func (s *Service) prepareGetOrQueue(req Request) (getOrQueuePrepared, Response, 
 	now := time.Now().UTC()
 	month := now.Format("2006-01")
 	pricingMultiplierBps := req.PricingMultiplierBps
-	if pricingMultiplierBps <= 0 || pricingMultiplierBps >= 10000 {
+	if pricingMultiplierBps <= 0 {
 		pricingMultiplierBps = 10000
 	}
 	creditsRequested := billing.PricedCredits(req.BaseCredits, pricingMultiplierBps)
@@ -535,8 +535,10 @@ func (s *Service) queueWithDebit(ctx context.Context, prepared getOrQueuePrepare
 	pk := fmt.Sprintf("INSTANCE#%s", prepared.InstanceSlug)
 	sk := fmt.Sprintf("BUDGET#%s", prepared.Month)
 	maxUsed := int64(0)
+	expectedIncluded := int64(0)
 	if budget != nil {
 		maxUsed = budget.IncludedCredits - prepared.CreditsRequested
+		expectedIncluded = budget.IncludedCredits
 	}
 
 	err := s.store.DB.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
@@ -544,7 +546,7 @@ func (s *Service) queueWithDebit(ctx context.Context, prepared getOrQueuePrepare
 		tx.Put(ledger)
 		tx.Put(auditBudget)
 		tx.Put(auditJob)
-		return s.applyBudgetDebit(tx, updateBudget, prepared.Now, maxUsed, prepared.CreditsRequested, req.AllowOverage)
+		return s.applyBudgetDebit(tx, updateBudget, prepared.Now, expectedIncluded, maxUsed, prepared.CreditsRequested, req.AllowOverage)
 	})
 	if theoryErrors.IsConditionFailed(err) {
 		return s.handleDebitConditionFailed(ctx, prepared, pk, sk, prepared.CreditsRequested)
@@ -557,7 +559,7 @@ func (s *Service) queueWithDebit(ctx context.Context, prepared getOrQueuePrepare
 	return queuedWithDebitResponse(prepared, latest, overageDebited), nil
 }
 
-func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.InstanceBudgetMonth, now time.Time, maxUsed int64, creditsRequested int64, allowOverage bool) error {
+func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.InstanceBudgetMonth, now time.Time, expectedIncludedCredits int64, maxUsed int64, creditsRequested int64, allowOverage bool) error {
 	if tx == nil || budget == nil {
 		return nil
 	}
@@ -567,7 +569,10 @@ func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.In
 			ub.Add("UsedCredits", creditsRequested)
 			ub.Set("UpdatedAt", now)
 			return nil
-		}, tabletheory.IfExists())
+		},
+			tabletheory.IfExists(),
+			tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits),
+		)
 		return nil
 	}
 
@@ -577,6 +582,7 @@ func (s *Service) applyBudgetDebit(tx core.TransactionBuilder, budget *models.In
 		return nil
 	},
 		tabletheory.IfExists(),
+		tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits),
 		tabletheory.ConditionExpression(
 			"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 			map[string]any{

--- a/internal/aiworker/claim_verify_llm_internal_test.go
+++ b/internal/aiworker/claim_verify_llm_internal_test.go
@@ -387,7 +387,7 @@ func TestIssueClaimVerifyAttestationV1_ReturnsAttestationUnavailableForNonStore(
 		fakeComprehend{},
 		fakeRekognition{},
 	)
-	job := &models.AIJob{Module: "claim_verify_llm", PolicyVersion: "v1"}
+	job := &models.AIJob{InstanceSlug: "inst", Module: "claim_verify_llm", PolicyVersion: "v1"}
 	in := ai.ClaimVerifyInputsV1{ActorURI: "a", ObjectURI: "o", ContentHash: "h"}
 	res := ai.ClaimVerifyResultV1{Kind: "claim_verify", Version: "v1"}
 	errs := srv.issueClaimVerifyAttestationV1(context.Background(), job, in, res)

--- a/internal/aiworker/server.go
+++ b/internal/aiworker/server.go
@@ -419,14 +419,12 @@ func (s *Server) processRenderSummaryGroup(ctx context.Context, requestID string
 		return nil
 	}
 
-	items := renderSummaryBatchItems(group)
-	if len(items) == 0 {
-		return nil
-	}
-
-	results, usage, commonErrs := s.renderSummaryBatchResults(ctx, modelSet, items)
-
 	for _, pj := range group {
+		items := renderSummaryBatchItems([]renderSummaryParsedJob{pj})
+		if len(items) == 0 {
+			continue
+		}
+		results, usage, commonErrs := s.renderSummaryBatchResults(ctx, modelSet, items)
 		if err := s.putRenderSummaryResult(ctx, requestID, now, pj, modelSet, results, usage, commonErrs); err != nil {
 			return err
 		}
@@ -1645,11 +1643,14 @@ type claimVerifyAttestationEvidenceV1 struct {
 }
 
 func (s *Server) issueClaimVerifyAttestationV1(ctx context.Context, job *models.AIJob, in ai.ClaimVerifyInputsV1, res ai.ClaimVerifyResultV1) []models.AIError {
-	if s == nil || s.attest == nil || !s.attest.Enabled() || job == nil {
+	if !s.claimVerifyAttestationEnabled(job) {
 		return nil
 	}
 
-	actorURI, objectURI, contentHash, ok := claimVerifyAttestationSubject(in)
+	instanceSlug, actorURI, objectURI, contentHash, errs, ok := claimVerifyAttestationSubjectForJob(job, in)
+	if len(errs) > 0 {
+		return errs
+	}
 	if !ok {
 		return nil
 	}
@@ -1664,7 +1665,7 @@ func (s *Server) issueClaimVerifyAttestationV1(ctx context.Context, job *models.
 		return nil
 	}
 
-	id := attestations.AttestationID(actorURI, objectURI, contentHash, module, policyVersion)
+	id := attestations.InstanceAttestationID(instanceSlug, actorURI, objectURI, contentHash, module, policyVersion)
 
 	exists, errs := s.attestationAlreadyExists(ctx, st, id)
 	if len(errs) > 0 {
@@ -1685,9 +1686,10 @@ func (s *Server) issueClaimVerifyAttestationV1(ctx context.Context, job *models.
 	payload := attestations.PayloadV1{
 		Type: attestations.PayloadTypeV1,
 
-		ActorURI:    actorURI,
-		ObjectURI:   objectURI,
-		ContentHash: contentHash,
+		ActorURI:     actorURI,
+		ObjectURI:    objectURI,
+		ContentHash:  contentHash,
+		InstanceSlug: instanceSlug,
 
 		Module:        module,
 		PolicyVersion: policyVersion,
@@ -1715,10 +1717,11 @@ func (s *Server) issueClaimVerifyAttestationV1(ctx context.Context, job *models.
 	}
 
 	item := &models.Attestation{
-		ID:          id,
-		ActorURI:    actorURI,
-		ObjectURI:   objectURI,
-		ContentHash: contentHash,
+		ID:           id,
+		ActorURI:     actorURI,
+		ObjectURI:    objectURI,
+		ContentHash:  contentHash,
+		InstanceSlug: instanceSlug,
 
 		Module:        module,
 		PolicyVersion: policyVersion,
@@ -1740,6 +1743,10 @@ func (s *Server) issueClaimVerifyAttestationV1(ctx context.Context, job *models.
 	return nil
 }
 
+func (s *Server) claimVerifyAttestationEnabled(job *models.AIJob) bool {
+	return s != nil && s.attest != nil && s.attest.Enabled() && job != nil
+}
+
 func claimVerifyAttestationSubject(in ai.ClaimVerifyInputsV1) (string, string, string, bool) {
 	actorURI := strings.TrimSpace(in.ActorURI)
 	objectURI := strings.TrimSpace(in.ObjectURI)
@@ -1748,6 +1755,21 @@ func claimVerifyAttestationSubject(in ai.ClaimVerifyInputsV1) (string, string, s
 		return "", "", "", false
 	}
 	return actorURI, objectURI, contentHash, true
+}
+
+func claimVerifyAttestationSubjectForJob(job *models.AIJob, in ai.ClaimVerifyInputsV1) (instanceSlug, actorURI, objectURI, contentHash string, errs []models.AIError, ok bool) {
+	actorURI, objectURI, contentHash, ok = claimVerifyAttestationSubject(in)
+	if !ok {
+		return "", "", "", "", nil, false
+	}
+	if job == nil {
+		return "", "", "", "", nil, false
+	}
+	instanceSlug = strings.ToLower(strings.TrimSpace(job.InstanceSlug))
+	if instanceSlug == "" {
+		return "", "", "", "", []models.AIError{{Code: "attestation_failed", Message: "Attestation subject is missing instance binding", Retryable: false}}, false
+	}
+	return instanceSlug, actorURI, objectURI, contentHash, nil, true
 }
 
 func (s *Server) attestationStoreForAIJob() (*store.Store, error) {

--- a/internal/attestations/id.go
+++ b/internal/attestations/id.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-// AttestationID derives a deterministic attestation ID from canonical identity inputs.
+// AttestationID derives the legacy deterministic attestation ID from canonical identity inputs.
+//
+// New trust writes should use InstanceAttestationID so public attestations are
+// bound to the authenticated instance that produced them. This helper remains
+// for tests and for recognizing legacy, pre-live records.
 func AttestationID(actorURI string, objectURI string, contentHash string, module string, policyVersion string) string {
 	actorURI = strings.TrimSpace(actorURI)
 	objectURI = strings.TrimSpace(objectURI)
@@ -16,6 +20,30 @@ func AttestationID(actorURI string, objectURI string, contentHash string, module
 
 	canonical := strings.Join([]string{
 		"lesser.host/attestation/v1",
+		actorURI,
+		objectURI,
+		contentHash,
+		module,
+		policyVersion,
+	}, "\n")
+	sum := sha256.Sum256([]byte(canonical))
+	return hex.EncodeToString(sum[:])
+}
+
+// InstanceAttestationID derives a deterministic attestation ID bound to the
+// authenticated instance slug. Binding the slug prevents one tenant from
+// squatting or minting attestations for another tenant's tuple.
+func InstanceAttestationID(instanceSlug string, actorURI string, objectURI string, contentHash string, module string, policyVersion string) string {
+	instanceSlug = strings.ToLower(strings.TrimSpace(instanceSlug))
+	actorURI = strings.TrimSpace(actorURI)
+	objectURI = strings.TrimSpace(objectURI)
+	contentHash = strings.ToLower(strings.TrimSpace(contentHash))
+	module = strings.ToLower(strings.TrimSpace(module))
+	policyVersion = strings.TrimSpace(policyVersion)
+
+	canonical := strings.Join([]string{
+		"lesser.host/attestation/v1/instance",
+		instanceSlug,
 		actorURI,
 		objectURI,
 		contentHash,

--- a/internal/attestations/jws_rs256_test.go
+++ b/internal/attestations/jws_rs256_test.go
@@ -133,3 +133,26 @@ func TestAttestationID_IsDeterministic(t *testing.T) {
 		t.Fatalf("expected different ids")
 	}
 }
+
+func TestInstanceAttestationID_BindsInstanceSlug(t *testing.T) {
+	t.Parallel()
+
+	id1 := InstanceAttestationID(" inst ", "actor", "object", "hash", "module", "v1")
+	id2 := InstanceAttestationID("INST", "actor", "object", "HASH", "MODULE", "v1")
+	if id1 == "" || len(id1) != 64 {
+		t.Fatalf("unexpected id: %q", id1)
+	}
+	if id1 != id2 {
+		t.Fatalf("expected normalized inputs to match: %q vs %q", id1, id2)
+	}
+
+	legacyID := AttestationID("actor", "object", "hash", "module", "v1")
+	if id1 == legacyID {
+		t.Fatalf("expected instance-bound id to differ from legacy id")
+	}
+
+	id3 := InstanceAttestationID("other", "actor", "object", "hash", "module", "v1")
+	if id3 == id1 {
+		t.Fatalf("expected different ids for different instance slugs")
+	}
+}

--- a/internal/attestations/schema_v1.go
+++ b/internal/attestations/schema_v1.go
@@ -18,6 +18,9 @@ type PayloadV1 struct {
 	ActorURI    string `json:"actor_uri,omitempty"`
 	ObjectURI   string `json:"object_uri,omitempty"`
 	ContentHash string `json:"content_hash,omitempty"`
+	// InstanceSlug binds the signed claim to the authenticated lesser.host
+	// instance that produced it. Public lookup IDs are derived from this value.
+	InstanceSlug string `json:"instance_slug,omitempty"`
 
 	Module        string `json:"module"`
 	PolicyVersion string `json:"policy_version"`

--- a/internal/billing/billing.go
+++ b/internal/billing/billing.go
@@ -18,8 +18,12 @@ func PricedCredits(base int64, multiplierBps int64) int64 {
 	if multiplierBps <= 0 {
 		return base
 	}
-	if multiplierBps >= 10000 {
+	if multiplierBps == 10000 {
 		return base
+	}
+	const maxInt64 = int64(1<<63 - 1)
+	if base > (maxInt64-9999)/multiplierBps {
+		return maxInt64
 	}
 	return (base*multiplierBps + 9999) / 10000
 }

--- a/internal/billing/billing_test.go
+++ b/internal/billing/billing_test.go
@@ -16,10 +16,16 @@ func TestPricedCredits(t *testing.T) {
 		t.Fatalf("expected passthrough, got %d", got)
 	}
 	if got := PricedCredits(10, 10000); got != 10 {
-		t.Fatalf("expected passthrough for >=10000, got %d", got)
+		t.Fatalf("expected passthrough for 10000, got %d", got)
+	}
+	if got := PricedCredits(10, 15000); got != 15 {
+		t.Fatalf("expected surcharge multiplier to apply, got %d", got)
 	}
 	if got := PricedCredits(1, 9999); got != 1 {
 		t.Fatalf("expected ceil to 1, got %d", got)
+	}
+	if got := PricedCredits(1<<62, 30000); got != int64(1<<63-1) {
+		t.Fatalf("expected overflow saturation, got %d", got)
 	}
 }
 

--- a/internal/controlplane/handlers_portal_instance_keys.go
+++ b/internal/controlplane/handlers_portal_instance_keys.go
@@ -13,10 +13,10 @@ import (
 )
 
 type instanceKeyListItem struct {
-	ID         string    `json:"id"`
-	CreatedAt  time.Time `json:"created_at"`
-	LastUsedAt time.Time `json:"last_used_at,omitempty"`
-	RevokedAt  time.Time `json:"revoked_at,omitempty"`
+	ID         string     `json:"id"`
+	CreatedAt  time.Time  `json:"created_at"`
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	RevokedAt  *time.Time `json:"revoked_at,omitempty"`
 }
 
 type listInstanceKeysResponse struct {
@@ -34,12 +34,19 @@ func instanceKeyListItemFromModel(k *models.InstanceKey) instanceKeyListItem {
 	if k == nil {
 		return instanceKeyListItem{}
 	}
-	return instanceKeyListItem{
-		ID:         strings.TrimSpace(k.ID),
-		CreatedAt:  k.CreatedAt,
-		LastUsedAt: k.LastUsedAt,
-		RevokedAt:  k.RevokedAt,
+	out := instanceKeyListItem{
+		ID:        strings.TrimSpace(k.ID),
+		CreatedAt: k.CreatedAt,
 	}
+	if !k.LastUsedAt.IsZero() {
+		lastUsedAt := k.LastUsedAt
+		out.LastUsedAt = &lastUsedAt
+	}
+	if !k.RevokedAt.IsZero() {
+		revokedAt := k.RevokedAt
+		out.RevokedAt = &revokedAt
+	}
+	return out
 }
 
 func (s *Server) handlePortalListInstanceKeys(ctx *apptheory.Context) (*apptheory.Response, error) {

--- a/internal/controlplane/handlers_portal_instance_keys_internal_test.go
+++ b/internal/controlplane/handlers_portal_instance_keys_internal_test.go
@@ -24,6 +24,30 @@ func TestInstanceKeyListItemFromModel_Nil(t *testing.T) {
 	require.Empty(t, out.ID)
 }
 
+func TestInstanceKeyListItemFromModel_OmitsZeroTimes(t *testing.T) {
+	t.Parallel()
+
+	created := time.Unix(1, 0).UTC()
+	out := instanceKeyListItemFromModel(&models.InstanceKey{ID: " k1 ", CreatedAt: created})
+	require.Equal(t, "k1", out.ID)
+	require.Equal(t, created, out.CreatedAt)
+	require.Nil(t, out.LastUsedAt)
+	require.Nil(t, out.RevokedAt)
+
+	b, err := json.Marshal(out)
+	require.NoError(t, err)
+	require.NotContains(t, string(b), "last_used_at")
+	require.NotContains(t, string(b), "revoked_at")
+
+	lastUsedAt := time.Unix(2, 0).UTC()
+	revokedAt := time.Unix(3, 0).UTC()
+	out = instanceKeyListItemFromModel(&models.InstanceKey{ID: "k2", CreatedAt: created, LastUsedAt: lastUsedAt, RevokedAt: revokedAt})
+	require.NotNil(t, out.LastUsedAt)
+	require.Equal(t, lastUsedAt, *out.LastUsedAt)
+	require.NotNil(t, out.RevokedAt)
+	require.Equal(t, revokedAt, *out.RevokedAt)
+}
+
 func TestHandlePortalListInstanceKeys_ReturnsKeys(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_continuity.go
+++ b/internal/controlplane/handlers_soul_continuity.go
@@ -195,7 +195,8 @@ func parseSoulSignedTimestamp(raw string, now time.Time, field string) (time.Tim
 	if parsedTS.Before(now.Add(-soulSignedRequestMaxAge)) {
 		return time.Time{}, "", &apptheory.AppError{Code: "app.bad_request", Message: field + " is too far in the past"}
 	}
-	return parsedTS, canonicalSoulSignedTimestamp(parsedTS), nil
+	canonicalTS := parsedTS.Truncate(time.Millisecond)
+	return canonicalTS, canonicalSoulSignedTimestamp(canonicalTS), nil
 }
 
 func canonicalSoulSignedTimestamp(ts time.Time) string {

--- a/internal/controlplane/handlers_soul_continuity_internal_test.go
+++ b/internal/controlplane/handlers_soul_continuity_internal_test.go
@@ -121,12 +121,15 @@ func TestParseSoulSignedTimestamp_CanonicalizesLikeJavaScriptISOString(t *testin
 	t.Parallel()
 
 	now := time.Date(2026, 4, 29, 3, 15, 0, 0, time.UTC)
-	_, canonical, appErr := parseSoulSignedTimestamp("2026-04-29T03:14:59.120Z", now, "timestamp")
+	parsed, canonical, appErr := parseSoulSignedTimestamp("2026-04-29T03:14:59.120987654Z", now, "timestamp")
 	if appErr != nil {
 		t.Fatalf("unexpected appErr: %#v", appErr)
 	}
 	if canonical != "2026-04-29T03:14:59.120Z" {
 		t.Fatalf("unexpected canonical timestamp: %q", canonical)
+	}
+	if parsed.Nanosecond() != 120_000_000 {
+		t.Fatalf("expected millisecond-truncated timestamp, got %s", parsed.Format(time.RFC3339Nano))
 	}
 
 	_, _, appErr = parseSoulSignedTimestamp("2026-04-29T02:59:59.999Z", now, "timestamp")

--- a/internal/provisionworker/server_test.go
+++ b/internal/provisionworker/server_test.go
@@ -112,7 +112,7 @@ func TestFailJob_UpdatesJobAndTransacts(t *testing.T) {
 	if err := s.failJob(context.Background(), job, "req", now, "code", "msg"); err != nil {
 		t.Fatalf("failJob: %v", err)
 	}
-	if job.Status != models.ProvisionJobStatusError || job.Step != "failed" {
+	if job.Status != models.ProvisionJobStatusError || job.Step != provisionStepFailed {
 		t.Fatalf("expected job marked failed, got status=%q step=%q", job.Status, job.Step)
 	}
 	if job.ErrorCode != "code" || job.ErrorMessage != "msg" {

--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -2479,6 +2479,11 @@ func (s *Server) advanceUpdateVerify(ctx context.Context, job *models.UpdateJob,
 	job.VerifyAIOK = &aiOK
 	job.VerifyAIErr = strings.TrimSpace(aiErr)
 
+	if !transOK || !trustOK || !tipsOK || !aiOK {
+		job.FailedPhase = updatePhaseVerify
+		return 0, true, s.failUpdateJob(ctx, job, requestID, now, "verification_failed", managedUpdateVerificationFailureMessage(job))
+	}
+
 	job.ActivePhase = updatePhaseNone
 	job.Step = updateStepDone
 	job.Status = models.UpdateJobStatusOK

--- a/internal/provisionworker/update_jobs_flow_internal_test.go
+++ b/internal/provisionworker/update_jobs_flow_internal_test.go
@@ -73,7 +73,11 @@ func TestRunManagedUpdateStateMachine_HappyPath(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":        "ok",
+			"instance_slug": "slug",
+		})
 	})
 	handler.HandleFunc("/api/v1/ai/jobs/", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNotFound)

--- a/internal/provisionworker/update_trust_auth.go
+++ b/internal/provisionworker/update_trust_auth.go
@@ -2,21 +2,32 @@ package provisionworker
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
-func verifyTrustAuthEndpoint(ctx context.Context, client *http.Client, baseURL string, instanceKey string) (bool, string) {
+type trustAuthVerifyResponse struct {
+	Status       string `json:"status"`
+	InstanceSlug string `json:"instance_slug"`
+}
+
+func verifyTrustAuthEndpoint(ctx context.Context, client *http.Client, baseURL string, instanceKey string, expectedInstanceSlug string) (bool, string) {
 	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
 	instanceKey = strings.TrimSpace(instanceKey)
+	expectedInstanceSlug = strings.TrimSpace(expectedInstanceSlug)
 	if baseURL == "" {
 		return false, "lesser host base url is missing"
 	}
 	if instanceKey == "" {
 		return false, "instance key is missing"
+	}
+	if expectedInstanceSlug == "" {
+		return false, "expected instance slug is missing"
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/api/v1/trust/verify", nil)
@@ -35,13 +46,28 @@ func verifyTrustAuthEndpoint(ctx context.Context, client *http.Client, baseURL s
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
-		return true, ""
-	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
 		return false, fmt.Sprintf("unauthorized (HTTP %d)", resp.StatusCode)
 	}
-	return false, fmt.Sprintf("unexpected status (HTTP %d)", resp.StatusCode)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, fmt.Sprintf("unexpected status (HTTP %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if err != nil {
+		return false, "failed to read trust verify response"
+	}
+	var out trustAuthVerifyResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return false, "invalid trust verify response"
+	}
+	if strings.TrimSpace(out.Status) != "ok" {
+		return false, "trust verify response status is not ok"
+	}
+	if strings.TrimSpace(out.InstanceSlug) != expectedInstanceSlug {
+		return false, fmt.Sprintf("expected instance_slug %q, got %q", expectedInstanceSlug, strings.TrimSpace(out.InstanceSlug))
+	}
+	return true, ""
 }
 
 func (s *Server) verifyUpdateTrustAuth(ctx context.Context, client *http.Client, job *models.UpdateJob) (bool, string) {
@@ -56,5 +82,5 @@ func (s *Server) verifyUpdateTrustAuth(ctx context.Context, client *http.Client,
 	if baseURL == "" {
 		baseURL = strings.TrimSpace(s.publicBaseURL())
 	}
-	return verifyTrustAuthEndpoint(ctx, client, baseURL, key)
+	return verifyTrustAuthEndpoint(ctx, client, baseURL, key, strings.TrimSpace(job.InstanceSlug))
 }

--- a/internal/provisionworker/update_verify_failure.go
+++ b/internal/provisionworker/update_verify_failure.go
@@ -1,0 +1,38 @@
+package provisionworker
+
+import (
+	"strings"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func managedUpdateVerificationFailureMessage(job *models.UpdateJob) string {
+	if job == nil {
+		return "managed update verification failed"
+	}
+	failures := make([]string, 0, 4)
+	if job.VerifyTranslationOK != nil && !*job.VerifyTranslationOK {
+		failures = append(failures, "translation: "+verificationFailureDetail(job.VerifyTranslationErr))
+	}
+	if job.VerifyTrustOK != nil && !*job.VerifyTrustOK {
+		failures = append(failures, "trust: "+verificationFailureDetail(job.VerifyTrustErr))
+	}
+	if job.VerifyTipsOK != nil && !*job.VerifyTipsOK {
+		failures = append(failures, "tips: "+verificationFailureDetail(job.VerifyTipsErr))
+	}
+	if job.VerifyAIOK != nil && !*job.VerifyAIOK {
+		failures = append(failures, "ai: "+verificationFailureDetail(job.VerifyAIErr))
+	}
+	if len(failures) == 0 {
+		return "managed update verification failed"
+	}
+	return "managed update verification failed: " + strings.Join(failures, "; ")
+}
+
+func verificationFailureDetail(detail string) string {
+	detail = strings.TrimSpace(detail)
+	if detail == "" {
+		return "failed"
+	}
+	return detail
+}

--- a/internal/provisionworker/update_verify_internal_test.go
+++ b/internal/provisionworker/update_verify_internal_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 func TestNormalizeVerifyHost(t *testing.T) {
@@ -149,7 +151,8 @@ func TestVerifyTrustAuthEndpoint_RequiresBearerKey(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		w.WriteHeader(http.StatusNoContent)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","instance_slug":"slug"}`))
 	})
 	ts := httptest.NewTLSServer(handler)
 	t.Cleanup(ts.Close)
@@ -157,11 +160,35 @@ func TestVerifyTrustAuthEndpoint_RequiresBearerKey(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	t.Cleanup(cancel)
 
-	ok, msg := verifyTrustAuthEndpoint(ctx, ts.Client(), ts.URL, "lhk_test")
+	ok, msg := verifyTrustAuthEndpoint(ctx, ts.Client(), ts.URL, "lhk_test", "slug")
 	require.True(t, ok)
 	require.Empty(t, msg)
 
-	ok, msg = verifyTrustAuthEndpoint(ctx, ts.Client(), ts.URL, "wrong")
+	ok, msg = verifyTrustAuthEndpoint(ctx, ts.Client(), ts.URL, "wrong", "slug")
 	require.False(t, ok)
 	require.Contains(t, msg, "unauthorized")
+
+	ok, msg = verifyTrustAuthEndpoint(ctx, ts.Client(), ts.URL, "lhk_test", "other")
+	require.False(t, ok)
+	require.Contains(t, msg, "instance_slug")
+}
+
+func TestManagedUpdateVerificationFailureMessage(t *testing.T) {
+	t.Parallel()
+
+	trustOK := false
+	aiOK := true
+	job := &models.UpdateJob{
+		VerifyTrustOK:  &trustOK,
+		VerifyTrustErr: "expected instance_slug \"slug\", got \"other\"",
+		VerifyAIOK:     &aiOK,
+	}
+	got := managedUpdateVerificationFailureMessage(job)
+	require.Contains(t, got, "managed update verification failed")
+	require.Contains(t, got, "trust: expected instance_slug")
+	require.NotContains(t, got, "ai:")
+	require.Equal(t, "managed update verification failed", managedUpdateVerificationFailureMessage(nil))
+	translationOK := false
+	got = managedUpdateVerificationFailureMessage(&models.UpdateJob{VerifyTranslationOK: &translationOK})
+	require.Contains(t, got, "translation: failed")
 }

--- a/internal/store/models/attestation.go
+++ b/internal/store/models/attestation.go
@@ -16,9 +16,10 @@ type Attestation struct {
 
 	ID string `theorydb:"attr:id" json:"id"`
 
-	ActorURI    string `theorydb:"attr:actorUri" json:"actor_uri,omitempty"`
-	ObjectURI   string `theorydb:"attr:objectUri" json:"object_uri,omitempty"`
-	ContentHash string `theorydb:"attr:contentHash" json:"content_hash,omitempty"`
+	ActorURI     string `theorydb:"attr:actorUri" json:"actor_uri,omitempty"`
+	ObjectURI    string `theorydb:"attr:objectUri" json:"object_uri,omitempty"`
+	ContentHash  string `theorydb:"attr:contentHash" json:"content_hash,omitempty"`
+	InstanceSlug string `theorydb:"attr:instanceSlug" json:"instance_slug,omitempty"`
 
 	Module        string `theorydb:"attr:module" json:"module"`
 	PolicyVersion string `theorydb:"attr:policyVersion" json:"policy_version"`
@@ -55,6 +56,7 @@ func (a *Attestation) UpdateKeys() error {
 	a.ActorURI = strings.TrimSpace(a.ActorURI)
 	a.ObjectURI = strings.TrimSpace(a.ObjectURI)
 	a.ContentHash = strings.TrimSpace(a.ContentHash)
+	a.InstanceSlug = strings.ToLower(strings.TrimSpace(a.InstanceSlug))
 
 	a.Module = strings.ToLower(strings.TrimSpace(a.Module))
 	a.PolicyVersion = strings.TrimSpace(a.PolicyVersion)

--- a/internal/store/models/soul_agent_continuity.go
+++ b/internal/store/models/soul_agent_continuity.go
@@ -90,7 +90,8 @@ func (c *SoulAgentContinuity) UpdateKeys() error {
 	}
 	c.Signature = strings.ToLower(strings.TrimSpace(c.Signature))
 
-	ts := c.Timestamp.UTC().Format("2006-01-02T15:04:05.000000000Z")
+	c.Timestamp = c.Timestamp.UTC().Truncate(time.Millisecond)
+	ts := c.Timestamp.Format("2006-01-02T15:04:05.000Z")
 	c.PK = fmt.Sprintf("SOUL#AGENT#%s", c.AgentID)
 	c.SK = fmt.Sprintf("CONTINUITY#%s#%s", ts, c.Type)
 	return nil

--- a/internal/store/models/soul_agent_index_relationship_from.go
+++ b/internal/store/models/soul_agent_index_relationship_from.go
@@ -45,7 +45,8 @@ func (i *SoulRelationshipFromIndex) UpdateKeys() error {
 	i.ToAgentID = strings.ToLower(strings.TrimSpace(i.ToAgentID))
 	i.Type = strings.ToLower(strings.TrimSpace(i.Type))
 
-	ts := i.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z")
+	i.CreatedAt = i.CreatedAt.UTC().Truncate(time.Millisecond)
+	ts := i.CreatedAt.Format("2006-01-02T15:04:05.000Z")
 	i.PK = fmt.Sprintf("SOUL#RELATIONSHIPS_FROM#%s", i.FromAgentID)
 	i.SK = fmt.Sprintf("TO#%s#%s", i.ToAgentID, ts)
 	return nil

--- a/internal/store/models/soul_agent_relationship.go
+++ b/internal/store/models/soul_agent_relationship.go
@@ -82,7 +82,8 @@ func (r *SoulAgentRelationship) UpdateKeys() error {
 	r.Message = strings.TrimSpace(r.Message)
 	r.Signature = strings.ToLower(strings.TrimSpace(r.Signature))
 
-	ts := r.CreatedAt.UTC().Format("2006-01-02T15:04:05.000000000Z")
+	r.CreatedAt = r.CreatedAt.UTC().Truncate(time.Millisecond)
+	ts := r.CreatedAt.Format("2006-01-02T15:04:05.000Z")
 	r.PK = fmt.Sprintf("SOUL#AGENT#%s", r.ToAgentID)
 	r.SK = fmt.Sprintf("RELATIONSHIP#%s#%s", r.FromAgentID, ts)
 	return nil

--- a/internal/store/models/soul_models_v2_test.go
+++ b/internal/store/models/soul_models_v2_test.go
@@ -133,7 +133,7 @@ func TestSoulAgentBoundary_CategoryConstants(t *testing.T) {
 // --- SoulAgentContinuity ---
 
 func TestSoulAgentContinuity_Keys(t *testing.T) {
-	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	ts := time.Date(2026, 3, 1, 12, 0, 0, 987654321, time.UTC)
 	c := &SoulAgentContinuity{
 		AgentID:   " 0xABC ",
 		Type:      " SIGNIFICANT_FAILURE ",
@@ -146,7 +146,9 @@ func TestSoulAgentContinuity_Keys(t *testing.T) {
 
 	require.Equal(t, "SOUL#AGENT#0xabc", c.PK)
 	require.Contains(t, c.SK, "CONTINUITY#")
+	require.Contains(t, c.SK, "2026-03-01T12:00:00.987Z")
 	require.Contains(t, c.SK, "#significant_failure")
+	require.Equal(t, time.Date(2026, 3, 1, 12, 0, 0, 987000000, time.UTC), c.Timestamp)
 	require.Equal(t, "significant_failure", c.Type)
 	require.Equal(t, "Something failed.", c.Summary)
 	require.Equal(t, "Fixed it.", c.Recovery)
@@ -182,7 +184,7 @@ func TestSoulAgentContinuity_EntryTypeConstants(t *testing.T) {
 // --- SoulAgentRelationship ---
 
 func TestSoulAgentRelationship_Keys(t *testing.T) {
-	ts := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	ts := time.Date(2026, 3, 1, 12, 0, 0, 987654321, time.UTC)
 	r := &SoulAgentRelationship{
 		FromAgentID: " 0xFROM ",
 		ToAgentID:   " 0xTO ",
@@ -196,6 +198,8 @@ func TestSoulAgentRelationship_Keys(t *testing.T) {
 
 	require.Equal(t, "SOUL#AGENT#0xto", r.PK)
 	require.Contains(t, r.SK, "RELATIONSHIP#0xfrom#")
+	require.Contains(t, r.SK, "2026-03-01T12:00:00.987Z")
+	require.Equal(t, time.Date(2026, 3, 1, 12, 0, 0, 987000000, time.UTC), r.CreatedAt)
 	require.Equal(t, "0xfrom", r.FromAgentID)
 	require.Equal(t, "0xto", r.ToAgentID)
 	require.Equal(t, "delegation", r.Type)

--- a/internal/trust/ai_budget_precheck.go
+++ b/internal/trust/ai_budget_precheck.go
@@ -1,0 +1,81 @@
+package trust
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/ai"
+	"github.com/equaltoai/lesser-host/internal/billing"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func (s *Server) precheckAIBudget(ctx context.Context, instanceSlug string, baseCredits int64, pricingMultiplierBps int64, allowOverage bool) (*ai.BudgetDecision, *apptheory.AppError) {
+	instanceSlug = strings.TrimSpace(instanceSlug)
+	creditsRequested := billing.PricedCredits(baseCredits, pricingMultiplierBps)
+	month := time.Now().UTC().Format("2006-01")
+	if creditsRequested <= 0 {
+		return &ai.BudgetDecision{
+			Allowed:          true,
+			OverBudget:       false,
+			Reason:           "no_charge",
+			Month:            month,
+			RequestedCredits: creditsRequested,
+			DebitedCredits:   0,
+		}, nil
+	}
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	var budget models.InstanceBudgetMonth
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.InstanceBudgetMonth{}).
+		Where("PK", "=", fmt.Sprintf("INSTANCE#%s", instanceSlug)).
+		Where("SK", "=", fmt.Sprintf("BUDGET#%s", month)).
+		ConsistentRead().
+		First(&budget)
+	if theoryErrors.IsNotFound(err) {
+		return &ai.BudgetDecision{
+			Allowed:          false,
+			OverBudget:       true,
+			Reason:           budgetReasonNotConfigured,
+			Month:            month,
+			RequestedCredits: creditsRequested,
+			DebitedCredits:   0,
+		}, nil
+	}
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	remaining := budget.IncludedCredits - budget.UsedCredits
+	if remaining < creditsRequested && !allowOverage {
+		return &ai.BudgetDecision{
+			Allowed:          false,
+			OverBudget:       true,
+			Reason:           budgetReasonExceeded,
+			Month:            month,
+			IncludedCredits:  budget.IncludedCredits,
+			UsedCredits:      budget.UsedCredits,
+			RemainingCredits: remaining,
+			RequestedCredits: creditsRequested,
+			DebitedCredits:   0,
+		}, nil
+	}
+	return &ai.BudgetDecision{
+		Allowed:          true,
+		OverBudget:       remaining < creditsRequested,
+		Reason:           "precheck",
+		Month:            month,
+		IncludedCredits:  budget.IncludedCredits,
+		UsedCredits:      budget.UsedCredits,
+		RemainingCredits: remaining,
+		RequestedCredits: creditsRequested,
+		DebitedCredits:   0,
+	}, nil
+}

--- a/internal/trust/ai_budget_precheck_internal_test.go
+++ b/internal/trust/ai_budget_precheck_internal_test.go
@@ -1,0 +1,61 @@
+package trust
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+func TestPrecheckAIBudgetBranches(t *testing.T) {
+	t.Parallel()
+
+	decision, appErr := (*Server)(nil).precheckAIBudget(context.Background(), testBudgetInstanceSlug, 0, 10000, false)
+	require.Nil(t, appErr)
+	require.True(t, decision.Allowed)
+	require.Equal(t, "no_charge", decision.Reason)
+
+	_, appErr = (&Server{}).precheckAIBudget(context.Background(), testBudgetInstanceSlug, 1, 10000, false)
+	require.NotNil(t, appErr)
+	require.Equal(t, "app.internal", appErr.Code)
+
+	db := ttmocks.NewMockExtendedDB()
+	qBudget := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(qBudget).Maybe()
+	qBudget.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qBudget).Maybe()
+	qBudget.On("ConsistentRead").Return(qBudget).Maybe()
+	s := &Server{store: store.New(db)}
+
+	qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(theoryErrors.ErrItemNotFound).Once()
+	decision, appErr = s.precheckAIBudget(context.Background(), testBudgetInstanceSlug, 2, 10000, false)
+	require.Nil(t, appErr)
+	require.False(t, decision.Allowed)
+	require.Equal(t, budgetReasonNotConfigured, decision.Reason)
+
+	qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: testBudgetInstanceSlug, IncludedCredits: 3, UsedCredits: 2}
+	}).Once()
+	decision, appErr = s.precheckAIBudget(context.Background(), testBudgetInstanceSlug, 2, 10000, false)
+	require.Nil(t, appErr)
+	require.False(t, decision.Allowed)
+	require.Equal(t, budgetReasonExceeded, decision.Reason)
+
+	qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: testBudgetInstanceSlug, IncludedCredits: 3, UsedCredits: 2}
+	}).Once()
+	decision, appErr = s.precheckAIBudget(context.Background(), testBudgetInstanceSlug, 2, 10000, true)
+	require.Nil(t, appErr)
+	require.True(t, decision.Allowed)
+	require.True(t, decision.OverBudget)
+	require.Equal(t, "precheck", decision.Reason)
+}

--- a/internal/trust/ai_image_handlers_internal_test.go
+++ b/internal/trust/ai_image_handlers_internal_test.go
@@ -163,6 +163,51 @@ func newTestArtifactsStore(t *testing.T, bucket string) (*artifacts.Store, func(
 	return artifacts.NewWithClient(bucket, client), ts.Close
 }
 
+func TestValidateAIEvidenceImageObjectKey(t *testing.T) {
+	t.Parallel()
+
+	for _, key := range []string{
+		"evidence/inst/img",
+		"moderation/inst/img",
+	} {
+		if err := validateAIEvidenceImageObjectKey("inst", key); err != nil {
+			t.Fatalf("expected %q to be accepted: %v", key, err)
+		}
+	}
+
+	for _, key := range []string{
+		"evidence/other/img",
+		"moderation/other/img",
+		"renders/render-id/snapshot.txt",
+		"evidence/inst",
+		"",
+	} {
+		if err := validateAIEvidenceImageObjectKey("inst", key); err == nil || err.Code != appErrCodeBadRequest {
+			t.Fatalf("expected bad_request for %q, got %T: %v", key, err, err)
+		}
+	}
+
+	if err := validateAIEvidenceImageObjectKey("", "evidence/inst/img"); err == nil || err.Code != "app.unauthorized" {
+		t.Fatalf("expected unauthorized for missing instance, got %T: %v", err, err)
+	}
+}
+
+func TestHandleAIEvidenceImage_RejectsCrossInstanceObjectKeyBeforeStorage(t *testing.T) {
+	t.Parallel()
+
+	st := &store.Store{}
+	s := &Server{store: st, ai: ai.NewService(st), artifacts: artifacts.New("bucket")}
+	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "evidence/other/img"})
+	_, err := s.handleAIEvidenceImage(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != appErrCodeBadRequest || !strings.Contains(appErr.Message, "evidence/inst/") {
+		t.Fatalf("expected owned-prefix bad_request, got %T: %v", err, err)
+	}
+}
+
 func TestHandleAIEvidenceImage_DisabledShortCircuitsStorage(t *testing.T) {
 	t.Parallel()
 
@@ -173,7 +218,7 @@ func TestHandleAIEvidenceImage_DisabledShortCircuitsStorage(t *testing.T) {
 		artifacts: artifacts.New("bucket"),
 	}
 
-	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "missing"})
+	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "evidence/inst/missing"})
 	resp, err := s.handleAIEvidenceImage(&apptheory.Context{
 		AuthIdentity: testBudgetInstanceSlug,
 		Request:      apptheory.Request{Body: body},
@@ -227,7 +272,7 @@ func TestHandleAIEvidenceImage_BudgetNotConfigured(t *testing.T) {
 	art, cleanup := newTestArtifactsStore(t, "bucket")
 	t.Cleanup(cleanup)
 
-	if err := art.PutObject(ctx, "img1", []byte("abc"), "image/png", ""); err != nil {
+	if err := art.PutObject(ctx, "evidence/demo/img1", []byte("abc"), "image/png", ""); err != nil {
 		t.Fatalf("PutObject: %v", err)
 	}
 
@@ -255,7 +300,7 @@ func TestHandleAIEvidenceImage_BudgetNotConfigured(t *testing.T) {
 	// Budget month missing => not_checked_budget response.
 	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(theoryErrors.ErrItemNotFound).Once()
 
-	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "img1"})
+	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "evidence/demo/img1"})
 	resp, err := s.handleAIEvidenceImage(&apptheory.Context{
 		AuthIdentity: "demo",
 		Request:      apptheory.Request{Body: body},

--- a/internal/trust/ai_image_handlers_internal_test.go
+++ b/internal/trust/ai_image_handlers_internal_test.go
@@ -163,6 +163,63 @@ func newTestArtifactsStore(t *testing.T, bucket string) (*artifacts.Store, func(
 	return artifacts.NewWithClient(bucket, client), ts.Close
 }
 
+func TestHandleAIEvidenceImage_DisabledShortCircuitsStorage(t *testing.T) {
+	t.Parallel()
+
+	st := &store.Store{}
+	s := &Server{
+		store:     st,
+		ai:        ai.NewService(st),
+		artifacts: artifacts.New("bucket"),
+	}
+
+	body, _ := json.Marshal(aiEvidenceImageRequest{ObjectKey: "missing"})
+	resp, err := s.handleAIEvidenceImage(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out aiEvidenceResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusDisabled || out.Budget.Reason != aiDisabledForInstanceReason {
+		t.Fatalf("expected disabled response before storage use, got %#v", out)
+	}
+	if out.Contract.Module != aiEvidenceImageModule || out.Contract.InputsHash == "" {
+		t.Fatalf("expected image contract with precheck hash, got %#v", out.Contract)
+	}
+	if out.Budget.RequestedCredits != aiEvidenceImageBaseCredits || out.Budget.DebitedCredits != 0 || out.Budget.Allowed {
+		t.Fatalf("unexpected budget decision: %#v", out.Budget)
+	}
+}
+
+func TestAIEvidenceDisabledResponses(t *testing.T) {
+	t.Parallel()
+
+	if got := aiEvidenceTextDisabledResponse(instanceTrustConfig{AIEnabled: true}, "hash"); got != nil {
+		t.Fatalf("expected enabled config to return nil, got %#v", got)
+	}
+	textResp := aiEvidenceTextDisabledResponse(instanceTrustConfig{AIEnabled: false, AIPricingMultiplierBps: 25000}, " hash ")
+	if textResp == nil || textResp.Status != statusDisabled || textResp.Budget.RequestedCredits != 3 {
+		t.Fatalf("unexpected text disabled response: %#v", textResp)
+	}
+
+	resp := aiEvidenceDisabledResponse(" module ", " policy ", " model ", " input ", 7, " disabled ")
+	if resp.Contract.Module != "module" || resp.Contract.PolicyVersion != "policy" || resp.Contract.ModelSet != "model" || resp.Contract.InputsHash != "input" {
+		t.Fatalf("expected trimmed contract, got %#v", resp.Contract)
+	}
+	if resp.Budget.Reason != statusDisabled || resp.Budget.RequestedCredits != 7 || resp.Budget.Allowed {
+		t.Fatalf("unexpected budget: %#v", resp.Budget)
+	}
+}
+
 func TestHandleAIEvidenceImage_BudgetNotConfigured(t *testing.T) {
 	t.Parallel()
 
@@ -182,8 +239,11 @@ func TestHandleAIEvidenceImage_BudgetNotConfigured(t *testing.T) {
 		artifacts: art,
 	}
 
-	// loadInstanceTrustConfig falls back to defaults when instance not found.
-	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+	enabled := true
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", AIEnabled: &enabled}
+	}).Once()
 	// No cached result, no job exists.
 	tdb.qResult.On("First", mock.AnythingOfType("*models.AIResult")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qJob.On("First", mock.AnythingOfType("*models.AIJob")).Return(theoryErrors.ErrItemNotFound).Once()
@@ -263,6 +323,7 @@ func TestHandleAIModerationTextAndImageReport_BudgetNotConfigured(t *testing.T) 
 	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
 		v := true
+		dest.AIEnabled = &v
 		dest.ModerationEnabled = &v
 	}).Twice()
 

--- a/internal/trust/attestation_subjects.go
+++ b/internal/trust/attestation_subjects.go
@@ -1,0 +1,175 @@
+package trust
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/domains"
+	"github.com/equaltoai/lesser-host/internal/manageddomain"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type instanceAttestationSubject struct {
+	InstanceSlug string
+	ActorURI     string
+	ObjectURI    string
+	ContentHash  string
+}
+
+func (s *Server) normalizeInstanceAttestationSubject(ctx context.Context, instanceSlug, actorURI, objectURI, contentHash string) (instanceAttestationSubject, *apptheory.AppError) {
+	subject := instanceAttestationSubject{
+		InstanceSlug: strings.ToLower(strings.TrimSpace(instanceSlug)),
+		ActorURI:     strings.TrimSpace(actorURI),
+		ObjectURI:    strings.TrimSpace(objectURI),
+		ContentHash:  strings.TrimSpace(contentHash),
+	}
+	if subject.ActorURI == "" && subject.ObjectURI == "" && subject.ContentHash == "" {
+		return subject, nil
+	}
+	if subject.ActorURI == "" || subject.ObjectURI == "" || subject.ContentHash == "" {
+		return instanceAttestationSubject{}, &apptheory.AppError{Code: "app.bad_request", Message: "actor_uri, object_uri, and content_hash are required together"}
+	}
+	if subject.InstanceSlug == "" {
+		return instanceAttestationSubject{}, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+
+	actorHost, err := attestationSubjectURIHost(subject.ActorURI)
+	if err != nil {
+		return instanceAttestationSubject{}, &apptheory.AppError{Code: "app.bad_request", Message: "actor_uri must be an http(s) URI with an instance-owned host"}
+	}
+	objectHost, err := attestationSubjectURIHost(subject.ObjectURI)
+	if err != nil {
+		return instanceAttestationSubject{}, &apptheory.AppError{Code: "app.bad_request", Message: "object_uri must be an http(s) URI with an instance-owned host"}
+	}
+
+	ok, appErr := s.instanceOwnsAttestationHosts(ctx, subject.InstanceSlug, actorHost, objectHost)
+	if appErr != nil {
+		return instanceAttestationSubject{}, appErr
+	}
+	if !ok {
+		return instanceAttestationSubject{}, &apptheory.AppError{Code: "app.bad_request", Message: "attestation subject is not owned by authenticated instance"}
+	}
+	return subject, nil
+}
+
+func attestationSubjectURIHost(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("uri is required")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", err
+	}
+	scheme := strings.ToLower(strings.TrimSpace(u.Scheme))
+	if scheme != schemeHTTP && scheme != schemeHTTPS {
+		return "", fmt.Errorf("unsupported scheme")
+	}
+	host := strings.TrimSpace(u.Hostname())
+	if host == "" {
+		return "", fmt.Errorf("host is required")
+	}
+	return domains.NormalizeDomain(host)
+}
+
+func (s *Server) instanceOwnsAttestationHosts(ctx context.Context, instanceSlug, actorHost, objectHost string) (bool, *apptheory.AppError) {
+	instanceSlug = strings.ToLower(strings.TrimSpace(instanceSlug))
+	actorHost = strings.ToLower(strings.TrimSpace(actorHost))
+	objectHost = strings.ToLower(strings.TrimSpace(objectHost))
+	if instanceSlug == "" || actorHost == "" || objectHost == "" {
+		return false, nil
+	}
+	inst, found, appErr := s.loadAttestationSubjectInstance(ctx, instanceSlug)
+	if appErr != nil || !found {
+		return false, appErr
+	}
+
+	owned := map[string]struct{}{}
+	addOwnedAttestationDomain(owned, inst.HostedBaseDomain)
+	addOwnedAttestationDomain(owned, manageddomain.StageDomain(s.cfg.Stage, inst.HostedBaseDomain))
+	if attestationHostsInSet(owned, actorHost, objectHost) {
+		return true, nil
+	}
+
+	domainItems, appErr := s.loadAttestationSubjectDomains(ctx, instanceSlug)
+	if appErr != nil {
+		return false, appErr
+	}
+	for _, d := range domainItems {
+		if d == nil || !attestationDomainActive(d.Status) {
+			continue
+		}
+		addOwnedAttestationDomain(owned, d.Domain)
+		if strings.EqualFold(strings.TrimSpace(d.Type), models.DomainTypePrimary) || strings.EqualFold(strings.TrimSpace(d.Domain), strings.TrimSpace(inst.HostedBaseDomain)) {
+			addOwnedAttestationDomain(owned, manageddomain.StageDomain(s.cfg.Stage, d.Domain))
+		}
+	}
+	return attestationHostsInSet(owned, actorHost, objectHost), nil
+}
+
+func (s *Server) loadAttestationSubjectInstance(ctx context.Context, instanceSlug string) (models.Instance, bool, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return models.Instance{}, false, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	var inst models.Instance
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.Instance{}).
+		Where("PK", "=", "INSTANCE#"+instanceSlug).
+		Where("SK", "=", models.SKMetadata).
+		ConsistentRead().
+		First(&inst)
+	if theoryErrors.IsNotFound(err) {
+		return models.Instance{}, false, nil
+	}
+	if err != nil {
+		return models.Instance{}, false, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return inst, true, nil
+}
+
+func (s *Server) loadAttestationSubjectDomains(ctx context.Context, instanceSlug string) ([]*models.Domain, *apptheory.AppError) {
+	var domainItems []*models.Domain
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.Domain{}).
+		Index("gsi1").
+		Where("gsi1PK", "=", "INSTANCE_DOMAINS#"+instanceSlug).
+		All(&domainItems)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	return domainItems, nil
+}
+
+func addOwnedAttestationDomain(owned map[string]struct{}, raw string) {
+	if owned == nil {
+		return
+	}
+	d, err := domains.NormalizeDomain(raw)
+	if err != nil || d == "" {
+		return
+	}
+	owned[d] = struct{}{}
+}
+
+func attestationHostsInSet(owned map[string]struct{}, actorHost, objectHost string) bool {
+	if len(owned) == 0 {
+		return false
+	}
+	_, actorOK := owned[strings.ToLower(strings.TrimSpace(actorHost))]
+	_, objectOK := owned[strings.ToLower(strings.TrimSpace(objectHost))]
+	return actorOK && objectOK
+}
+
+func attestationDomainActive(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case models.DomainStatusVerified, models.DomainStatusActive:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/trust/attestation_subjects_internal_test.go
+++ b/internal/trust/attestation_subjects_internal_test.go
@@ -1,0 +1,130 @@
+package trust
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+func TestNormalizeInstanceAttestationSubject_BlankOrPartial(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{}
+	subject, err := s.normalizeInstanceAttestationSubject(t.Context(), " "+testBudgetInstanceSlug+" ", " ", "", "")
+	if err != nil {
+		t.Fatalf("unexpected blank subject error: %v", err)
+	}
+	if subject.InstanceSlug != testBudgetInstanceSlug || subject.ActorURI != "" || subject.ObjectURI != "" || subject.ContentHash != "" {
+		t.Fatalf("unexpected blank subject: %#v", subject)
+	}
+
+	_, err = s.normalizeInstanceAttestationSubject(t.Context(), testBudgetInstanceSlug, "https://inst.example/@alice", "", "hash")
+	if err == nil || err.Code != appErrCodeBadRequest {
+		t.Fatalf("expected bad_request for partial subject, got %T: %v", err, err)
+	}
+}
+
+func TestNormalizeInstanceAttestationSubject_RequiresOwnedHTTPHosts(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+	qDomain := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
+	for _, q := range []*ttmocks.MockQuery{qInst, qDomain} {
+		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("Index", mock.Anything).Return(q).Maybe()
+		q.On("ConsistentRead").Return(q).Maybe()
+	}
+
+	s := NewServer(config.Config{Stage: "lab"}, store.New(db))
+
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: testBudgetInstanceSlug, HostedBaseDomain: "inst.example"}
+	}).Once()
+	subject, err := s.normalizeInstanceAttestationSubject(
+		t.Context(),
+		testBudgetInstanceSlug,
+		"https://inst.example/@alice",
+		"https://inst.example/posts/1",
+		"sha256:abc",
+	)
+	if err != nil {
+		t.Fatalf("unexpected owned subject error: %v", err)
+	}
+	if subject.ActorURI != "https://inst.example/@alice" || subject.ContentHash != "sha256:abc" {
+		t.Fatalf("unexpected subject: %#v", subject)
+	}
+
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: testBudgetInstanceSlug, HostedBaseDomain: "inst.example"}
+	}).Once()
+	qDomain.On("All", mock.AnythingOfType("*[]*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = nil
+	}).Once()
+	_, err = s.normalizeInstanceAttestationSubject(
+		t.Context(),
+		testBudgetInstanceSlug,
+		"https://other.example/@alice",
+		"https://inst.example/posts/1",
+		"sha256:abc",
+	)
+	if err == nil || err.Code != appErrCodeBadRequest {
+		t.Fatalf("expected bad_request for unowned subject, got %T: %v", err, err)
+	}
+
+	_, err = s.normalizeInstanceAttestationSubject(t.Context(), testBudgetInstanceSlug, "at://did:example:alice/post/1", "https://inst.example/posts/1", "hash")
+	if err == nil || err.Code != appErrCodeBadRequest {
+		t.Fatalf("expected bad_request for non-http actor URI, got %T: %v", err, err)
+	}
+}
+
+func TestAttestationSubjectHostHelpers(t *testing.T) {
+	t.Parallel()
+
+	host, err := attestationSubjectURIHost(" https://Example.COM:443/users/alice ")
+	if err != nil || host != "example.com" {
+		t.Fatalf("unexpected host parse: host=%q err=%v", host, err)
+	}
+	for _, raw := range []string{"", "at://example.com/users/alice", "https:///missing-host"} {
+		if _, err := attestationSubjectURIHost(raw); err == nil {
+			t.Fatalf("expected parse error for %q", raw)
+		}
+	}
+
+	owned := map[string]struct{}{}
+	addOwnedAttestationDomain(nil, "example.com")
+	addOwnedAttestationDomain(owned, " EXAMPLE.com ")
+	addOwnedAttestationDomain(owned, "not a host")
+	if !attestationHostsInSet(owned, "example.com", "EXAMPLE.COM") {
+		t.Fatalf("expected exact owned host match")
+	}
+	if attestationHostsInSet(owned, "sub.example.com", "example.com") {
+		t.Fatalf("expected exact matching, not suffix matching")
+	}
+	if attestationHostsInSet(nil, "example.com", "example.com") {
+		t.Fatalf("expected empty owned map to fail")
+	}
+}
+
+func TestAttestationDomainActive(t *testing.T) {
+	t.Parallel()
+
+	if !attestationDomainActive(models.DomainStatusVerified) || !attestationDomainActive(models.DomainStatusActive) {
+		t.Fatalf("expected verified and active domains to be accepted")
+	}
+	if attestationDomainActive("pending") {
+		t.Fatalf("expected pending domain to be rejected")
+	}
+}

--- a/internal/trust/attestations_issue.go
+++ b/internal/trust/attestations_issue.go
@@ -16,12 +16,12 @@ func (s *Server) ensureLinkSafetyBasicAttestation(ctx context.Context, result *m
 		return "", nil
 	}
 
-	actorURI, objectURI, contentHash, ok := linkSafetyBasicAttestationParts(result)
+	instanceSlug, actorURI, objectURI, contentHash, ok := linkSafetyBasicAttestationParts(result)
 	if !ok {
 		return "", nil
 	}
 
-	id := attestations.AttestationID(actorURI, objectURI, contentHash, "link_safety_basic", linkSafetyBasicPolicyVersion)
+	id := attestations.InstanceAttestationID(instanceSlug, actorURI, objectURI, contentHash, "link_safety_basic", linkSafetyBasicPolicyVersion)
 
 	existing, err := s.store.GetAttestation(ctx, id)
 	if err == nil {
@@ -35,9 +35,10 @@ func (s *Server) ensureLinkSafetyBasicAttestation(ctx context.Context, result *m
 	payload := attestations.PayloadV1{
 		Type: attestations.PayloadTypeV1,
 
-		ActorURI:    actorURI,
-		ObjectURI:   objectURI,
-		ContentHash: contentHash,
+		ActorURI:     actorURI,
+		ObjectURI:    objectURI,
+		ContentHash:  contentHash,
+		InstanceSlug: instanceSlug,
 
 		Module:        "link_safety_basic",
 		PolicyVersion: linkSafetyBasicPolicyVersion,
@@ -64,10 +65,11 @@ func (s *Server) ensureLinkSafetyBasicAttestation(ctx context.Context, result *m
 	}
 
 	item := &models.Attestation{
-		ID:          id,
-		ActorURI:    actorURI,
-		ObjectURI:   objectURI,
-		ContentHash: contentHash,
+		ID:           id,
+		ActorURI:     actorURI,
+		ObjectURI:    objectURI,
+		ContentHash:  contentHash,
+		InstanceSlug: instanceSlug,
 
 		Module:        "link_safety_basic",
 		PolicyVersion: linkSafetyBasicPolicyVersion,
@@ -96,15 +98,16 @@ func (s *Server) canIssueAttestations() bool {
 	return s.attest.Enabled()
 }
 
-func linkSafetyBasicAttestationParts(result *models.LinkSafetyBasicResult) (actorURI, objectURI, contentHash string, ok bool) {
+func linkSafetyBasicAttestationParts(result *models.LinkSafetyBasicResult) (instanceSlug, actorURI, objectURI, contentHash string, ok bool) {
 	if result == nil {
-		return "", "", "", false
+		return "", "", "", "", false
 	}
+	instanceSlug = strings.ToLower(strings.TrimSpace(result.InstanceSlug))
 	actorURI = strings.TrimSpace(result.ActorURI)
 	objectURI = strings.TrimSpace(result.ObjectURI)
 	contentHash = strings.TrimSpace(result.ContentHash)
-	if actorURI == "" || objectURI == "" || contentHash == "" {
-		return "", "", "", false
+	if instanceSlug == "" || actorURI == "" || objectURI == "" || contentHash == "" {
+		return "", "", "", "", false
 	}
-	return actorURI, objectURI, contentHash, true
+	return instanceSlug, actorURI, objectURI, contentHash, true
 }

--- a/internal/trust/budget_debit_tx.go
+++ b/internal/trust/budget_debit_tx.go
@@ -1,0 +1,51 @@
+package trust
+
+import (
+	"time"
+
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func addBudgetDebitUpdate(
+	tx core.TransactionBuilder,
+	update *models.InstanceBudgetMonth,
+	credits int64,
+	now time.Time,
+	allowOverage bool,
+	expectedIncludedCredits int64,
+	maxUsed int64,
+) {
+	if tx == nil || update == nil {
+		return
+	}
+	tx.UpdateWithBuilder(
+		update,
+		func(ub core.UpdateBuilder) error {
+			ub.Add("UsedCredits", credits)
+			ub.Set("UpdatedAt", now)
+			return nil
+		},
+		budgetDebitConditions(allowOverage, expectedIncludedCredits, maxUsed)...,
+	)
+}
+
+func budgetDebitConditions(allowOverage bool, expectedIncludedCredits int64, maxUsed int64) []core.TransactCondition {
+	conditions := []core.TransactCondition{
+		tabletheory.IfExists(),
+		tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits),
+	}
+	if allowOverage {
+		return conditions
+	}
+	return append(conditions,
+		tabletheory.ConditionExpression(
+			"attribute_not_exists(usedCredits) OR usedCredits <= :max",
+			map[string]any{
+				":max": maxUsed,
+			},
+		),
+	)
+}

--- a/internal/trust/handlers_ai_claims.go
+++ b/internal/trust/handlers_ai_claims.go
@@ -11,15 +11,20 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/ai"
 	"github.com/equaltoai/lesser-host/internal/attestations"
+	"github.com/equaltoai/lesser-host/internal/billing"
 	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 const (
 	claimVerifyMaxClaims           = 10
+	claimVerifyMaxTextBytes        = int64(16 * 1024)
 	claimVerifyMaxEvidenceItems    = 5
 	claimVerifyMaxEvidenceBytes    = int64(8 * 1024)
 	claimVerifyMaxTotalEvidence    = int64(64 * 1024)
+	claimVerifyMaxSourceIDBytes    = int64(128)
+	claimVerifyMaxURLBytes         = int64(2048)
+	claimVerifyMaxTitleBytes       = int64(240)
 	claimVerifyBaseCreditsMin      = int64(10)
 	claimVerifyBaseCreditsPerClaim = int64(2)
 )
@@ -140,14 +145,24 @@ func (s *Server) handleAIClaimVerify(ctx *apptheory.Context) (*apptheory.Respons
 	actorURI := strings.TrimSpace(req.ActorURI)
 	objectURI := strings.TrimSpace(req.ObjectURI)
 	contentHash := strings.TrimSpace(req.ContentHash)
+	subject, appErr := s.normalizeInstanceAttestationSubject(ctx.Context(), instanceSlug, actorURI, objectURI, contentHash)
+	if appErr != nil {
+		return nil, appErr
+	}
+	actorURI = subject.ActorURI
+	objectURI = subject.ObjectURI
+	contentHash = subject.ContentHash
 
-	text := strings.TrimSpace(req.Text)
+	text, appErr := normalizeClaimVerifyText(req.Text)
+	if appErr != nil {
+		return nil, appErr
+	}
 	claims := sanitizeClaimVerifyClaims(req.Claims)
 
 	retrieval := normalizeClaimVerifyRetrieval(req.Retrieval)
 	retrievalMode := claimVerifyRetrievalMode(retrieval)
-	if appErr := validateClaimVerifyRequest(text, claims, req.Evidence, retrievalMode); appErr != nil {
-		return nil, appErr
+	if validateErr := validateClaimVerifyRequest(text, claims, req.Evidence, retrievalMode); validateErr != nil {
+		return nil, validateErr
 	}
 
 	evidence, totalEvidenceBytes, err := buildClaimVerifyEvidence(req.Evidence)
@@ -159,11 +174,6 @@ func (s *Server) handleAIClaimVerify(ctx *apptheory.Context) (*apptheory.Respons
 	allowOverage := strings.ToLower(strings.TrimSpace(instCfg.OveragePolicy)) == overagePolicyAllow
 	baseCredits := estimateClaimVerifyCredits(text, claims, retrieval, retrievalMode, totalEvidenceBytes)
 
-	modelSet, appErr := claimVerifyModelSet(instCfg, retrievalMode)
-	if appErr != nil {
-		return nil, appErr
-	}
-
 	inputs := ai.ClaimVerifyInputsV1{
 		ActorURI:    actorURI,
 		ObjectURI:   objectURI,
@@ -174,6 +184,31 @@ func (s *Server) handleAIClaimVerify(ctx *apptheory.Context) (*apptheory.Respons
 		Retrieval:   retrieval,
 	}
 	inputsHash, _ := ai.InputsHash(inputs)
+	if !instCfg.AIEnabled {
+		out := aiClaimVerifyResponse{
+			Status: statusDisabled,
+			Cached: false,
+			Budget: ai.BudgetDecision{
+				Allowed:          false,
+				OverBudget:       false,
+				Reason:           aiDisabledForInstanceReason,
+				RequestedCredits: billing.PricedCredits(baseCredits, instCfg.AIPricingMultiplierBps),
+				DebitedCredits:   0,
+			},
+			Contract: ai.ModuleContract{
+				Module:        ai.ClaimVerifyLLMModule,
+				PolicyVersion: ai.ClaimVerifyLLMPolicyVersion,
+				ModelSet:      modelSetDeterministic,
+				InputsHash:    strings.TrimSpace(inputsHash),
+			},
+		}
+		return apptheory.JSON(http.StatusOK, out)
+	}
+
+	modelSet, appErr := claimVerifyModelSet(instCfg, retrievalMode)
+	if appErr != nil {
+		return nil, appErr
+	}
 
 	resp, err := s.ai.GetOrQueue(ctx.Context(), ai.Request{
 		InstanceSlug:         instanceSlug,
@@ -204,7 +239,7 @@ func (s *Server) handleAIClaimVerify(ctx *apptheory.Context) (*apptheory.Respons
 	attID := ""
 	attURL := ""
 	if actorURI != "" && objectURI != "" && contentHash != "" {
-		attID = attestations.AttestationID(actorURI, objectURI, contentHash, ai.ClaimVerifyLLMModule, ai.ClaimVerifyLLMPolicyVersion)
+		attID = attestations.InstanceAttestationID(instanceSlug, actorURI, objectURI, contentHash, ai.ClaimVerifyLLMModule, ai.ClaimVerifyLLMPolicyVersion)
 		attURL = attestationURL(ctx, attID, s.cfg.PublicBaseURL)
 	}
 
@@ -247,6 +282,28 @@ func sanitizeClaimVerifyClaims(in []string) []string {
 	return claims
 }
 
+func normalizeClaimVerifyText(raw string) (string, *apptheory.AppError) {
+	text := strings.TrimSpace(raw)
+	if text == "" {
+		return "", nil
+	}
+	if int64(len([]byte(text))) > claimVerifyMaxTextBytes {
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: "text is too large"}
+	}
+	return text, nil
+}
+
+func normalizeClaimVerifyMetadata(field string, value string, maxBytes int64) (string, *apptheory.AppError) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", nil
+	}
+	if int64(len([]byte(value))) > maxBytes {
+		return "", &apptheory.AppError{Code: "app.bad_request", Message: field + " is too large"}
+	}
+	return value, nil
+}
+
 func buildClaimVerifyEvidence(req []claimVerifyEvidenceRequest) ([]ai.ClaimVerifyEvidenceV1, int64, error) {
 	// Evidence policy v1: caller must supply bounded evidence texts for citations.
 	if len(req) > claimVerifyMaxEvidenceItems {
@@ -258,33 +315,12 @@ func buildClaimVerifyEvidence(req []claimVerifyEvidenceRequest) ([]ai.ClaimVerif
 	seenIDs := map[string]struct{}{}
 
 	for _, e := range req {
-		id := strings.TrimSpace(e.SourceID)
-		if id == "" {
-			return nil, 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence.source_id is required"}
+		item, itemBytes, err := buildClaimVerifyEvidenceItem(e, seenIDs)
+		if err != nil {
+			return nil, 0, err
 		}
-		if _, ok := seenIDs[id]; ok {
-			return nil, 0, &apptheory.AppError{Code: "app.bad_request", Message: "duplicate evidence.source_id"}
-		}
-		seenIDs[id] = struct{}{}
-
-		renderID := strings.TrimSpace(e.RenderID)
-		if renderID != "" && !aiJobIDRE.MatchString(renderID) {
-			return nil, 0, &apptheory.AppError{Code: "app.bad_request", Message: "invalid evidence.render_id"}
-		}
-
-		evText := ""
-		b := int64(0)
-		if strings.TrimSpace(e.Text) != "" {
-			var err error
-			evText, b, err = clampEvidenceText(e.Text, claimVerifyMaxEvidenceBytes)
-			if err != nil {
-				return nil, 0, err
-			}
-		} else if renderID == "" {
-			return nil, 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence.text or evidence.render_id is required"}
-		}
-		totalEvidenceBytes += b
-		if renderID != "" && b == 0 {
+		totalEvidenceBytes += itemBytes
+		if item.RenderID != "" && itemBytes == 0 {
 			// Approximate bounded evidence size when using render snapshots to avoid under-estimating costs.
 			totalEvidenceBytes += claimVerifyMaxEvidenceBytes
 		}
@@ -292,16 +328,61 @@ func buildClaimVerifyEvidence(req []claimVerifyEvidenceRequest) ([]ai.ClaimVerif
 			return nil, 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence too large"}
 		}
 
-		evidence = append(evidence, ai.ClaimVerifyEvidenceV1{
-			SourceID: id,
-			URL:      strings.TrimSpace(e.URL),
-			Title:    strings.TrimSpace(e.Title),
-			RenderID: renderID,
-			Text:     evText,
-		})
+		evidence = append(evidence, item)
 	}
 
 	return evidence, totalEvidenceBytes, nil
+}
+
+func buildClaimVerifyEvidenceItem(e claimVerifyEvidenceRequest, seenIDs map[string]struct{}) (ai.ClaimVerifyEvidenceV1, int64, error) {
+	id, appErr := normalizeClaimVerifyMetadata("evidence.source_id", e.SourceID, claimVerifyMaxSourceIDBytes)
+	if appErr != nil {
+		return ai.ClaimVerifyEvidenceV1{}, 0, appErr
+	}
+	if id == "" {
+		return ai.ClaimVerifyEvidenceV1{}, 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence.source_id is required"}
+	}
+	if _, ok := seenIDs[id]; ok {
+		return ai.ClaimVerifyEvidenceV1{}, 0, &apptheory.AppError{Code: "app.bad_request", Message: "duplicate evidence.source_id"}
+	}
+	seenIDs[id] = struct{}{}
+
+	renderID := strings.TrimSpace(e.RenderID)
+	if renderID != "" && !aiJobIDRE.MatchString(renderID) {
+		return ai.ClaimVerifyEvidenceV1{}, 0, &apptheory.AppError{Code: "app.bad_request", Message: "invalid evidence.render_id"}
+	}
+
+	url, appErr := normalizeClaimVerifyMetadata("evidence.url", e.URL, claimVerifyMaxURLBytes)
+	if appErr != nil {
+		return ai.ClaimVerifyEvidenceV1{}, 0, appErr
+	}
+	title, appErr := normalizeClaimVerifyMetadata("evidence.title", e.Title, claimVerifyMaxTitleBytes)
+	if appErr != nil {
+		return ai.ClaimVerifyEvidenceV1{}, 0, appErr
+	}
+
+	evText, textBytes, err := claimVerifyEvidenceText(e.Text, renderID)
+	if err != nil {
+		return ai.ClaimVerifyEvidenceV1{}, 0, err
+	}
+
+	return ai.ClaimVerifyEvidenceV1{
+		SourceID: id,
+		URL:      url,
+		Title:    title,
+		RenderID: renderID,
+		Text:     evText,
+	}, textBytes, nil
+}
+
+func claimVerifyEvidenceText(text string, renderID string) (string, int64, error) {
+	if strings.TrimSpace(text) != "" {
+		return clampEvidenceText(text, claimVerifyMaxEvidenceBytes)
+	}
+	if strings.TrimSpace(renderID) == "" {
+		return "", 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence.text or evidence.render_id is required"}
+	}
+	return "", 0, nil
 }
 
 func normalizeClaimVerifyRetrieval(req *claimVerifyRetrievalRequest) *ai.ClaimVerifyRetrievalV1 {
@@ -353,8 +434,7 @@ func clampEvidenceText(raw string, maxBytes int64) (string, int64, error) {
 		return evText, b, nil
 	}
 
-	trimmed := strings.TrimSpace(string([]byte(evText)[:maxBytes]))
-	return trimmed, int64(len([]byte(trimmed))), nil
+	return "", 0, &apptheory.AppError{Code: "app.bad_request", Message: "evidence.text is too large"}
 }
 
 func estimateClaimVerifyBaseCredits(claimCount int64, totalEvidenceBytes int64) int64 {

--- a/internal/trust/handlers_ai_claims_internal_test.go
+++ b/internal/trust/handlers_ai_claims_internal_test.go
@@ -6,11 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/equaltoai/lesser-host/internal/ai"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
 )
 
 func TestClaimVerifyRetrievalMode(t *testing.T) {
@@ -121,75 +124,113 @@ func TestSanitizeClaimVerifyClaims(t *testing.T) {
 	}
 }
 
-func TestBuildClaimVerifyEvidence(t *testing.T) {
+func TestHandleAIClaimVerify_DisabledShortCircuitsProvider(t *testing.T) {
 	t.Parallel()
 
-	t.Run("TooManyItems", func(t *testing.T) {
-		t.Parallel()
-
-		req := make([]claimVerifyEvidenceRequest, claimVerifyMaxEvidenceItems+1)
-		_, _, err := buildClaimVerifyEvidence(req)
-		if err == nil {
-			t.Fatalf("expected error")
-		}
+	st := &store.Store{}
+	s := &Server{store: st, ai: ai.NewService(st)}
+	body, _ := json.Marshal(claimVerifyRequest{
+		Text: testHello,
+		Evidence: []claimVerifyEvidenceRequest{{
+			SourceID: "src",
+			Text:     testHello,
+		}},
 	})
-
-	t.Run("MissingSourceID", func(t *testing.T) {
-		t.Parallel()
-
-		_, _, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{{SourceID: " ", Text: "x"}})
-		if err == nil {
-			t.Fatalf("expected error")
-		}
+	resp, err := s.handleAIClaimVerify(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
 	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
 
-	t.Run("DuplicateSourceID", func(t *testing.T) {
-		t.Parallel()
+	var out aiClaimVerifyResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusDisabled || out.Budget.Reason != aiDisabledForInstanceReason {
+		t.Fatalf("expected disabled claim response before provider use, got %#v", out)
+	}
+	if out.Contract.Module != ai.ClaimVerifyLLMModule || out.Contract.ModelSet != modelSetDeterministic || out.Contract.InputsHash == "" {
+		t.Fatalf("unexpected contract: %#v", out.Contract)
+	}
+}
 
-		_, _, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{
-			{SourceID: "a", Text: "x"},
-			{SourceID: "a", Text: "y"},
+func TestNormalizeClaimVerifyTextBounds(t *testing.T) {
+	t.Parallel()
+
+	text, err := normalizeClaimVerifyText(" hello ")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if text != testHello {
+		t.Fatalf("expected trim, got %q", text)
+	}
+
+	if _, err := normalizeClaimVerifyText(strings.Repeat("x", int(claimVerifyMaxTextBytes)+1)); err == nil {
+		t.Fatalf("expected oversized text error")
+	}
+}
+
+func TestBuildClaimVerifyEvidenceRejectsInvalidRequests(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		req  []claimVerifyEvidenceRequest
+	}{
+		{"TooManyItems", make([]claimVerifyEvidenceRequest, claimVerifyMaxEvidenceItems+1)},
+		{"MissingSourceID", []claimVerifyEvidenceRequest{{SourceID: " ", Text: "x"}}},
+		{"DuplicateSourceID", []claimVerifyEvidenceRequest{{SourceID: "a", Text: "x"}, {SourceID: "a", Text: "y"}}},
+		{"InvalidRenderID", []claimVerifyEvidenceRequest{{SourceID: "a", RenderID: "nope"}}},
+		{"MissingTextAndRenderID", []claimVerifyEvidenceRequest{{SourceID: "a"}}},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if _, _, err := buildClaimVerifyEvidence(tc.req); err == nil {
+				t.Fatalf("expected error")
+			}
 		})
-		if err == nil {
-			t.Fatalf("expected error")
-		}
-	})
+	}
+}
 
-	t.Run("InvalidRenderID", func(t *testing.T) {
-		t.Parallel()
+func TestBuildClaimVerifyEvidenceRejectsOversizedMetadata(t *testing.T) {
+	t.Parallel()
 
-		_, _, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{{SourceID: "a", RenderID: "nope"}})
-		if err == nil {
-			t.Fatalf("expected error")
+	cases := []claimVerifyEvidenceRequest{
+		{SourceID: strings.Repeat("s", int(claimVerifyMaxSourceIDBytes)+1), Text: "x"},
+		{SourceID: "s", URL: strings.Repeat("u", int(claimVerifyMaxURLBytes)+1), Text: "x"},
+		{SourceID: "s", Title: strings.Repeat("t", int(claimVerifyMaxTitleBytes)+1), Text: "x"},
+		{SourceID: "s", Text: strings.Repeat("x", int(claimVerifyMaxEvidenceBytes)+1)},
+	}
+	for _, tc := range cases {
+		if _, _, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{tc}); err == nil {
+			t.Fatalf("expected oversized metadata/text error for %#v", tc)
 		}
-	})
+	}
+}
 
-	t.Run("MissingTextAndRenderID", func(t *testing.T) {
-		t.Parallel()
+func TestBuildClaimVerifyEvidenceSuccessText(t *testing.T) {
+	t.Parallel()
 
-		_, _, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{{SourceID: "a"}})
-		if err == nil {
-			t.Fatalf("expected error")
-		}
-	})
-
-	t.Run("Success_Text", func(t *testing.T) {
-		t.Parallel()
-
-		evidence, total, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{{SourceID: "a", URL: " u ", Title: " t ", Text: " hello "}})
-		if err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-		if len(evidence) != 1 {
-			t.Fatalf("expected 1 item, got %#v", evidence)
-		}
-		if evidence[0].SourceID != "a" || evidence[0].Text != "hello" {
-			t.Fatalf("unexpected evidence: %#v", evidence[0])
-		}
-		if total <= 0 {
-			t.Fatalf("expected positive total bytes, got %d", total)
-		}
-	})
+	evidence, total, err := buildClaimVerifyEvidence([]claimVerifyEvidenceRequest{{SourceID: "a", URL: " u ", Title: " t ", Text: " hello "}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(evidence) != 1 {
+		t.Fatalf("expected 1 item, got %#v", evidence)
+	}
+	if evidence[0].SourceID != "a" || evidence[0].Text != testHello {
+		t.Fatalf("unexpected evidence: %#v", evidence[0])
+	}
+	if total <= 0 {
+		t.Fatalf("expected positive total bytes, got %d", total)
+	}
 }
 
 func TestNormalizeClaimVerifyRetrieval(t *testing.T) {
@@ -235,14 +276,11 @@ func TestClampEvidenceText(t *testing.T) {
 
 	long := strings.Repeat("x", 50)
 	trimmed, b, err = clampEvidenceText(long, 10)
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+	if err == nil {
+		t.Fatalf("expected oversized evidence error")
 	}
-	if len([]byte(trimmed)) > 10 {
-		t.Fatalf("expected <= 10 bytes, got %d", len([]byte(trimmed)))
-	}
-	if b != int64(len([]byte(trimmed))) {
-		t.Fatalf("expected bytes to match, got %d want %d", b, len([]byte(trimmed)))
+	if trimmed != "" || b != 0 {
+		t.Fatalf("expected empty oversized output, got %q (%d)", trimmed, b)
 	}
 }
 
@@ -351,21 +389,37 @@ func TestHandleAIClaimVerify_OpenAIWebSearchRequiresOpenAIModel(t *testing.T) {
 		Request:      apptheory.Request{Body: body},
 	}
 
-	_, err := s.handleAIClaimVerify(ctx)
-	if err == nil {
-		t.Fatalf("expected error")
+	resp, err := s.handleAIClaimVerify(ctx)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
-	if appErr, ok := err.(*apptheory.AppError); !ok || appErr.Code != "app.bad_request" {
-		t.Fatalf("expected bad_request, got %T: %v", err, err)
+	var out aiClaimVerifyResponse
+	if unmarshalErr := json.Unmarshal(resp.Body, &out); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
+	}
+	if out.Status != statusDisabled || out.Budget.Allowed {
+		t.Fatalf("expected disabled response, got %#v", out)
 	}
 }
 
 func TestHandleAIClaimVerify_ReturnsInternalErrorWhenAIServiceNotReady(t *testing.T) {
 	t.Parallel()
 
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+	enabled := true
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "inst", AIEnabled: &enabled}
+	}).Once()
+
 	s := &Server{
 		ai:    ai.NewService(nil),
-		store: store.New(nil), // trust config store not ready -> default config
+		store: store.New(db),
 	}
 
 	body, _ := json.Marshal(claimVerifyRequest{

--- a/internal/trust/handlers_ai_evidence.go
+++ b/internal/trust/handlers_ai_evidence.go
@@ -321,6 +321,9 @@ func (s *Server) prepareAIEvidenceImage(ctx *apptheory.Context) (aiEvidenceImage
 	if key == "" {
 		return aiEvidenceImagePrepared{}, &apptheory.AppError{Code: "app.bad_request", Message: "object_key is required"}
 	}
+	if appErr := validateAIEvidenceImageObjectKey(instanceSlug, key); appErr != nil {
+		return aiEvidenceImagePrepared{}, appErr
+	}
 
 	instCfg := s.loadInstanceTrustConfig(ctx.Context(), instanceSlug)
 	allowOverage := strings.ToLower(strings.TrimSpace(instCfg.OveragePolicy)) == overagePolicyAllow
@@ -402,6 +405,36 @@ func aiEvidenceDisabledResponse(module string, policyVersion string, modelSet st
 			ModelSet:      strings.TrimSpace(modelSet),
 			InputsHash:    strings.TrimSpace(inputsHash),
 		},
+	}
+}
+
+func validateAIEvidenceImageObjectKey(instanceSlug string, key string) *apptheory.AppError {
+	instanceSlug = strings.TrimSpace(instanceSlug)
+	key = strings.TrimSpace(key)
+	if instanceSlug == "" {
+		return &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	}
+	if key == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "object_key is required"}
+	}
+
+	prefixes := aiEvidenceImageObjectKeyPrefixes(instanceSlug)
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(key, prefix) {
+			return nil
+		}
+	}
+	return &apptheory.AppError{Code: "app.bad_request", Message: "object_key must be under " + strings.Join(prefixes, " or ")}
+}
+
+func aiEvidenceImageObjectKeyPrefixes(instanceSlug string) []string {
+	instanceSlug = strings.TrimSpace(instanceSlug)
+	if instanceSlug == "" {
+		return nil
+	}
+	return []string{
+		"evidence/" + instanceSlug + "/",
+		"moderation/" + instanceSlug + "/",
 	}
 }
 

--- a/internal/trust/handlers_ai_evidence.go
+++ b/internal/trust/handlers_ai_evidence.go
@@ -13,6 +13,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/ai"
+	"github.com/equaltoai/lesser-host/internal/billing"
 	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
@@ -123,21 +124,14 @@ func (s *Server) handleGetAIJob(ctx *apptheory.Context) (*apptheory.Response, er
 }
 
 func (s *Server) handleAIEvidenceText(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if s == nil || s.ai == nil || s.store == nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-	if ctx == nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
-	}
-
-	instanceSlug := strings.TrimSpace(ctx.AuthIdentity)
-	if instanceSlug == "" {
-		return nil, &apptheory.AppError{Code: "app.unauthorized", Message: "unauthorized"}
+	instanceSlug, err := s.requireAIHandler(ctx)
+	if err != nil {
+		return nil, err
 	}
 
 	var req aiEvidenceTextRequest
-	if err := httpx.ParseJSON(ctx, &req); err != nil {
-		return nil, err
+	if parseErr := httpx.ParseJSON(ctx, &req); parseErr != nil {
+		return nil, parseErr
 	}
 
 	text := strings.TrimSpace(req.Text)
@@ -159,6 +153,9 @@ func (s *Server) handleAIEvidenceText(ctx *apptheory.Context) (*apptheory.Respon
 
 	inputs := aiEvidenceTextInputsV1{Text: text}
 	inputsHash, _ := ai.InputsHash(inputs)
+	if disabled := aiEvidenceTextDisabledResponse(instCfg, inputsHash); disabled != nil {
+		return apptheory.JSON(http.StatusOK, *disabled)
+	}
 
 	resp, err := s.ai.GetOrQueue(ctx.Context(), ai.Request{
 		InstanceSlug:         instanceSlug,
@@ -212,10 +209,28 @@ func (s *Server) handleAIEvidenceText(ctx *apptheory.Context) (*apptheory.Respon
 	return apptheory.JSON(http.StatusOK, out)
 }
 
+func aiEvidenceTextDisabledResponse(instCfg instanceTrustConfig, inputsHash string) *aiEvidenceResponse {
+	if instCfg.AIEnabled {
+		return nil
+	}
+	resp := aiEvidenceDisabledResponse(
+		aiEvidenceTextModule,
+		aiEvidenceTextPolicyVersion,
+		aiEvidenceTextModelSet,
+		inputsHash,
+		billing.PricedCredits(aiEvidenceTextBaseCredits, instCfg.AIPricingMultiplierBps),
+		aiDisabledForInstanceReason,
+	)
+	return &resp
+}
+
 func (s *Server) handleAIEvidenceImage(ctx *apptheory.Context) (*apptheory.Response, error) {
 	prepared, err := s.prepareAIEvidenceImage(ctx)
 	if err != nil {
 		return nil, err
+	}
+	if prepared.EarlyResponse != nil {
+		return apptheory.JSON(http.StatusOK, *prepared.EarlyResponse)
 	}
 
 	resp, err := s.ai.GetOrQueue(ctx.Context(), ai.Request{
@@ -272,12 +287,13 @@ func (s *Server) handleAIEvidenceImage(ctx *apptheory.Context) (*apptheory.Respo
 }
 
 type aiEvidenceImagePrepared struct {
-	InstanceSlug string
-	InstCfg      instanceTrustConfig
-	AllowOverage bool
-	Inputs       aiEvidenceImageInputsV1
-	InputsHash   string
-	Evidence     []models.AIEvidenceRef
+	InstanceSlug  string
+	InstCfg       instanceTrustConfig
+	AllowOverage  bool
+	EarlyResponse *aiEvidenceResponse
+	Inputs        aiEvidenceImageInputsV1
+	InputsHash    string
+	Evidence      []models.AIEvidenceRef
 }
 
 func (s *Server) prepareAIEvidenceImage(ctx *apptheory.Context) (aiEvidenceImagePrepared, error) {
@@ -306,13 +322,42 @@ func (s *Server) prepareAIEvidenceImage(ctx *apptheory.Context) (aiEvidenceImage
 		return aiEvidenceImagePrepared{}, &apptheory.AppError{Code: "app.bad_request", Message: "object_key is required"}
 	}
 
+	instCfg := s.loadInstanceTrustConfig(ctx.Context(), instanceSlug)
+	allowOverage := strings.ToLower(strings.TrimSpace(instCfg.OveragePolicy)) == overagePolicyAllow
+	precheckInputs := aiEvidenceImageInputsV1{ObjectKey: key}
+	precheckHash, _ := ai.InputsHash(precheckInputs)
+	if !instCfg.AIEnabled {
+		resp := aiEvidenceDisabledResponse(
+			aiEvidenceImageModule,
+			aiEvidenceImagePolicyVersion,
+			aiEvidenceImageModelSet,
+			precheckHash,
+			billing.PricedCredits(aiEvidenceImageBaseCredits, instCfg.AIPricingMultiplierBps),
+			aiDisabledForInstanceReason,
+		)
+		return aiEvidenceImagePrepared{InstanceSlug: instanceSlug, InstCfg: instCfg, AllowOverage: allowOverage, EarlyResponse: &resp}, nil
+	}
+	if precheck, appErr := s.precheckAIBudget(ctx.Context(), instanceSlug, aiEvidenceImageBaseCredits, instCfg.AIPricingMultiplierBps, allowOverage); appErr != nil {
+		return aiEvidenceImagePrepared{}, appErr
+	} else if precheck != nil && !precheck.Allowed {
+		resp := aiEvidenceResponse{
+			Status: string(ai.JobStatusNotCheckedBudget),
+			Cached: false,
+			Budget: *precheck,
+			Contract: ai.ModuleContract{
+				Module:        aiEvidenceImageModule,
+				PolicyVersion: aiEvidenceImagePolicyVersion,
+				ModelSet:      aiEvidenceImageModelSet,
+				InputsHash:    strings.TrimSpace(precheckHash),
+			},
+		}
+		return aiEvidenceImagePrepared{InstanceSlug: instanceSlug, InstCfg: instCfg, AllowOverage: allowOverage, EarlyResponse: &resp}, nil
+	}
+
 	contentType, etag, size, err := s.headAndValidateEvidenceImageObject(ctx.Context(), key)
 	if err != nil {
 		return aiEvidenceImagePrepared{}, err
 	}
-
-	instCfg := s.loadInstanceTrustConfig(ctx.Context(), instanceSlug)
-	allowOverage := strings.ToLower(strings.TrimSpace(instCfg.OveragePolicy)) == overagePolicyAllow
 
 	inputs := aiEvidenceImageInputsV1{
 		ObjectKey:   key,
@@ -338,6 +383,26 @@ func (s *Server) prepareAIEvidenceImage(ctx *apptheory.Context) (aiEvidenceImage
 		InputsHash:   strings.TrimSpace(inputsHash),
 		Evidence:     []models.AIEvidenceRef{evidence},
 	}, nil
+}
+
+func aiEvidenceDisabledResponse(module string, policyVersion string, modelSet string, inputsHash string, creditsRequested int64, message string) aiEvidenceResponse {
+	return aiEvidenceResponse{
+		Status: statusDisabled,
+		Cached: false,
+		Budget: ai.BudgetDecision{
+			Allowed:          false,
+			OverBudget:       false,
+			Reason:           strings.TrimSpace(message),
+			RequestedCredits: creditsRequested,
+			DebitedCredits:   0,
+		},
+		Contract: ai.ModuleContract{
+			Module:        strings.TrimSpace(module),
+			PolicyVersion: strings.TrimSpace(policyVersion),
+			ModelSet:      strings.TrimSpace(modelSet),
+			InputsHash:    strings.TrimSpace(inputsHash),
+		},
+	}
 }
 
 func (s *Server) headAndValidateEvidenceImageObject(ctx context.Context, key string) (contentType, etag string, size int64, err error) {

--- a/internal/trust/handlers_ai_evidence_internal_test.go
+++ b/internal/trust/handlers_ai_evidence_internal_test.go
@@ -61,6 +61,35 @@ func newAIEvidenceTestDB() aiEvidenceTestDB {
 	}
 }
 
+func TestHandleAIEvidenceText_DisabledShortCircuitsAIQueue(t *testing.T) {
+	t.Parallel()
+
+	st := &store.Store{}
+	s := &Server{store: st, ai: ai.NewService(st)}
+	body, _ := json.Marshal(aiEvidenceTextRequest{Text: testHello})
+	resp, err := s.handleAIEvidenceText(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out aiEvidenceResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusDisabled || out.Budget.Reason != aiDisabledForInstanceReason {
+		t.Fatalf("expected disabled response before queue use, got %#v", out)
+	}
+	if out.Contract.Module != aiEvidenceTextModule || out.Contract.InputsHash == "" {
+		t.Fatalf("expected text contract hash, got %#v", out.Contract)
+	}
+}
+
 func TestHandleAIEvidenceText_BudgetNotConfigured(t *testing.T) {
 	t.Parallel()
 
@@ -71,8 +100,11 @@ func TestHandleAIEvidenceText_BudgetNotConfigured(t *testing.T) {
 		ai:    ai.NewService(st),
 	}
 
-	// loadInstanceTrustConfig falls back to defaults when instance not found.
-	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+	enabled := true
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", AIEnabled: &enabled}
+	}).Once()
 	// No cached result, no job exists.
 	tdb.qResult.On("First", mock.AnythingOfType("*models.AIResult")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qJob.On("First", mock.AnythingOfType("*models.AIJob")).Return(theoryErrors.ErrItemNotFound).Once()

--- a/internal/trust/handlers_ai_moderation.go
+++ b/internal/trust/handlers_ai_moderation.go
@@ -157,6 +157,19 @@ func (s *Server) handleAIModerationTextTriggered(ctx *apptheory.Context, action 
 	inputsHash, _ := ai.InputsHash(inputs)
 
 	creditsRequested := billing.PricedCredits(aiModerationTextBaseCredits, instCfg.AIPricingMultiplierBps)
+	if !instCfg.AIEnabled {
+		return apptheory.JSON(
+			http.StatusOK,
+			moderationDisabledResponse(
+				ai.ModerationTextLLMModule,
+				ai.ModerationTextLLMPolicyVersion,
+				modelSet,
+				inputsHash,
+				creditsRequested,
+				aiDisabledForInstanceReason,
+			),
+		)
+	}
 	if !instCfg.ModerationEnabled {
 		return apptheory.JSON(
 			http.StatusOK,
@@ -242,19 +255,8 @@ func (s *Server) handleAIModerationImageTriggered(ctx *apptheory.Context, action
 		return nil, parseErr
 	}
 
-	key, contentType, etag, size, err := s.prepareModerationImageInput(ctx.Context(), instanceSlug, req)
-	if err != nil {
-		return nil, err
-	}
-	if key == "" {
+	if strings.TrimSpace(req.ObjectKey) == "" && strings.TrimSpace(req.URL) == "" {
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "object_key or url is required"}
-	}
-
-	if size <= 0 || size > 5*1024*1024 {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "object too large"}
-	}
-	if ct := strings.ToLower(strings.TrimSpace(contentType)); ct != "" && !strings.HasPrefix(ct, "image/") {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "object must be an image"}
 	}
 
 	instCfg := s.loadInstanceTrustConfig(ctx.Context(), instanceSlug)
@@ -262,45 +264,26 @@ func (s *Server) handleAIModerationImageTriggered(ctx *apptheory.Context, action
 
 	modelSet := moderationModelSet(instCfg)
 
-	inputs := ai.ModerationImageInputsV1{
-		ObjectKey:   key,
-		ObjectETag:  strings.TrimSpace(etag),
-		Bytes:       size,
-		ContentType: strings.TrimSpace(contentType),
+	precheckInputs := map[string]string{
+		"object_key": strings.TrimSpace(req.ObjectKey),
+		"url":        strings.TrimSpace(req.URL),
 	}
-	inputsHash, _ := ai.InputsHash(inputs)
+	inputsHash, _ := ai.InputsHash(precheckInputs)
 
 	creditsRequested := billing.PricedCredits(aiModerationImageBaseCredits, instCfg.AIPricingMultiplierBps)
-	if !instCfg.ModerationEnabled {
-		return apptheory.JSON(
-			http.StatusOK,
-			moderationDisabledResponse(
-				ai.ModerationImageLLMModule,
-				ai.ModerationImageLLMPolicyVersion,
-				modelSet,
-				inputsHash,
-				creditsRequested,
-				"moderation scanning disabled for instance",
-			),
-		)
+	if disabled := moderationImageDisabledResponse(action, req, instCfg, modelSet, inputsHash, creditsRequested); disabled != nil {
+		return apptheory.JSON(http.StatusOK, *disabled)
 	}
 
-	if strings.EqualFold(action, "moderation.scan.request") {
-		trigger := strings.ToLower(strings.TrimSpace(instCfg.ModerationTrigger))
-		ok, msg := moderationRequestAllowed(trigger, req.Context, instCfg.ModerationViralityMin, "image")
-		if !ok {
-			return apptheory.JSON(
-				http.StatusOK,
-				moderationDisabledResponse(
-					ai.ModerationImageLLMModule,
-					ai.ModerationImageLLMPolicyVersion,
-					modelSet,
-					inputsHash,
-					creditsRequested,
-					msg,
-				),
-			)
-		}
+	if budgetResp, appErr := s.moderationImageBudgetPrecheckResponse(ctx.Context(), instanceSlug, instCfg, allowOverage, modelSet, inputsHash); appErr != nil {
+		return nil, appErr
+	} else if budgetResp != nil {
+		return apptheory.JSON(http.StatusOK, *budgetResp)
+	}
+
+	inputs, inputsHash, err := s.prepareModerationImageInputs(ctx.Context(), instanceSlug, req)
+	if err != nil {
+		return nil, err
 	}
 
 	resp, err := s.ai.GetOrQueue(ctx.Context(), ai.Request{
@@ -331,6 +314,71 @@ func (s *Server) handleAIModerationImageTriggered(ctx *apptheory.Context, action
 	s.emitAIRequestMetrics(instanceSlug, ai.ModerationImageLLMModule, resp, nil)
 
 	return apptheory.JSON(http.StatusOK, buildAIModerationResponse(resp, ai.ModerationImageLLMModule, ai.ModerationImageLLMPolicyVersion, modelSet, inputsHash))
+}
+
+func (s *Server) prepareModerationImageInputs(ctx context.Context, instanceSlug string, req aiModerationImageRequest) (ai.ModerationImageInputsV1, string, error) {
+	key, contentType, etag, size, err := s.prepareModerationImageInput(ctx, instanceSlug, req)
+	if err != nil {
+		return ai.ModerationImageInputsV1{}, "", err
+	}
+	if key == "" {
+		return ai.ModerationImageInputsV1{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "object_key or url is required"}
+	}
+	if size <= 0 || size > 5*1024*1024 {
+		return ai.ModerationImageInputsV1{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "object too large"}
+	}
+	if ct := strings.ToLower(strings.TrimSpace(contentType)); ct != "" && !strings.HasPrefix(ct, "image/") {
+		return ai.ModerationImageInputsV1{}, "", &apptheory.AppError{Code: "app.bad_request", Message: "object must be an image"}
+	}
+	inputs := ai.ModerationImageInputsV1{
+		ObjectKey:   key,
+		ObjectETag:  strings.TrimSpace(etag),
+		Bytes:       size,
+		ContentType: strings.TrimSpace(contentType),
+	}
+	inputsHash, _ := ai.InputsHash(inputs)
+	return inputs, inputsHash, nil
+}
+
+func moderationImageDisabledResponse(action string, req aiModerationImageRequest, instCfg instanceTrustConfig, modelSet string, inputsHash string, creditsRequested int64) *aiModerationResponse {
+	if !instCfg.AIEnabled {
+		resp := moderationDisabledResponse(ai.ModerationImageLLMModule, ai.ModerationImageLLMPolicyVersion, modelSet, inputsHash, creditsRequested, aiDisabledForInstanceReason)
+		return &resp
+	}
+	if !instCfg.ModerationEnabled {
+		resp := moderationDisabledResponse(ai.ModerationImageLLMModule, ai.ModerationImageLLMPolicyVersion, modelSet, inputsHash, creditsRequested, "moderation scanning disabled for instance")
+		return &resp
+	}
+	if !strings.EqualFold(action, "moderation.scan.request") {
+		return nil
+	}
+	trigger := strings.ToLower(strings.TrimSpace(instCfg.ModerationTrigger))
+	ok, msg := moderationRequestAllowed(trigger, req.Context, instCfg.ModerationViralityMin, "image")
+	if ok {
+		return nil
+	}
+	resp := moderationDisabledResponse(ai.ModerationImageLLMModule, ai.ModerationImageLLMPolicyVersion, modelSet, inputsHash, creditsRequested, msg)
+	return &resp
+}
+
+func (s *Server) moderationImageBudgetPrecheckResponse(ctx context.Context, instanceSlug string, instCfg instanceTrustConfig, allowOverage bool, modelSet string, inputsHash string) (*aiModerationResponse, *apptheory.AppError) {
+	precheck, appErr := s.precheckAIBudget(ctx, instanceSlug, aiModerationImageBaseCredits, instCfg.AIPricingMultiplierBps, allowOverage)
+	if appErr != nil || precheck == nil || precheck.Allowed {
+		return nil, appErr
+	}
+	return &aiModerationResponse{
+		Status: string(ai.JobStatusNotCheckedBudget),
+		Cached: false,
+		Budget: *precheck,
+		Contract: ai.ModuleContract{
+			Module:        ai.ModerationImageLLMModule,
+			PolicyVersion: ai.ModerationImageLLMPolicyVersion,
+			ModelSet:      modelSet,
+			InputsHash:    inputsHash,
+		},
+		ErrorCode:    statusNotCheckedBudget,
+		ErrorMessage: strings.TrimSpace(precheck.Reason),
+	}, nil
 }
 
 func (s *Server) prepareModerationImageInput(ctx context.Context, instanceSlug string, req aiModerationImageRequest) (key string, contentType string, etag string, size int64, err error) {

--- a/internal/trust/handlers_ai_moderation_internal_test.go
+++ b/internal/trust/handlers_ai_moderation_internal_test.go
@@ -54,6 +54,92 @@ func TestModerationModelSet(t *testing.T) {
 	}
 }
 
+func TestHandleAIModerationText_DisabledShortCircuitsQueue(t *testing.T) {
+	t.Parallel()
+
+	st := &store.Store{}
+	s := &Server{store: st, ai: ai.NewService(st)}
+	body, _ := json.Marshal(aiModerationTextRequest{Text: testHello})
+	resp, err := s.handleAIModerationText(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out aiModerationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusDisabled || out.ErrorMessage != aiDisabledForInstanceReason {
+		t.Fatalf("expected disabled moderation response, got %#v", out)
+	}
+	if out.Contract.Module != ai.ModerationTextLLMModule || out.Contract.InputsHash == "" {
+		t.Fatalf("expected text moderation contract, got %#v", out.Contract)
+	}
+}
+
+func TestHandleAIModerationImage_DisabledShortCircuitsFetch(t *testing.T) {
+	t.Parallel()
+
+	st := &store.Store{}
+	s := &Server{store: st, ai: ai.NewService(st), artifacts: artifacts.New("bucket")}
+	body, _ := json.Marshal(aiModerationImageRequest{URL: "https://example.com/image.png"})
+	resp, err := s.handleAIModerationImage(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out aiModerationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusDisabled || out.ErrorMessage != aiDisabledForInstanceReason {
+		t.Fatalf("expected disabled image moderation response before fetch, got %#v", out)
+	}
+	if out.Contract.Module != ai.ModerationImageLLMModule || out.Contract.InputsHash == "" {
+		t.Fatalf("expected image moderation contract, got %#v", out.Contract)
+	}
+}
+
+func TestModerationImageDisabledResponse(t *testing.T) {
+	t.Parallel()
+
+	req := aiModerationImageRequest{Context: &aiModerationScanCtxV1{ViralityScore: 0}}
+	resp := moderationImageDisabledResponse("moderation.scan.request", req, instanceTrustConfig{AIEnabled: false}, modelSetDeterministic, "hash", 3)
+	if resp == nil || resp.ErrorMessage != aiDisabledForInstanceReason {
+		t.Fatalf("expected ai disabled response, got %#v", resp)
+	}
+
+	enabled := instanceTrustConfig{AIEnabled: true, ModerationEnabled: false}
+	resp = moderationImageDisabledResponse("moderation.scan.request", req, enabled, modelSetDeterministic, "hash", 3)
+	if resp == nil || resp.ErrorMessage != "moderation scanning disabled for instance" {
+		t.Fatalf("expected moderation disabled response, got %#v", resp)
+	}
+
+	enabled.ModerationEnabled = true
+	enabled.ModerationTrigger = moderationTriggerVirality
+	enabled.ModerationViralityMin = 10
+	resp = moderationImageDisabledResponse("moderation.scan.request", req, enabled, modelSetDeterministic, "hash", 3)
+	if resp == nil || !strings.Contains(resp.ErrorMessage, "virality") {
+		t.Fatalf("expected trigger disabled response, got %#v", resp)
+	}
+
+	if resp = moderationImageDisabledResponse("moderation.scan.report", req, enabled, modelSetDeterministic, "hash", 3); resp != nil {
+		t.Fatalf("expected report action to bypass trigger response, got %#v", resp)
+	}
+}
+
 func TestBuildAIModerationResponse(t *testing.T) {
 	t.Parallel()
 

--- a/internal/trust/handlers_attestations.go
+++ b/internal/trust/handlers_attestations.go
@@ -56,14 +56,15 @@ func (s *Server) handleLookupAttestation(ctx *apptheory.Context) (*apptheory.Res
 	actorURI := strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "actor_uri"))
 	objectURI := strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "object_uri"))
 	contentHash := strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "content_hash"))
+	instanceSlug := strings.ToLower(strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "instance_slug")))
 	module := strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "module"))
 	policyVersion := strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "policy_version"))
 
-	if actorURI == "" || objectURI == "" || contentHash == "" || module == "" || policyVersion == "" {
+	if actorURI == "" || objectURI == "" || contentHash == "" || instanceSlug == "" || module == "" || policyVersion == "" {
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "missing required query parameters"}
 	}
 
-	id := attestations.AttestationID(actorURI, objectURI, contentHash, module, policyVersion)
+	id := attestations.InstanceAttestationID(instanceSlug, actorURI, objectURI, contentHash, module, policyVersion)
 	return s.serveAttestationByID(ctx, id)
 }
 
@@ -94,6 +95,9 @@ func (s *Server) serveAttestationByID(ctx *apptheory.Context, id string) (*appth
 	}
 	if err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if strings.TrimSpace(item.InstanceSlug) == "" {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "attestation not found"}
 	}
 
 	headerBytes, payloadBytes, _, err := attestations.ParseCompactJWS(strings.TrimSpace(item.JWS))

--- a/internal/trust/handlers_attestations_test.go
+++ b/internal/trust/handlers_attestations_test.go
@@ -83,9 +83,10 @@ func TestServeAttestationByID_Success(t *testing.T) {
 	q.On("First", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Attestation](t, args, 0)
 		*dest = models.Attestation{
-			ID:        "id",
-			JWS:       jws,
-			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+			ID:           "id",
+			InstanceSlug: "inst",
+			JWS:          jws,
+			ExpiresAt:    time.Now().UTC().Add(1 * time.Hour),
 		}
 	}).Once()
 
@@ -141,14 +142,16 @@ func TestHandleLookupAttestation_ValidatesAndServes(t *testing.T) {
 	contentHash := "sha256:deadbeef"
 	module := "claim_verify_llm"
 	policyVersion := "v1"
-	id := attestations.AttestationID(actorURI, objectURI, contentHash, module, policyVersion)
+	instanceSlug := testBudgetInstanceSlug
+	id := attestations.InstanceAttestationID(instanceSlug, actorURI, objectURI, contentHash, module, policyVersion)
 
 	q.On("First", mock.AnythingOfType("*models.Attestation")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Attestation](t, args, 0)
 		*dest = models.Attestation{
-			ID:        id,
-			JWS:       jws,
-			ExpiresAt: time.Now().UTC().Add(1 * time.Hour),
+			ID:           id,
+			InstanceSlug: instanceSlug,
+			JWS:          jws,
+			ExpiresAt:    time.Now().UTC().Add(1 * time.Hour),
 		}
 	}).Once()
 
@@ -163,6 +166,7 @@ func TestHandleLookupAttestation_ValidatesAndServes(t *testing.T) {
 		"actor_uri":      {actorURI},
 		"object_uri":     {objectURI},
 		"content_hash":   {contentHash},
+		"instance_slug":  {instanceSlug},
 		"module":         {module},
 		"policy_version": {policyVersion},
 	}}}

--- a/internal/trust/handlers_budget.go
+++ b/internal/trust/handlers_budget.go
@@ -87,7 +87,7 @@ func (s *Server) handleBudgetDebit(ctx *apptheory.Context) (*apptheory.Response,
 	audit := buildBudgetDebitAuditEntry(prepared, now)
 
 	maxUsed := budget.IncludedCredits - prepared.Credits
-	err = s.transactBudgetDebit(ctx.Context(), update, prepared.AllowOverage, maxUsed, prepared.Credits, now, ledger, audit)
+	err = s.transactBudgetDebit(ctx.Context(), update, prepared.AllowOverage, budget.IncludedCredits, maxUsed, prepared.Credits, now, ledger, audit)
 	if theoryErrors.IsConditionFailed(err) {
 		latest, _, _ := s.loadInstanceBudgetMonth(ctx.Context(), prepared.PK, prepared.SK)
 		remaining = latest.IncludedCredits - latest.UsedCredits
@@ -160,10 +160,10 @@ func (s *Server) prepareBudgetDebit(ctx *apptheory.Context) (budgetDebitPrepared
 		return budgetDebitPrepared{}, &apptheory.AppError{Code: "app.bad_request", Message: "credits must be > 0"}
 	}
 
-	month, err := normalizeBudgetMonth(req.Month, time.Now().UTC())
-	if err != nil {
-		return budgetDebitPrepared{}, &apptheory.AppError{Code: "app.bad_request", Message: "month must be YYYY-MM"}
-	}
+	// The authenticated instance is the metered party, so it cannot select the
+	// accounting period. Always debit the server's current month; the request
+	// field is ignored for backwards-compatible clients.
+	month := time.Now().UTC().Format("2006-01")
 
 	return budgetDebitPrepared{
 		InstanceSlug: instanceSlug,
@@ -213,6 +213,7 @@ func (s *Server) transactBudgetDebit(
 	ctx context.Context,
 	update *models.InstanceBudgetMonth,
 	allowOverage bool,
+	expectedIncludedCredits int64,
 	maxUsed int64,
 	credits int64,
 	now time.Time,
@@ -225,6 +226,7 @@ func (s *Server) transactBudgetDebit(
 
 	return s.store.DB.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
 		conditions := []core.TransactCondition{tabletheory.IfExists()}
+		conditions = append(conditions, tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits))
 		if !allowOverage {
 			conditions = append(conditions,
 				tabletheory.ConditionExpression(

--- a/internal/trust/handlers_budget_internal_test.go
+++ b/internal/trust/handlers_budget_internal_test.go
@@ -77,15 +77,7 @@ func TestPrepareBudgetDebit_ErrorsAndSuccess(t *testing.T) {
 	}
 
 	{
-		body, _ := json.Marshal(budgetDebitRequest{Credits: 1, Month: "bad"})
-		_, err := s.prepareBudgetDebit(&apptheory.Context{AuthIdentity: "inst", Request: apptheory.Request{Body: body}})
-		if err == nil {
-			t.Fatalf("expected error for invalid month")
-		}
-	}
-
-	{
-		body, _ := json.Marshal(budgetDebitRequest{Credits: 5, Month: testBudgetMonth202601})
+		body, _ := json.Marshal(budgetDebitRequest{Credits: 5, Month: "bad"})
 		prepared, err := s.prepareBudgetDebit(&apptheory.Context{
 			AuthIdentity: testBudgetInstanceSlug,
 			RequestID:    "rid",
@@ -94,10 +86,11 @@ func TestPrepareBudgetDebit_ErrorsAndSuccess(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected err: %v", err)
 		}
-		if prepared.InstanceSlug != testBudgetInstanceSlug || prepared.Month != testBudgetMonth202601 || prepared.Credits != 5 {
+		expectedMonth := time.Now().UTC().Format("2006-01")
+		if prepared.InstanceSlug != testBudgetInstanceSlug || prepared.Month != expectedMonth || prepared.Credits != 5 {
 			t.Fatalf("unexpected prepared: %#v", prepared)
 		}
-		if prepared.PK != "INSTANCE#"+testBudgetInstanceSlug || prepared.SK != "BUDGET#"+testBudgetMonth202601 || prepared.RequestID != "rid" {
+		if prepared.PK != "INSTANCE#"+testBudgetInstanceSlug || prepared.SK != "BUDGET#"+expectedMonth || prepared.RequestID != "rid" {
 			t.Fatalf("unexpected prepared keys: %#v", prepared)
 		}
 		if prepared.AllowOverage {
@@ -150,10 +143,10 @@ func TestTransactBudgetDebit(t *testing.T) {
 	audit := &models.AuditLogEntry{Actor: testBudgetInstanceSlug, Action: "budget.debit", Target: "x"}
 	_ = audit.UpdateKeys()
 
-	if err := s.transactBudgetDebit(context.Background(), update, false, 5, 5, now, ledger, audit); err != nil {
+	if err := s.transactBudgetDebit(context.Background(), update, false, 5, 5, update.IncludedCredits, now, ledger, audit); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if err := s.transactBudgetDebit(context.Background(), update, true, 5, 5, now, ledger, audit); err != nil {
+	if err := s.transactBudgetDebit(context.Background(), update, true, 5, 5, update.IncludedCredits, now, ledger, audit); err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
 }
@@ -209,6 +202,48 @@ func TestHandleBudgetDebit_NotConfiguredAndExceeded(t *testing.T) {
 	resp, err = s.handleBudgetDebit(ctx)
 	if err != nil || resp == nil || resp.Status != 200 {
 		t.Fatalf("unexpected resp: %#v err=%v", resp, err)
+	}
+}
+
+func TestHandleBudgetDebit_Success(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	q := new(ttmocks.MockQuery)
+	tx := new(ttmocks.MockTransactionBuilder)
+	db.TransactWriteBuilder = tx
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.Anything).Return(q).Maybe()
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+	q.On("ConsistentRead").Return(q).Maybe()
+	q.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Maybe()
+
+	expectedMonth := time.Now().UTC().Format("2006-01")
+	q.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: testBudgetInstanceSlug, Month: expectedMonth, IncludedCredits: 10, UsedCredits: 2}
+	}).Once()
+	q.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: testBudgetInstanceSlug, Month: expectedMonth, IncludedCredits: 10, UsedCredits: 7}
+	}).Once()
+
+	s := &Server{store: store.New(db)}
+	body, _ := json.Marshal(budgetDebitRequest{Credits: 5, Month: testBudgetMonth202601})
+	resp, err := s.handleBudgetDebit(&apptheory.Context{AuthIdentity: testBudgetInstanceSlug, RequestID: "rid", Request: apptheory.Request{Body: body}})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp == nil || resp.Status != 200 {
+		t.Fatalf("unexpected resp: %#v", resp)
+	}
+	var out budgetDebitResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.Allowed || out.Reason != budgetReasonDebited || out.Month != expectedMonth || out.UsedCredits != 7 || out.RemainingCredits != 3 {
+		t.Fatalf("unexpected output: %#v", out)
 	}
 }
 

--- a/internal/trust/handlers_previews.go
+++ b/internal/trust/handlers_previews.go
@@ -541,7 +541,10 @@ func (s *Server) debitBudgetForPreviewRender(ctx *apptheory.Context, instanceSlu
 	_ = auditBudget.UpdateKeys()
 
 	maxUsed := budget.IncludedCredits - linkRenderCreditCost
-	budgetUpdateConditions := []core.TransactCondition{tabletheory.IfExists()}
+	budgetUpdateConditions := []core.TransactCondition{
+		tabletheory.IfExists(),
+		tabletheory.Condition("IncludedCredits", "=", budget.IncludedCredits),
+	}
 	if !allowOverage {
 		budgetUpdateConditions = append(budgetUpdateConditions,
 			tabletheory.ConditionExpression(

--- a/internal/trust/handlers_publish_jobs.go
+++ b/internal/trust/handlers_publish_jobs.go
@@ -100,6 +100,13 @@ func (s *Server) handlePublishJob(ctx *apptheory.Context) (*apptheory.Response, 
 	actorURI := strings.TrimSpace(req.ActorURI)
 	objectURI := strings.TrimSpace(req.ObjectURI)
 	contentHash := strings.TrimSpace(req.ContentHash)
+	subject, appErr := s.normalizeInstanceAttestationSubject(ctx.Context(), instanceSlug, actorURI, objectURI, contentHash)
+	if appErr != nil {
+		return nil, appErr
+	}
+	actorURI = subject.ActorURI
+	objectURI = subject.ObjectURI
+	contentHash = subject.ContentHash
 
 	// Default modules when omitted.
 	modules := req.Modules
@@ -109,7 +116,10 @@ func (s *Server) handlePublishJob(ctx *apptheory.Context) (*apptheory.Response, 
 
 	pricingMultiplierBps := int64(10000)
 	if req.Pricing != nil && req.Pricing.AuthorAtPublish {
-		pricingMultiplierBps = authorPublishDiscountBPS
+		// The client-provided flag is retained for request compatibility, but
+		// discounts are not applied until host has a server-authoritative proof
+		// that the work is eligible for author-at-initial-publish pricing.
+		pricingMultiplierBps = 10000
 	}
 
 	canonical := canonicalizePublishLinks(req.Links)
@@ -117,7 +127,7 @@ func (s *Server) handlePublishJob(ctx *apptheory.Context) (*apptheory.Response, 
 	linksHash := linkSafetyBasicLinksHash(canonical)
 
 	// For now we only support link_safety_basic; return a stable job id regardless.
-	jobID := linkSafetyBasicJobID(actorURI, objectURI, contentHash, linksHash)
+	jobID := linkSafetyBasicJobID(instanceSlug, actorURI, objectURI, contentHash, linksHash)
 
 	out := publishJobResponse{
 		JobID:       jobID,
@@ -267,10 +277,6 @@ func (s *Server) runPublishJobModule(
 	}
 }
 
-const (
-	authorPublishDiscountBPS int64 = 5000 // 50% discount when explicitly flagged as "author at publish".
-)
-
 var publishJobIDRE = regexp.MustCompile(`^[0-9a-f]{64}$`)
 
 func (s *Server) handleGetPublishJob(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -299,7 +305,7 @@ func (s *Server) handleGetPublishJob(ctx *apptheory.Context) (*apptheory.Respons
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	if strings.TrimSpace(item.InstanceSlug) != "" && strings.TrimSpace(item.InstanceSlug) != instanceSlug {
+	if strings.TrimSpace(item.InstanceSlug) != instanceSlug {
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "job not found"}
 	}
 
@@ -356,6 +362,21 @@ func (s *Server) storeLinkSafetyBasicNoLinksResult(
 	})
 	if theoryErrors.IsConditionFailed(err) {
 		if cached, err2 := s.store.GetLinkSafetyBasicResult(ctx.Context(), jobID); err2 == nil {
+			if !linkSafetyBasicResultOwnedByInstance(cached, instanceSlug) {
+				return publishJobModuleResponse{
+					Name:          "link_safety_basic",
+					PolicyVersion: linkSafetyBasicPolicyVersion,
+					Status:        statusError,
+					Cached:        false,
+					Budget: budgetDecision{
+						Allowed:          true,
+						OverBudget:       false,
+						Reason:           "owner conflict",
+						RequestedCredits: 0,
+						DebitedCredits:   0,
+					},
+				}
+			}
 			attID, _ := s.ensureLinkSafetyBasicAttestation(ctx.Context(), cached)
 			return publishJobModuleResponse{
 				Name:          "link_safety_basic",
@@ -489,6 +510,7 @@ func (s *Server) precheckLinkSafetyBasicBudget(
 func (s *Server) transactDebitBudgetAndStoreLinkSafetyBasic(
 	ctx *apptheory.Context,
 	allowOverage bool,
+	expectedIncludedCredits int64,
 	maxUsed int64,
 	update *models.InstanceBudgetMonth,
 	ledger *models.UsageLedgerEntry,
@@ -504,7 +526,10 @@ func (s *Server) transactDebitBudgetAndStoreLinkSafetyBasic(
 				ub.Add("UsedCredits", creditsPriced)
 				ub.Set("UpdatedAt", now)
 				return nil
-			}, tabletheory.IfExists())
+			},
+				tabletheory.IfExists(),
+				tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits),
+			)
 			tx.Put(auditBudget)
 			tx.Put(ledger)
 			tx.Create(item)
@@ -520,6 +545,7 @@ func (s *Server) transactDebitBudgetAndStoreLinkSafetyBasic(
 			return nil
 		},
 			tabletheory.IfExists(),
+			tabletheory.Condition("IncludedCredits", "=", expectedIncludedCredits),
 			tabletheory.ConditionExpression(
 				"attribute_not_exists(usedCredits) OR usedCredits <= :max",
 				map[string]any{
@@ -552,6 +578,21 @@ func (s *Server) handleLinkSafetyBasicConditionFailed(
 	now time.Time,
 ) publishJobModuleResponse {
 	if cached, err2 := s.store.GetLinkSafetyBasicResult(ctx.Context(), jobID); err2 == nil {
+		if !linkSafetyBasicResultOwnedByInstance(cached, instanceSlug) {
+			return publishJobModuleResponse{
+				Name:          "link_safety_basic",
+				PolicyVersion: linkSafetyBasicPolicyVersion,
+				Status:        statusError,
+				Cached:        false,
+				Budget: budgetDecision{
+					Allowed:          true,
+					OverBudget:       false,
+					Reason:           "owner conflict",
+					RequestedCredits: creditsPriced,
+					DebitedCredits:   0,
+				},
+			}
+		}
 		return s.linkSafetyBasicCacheHitResponse(
 			ctx,
 			instanceSlug,
@@ -688,6 +729,21 @@ func (s *Server) runLinkSafetyBasicJob(
 
 	// Cache hit path (no charge).
 	if cached, err := s.store.GetLinkSafetyBasicResult(ctx.Context(), jobID); err == nil {
+		if !linkSafetyBasicResultOwnedByInstance(cached, instanceSlug) {
+			return publishJobModuleResponse{
+				Name:          "link_safety_basic",
+				PolicyVersion: linkSafetyBasicPolicyVersion,
+				Status:        statusError,
+				Cached:        false,
+				Budget: budgetDecision{
+					Allowed:          true,
+					OverBudget:       false,
+					Reason:           "owner conflict",
+					RequestedCredits: creditsPriced,
+					DebitedCredits:   0,
+				},
+			}
+		}
 		return s.linkSafetyBasicCacheHitResponse(
 			ctx,
 			instanceSlug,
@@ -790,7 +846,7 @@ func (s *Server) runLinkSafetyBasicJob(
 
 	allowOverage := strings.ToLower(strings.TrimSpace(overagePolicy)) == overagePolicyAllow
 	maxUsed := budget.IncludedCredits - creditsPriced
-	txnErr := s.transactDebitBudgetAndStoreLinkSafetyBasic(ctx, allowOverage, maxUsed, update, ledger, item, auditBudget, auditScan, creditsPriced, now)
+	txnErr := s.transactDebitBudgetAndStoreLinkSafetyBasic(ctx, allowOverage, budget.IncludedCredits, maxUsed, update, ledger, item, auditBudget, auditScan, creditsPriced, now)
 	if theoryErrors.IsConditionFailed(txnErr) {
 		return s.handleLinkSafetyBasicConditionFailed(
 			ctx,
@@ -884,4 +940,11 @@ func (s *Server) linkSafetyBasicCacheHitResponse(
 		AttestationURL: attestationURL(ctx, attID, s.cfg.PublicBaseURL),
 		Result:         cached,
 	}
+}
+
+func linkSafetyBasicResultOwnedByInstance(item *models.LinkSafetyBasicResult, instanceSlug string) bool {
+	if item == nil {
+		return false
+	}
+	return strings.TrimSpace(item.InstanceSlug) == strings.TrimSpace(instanceSlug)
 }

--- a/internal/trust/handlers_publish_jobs_internal_test.go
+++ b/internal/trust/handlers_publish_jobs_internal_test.go
@@ -99,10 +99,8 @@ func TestHandlePublishJob_NoModulesRequested_ReturnsNoop(t *testing.T) {
 	tdb.qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	body, _ := json.Marshal(publishJobRequest{
-		ActorURI:  "https://actor.example",
-		ObjectURI: "https://obj.example",
-		Modules:   []publishJobModuleRequest{{Name: " "}}, // skip all modules -> no-op
-		Links:     []string{"https://example.com"},
+		Modules: []publishJobModuleRequest{{Name: " "}}, // skip all modules -> no-op
+		Links:   []string{"https://example.com"},
 	})
 	ctx := &apptheory.Context{
 		AuthIdentity: "inst",
@@ -146,11 +144,8 @@ func TestHandlePublishJob_LinkSafetyBasic_NoLinks(t *testing.T) {
 	tdb.qLSB.On("First", mock.AnythingOfType("*models.LinkSafetyBasicResult")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	body, _ := json.Marshal(publishJobRequest{
-		ActorURI:    "https://actor.example",
-		ObjectURI:   "https://obj.example",
-		ContentHash: "hash",
-		Modules:     []publishJobModuleRequest{{Name: "link_safety_basic"}},
-		Links:       nil,
+		Modules: []publishJobModuleRequest{{Name: "link_safety_basic"}},
+		Links:   nil,
 	})
 	ctx := &apptheory.Context{
 		AuthIdentity: "inst",
@@ -277,6 +272,7 @@ func TestRunLinkSafetyBasicJob_CacheHit(t *testing.T) {
 		dest := testutil.RequireMockArg[*models.LinkSafetyBasicResult](t, args, 0)
 		*dest = models.LinkSafetyBasicResult{
 			ID:            strings.Repeat("a", 64),
+			InstanceSlug:  "inst",
 			PolicyVersion: linkSafetyBasicPolicyVersion,
 			ActorURI:      "https://actor.example",
 			ObjectURI:     "https://obj.example",
@@ -351,7 +347,7 @@ func TestHandleGetPublishJob_ValidationNotFoundAndSuccess(t *testing.T) {
 	// Success.
 	tdb.qLSB.On("First", mock.AnythingOfType("*models.LinkSafetyBasicResult")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.LinkSafetyBasicResult](t, args, 0)
-		*dest = models.LinkSafetyBasicResult{ID: jobID, PolicyVersion: linkSafetyBasicPolicyVersion, CreatedAt: time.Now().UTC()}
+		*dest = models.LinkSafetyBasicResult{ID: jobID, InstanceSlug: "inst", PolicyVersion: linkSafetyBasicPolicyVersion, CreatedAt: time.Now().UTC()}
 		_ = dest.UpdateKeys()
 	}).Once()
 

--- a/internal/trust/handlers_publish_jobs_renders.go
+++ b/internal/trust/handlers_publish_jobs_renders.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
-	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
@@ -492,27 +491,7 @@ func (s *Server) debitLinkRenderBudget(
 
 	maxUsed := budget.IncludedCredits - creditsNeededPriced
 	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
-		if allowOverage {
-			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
-				ub.Add("UsedCredits", creditsNeededPriced)
-				ub.Set("UpdatedAt", now)
-				return nil
-			}, tabletheory.IfExists())
-		} else {
-			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
-				ub.Add("UsedCredits", creditsNeededPriced)
-				ub.Set("UpdatedAt", now)
-				return nil
-			},
-				tabletheory.IfExists(),
-				tabletheory.ConditionExpression(
-					"attribute_not_exists(usedCredits) OR usedCredits <= :max",
-					map[string]any{
-						":max": maxUsed,
-					},
-				),
-			)
-		}
+		addBudgetDebitUpdate(tx, update, creditsNeededPriced, now, allowOverage, budget.IncludedCredits, maxUsed)
 		tx.Put(auditBudget)
 		tx.Put(ledger)
 		return nil

--- a/internal/trust/handlers_publish_jobs_summaries.go
+++ b/internal/trust/handlers_publish_jobs_summaries.go
@@ -521,28 +521,19 @@ func (s *Server) processQueuedRenderSummaries(ctx *apptheory.Context, instanceSl
 	shards := shardQueuedSummaries(queued, cfg.BatchMaxItems, cfg.BatchMaxTotalBytes)
 	if inline {
 		for _, shard := range shards {
-			s.processRenderSummaryShard(ctx, instanceSlug, now, cfg.ModelSet, shard, out, true)
+			for _, q := range shard {
+				s.processRenderSummaryShard(ctx, instanceSlug, now, cfg.ModelSet, []queuedRenderSummary{q}, out, true)
+			}
 		}
 		return
 	}
 
 	for _, shard := range shards {
-		if cfg.BatchingMode == aiBatchingModeNone {
-			for _, q := range shard {
-				id := strings.TrimSpace(q.JobID)
-				if err := s.enqueueRenderSummaryJobs(ctx, cfg.BatchingMode, []string{id}); err != nil {
-					s.processRenderSummaryShard(ctx, instanceSlug, now, cfg.ModelSet, []queuedRenderSummary{q}, out, true)
-				}
-			}
-			continue
-		}
-
-		ids := make([]string, 0, len(shard))
 		for _, q := range shard {
-			ids = append(ids, strings.TrimSpace(q.JobID))
-		}
-		if err := s.enqueueRenderSummaryJobs(ctx, cfg.BatchingMode, ids); err != nil {
-			s.processRenderSummaryShard(ctx, instanceSlug, now, cfg.ModelSet, shard, out, true)
+			id := strings.TrimSpace(q.JobID)
+			if err := s.enqueueRenderSummaryJobs(ctx, cfg.BatchingMode, []string{id}); err != nil {
+				s.processRenderSummaryShard(ctx, instanceSlug, now, cfg.ModelSet, []queuedRenderSummary{q}, out, true)
+			}
 		}
 	}
 }
@@ -576,15 +567,17 @@ func (s *Server) enqueueRenderSummaryJobs(ctx *apptheory.Context, mode string, j
 		return fmt.Errorf("ai queue not configured")
 	}
 
-	msg := ai.JobMessage{}
-	if len(jobIDs) == 1 && mode == aiBatchingModeNone {
-		msg.Kind = "ai_job"
-		msg.JobID = jobIDs[0]
-	} else {
-		msg.Kind = "ai_job_batch"
-		msg.JobIDs = append([]string(nil), jobIDs...)
+	for _, id := range jobIDs {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		msg := ai.JobMessage{Kind: "ai_job", JobID: id}
+		if err := s.queues.enqueueAIJob(ctx.Context(), msg); err != nil {
+			return err
+		}
 	}
-	return s.queues.enqueueAIJob(ctx.Context(), msg)
+	return nil
 }
 
 func (s *Server) processRenderSummaryShard(

--- a/internal/trust/handlers_renders.go
+++ b/internal/trust/handlers_renders.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
-	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
@@ -350,27 +349,7 @@ func (s *Server) debitBudgetForCreateRender(
 
 	maxUsed := budget.IncludedCredits - linkRenderCreditCost
 	err = s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
-		if allowOverage {
-			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
-				ub.Add("UsedCredits", linkRenderCreditCost)
-				ub.Set("UpdatedAt", now)
-				return nil
-			}, tabletheory.IfExists())
-		} else {
-			tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
-				ub.Add("UsedCredits", linkRenderCreditCost)
-				ub.Set("UpdatedAt", now)
-				return nil
-			},
-				tabletheory.IfExists(),
-				tabletheory.ConditionExpression(
-					"attribute_not_exists(usedCredits) OR usedCredits <= :max",
-					map[string]any{
-						":max": maxUsed,
-					},
-				),
-			)
-		}
+		addBudgetDebitUpdate(tx, update, linkRenderCreditCost, now, allowOverage, budget.IncludedCredits, maxUsed)
 		tx.Put(ledger)
 		tx.Put(auditBudget)
 		return nil

--- a/internal/trust/handlers_renders_internal_test.go
+++ b/internal/trust/handlers_renders_internal_test.go
@@ -37,7 +37,7 @@ func TestRequireCreateRenderAuth(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if instanceSlug != "inst" {
+	if instanceSlug != testBudgetInstanceSlug {
 		t.Fatalf("expected trimmed identity, got %q", instanceSlug)
 	}
 }

--- a/internal/trust/link_safety_basic.go
+++ b/internal/trust/link_safety_basic.go
@@ -55,10 +55,11 @@ func normalizeLinkURLDeterministic(raw string) string {
 	return normalizeURLForSafety(u, scheme, asciiHost, port)
 }
 
-func linkSafetyBasicJobID(actorURI, objectURI, contentHash, linksHash string) string {
+func linkSafetyBasicJobID(instanceSlug, actorURI, objectURI, contentHash, linksHash string) string {
 	sum := sha256.Sum256([]byte(strings.Join([]string{
 		"link_safety_basic",
 		linkSafetyBasicPolicyVersion,
+		strings.ToLower(strings.TrimSpace(instanceSlug)),
 		strings.TrimSpace(actorURI),
 		strings.TrimSpace(objectURI),
 		strings.TrimSpace(contentHash),

--- a/internal/trust/link_safety_basic_test.go
+++ b/internal/trust/link_safety_basic_test.go
@@ -106,21 +106,22 @@ func TestComputeLinkSafetyBasicSummary(t *testing.T) {
 func TestLinkSafetyBasicAttestationParts_ValidatesFields(t *testing.T) {
 	t.Parallel()
 
-	if _, _, _, ok := linkSafetyBasicAttestationParts(nil); ok {
+	if _, _, _, _, ok := linkSafetyBasicAttestationParts(nil); ok {
 		t.Fatalf("expected nil to be invalid")
 	}
 
-	if _, _, _, ok := linkSafetyBasicAttestationParts(&models.LinkSafetyBasicResult{ActorURI: "a"}); ok {
+	if _, _, _, _, ok := linkSafetyBasicAttestationParts(&models.LinkSafetyBasicResult{ActorURI: "a"}); ok {
 		t.Fatalf("expected missing fields to be invalid")
 	}
 
-	actor, object, hash, ok := linkSafetyBasicAttestationParts(&models.LinkSafetyBasicResult{
-		ActorURI:    " actor ",
-		ObjectURI:   " object ",
-		ContentHash: " hash ",
+	instance, actor, object, hash, ok := linkSafetyBasicAttestationParts(&models.LinkSafetyBasicResult{
+		InstanceSlug: " inst ",
+		ActorURI:     " actor ",
+		ObjectURI:    " object ",
+		ContentHash:  " hash ",
 	})
-	if !ok || actor != "actor" || object != "object" || hash != "hash" {
-		t.Fatalf("unexpected parts: ok=%v actor=%q object=%q hash=%q", ok, actor, object, hash)
+	if !ok || instance != "inst" || actor != "actor" || object != "object" || hash != "hash" {
+		t.Fatalf("unexpected parts: ok=%v instance=%q actor=%q object=%q hash=%q", ok, instance, actor, object, hash)
 	}
 }
 

--- a/internal/trust/string_consts.go
+++ b/internal/trust/string_consts.go
@@ -35,11 +35,12 @@ const (
 
 	modelSetDeterministic = "deterministic"
 
-	budgetReasonDebited       = "debited"
-	budgetReasonOverage       = "overage"
-	budgetReasonCacheHit      = "cache_hit"
-	budgetReasonNotConfigured = "budget not configured"
-	budgetReasonExceeded      = "budget exceeded"
+	budgetReasonDebited         = "debited"
+	budgetReasonOverage         = "overage"
+	budgetReasonCacheHit        = "cache_hit"
+	budgetReasonNotConfigured   = "budget not configured"
+	budgetReasonExceeded        = "budget exceeded"
+	aiDisabledForInstanceReason = "ai disabled for instance"
 
 	budgetErrKindInternal      = "internal"
 	budgetErrKindExceeded      = "exceeded"


### PR DESCRIPTION
## Milestone
M7 — Trust / AI / billing remediation before downstream greater-components + simulacrum rollout.

## Classification
security / tenant-isolation / managed-update / soul-registry / trust-API / operational-reliability / billing

## Surfaces affected
- Trust API instance-authenticated attestation issuance and public lookup
- Managed-update verification probes and failure handling
- Soul continuity / relationship timestamp storage
- AI evidence, moderation, claim verification, and render-summary worker paths
- Budget debit / AI pricing enforcement
- Portal instance-key response serialization
- `docs/attestations.md`

## Specialist walks referenced
- Governance rubric: no rubric weakening; full gov-infra verifier PASS locally (29 pass / 0 fail / 0 blocked).
- Provisioning / managed-update / release verification: managed-update verification now fails closed on bad probes; no consumer release-verification bypass.
- Soul registry: timestamp canonicalization only; no contract or on-chain deployment changes.
- Trust API / CSP / instance-auth: attestation subjects are bound to authenticated instance-owned HTTP(S) hosts; no CSP changes.
- Framework: idiomatic AppTheory/TableTheory usage; no local framework patch.

## Multi-tenant isolation impact
Elevated scrutiny. Attestation issuance/lookup now binds IDs and payloads to the authenticated instance slug, requires owned subject hosts, denies cross-instance job reads, and refuses legacy unbound attestation reads.

## On-chain impact
No Solidity or mainnet changes. Soul timestamp canonicalization affects off-chain state normalization only.

## Consumer impact
Managed operators and lab managed instances. This should land in lesser-host before the coordinated Lesser/gretater-components/simulacrum rollout; lab canary remains `simulacrum` through host lab.

## Tasks
- [x] Closes #237 — Bind trust attestations to authenticated instance-owned subjects
- [x] Closes #238 — Validate trust auth probe identity and fail managed updates closed
- [x] Closes #239 — Canonicalize soul signed timestamps before storage
- [x] Closes #240 — Gate AI endpoints/image ingest before provider/storage use
- [x] Closes #241 — Bound claim verification and isolate render summary LLM inputs
- [x] Closes #242 — Correct budget debit and AI pricing enforcement
- [x] Security finding row 40 — omit zero instance-key timestamps from portal responses

## Validation
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l $(git ls-files '*.go'; git ls-files --others --exclude-standard '*.go')` empty
- [x] `PATH="$PWD/gov-infra/.tools/bin:$PATH" golangci-lint run --timeout=10m` — 0 issues
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29/0/0)
- [x] CI gov-infra verifiers

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deploy lesser-host to `lab`
- [ ] Run lab managed-update canary against `simulacrum`
- [ ] Coordinate Lesser release/profile compatibility and verify managed Lesser/body update path
- [ ] Lab soak complete
- [ ] Cut lesser-host release for downstream greater-components/simulacrum work
- [ ] Live deploy later only after explicit operator authorization and lab soak

## Cross-repo coordination
Required with Lesser for the managed update path and then greater-components/simulacrum once lesser-host remediation is released. No sibling-repo code changes in this PR.

## Advisor-brief authorization
Not advisor-dispatched.

