### PR TITLE
fix(security): remediate M8 comms operator web findings

### DIFF
--- a/internal/commmailbox/content_store.go
+++ b/internal/commmailbox/content_store.go
@@ -142,7 +142,7 @@ func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPo
 	})
 	if err != nil {
 		if isS3PreconditionFailed(err) {
-			return s.existingPointer(ctx, client, bucket, key, contentType)
+			return s.existingPointer(ctx, client, bucket, key, digest, int64(len(body)), contentType)
 		}
 		return ContentPointer{}, err
 	}
@@ -157,7 +157,7 @@ func (s *S3Store) PutContent(ctx context.Context, input ContentInput) (ContentPo
 	}, nil
 }
 
-func (s *S3Store) existingPointer(ctx context.Context, client s3API, bucket string, key string, fallbackContentType string) (ContentPointer, error) {
+func (s *S3Store) existingPointer(ctx context.Context, client s3API, bucket string, key string, expectedDigest string, expectedBytes int64, fallbackContentType string) (ContentPointer, error) {
 	out, err := client.HeadObject(ctx, &s3.HeadObjectInput{
 		Bucket: aws.String(bucket),
 		Key:    aws.String(key),
@@ -166,6 +166,10 @@ func (s *S3Store) existingPointer(ctx context.Context, client s3API, bucket stri
 		return ContentPointer{}, err
 	}
 	digest := strings.ToLower(strings.TrimSpace(out.Metadata["sha256"]))
+	expectedDigest = strings.ToLower(strings.TrimSpace(expectedDigest))
+	if expectedDigest == "" || digest == "" || digest != expectedDigest {
+		return ContentPointer{}, fmt.Errorf("content sha256 mismatch")
+	}
 	contentType := strings.TrimSpace(fallbackContentType)
 	if out.ContentType != nil && strings.TrimSpace(*out.ContentType) != "" {
 		contentType = strings.TrimSpace(*out.ContentType)
@@ -173,6 +177,9 @@ func (s *S3Store) existingPointer(ctx context.Context, client s3API, bucket stri
 	var bytes int64
 	if out.ContentLength != nil {
 		bytes = *out.ContentLength
+	}
+	if expectedBytes >= 0 && bytes != 0 && bytes != expectedBytes {
+		return ContentPointer{}, fmt.Errorf("content length mismatch")
 	}
 	return ContentPointer{
 		Storage:     ContentStorageS3,

--- a/internal/commmailbox/content_store_test.go
+++ b/internal/commmailbox/content_store_test.go
@@ -2,6 +2,8 @@ package commmailbox
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
 	"strings"
@@ -85,12 +87,14 @@ func TestS3StorePutContent(t *testing.T) {
 
 func TestS3StorePutContentReturnsExistingPointerOnReplay(t *testing.T) {
 	preconditionErr := &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "object exists"}
+	sum := sha256.Sum256([]byte("Replay body"))
+	digest := hex.EncodeToString(sum[:])
 	client := &fakeS3PutClient{
 		putErr: preconditionErr,
 		headOutput: &s3.HeadObjectOutput{
-			ContentLength: aws.Int64(13),
+			ContentLength: aws.Int64(int64(len("Replay body"))),
 			ContentType:   aws.String("text/plain"),
-			Metadata:      map[string]string{"sha256": "existing-digest"},
+			Metadata:      map[string]string{"sha256": digest},
 		},
 	}
 	store := NewS3StoreWithClient("mailbox-bucket", client)
@@ -107,11 +111,37 @@ func TestS3StorePutContentReturnsExistingPointerOnReplay(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PutContent replay: %v", err)
 	}
-	if ptr.SHA256 != "existing-digest" || ptr.Bytes != 13 || ptr.ContentType != "text/plain" {
+	if ptr.SHA256 != digest || ptr.Bytes != int64(len("Replay body")) || ptr.ContentType != "text/plain" {
 		t.Fatalf("unexpected replay pointer: %#v", ptr)
 	}
 	if client.headInput == nil || aws.ToString(client.headInput.Key) != ptr.Key {
 		t.Fatalf("expected head of existing key, got %#v", client.headInput)
+	}
+}
+
+func TestS3StorePutContentRejectsReplayDigestMismatch(t *testing.T) {
+	preconditionErr := &smithy.GenericAPIError{Code: "PreconditionFailed", Message: "object exists"}
+	client := &fakeS3PutClient{
+		putErr: preconditionErr,
+		headOutput: &s3.HeadObjectOutput{
+			ContentLength: aws.Int64(13),
+			ContentType:   aws.String("text/plain"),
+			Metadata:      map[string]string{"sha256": "different-digest"},
+		},
+	}
+	store := NewS3StoreWithClient("mailbox-bucket", client)
+
+	_, err := store.PutContent(context.Background(), ContentInput{
+		DeliveryID:   "comm-delivery-replay",
+		InstanceSlug: "Demo",
+		AgentID:      "0xABC",
+		MessageID:    "msg-1",
+		Direction:    "Inbound",
+		ChannelType:  "Email",
+		Body:         "Replay body",
+	})
+	if err == nil || !strings.Contains(err.Error(), "content sha256 mismatch") {
+		t.Fatalf("expected replay digest mismatch, got %v", err)
 	}
 }
 

--- a/internal/controlplane/handlers_operator_provisioning.go
+++ b/internal/controlplane/handlers_operator_provisioning.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -99,10 +100,18 @@ func operatorProvisionJobListItemFromModel(j *models.ProvisionJob) operatorProvi
 }
 
 func operatorProvisionJobDetailFromModel(j *models.ProvisionJob) operatorProvisionJobDetail {
+	return operatorProvisionJobDetailFromModelForRole(j, models.RoleAdmin)
+}
+
+func operatorProvisionJobDetailFromModelForRole(j *models.ProvisionJob, role string) operatorProvisionJobDetail {
 	if j == nil {
 		return operatorProvisionJobDetail{}
 	}
 	base := operatorProvisionJobListItemFromModel(j)
+	receiptJSON := ""
+	if strings.TrimSpace(role) == models.RoleAdmin {
+		receiptJSON = redactProvisionReceiptJSON(j.ReceiptJSON)
+	}
 	return operatorProvisionJobDetail{
 		operatorProvisionJobListItem: base,
 		Mode:                         strings.TrimSpace(j.Mode),
@@ -117,8 +126,76 @@ func operatorProvisionJobDetailFromModel(j *models.ProvisionJob) operatorProvisi
 		BaseDomain:                   strings.TrimSpace(j.BaseDomain),
 		ChildHostedZoneID:            strings.TrimSpace(j.ChildHostedZoneID),
 		ChildNameServers:             append([]string(nil), j.ChildNameServers...),
-		ReceiptJSON:                  strings.TrimSpace(j.ReceiptJSON),
+		ReceiptJSON:                  receiptJSON,
 	}
+}
+
+func redactProvisionReceiptJSON(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	var parsed any
+	dec := json.NewDecoder(strings.NewReader(raw))
+	dec.UseNumber()
+	if err := dec.Decode(&parsed); err != nil {
+		return `{"redacted":true}`
+	}
+
+	out, err := json.Marshal(redactProvisionReceiptValue(parsed, ""))
+	if err != nil {
+		return `{"redacted":true}`
+	}
+	return string(out)
+}
+
+func redactProvisionReceiptValue(value any, key string) any {
+	if provisionReceiptKeySensitive(key) {
+		return "[redacted]"
+	}
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for k, v := range typed {
+			out[k] = redactProvisionReceiptValue(v, k)
+		}
+		return out
+	case []any:
+		out := make([]any, len(typed))
+		for i, v := range typed {
+			out[i] = redactProvisionReceiptValue(v, key)
+		}
+		return out
+	default:
+		return value
+	}
+}
+
+func provisionReceiptKeySensitive(key string) bool {
+	key = strings.ToLower(strings.TrimSpace(key))
+	if key == "" {
+		return false
+	}
+	normalized := strings.NewReplacer("_", "", "-", "", ".", "", " ", "").Replace(key)
+	for _, token := range []string{
+		"secret",
+		"password",
+		"token",
+		"privatekey",
+		"apikey",
+		"credential",
+		"authorization",
+		"bearer",
+		"accesskey",
+		"sessionkey",
+		"instancekey",
+	} {
+		if strings.Contains(normalized, token) {
+			return true
+		}
+	}
+	return false
 }
 
 func queryFirst(ctx *apptheory.Context, key string) string {
@@ -389,7 +466,7 @@ func (s *Server) handleGetOperatorProvisionJob(ctx *apptheory.Context) (*apptheo
 		}
 	}
 
-	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(job))
+	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModelForRole(job, operatorRoleFromContext(ctx)))
 }
 
 func (s *Server) handleRetryOperatorProvisionJob(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -482,7 +559,7 @@ func (s *Server) handleRetryOperatorProvisionJob(ctx *apptheory.Context) (*appth
 		}
 	} else {
 		if !shouldNudgeAsyncJob(now, job.UpdatedAt) || job.HasActiveLease(now) {
-			return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(job))
+			return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModelForRole(job, operatorRoleFromContext(ctx)))
 		}
 		audit := &models.AuditLogEntry{
 			Actor:     actor,
@@ -501,7 +578,7 @@ func (s *Server) handleRetryOperatorProvisionJob(ctx *apptheory.Context) (*appth
 	})
 
 	updated, _ := s.store.GetProvisionJob(ctx.Context(), strings.TrimSpace(job.ID))
-	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(updated))
+	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModelForRole(updated, operatorRoleFromContext(ctx)))
 }
 
 func (s *Server) handleAdoptOperatorProvisionJobAccount(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -545,7 +622,7 @@ func (s *Server) handleAdoptOperatorProvisionJobAccount(ctx *apptheory.Context) 
 	})
 
 	updated, _ := s.store.GetProvisionJob(ctx.Context(), strings.TrimSpace(job.ID))
-	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(updated))
+	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModelForRole(updated, operatorRoleFromContext(ctx)))
 }
 
 func (s *Server) requireProvisionRetryReady() *apptheory.AppError {
@@ -630,5 +707,5 @@ func (s *Server) handleAppendOperatorProvisionJobNote(ctx *apptheory.Context) (*
 	}
 
 	updated, _ := s.store.GetProvisionJob(ctx.Context(), strings.TrimSpace(job.ID))
-	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModel(updated))
+	return apptheory.JSON(http.StatusOK, operatorProvisionJobDetailFromModelForRole(updated, operatorRoleFromContext(ctx)))
 }

--- a/internal/controlplane/handlers_operator_provisioning_internal_test.go
+++ b/internal/controlplane/handlers_operator_provisioning_internal_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -48,6 +49,12 @@ func newOperatorProvisioningTestDB() operatorProvisioningTestDB {
 func operatorCtx() *apptheory.Context {
 	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
 	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+	return ctx
+}
+
+func provisionOperatorRoleCtx() *apptheory.Context {
+	ctx := &apptheory.Context{AuthIdentity: "ops", RequestID: "rid"}
+	ctx.Set(ctxKeyOperatorRole, models.RoleOperator)
 	return ctx
 }
 
@@ -132,6 +139,60 @@ func TestHandleGetOperatorProvisionJob_NotFoundAndSuccess(t *testing.T) {
 	resp, err := s.handleGetOperatorProvisionJob(ctx)
 	if err != nil || resp.Status != 200 {
 		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+}
+
+func TestHandleGetOperatorProvisionJob_RedactsReceiptForOperator(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorProvisioningTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	ctx := provisionOperatorRoleCtx()
+	ctx.Params = map[string]string{"id": "j1"}
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:           "j1",
+			InstanceSlug: "inst",
+			Status:       models.ProvisionJobStatusOK,
+			ReceiptJSON:  `{"endpoint":"https://inst.example","instance_key":"raw-secret"}`,
+		}
+		_ = dest.UpdateKeys()
+	}).Once()
+
+	resp, err := s.handleGetOperatorProvisionJob(ctx)
+	if err != nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+	var out operatorProvisionJobDetail
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !out.HasReceipt {
+		t.Fatalf("expected has_receipt to remain true")
+	}
+	if out.ReceiptJSON != "" {
+		t.Fatalf("expected non-admin operator receipt to be omitted, got %q", out.ReceiptJSON)
+	}
+}
+
+func TestOperatorProvisionJobDetail_RedactsAdminReceiptSecrets(t *testing.T) {
+	t.Parallel()
+
+	detail := operatorProvisionJobDetailFromModel(&models.ProvisionJob{
+		ID:           "j1",
+		InstanceSlug: "inst",
+		ReceiptJSON:  `{"endpoint":"https://inst.example","instance_key":"raw-secret","nested":{"token":"tok","ok":"value"}}`,
+	})
+	if detail.ReceiptJSON == "" {
+		t.Fatalf("expected admin diagnostic receipt")
+	}
+	if strings.Contains(detail.ReceiptJSON, "raw-secret") || strings.Contains(detail.ReceiptJSON, `"tok"`) {
+		t.Fatalf("expected sensitive receipt fields to be redacted, got %q", detail.ReceiptJSON)
+	}
+	if !strings.Contains(detail.ReceiptJSON, "https://inst.example") || !strings.Contains(detail.ReceiptJSON, "value") {
+		t.Fatalf("expected non-sensitive receipt fields to remain, got %q", detail.ReceiptJSON)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -636,6 +636,9 @@ func soulCommReplyBoundaryMatchesRecipient(items []*models.SoulAgentCommActivity
 		if item == nil {
 			continue
 		}
+		if !soulCommActivityEligibleForReplyBoundary(item) {
+			continue
+		}
 		if strings.ToLower(strings.TrimSpace(item.ChannelType)) != channelType {
 			continue
 		}
@@ -647,6 +650,29 @@ func soulCommReplyBoundaryMatchesRecipient(items []*models.SoulAgentCommActivity
 		}
 	}
 	return false
+}
+
+func soulCommActivityEligibleForReplyBoundary(item *models.SoulAgentCommActivity) bool {
+	if item == nil {
+		return false
+	}
+	if item.PreferenceRespected != nil && !*item.PreferenceRespected {
+		return false
+	}
+	boundaryCheck := strings.ToLower(strings.TrimSpace(item.BoundaryCheck))
+	if boundaryCheck == models.SoulCommBoundaryCheckViolated {
+		return false
+	}
+	if strings.ToLower(strings.TrimSpace(item.Direction)) == models.SoulCommDirectionOutbound &&
+		boundaryCheck != "" &&
+		boundaryCheck != models.SoulCommBoundaryCheckPassed {
+		return false
+	}
+	action := strings.ToLower(strings.TrimSpace(item.Action))
+	if action == "drop" || action == "bounce" {
+		return false
+	}
+	return true
 }
 
 func soulCommNormalizeBoundaryCounterparty(channelType string, counterparty string) string {
@@ -1605,24 +1631,34 @@ func buildOutboundEmailRFC5322(input outboundEmailRFC5322Input) ([]byte, []strin
 	if date.IsZero() {
 		date = time.Now().UTC()
 	}
+	fromHeader := safeRFC5322HeaderValue(from)
+	toHeader := safeRFC5322HeaderValue(to)
+	replyToHeader := safeRFC5322HeaderValue(replyTo)
+	subjectHeader := safeRFC5322HeaderValue(subject)
+	messageIDHeader := safeRFC5322HeaderValue(messageID)
+	if fromHeader == "" || toHeader == "" || replyToHeader == "" || subjectHeader == "" || messageIDHeader == "" {
+		return nil, nil, apptheory.NewAppTheoryError(commCodeInvalidRequest, "invalid email payload").WithStatusCode(http.StatusBadRequest)
+	}
 
 	headers := []string{
-		fmt.Sprintf("From: %s", from),
-		fmt.Sprintf("To: %s", to),
-		fmt.Sprintf("Reply-To: %s", replyTo),
-		fmt.Sprintf("Subject: %s", subject),
+		fmt.Sprintf("From: %s", fromHeader),
+		fmt.Sprintf("To: %s", toHeader),
+		fmt.Sprintf("Reply-To: %s", replyToHeader),
+		fmt.Sprintf("Subject: %s", subjectHeader),
 		fmt.Sprintf("Date: %s", date.Format(time.RFC1123Z)),
-		fmt.Sprintf("Message-ID: %s", messageID),
+		fmt.Sprintf("Message-ID: %s", messageIDHeader),
 		"MIME-Version: 1.0",
 		"Content-Type: text/plain; charset=utf-8",
 		"Content-Transfer-Encoding: 8bit",
 	}
 	if len(cc) > 0 {
-		headers = append(headers, fmt.Sprintf("Cc: %s", strings.Join(cc, ", ")))
+		headers = append(headers, fmt.Sprintf("Cc: %s", safeRFC5322HeaderValue(strings.Join(cc, ", "))))
 	}
 	if inReplyTo != "" {
 		// Best-effort: if caller supplied a known message id token, embed it as a Message-ID reference.
-		headers = append(headers, fmt.Sprintf("In-Reply-To: %s", emailMessageIDReference(inReplyTo)))
+		if ref := safeRFC5322HeaderValue(emailMessageIDReference(inReplyTo)); ref != "" {
+			headers = append(headers, fmt.Sprintf("In-Reply-To: %s", ref))
+		}
 	}
 
 	raw := strings.Join(headers, "\r\n") + "\r\n\r\n" + body + "\r\n"
@@ -1637,7 +1673,7 @@ func mailboxProviderReplyReference(req validatedSoulCommSendRequest) string {
 }
 
 func emailMessageIDReference(value string) string {
-	value = strings.TrimSpace(value)
+	value = safeRFC5322HeaderValue(value)
 	if value == "" {
 		return ""
 	}
@@ -1646,6 +1682,25 @@ func emailMessageIDReference(value string) string {
 		return "<" + trimmed + ">"
 	}
 	return "<" + trimmed + "@lessersoul.ai>"
+}
+
+func safeRFC5322HeaderValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	value = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\t':
+			return ' '
+		default:
+			if r < 0x20 || r == 0x7f {
+				return -1
+			}
+			return r
+		}
+	}, value)
+	return strings.Join(strings.Fields(value), " ")
 }
 
 func validateCommEmailAddress(value string, field string) *apptheory.AppTheoryError {

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -1590,6 +1590,73 @@ type outboundEmailRFC5322Input struct {
 	SentAt             time.Time
 }
 
+func validateOutboundEmailRequiredFields(values ...string) *apptheory.AppTheoryError {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return apptheory.NewAppTheoryError("comm.invalid_request", "invalid email payload").WithStatusCode(http.StatusBadRequest)
+		}
+	}
+	return nil
+}
+
+func validateOutboundEmailEnvelope(from string, to string, replyTo string) *apptheory.AppTheoryError {
+	for _, field := range []struct {
+		value string
+		label string
+	}{
+		{value: from, label: "from"},
+		{value: to, label: "to"},
+		{value: replyTo, label: "replyTo"},
+	} {
+		if appErr := validateCommEmailAddress(field.value, field.label); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+type outboundEmailSafeHeaders struct {
+	From      string
+	To        string
+	ReplyTo   string
+	Subject   string
+	MessageID string
+}
+
+func safeRequiredOutboundEmailHeaders(from string, to string, replyTo string, subject string, messageID string) (outboundEmailSafeHeaders, *apptheory.AppTheoryError) {
+	var headers outboundEmailSafeHeaders
+	for _, field := range []struct {
+		value  string
+		target *string
+	}{
+		{value: from, target: &headers.From},
+		{value: to, target: &headers.To},
+		{value: replyTo, target: &headers.ReplyTo},
+		{value: subject, target: &headers.Subject},
+		{value: messageID, target: &headers.MessageID},
+	} {
+		safe := safeRFC5322HeaderValue(field.value)
+		if safe == "" {
+			return outboundEmailSafeHeaders{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "invalid email payload").WithStatusCode(http.StatusBadRequest)
+		}
+		*field.target = safe
+	}
+	return headers, nil
+}
+
+func appendOptionalOutboundEmailHeaders(headers []string, cc []string, inReplyTo string) []string {
+	if len(cc) > 0 {
+		headers = append(headers, fmt.Sprintf("Cc: %s", safeRFC5322HeaderValue(strings.Join(cc, ", "))))
+	}
+	if inReplyTo != "" {
+		// Best-effort: if caller supplied a known message id token, embed it as a Message-ID reference.
+		if ref := safeRFC5322HeaderValue(emailMessageIDReference(inReplyTo)); ref != "" {
+			headers = append(headers, fmt.Sprintf("In-Reply-To: %s", ref))
+		}
+	}
+	return headers
+}
+
 func buildOutboundEmailRFC5322(input outboundEmailRFC5322Input) ([]byte, []string, *apptheory.AppTheoryError) {
 	from := strings.TrimSpace(input.From)
 	to := strings.TrimSpace(input.To)
@@ -1599,20 +1666,14 @@ func buildOutboundEmailRFC5322(input outboundEmailRFC5322Input) ([]byte, []strin
 	messageID := strings.TrimSpace(input.MessageID)
 	inReplyTo := strings.TrimSpace(input.InReplyToMessageID)
 
-	if from == "" || to == "" || subject == "" || body == "" || messageID == "" {
-		return nil, nil, apptheory.NewAppTheoryError("comm.invalid_request", "invalid email payload").WithStatusCode(http.StatusBadRequest)
+	if appErr := validateOutboundEmailRequiredFields(from, to, subject, body, messageID); appErr != nil {
+		return nil, nil, appErr
 	}
 	if replyTo == "" {
 		replyTo = from
 	}
 
-	if appErr := validateCommEmailAddress(from, "from"); appErr != nil {
-		return nil, nil, appErr
-	}
-	if appErr := validateCommEmailAddress(to, "to"); appErr != nil {
-		return nil, nil, appErr
-	}
-	if appErr := validateCommEmailAddress(replyTo, "replyTo"); appErr != nil {
+	if appErr := validateOutboundEmailEnvelope(from, to, replyTo); appErr != nil {
 		return nil, nil, appErr
 	}
 
@@ -1631,35 +1692,23 @@ func buildOutboundEmailRFC5322(input outboundEmailRFC5322Input) ([]byte, []strin
 	if date.IsZero() {
 		date = time.Now().UTC()
 	}
-	fromHeader := safeRFC5322HeaderValue(from)
-	toHeader := safeRFC5322HeaderValue(to)
-	replyToHeader := safeRFC5322HeaderValue(replyTo)
-	subjectHeader := safeRFC5322HeaderValue(subject)
-	messageIDHeader := safeRFC5322HeaderValue(messageID)
-	if fromHeader == "" || toHeader == "" || replyToHeader == "" || subjectHeader == "" || messageIDHeader == "" {
-		return nil, nil, apptheory.NewAppTheoryError(commCodeInvalidRequest, "invalid email payload").WithStatusCode(http.StatusBadRequest)
+	safeHeaders, appErr := safeRequiredOutboundEmailHeaders(from, to, replyTo, subject, messageID)
+	if appErr != nil {
+		return nil, nil, appErr
 	}
 
 	headers := []string{
-		fmt.Sprintf("From: %s", fromHeader),
-		fmt.Sprintf("To: %s", toHeader),
-		fmt.Sprintf("Reply-To: %s", replyToHeader),
-		fmt.Sprintf("Subject: %s", subjectHeader),
+		fmt.Sprintf("From: %s", safeHeaders.From),
+		fmt.Sprintf("To: %s", safeHeaders.To),
+		fmt.Sprintf("Reply-To: %s", safeHeaders.ReplyTo),
+		fmt.Sprintf("Subject: %s", safeHeaders.Subject),
 		fmt.Sprintf("Date: %s", date.Format(time.RFC1123Z)),
-		fmt.Sprintf("Message-ID: %s", messageIDHeader),
+		fmt.Sprintf("Message-ID: %s", safeHeaders.MessageID),
 		"MIME-Version: 1.0",
 		"Content-Type: text/plain; charset=utf-8",
 		"Content-Transfer-Encoding: 8bit",
 	}
-	if len(cc) > 0 {
-		headers = append(headers, fmt.Sprintf("Cc: %s", safeRFC5322HeaderValue(strings.Join(cc, ", "))))
-	}
-	if inReplyTo != "" {
-		// Best-effort: if caller supplied a known message id token, embed it as a Message-ID reference.
-		if ref := safeRFC5322HeaderValue(emailMessageIDReference(inReplyTo)); ref != "" {
-			headers = append(headers, fmt.Sprintf("In-Reply-To: %s", ref))
-		}
-	}
+	headers = appendOptionalOutboundEmailHeaders(headers, cc, inReplyTo)
 
 	raw := strings.Join(headers, "\r\n") + "\r\n\r\n" + body + "\r\n"
 	return []byte(raw), recipients, nil

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -1492,12 +1492,22 @@ func TestParseSoulCommSendRequest_RejectsRecipientFailures(t *testing.T) {
 func TestSoulCommReplyBoundaryMatching(t *testing.T) {
 	t.Parallel()
 
+	denied := false
 	items := []*models.SoulAgentCommActivity{
 		nil,
 		{ChannelType: commChannelSMS, Counterparty: "+15550123", MessageID: "sms-1"},
 		{ChannelType: commChannelEmail, Counterparty: "Other <other@example.com>", MessageID: "email-2"},
 		{ChannelType: commChannelEmail, Counterparty: "Alice <ALICE@example.com>", MessageID: "comm-msg-prev"},
 		{ChannelType: commChannelEmail, Counterparty: "bob@example.com", InReplyTo: "<thread-1@lessersoul.ai>"},
+		{
+			ChannelType:         commChannelEmail,
+			Direction:           models.SoulCommDirectionOutbound,
+			Counterparty:        "charlie@example.com",
+			Action:              "send",
+			InReplyTo:           "denied-thread",
+			BoundaryCheck:       models.SoulCommBoundaryCheckViolated,
+			PreferenceRespected: &denied,
+		},
 	}
 
 	if !soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "alice@example.com", "<comm-msg-prev@lessersoul.ai>") {
@@ -1508,6 +1518,9 @@ func TestSoulCommReplyBoundaryMatching(t *testing.T) {
 	}
 	if soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "charlie@example.com", "comm-msg-prev") {
 		t.Fatalf("did not expect unmatched recipient to pass")
+	}
+	if soulCommReplyBoundaryMatchesRecipient(items, commChannelEmail, "charlie@example.com", "denied-thread") {
+		t.Fatalf("did not expect denied activity to satisfy reply boundary")
 	}
 	if !soulCommReplyBoundaryMatchesRecipient(items, commChannelSMS, "+1 (555) 0123", "sms-1") {
 		t.Fatalf("expected normalized phone recipient to match")
@@ -1521,6 +1534,31 @@ func TestSoulCommReplyBoundaryMatching(t *testing.T) {
 	})
 	if !reflect.DeepEqual(recipients, []string{"ALICE@example.com", "BOB@example.com", "carol@example.com"}) {
 		t.Fatalf("unexpected email boundary recipients: %#v", recipients)
+	}
+}
+
+func TestBuildOutboundEmailRFC5322_SanitizesHeaderInjection(t *testing.T) {
+	t.Parallel()
+
+	raw, _, appErr := buildOutboundEmailRFC5322(outboundEmailRFC5322Input{
+		From:               "agent@lessersoul.ai",
+		To:                 "alice@example.com",
+		ReplyTo:            "reply@example.com",
+		Subject:            "Hello\r\nBcc: victim@example.com",
+		Body:               "body",
+		MessageID:          "<comm-msg-1@lessersoul.ai>\r\nX-Bad: yes",
+		InReplyToMessageID: "<parent@lessersoul.ai>\r\nX-Bad: yes",
+		SentAt:             time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC),
+	})
+	if appErr != nil {
+		t.Fatalf("buildOutboundEmailRFC5322: %v", appErr)
+	}
+	text := string(raw)
+	if strings.Contains(text, "\r\nBcc: victim@example.com") || strings.Contains(text, "\r\nX-Bad: yes") {
+		t.Fatalf("header injection was not neutralized: %q", text)
+	}
+	if !strings.Contains(text, "Subject: Hello Bcc: victim@example.com\r\n") {
+		t.Fatalf("expected sanitized subject, got %q", text)
 	}
 }
 

--- a/internal/controlplane/handlers_tip_registry.go
+++ b/internal/controlplane/handlers_tip_registry.go
@@ -129,9 +129,6 @@ func (s *Server) normalizeTipRegistryWalletAddress(ctx context.Context, walletAd
 	if appErr := validateNotReservedWalletAddress(walletAddr, "wallet_address"); appErr != nil {
 		return "", appErr
 	}
-	if appErr := s.validateNotPrivilegedWalletAddress(ctx, walletTypeEthereum, walletAddr, "wallet_address"); appErr != nil {
-		return "", appErr
-	}
 	return walletAddr, nil
 }
 
@@ -983,7 +980,7 @@ type listTipRegistryOperationsResponse struct {
 }
 
 func (s *Server) handleListTipRegistryOperations(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if s == nil || s.store == nil || s.store.DB == nil {
@@ -1023,7 +1020,7 @@ func (s *Server) handleListTipRegistryOperations(ctx *apptheory.Context) (*appth
 }
 
 func (s *Server) handleGetTipRegistryOperation(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if s == nil || s.store == nil || s.store.DB == nil {
@@ -1051,7 +1048,7 @@ type recordTipRegistryExecutionRequest struct {
 }
 
 func (s *Server) handleRecordTipRegistryOperationExecution(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if appErr := s.requireTipRegistryConfigured(); appErr != nil {
@@ -1292,7 +1289,7 @@ type setTipRegistryHostActiveRequest struct {
 }
 
 func (s *Server) handleSetTipRegistryHostActive(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if appErr := s.requireTipRegistryConfigured(); appErr != nil {
@@ -1384,7 +1381,7 @@ type setTipRegistryTokenAllowedRequest struct {
 }
 
 func (s *Server) handleSetTipRegistryTokenAllowed(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if appErr := s.requireTipRegistryConfigured(); appErr != nil {
@@ -1467,7 +1464,7 @@ func (s *Server) handleSetTipRegistryTokenAllowed(ctx *apptheory.Context) (*appt
 }
 
 func (s *Server) handleEnsureTipRegistryHost(ctx *apptheory.Context) (*apptheory.Response, error) {
-	if err := requireOperator(ctx); err != nil {
+	if err := requireAdmin(ctx); err != nil {
 		return nil, err
 	}
 	if s == nil || s.store == nil || s.store.DB == nil {

--- a/internal/controlplane/handlers_tip_registry_coverage_internal_test.go
+++ b/internal/controlplane/handlers_tip_registry_coverage_internal_test.go
@@ -49,10 +49,10 @@ func newConfiguredTipRegistryServer(tdb tipRegistryTestDB) *Server {
 	}
 }
 
-func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
+func TestNormalizeTipRegistryWalletAddress_Branches(t *testing.T) {
 	t.Parallel()
 
-	t.Run("normalize_wallet_rejects_empty_invalid_and_reserved", func(t *testing.T) {
+	t.Run("rejects_empty_invalid_and_reserved", func(t *testing.T) {
 		t.Parallel()
 
 		tdb := newTipRegistryTestDB()
@@ -73,7 +73,7 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 		}
 	})
 
-	t.Run("normalize_wallet_success_lowercases", func(t *testing.T) {
+	t.Run("success_lowercases", func(t *testing.T) {
 		t.Parallel()
 
 		tdb := newTipRegistryTestDB()
@@ -87,8 +87,12 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 			t.Fatalf("expected lowercased address, got %q", got)
 		}
 	})
+}
 
-	t.Run("wallet_from_registration_branches", func(t *testing.T) {
+func TestTipRegistryWalletFromRegistration_Branches(t *testing.T) {
+	t.Parallel()
+
+	t.Run("rejects_invalid_reserved_and_privileged_wallets", func(t *testing.T) {
 		t.Parallel()
 
 		tdb := newTipRegistryTestDB()
@@ -116,6 +120,13 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 		if appErr == nil || appErr.Code != appErrCodeBadRequest {
 			t.Fatalf("expected privileged wallet error, got %#v", appErr)
 		}
+	})
+
+	t.Run("allows_public_unclaimed_wallets", func(t *testing.T) {
+		t.Parallel()
+
+		tdb := newTipRegistryTestDB()
+		s := newConfiguredTipRegistryServer(tdb)
 
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 		wallet, lower, appErr := s.tipRegistryWalletFromRegistration(context.Background(), &models.TipHostRegistration{WalletAddr: "0x00000000000000000000000000000000000000Bb"})

--- a/internal/controlplane/handlers_tip_registry_coverage_internal_test.go
+++ b/internal/controlplane/handlers_tip_registry_coverage_internal_test.go
@@ -52,7 +52,7 @@ func newConfiguredTipRegistryServer(tdb tipRegistryTestDB) *Server {
 func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 	t.Parallel()
 
-	t.Run("normalize_wallet_rejects_empty_invalid_reserved_and_privileged", func(t *testing.T) {
+	t.Run("normalize_wallet_rejects_empty_invalid_and_reserved", func(t *testing.T) {
 		t.Parallel()
 
 		tdb := newTipRegistryTestDB()
@@ -67,17 +67,10 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 		_, err = s.normalizeTipRegistryWalletAddress(context.Background(), reservedWalletLesserHostAdmin)
 		requireTipRegistryAppErrCode(t, err, "app.bad_request")
 
-		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*models.WalletIndex](t, args, 0)
-			*dest = models.WalletIndex{Username: "alice"}
-		}).Once()
-		tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
-			dest := testutil.RequireMockArg[*models.User](t, args, 0)
-			*dest = models.User{Username: "alice", Role: models.RoleAdmin}
-		}).Once()
-
-		_, err = s.normalizeTipRegistryWalletAddress(context.Background(), "0x00000000000000000000000000000000000000aa")
-		requireTipRegistryAppErrCode(t, err, "app.bad_request")
+		got, err := s.normalizeTipRegistryWalletAddress(context.Background(), "0x00000000000000000000000000000000000000Aa")
+		if err != nil || got != "0x00000000000000000000000000000000000000aa" {
+			t.Fatalf("expected public normalization without privileged preflight, got %q err=%v", got, err)
+		}
 	})
 
 	t.Run("normalize_wallet_success_lowercases", func(t *testing.T) {
@@ -85,8 +78,6 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 
 		tdb := newTipRegistryTestDB()
 		s := newConfiguredTipRegistryServer(tdb)
-
-		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
 		got, err := s.normalizeTipRegistryWalletAddress(context.Background(), "0x00000000000000000000000000000000000000Aa")
 		if err != nil {
@@ -111,6 +102,19 @@ func TestTipRegistryWalletHelpers_Branches(t *testing.T) {
 		_, _, appErr = s.tipRegistryWalletFromRegistration(context.Background(), &models.TipHostRegistration{WalletAddr: reservedWalletTipSplitterLesser})
 		if appErr == nil || appErr.Code != appErrCodeBadRequest {
 			t.Fatalf("expected reserved wallet error, got %#v", appErr)
+		}
+
+		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.WalletIndex](t, args, 0)
+			*dest = models.WalletIndex{Username: "alice"}
+		}).Once()
+		tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.User](t, args, 0)
+			*dest = models.User{Username: "alice", Role: models.RoleAdmin}
+		}).Once()
+		_, _, appErr = s.tipRegistryWalletFromRegistration(context.Background(), &models.TipHostRegistration{WalletAddr: "0x00000000000000000000000000000000000000Aa"})
+		if appErr == nil || appErr.Code != appErrCodeBadRequest {
+			t.Fatalf("expected privileged wallet error, got %#v", appErr)
 		}
 
 		tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()

--- a/internal/controlplane/handlers_tip_registry_internal_test.go
+++ b/internal/controlplane/handlers_tip_registry_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"math/big"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -92,7 +93,6 @@ func TestHandleTipHostRegistrationBegin_Success(t *testing.T) {
 		WalletAddr: "0x000000000000000000000000000000000000dEaD",
 		HostFeeBps: 5,
 	})
-	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	resp, err := s.handleTipHostRegistrationBegin(&apptheory.Context{RequestID: "r1", Request: apptheory.Request{Body: body}})
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -122,6 +122,34 @@ func TestHandleTipHostRegistrationBegin_Success(t *testing.T) {
 	}
 	if !strings.HasPrefix(out.Proofs[0].DNSName, tipRegistryProofPrefix) {
 		t.Fatalf("unexpected dns name: %#v", out.Proofs[0].DNSName)
+	}
+}
+
+func TestHandleTipHostRegistrationBegin_DoesNotPreflightPrivilegedWallet(t *testing.T) {
+	t.Parallel()
+
+	tdb := newTipRegistryTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			TipEnabled:         true,
+			TipChainID:         1,
+			TipContractAddress: "0x0000000000000000000000000000000000000001",
+			TipTxMode:          tipTxModeSafe,
+		},
+	}
+
+	body, _ := json.Marshal(tipHostRegistrationBeginRequest{
+		Domain:     "example.com",
+		WalletAddr: "0x00000000000000000000000000000000000000aa",
+		HostFeeBps: 5,
+	})
+	resp, err := s.handleTipHostRegistrationBegin(&apptheory.Context{RequestID: "r1", Request: apptheory.Request{Body: body}})
+	if err != nil {
+		t.Fatalf("begin should not disclose privileged wallet status during public preflight: %v", err)
+	}
+	if resp.Status != http.StatusCreated {
+		t.Fatalf("expected 201, got %d", resp.Status)
 	}
 }
 
@@ -222,6 +250,33 @@ func TestTipRegistryAdminEndpoints_ListAndGet(t *testing.T) {
 	getCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
 	if _, err := s.handleGetTipRegistryOperation(getCtx); err == nil {
 		t.Fatalf("expected not_found")
+	}
+}
+
+func TestTipRegistryAdminMutationsRequireAdmin(t *testing.T) {
+	t.Parallel()
+
+	tdb := newTipRegistryTestDB()
+	s := &Server{
+		store: store.New(tdb.db),
+		cfg: config.Config{
+			TipEnabled:          true,
+			TipChainID:          1,
+			TipContractAddress:  "0x0000000000000000000000000000000000000001",
+			TipTxMode:           tipTxModeSafe,
+			TipAdminSafeAddress: "0x0000000000000000000000000000000000000002",
+		},
+	}
+
+	ctx := &apptheory.Context{
+		AuthIdentity: "ops",
+		Request:      apptheory.Request{Body: []byte(`{"token_address":"0x00000000000000000000000000000000000000ff","allowed":true}`)},
+	}
+	ctx.Set(ctxKeyOperatorRole, models.RoleOperator)
+	if _, err := s.handleSetTipRegistryTokenAllowed(ctx); err == nil {
+		t.Fatalf("expected operator role to be denied tip registry admin mutation")
+	} else {
+		requireTipRegistryAppErrCode(t, err, "app.forbidden")
 	}
 }
 

--- a/internal/secrets/keys_test.go
+++ b/internal/secrets/keys_test.go
@@ -44,7 +44,7 @@ func TestLooksLikeJSONObject(t *testing.T) {
 func TestLoadFirstSSMParameterCached_TriesCandidatesInOrder(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	client := stubSSM{
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
@@ -94,7 +94,7 @@ func TestStripeStageAndCandidates(t *testing.T) {
 func TestLoadFirstSSMParameterCached_ErrorsOnEmptyCandidates(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	if _, err := loadFirstSSMParameterCached(context.Background(), stubSSM{}, nil, 1*time.Minute); err == nil {
 		t.Fatalf("expected error")
@@ -104,7 +104,7 @@ func TestLoadFirstSSMParameterCached_ErrorsOnEmptyCandidates(t *testing.T) {
 func TestProviderKeyLoaders_UseSSMClientAndParse(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	client := stubSSM{
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {

--- a/internal/secrets/ssm_test.go
+++ b/internal/secrets/ssm_test.go
@@ -3,6 +3,7 @@ package secrets
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -29,10 +30,20 @@ func clearParamCache() {
 	})
 }
 
+var paramCacheTestMu sync.Mutex
+
+func isolateParamCache(t *testing.T) {
+	t.Helper()
+	paramCacheTestMu.Lock()
+	clearParamCache()
+	t.Cleanup(func() {
+		clearParamCache()
+		paramCacheTestMu.Unlock()
+	})
+}
+
 func TestGetSSMParameter_TrimsAndValidates(t *testing.T) {
 	t.Parallel()
-
-	clearParamCache()
 
 	client := stubSSM{
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
@@ -65,8 +76,6 @@ func TestGetSSMParameter_TrimsAndValidates(t *testing.T) {
 func TestGetSSMParameter_ErrorsOnEmptyInputsAndResponses(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
-
 	client := stubSSM{
 		getParameter: func(_ context.Context, _ *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
 			return &ssm.GetParameterOutput{}, nil
@@ -84,7 +93,7 @@ func TestGetSSMParameter_ErrorsOnEmptyInputsAndResponses(t *testing.T) {
 func TestGetSSMParameterCached_CachesWithinTTL(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	calls := 0
 	client := stubSSM{

--- a/web/src/lib/api/portalInstances.test.ts
+++ b/web/src/lib/api/portalInstances.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeInstanceKeysResponse, normalizeInstanceKeyTimestamp } from './portalInstances';
+
+describe('instance key timestamp normalization', () => {
+	it('treats missing and Go zero timestamps as absent', () => {
+		expect(normalizeInstanceKeyTimestamp(undefined)).toBeUndefined();
+		expect(normalizeInstanceKeyTimestamp(null)).toBeUndefined();
+		expect(normalizeInstanceKeyTimestamp('')).toBeUndefined();
+		expect(normalizeInstanceKeyTimestamp('0001-01-01T00:00:00Z')).toBeUndefined();
+		expect(normalizeInstanceKeyTimestamp('0001-01-01T00:00:00.000Z')).toBeUndefined();
+	});
+
+	it('preserves non-zero timestamps', () => {
+		expect(normalizeInstanceKeyTimestamp(' 2026-05-01T12:34:56Z ')).toBe('2026-05-01T12:34:56Z');
+	});
+
+	it('removes zero optional timestamps from listed keys', () => {
+		const out = normalizeInstanceKeysResponse({
+			count: 1,
+			keys: [
+				{
+					id: 'k1',
+					created_at: '2026-05-01T12:00:00Z',
+					last_used_at: '0001-01-01T00:00:00Z',
+					revoked_at: '0001-01-01T00:00:00Z',
+				},
+			],
+		});
+
+		expect(out.keys).toEqual([
+			{
+				id: 'k1',
+				created_at: '2026-05-01T12:00:00Z',
+			},
+		]);
+	});
+});

--- a/web/src/lib/api/portalInstances.ts
+++ b/web/src/lib/api/portalInstances.ts
@@ -242,6 +242,29 @@ export interface ListUpdateJobsResponse {
 	count: number;
 }
 
+export function normalizeInstanceKeyTimestamp(value: string | null | undefined): string | undefined {
+	const trimmed = (value || '').trim();
+	if (!trimmed) return undefined;
+	if (trimmed.startsWith('0001-01-01T00:00:00')) return undefined;
+	return trimmed;
+}
+
+export function normalizeInstanceKeysResponse(res: ListInstanceKeysResponse): ListInstanceKeysResponse {
+	return {
+		...res,
+		keys: (res.keys ?? []).map((key) => {
+			const { last_used_at: rawLastUsedAt, revoked_at: rawRevokedAt, ...rest } = key;
+			const lastUsedAt = normalizeInstanceKeyTimestamp(rawLastUsedAt);
+			const revokedAt = normalizeInstanceKeyTimestamp(rawRevokedAt);
+			return {
+				...rest,
+				...(lastUsedAt ? { last_used_at: lastUsedAt } : {}),
+				...(revokedAt ? { revoked_at: revokedAt } : {}),
+			};
+		}),
+	};
+}
+
 export function portalListInstances(token: string): Promise<ListInstancesResponse> {
 	return fetchJson<ListInstancesResponse>('/api/v1/portal/instances', {
 		headers: {
@@ -374,7 +397,7 @@ export function portalListInstanceKeys(token: string, slug: string, limit?: numb
 		headers: {
 			authorization: `Bearer ${token}`,
 		},
-	});
+	}).then(normalizeInstanceKeysResponse);
 }
 
 export function portalRevokeInstanceKey(token: string, slug: string, keyId: string): Promise<RevokeInstanceKeyResponse> {

--- a/web/src/lib/auth/logout.test.ts
+++ b/web/src/lib/auth/logout.test.ts
@@ -31,5 +31,40 @@ describe('logout', () => {
 
 		expect(get(session)).toBeNull();
 	});
-});
 
+	it('clears the local session before the API call resolves', async () => {
+		const { session, setSession } = await import('src/lib/session');
+		const { logout } = await import('src/lib/auth/logout');
+
+		setSession({
+			tokenType: 'Bearer',
+			token: 'token',
+			expiresAt: new Date(Date.now() + 60_000).toISOString(),
+			username: 'alice',
+			role: 'customer',
+		});
+
+		let resolveLogout: ((value: Response) => void) | undefined;
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				() =>
+					new Promise<Response>((resolve) => {
+						resolveLogout = resolve;
+					}),
+			),
+		);
+
+		await logout();
+
+		expect(get(session)).toBeNull();
+		expect(resolveLogout).toBeTypeOf('function');
+
+		resolveLogout?.(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			}),
+		);
+	});
+});

--- a/web/src/lib/auth/logout.ts
+++ b/web/src/lib/auth/logout.ts
@@ -4,14 +4,11 @@ import { authLogout } from 'src/lib/api/auth';
 import { clearSession, session } from 'src/lib/session';
 
 export async function logout(): Promise<void> {
-	const current = get(session);
-	if (current?.token) {
-		try {
-			await authLogout(current.token);
-		} catch {
-			// Best-effort: always clear local session state.
-		}
-	}
+	const token = get(session)?.token;
 	clearSession();
+	if (token) {
+		void authLogout(token).catch(() => {
+			// Best-effort: local session state has already been cleared.
+		});
+	}
 }
-

--- a/web/src/pages/operator/InstanceSupport.svelte
+++ b/web/src/pages/operator/InstanceSupport.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy, onMount } from 'svelte';
+	import { onDestroy } from 'svelte';
 
 	import { type ApiError, safeHref } from 'src/lib/api/http';
 	import type { BudgetMonthResponse, ListBudgetsResponse } from 'src/lib/api/portalUsage';
@@ -39,6 +39,8 @@
 	let updateLesserBodyVersion = $state('');
 
 	let updatesPollController: AbortController | null = null;
+	let loadedSlug = $state<string | null>(null);
+	let loadGeneration = 0;
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -130,13 +132,28 @@
 		updatesPolling = false;
 	}
 
+	function clearLoadedState() {
+		errorMessage = null;
+		instance = null;
+		domains = [];
+		budgets = null;
+		provisioning = null;
+		updatesError = null;
+		updateJobs = [];
+		loading = false;
+		updatesLoading = false;
+		updateCreating = false;
+	}
+
 	async function loadUpdates(targetSlug: string) {
 		updatesError = null;
 		updatesLoading = true;
 		try {
 			const res = await portalListUpdateJobs(token, targetSlug, 50);
+			if (loadedSlug !== targetSlug) return;
 			updateJobs = res.jobs ?? [];
 		} catch (err) {
+			if (loadedSlug !== targetSlug) return;
 			if ((err as Partial<ApiError>).status === 401) {
 				await logout();
 				navigate('/login');
@@ -144,7 +161,9 @@
 			}
 			updatesError = formatError(err);
 		} finally {
-			updatesLoading = false;
+			if (loadedSlug === targetSlug) {
+				updatesLoading = false;
+			}
 		}
 	}
 
@@ -163,7 +182,9 @@
 		try {
 			await pollUntil(
 				async () => {
+					if (loadedSlug !== targetSlug) return null;
 					const res = await portalListUpdateJobs(token, targetSlug, 50);
+					if (loadedSlug !== targetSlug) return null;
 					updateJobs = res.jobs ?? [];
 					return (res.jobs ?? []).find((j) => j.id === jobId) ?? null;
 				},
@@ -176,6 +197,7 @@
 						factor: 1.6,
 					},
 					onUpdate: (job) => {
+						if (loadedSlug !== targetSlug) return;
 						if (!job) return;
 						const idx = updateJobs.findIndex((j) => j.id === job.id);
 						if (idx >= 0) {
@@ -184,8 +206,11 @@
 					},
 				},
 			);
-			void loadAll(targetSlug);
+			if (loadedSlug === targetSlug) {
+				void loadAll(targetSlug);
+			}
 		} catch (err) {
+			if (loadedSlug !== targetSlug) return;
 			if ((err as Partial<ApiError>).status === 401) {
 				await logout();
 				navigate('/login');
@@ -195,7 +220,9 @@
 				updatesError = formatError(err);
 			}
 		} finally {
-			updatesPolling = false;
+			if (loadedSlug === targetSlug) {
+				updatesPolling = false;
+			}
 			if (updatesPollController === controller) {
 				updatesPollController = null;
 			}
@@ -246,9 +273,11 @@
 			if (options?.bodyOnly) input.body_only = true;
 			if (options?.mcpOnly) input.mcp_only = true;
 			const job = await portalCreateUpdateJob(token, targetSlug, input);
+			if (loadedSlug !== targetSlug) return;
 			updateJobs = [job, ...updateJobs.filter((j) => j.id !== job.id)];
 			void pollUpdateJob(targetSlug, job.id);
 		} catch (err) {
+			if (loadedSlug !== targetSlug) return;
 			if ((err as Partial<ApiError>).status === 401) {
 				await logout();
 				navigate('/login');
@@ -256,11 +285,14 @@
 			}
 			updatesError = formatError(err);
 		} finally {
-			updateCreating = false;
+			if (loadedSlug === targetSlug) {
+				updateCreating = false;
+			}
 		}
 	}
 
 	async function loadAll(targetSlug: string) {
+		const generation = ++loadGeneration;
 		errorMessage = null;
 		instance = null;
 		domains = [];
@@ -277,6 +309,7 @@
 				portalListBudgets(token, targetSlug),
 				portalListUpdateJobs(token, targetSlug, 50),
 			]);
+			if (generation !== loadGeneration) return;
 			instance = inst;
 			domains = dom.domains ?? [];
 			budgets = bud;
@@ -284,7 +317,9 @@
 
 			try {
 				provisioning = await portalGetProvisioning(token, targetSlug);
+				if (generation !== loadGeneration) return;
 			} catch (err) {
+				if (generation !== loadGeneration) return;
 				const maybe = err as Partial<ApiError>;
 				if (maybe.status === 404) {
 					provisioning = null;
@@ -293,6 +328,7 @@
 				}
 			}
 		} catch (err) {
+			if (generation !== loadGeneration) return;
 			if ((err as Partial<ApiError>).status === 401) {
 				await logout();
 				navigate('/login');
@@ -300,7 +336,9 @@
 			}
 			errorMessage = formatError(err);
 		} finally {
-			loading = false;
+			if (generation === loadGeneration) {
+				loading = false;
+			}
 		}
 	}
 
@@ -310,22 +348,28 @@
 		navigate(`/operator/instances/${normalized}`);
 	}
 
-	onMount(() => {
-		const normalized = slug ? normalizeSlug(slug) : null;
-		if (normalized) {
-			void loadAll(normalized);
-		}
-	});
-
 	onDestroy(() => {
 		abortUpdatesPolling();
 	});
 
 	$effect(() => {
 		const normalized = slug ? normalizeSlug(slug) : null;
-		if (!normalized) return;
+		if (!normalized) {
+			if (loadedSlug !== null) {
+				loadGeneration++;
+				loadedSlug = null;
+				abortUpdatesPolling();
+				clearLoadedState();
+			}
+			return;
+		}
 		if (slugInput.trim().toLowerCase() !== normalized) {
 			slugInput = normalized;
+		}
+		if (loadedSlug !== normalized) {
+			loadedSlug = normalized;
+			abortUpdatesPolling();
+			void loadAll(normalized);
 		}
 	});
 </script>

--- a/web/src/pages/operator/InstanceSupport.svelte.test.ts
+++ b/web/src/pages/operator/InstanceSupport.svelte.test.ts
@@ -1,0 +1,23 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/pages/operator/InstanceSupport.svelte'), 'utf8');
+
+describe('InstanceSupport route changes', () => {
+	it('loads data from the slug effect instead of only at mount', () => {
+		expect(source).not.toContain('onMount(() =>');
+		expect(source).toContain('let loadedSlug = $state<string | null>(null);');
+		expect(source).toContain('let loadGeneration = 0;');
+		expect(source).toContain('if (loadedSlug !== normalized)');
+		expect(source).toContain('void loadAll(normalized);');
+	});
+
+	it('guards stale async responses when the route slug changes', () => {
+		expect(source).toContain('const generation = ++loadGeneration;');
+		expect(source).toContain('if (generation !== loadGeneration) return;');
+		expect(source).toContain('if (loadedSlug !== targetSlug) return;');
+	});
+});

--- a/web/src/pages/portal/InstanceDetail.svelte
+++ b/web/src/pages/portal/InstanceDetail.svelte
@@ -298,6 +298,7 @@
 		rotateInstanceKey?: boolean;
 		bodyOnly?: boolean;
 		mcpOnly?: boolean;
+		allowBlankLesserVersion?: boolean;
 	}) {
 		updatesError = null;
 
@@ -305,7 +306,10 @@
 		const bodyVersion = (options?.lesserBodyVersion || '').trim();
 		const versionErr =
 			!options?.bodyOnly && !options?.mcpOnly
-				? validateManagedReleaseTag(version, { label: 'Lesser version' })
+				? validateManagedReleaseTag(version, {
+						allowBlank: options?.allowBlankLesserVersion ?? false,
+						label: 'Lesser version',
+					})
 				: null;
 		const bodyVersionErr = options?.bodyOnly
 			? validateManagedReleaseTag(bodyVersion, { allowBlank: true, label: 'lesser-body version' })
@@ -750,7 +754,11 @@
 			<div class="instance-detail__row">
 				<Button
 					variant="solid"
-					onclick={() => void startUpdateJob({ lesserVersion: updateLesserVersion })}
+					onclick={() =>
+						void startUpdateJob({
+							lesserVersion: updateLesserVersion,
+							allowBlankLesserVersion: true,
+						})}
 					disabled={updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed}
 				>
 					Apply configuration
@@ -763,7 +771,12 @@
 			<div class="instance-detail__row">
 				<Button
 					variant="outline"
-					onclick={() => void startUpdateJob({ lesserVersion: updateLesserVersion, rotateInstanceKey: true })}
+					onclick={() =>
+						void startUpdateJob({
+							lesserVersion: updateLesserVersion,
+							rotateInstanceKey: true,
+							allowBlankLesserVersion: true,
+						})}
 					disabled={updateCreating || updatesPolling || updatesLoading || updateInProgress() || !managed}
 				>
 					Rotate instance key

--- a/web/src/pages/portal/InstanceDetail.svelte.test.ts
+++ b/web/src/pages/portal/InstanceDetail.svelte.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(join(process.cwd(), 'src/pages/portal/InstanceDetail.svelte'), 'utf8');
+
+describe('InstanceDetail managed update controls', () => {
+	it('allows blank Lesser versions for configuration apply and key rotation', () => {
+		expect(source).toContain('allowBlankLesserVersion?: boolean;');
+		expect(source).toContain('allowBlank: options?.allowBlankLesserVersion ?? false');
+		expect(source).toContain('allowBlankLesserVersion: true');
+
+		const applyConfig = source.indexOf('Apply configuration');
+		const rotateKey = source.indexOf('Rotate instance key');
+		const firstAllowBlank = source.indexOf('allowBlankLesserVersion: true');
+		const secondAllowBlank = source.indexOf('allowBlankLesserVersion: true', firstAllowBlank + 1);
+
+		expect(firstAllowBlank).toBeGreaterThanOrEqual(0);
+		expect(secondAllowBlank).toBeGreaterThan(firstAllowBlank);
+		expect(firstAllowBlank).toBeLessThan(applyConfig);
+		expect(secondAllowBlank).toBeLessThan(rotateKey);
+	});
+});


### PR DESCRIPTION
## Milestone
M8 — Harden comms, operator surfaces, web, and test reliability

## Classification
Security / comms / operator-surface / web correctness / operational reliability

## Surfaces affected
- Soul comm send/reply guard boundaries and mailbox content replay recovery
- Tip registry public/admin authorization surfaces
- Operator provisioning receipt presentation
- Portal instance-key/update/logout/support UX correctness
- SSM parameter cache test isolation
- Gov-infra complexity gates preserved by refactoring without verifier weakening

## Specialist walks referenced
- Governance rubric: no rubric weakening or pack changes; local gov-rubric PASS 29/0/0
- Provisioning / managed-update / release verification: no consumer-release-verification changes; provisioning receipt redaction only
- Soul registry: no on-chain mutation or contract deploy in M8
- Trust API / CSP / instance-auth: comm/body-facing API hardening only; no trust API auth or CSP loosening
- Framework: idiomatic host-side changes only; no framework patches

## Multi-tenant isolation impact
Elevated scrutiny for comm mailbox and operator receipt visibility. Changes reduce cross-tenant/stale/sensitive exposure: denied comm records no longer satisfy reply boundaries, S3 replay recovery requires matching body hashes, and non-admin operators cannot receive raw provisioning receipts.

## On-chain impact
None for M8. Tip registry RBAC/public preflight changes affect control-plane access only; Solidity TipSplitter work remains deferred to M9.

## Consumer impact
Managed operators, body comm-tool consumers, and portal users. No live/mainnet data migration or deploy is included in this PR.

## Tasks
- [x] #243 — Harden comm reply boundaries, S3 replay recovery, and RFC5322 headers
- [x] #244 — Tighten tip registry admin RBAC and public wallet preflight
- [x] #245 — Redact operator provisioning receipts
- [x] #246 — Fix portal key timestamps, logout, blank update versions, and support reload
- [x] #247 — Isolate SSM parameter cache tests

## Issue closure
Closes #243.
Closes #244.
Closes #245.
Closes #246.
Closes #247.

## Validation
- [x] `go test ./internal/commmailbox ./internal/controlplane` (#243)
- [x] `go test ./internal/controlplane -run 'TestHandleTipHostRegistrationBegin_DoesNotPreflightPrivilegedWallet|TestTipRegistryAdminMutationsRequireAdmin|TestTipRegistryWalletHelpers|TestHandleTipHostRegistrationBegin_Success|TestTipRegistryAdminEndpoints_ListAndGet|TestHandleSetTipRegistryTokenAllowed_ValidatesAndCreates|TestHandleEnsureTipRegistryHost_CreatesAutoOperation'` (#244)
- [x] `go test ./internal/controlplane -run 'TestHandleGetOperatorProvisionJob_RedactsReceiptForOperator|TestOperatorProvisionJobDetail_RedactsAdminReceiptSecrets|TestHandleGetOperatorProvisionJob_NotFoundAndSuccess|TestHandleRetryOperatorProvisionJob_QueuedAndErrorBranches|TestHandleAppendOperatorProvisionJobNote_ValidationsAndSuccess|TestHandleAdoptOperatorProvisionJobAccount|TestMiscHelpers'` (#245)
- [x] `cd web && npm run lint && npm run typecheck && npm test` (#246)
- [x] `go test -count=20 ./internal/secrets` (#247)
- [x] `gofmt -l .` (empty)
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `cd web && npm ci && npm run lint && npm run typecheck && npm test`
- [x] `cd web && npm run build -- --outDir /tmp/lesser-host-web-build` (clean outDir used because local `web/dist` permissions can interfere)
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete
- [ ] `theory` validation complete where relevant
- [ ] `simulacrum` canary complete where relevant
- [ ] Live deploy explicitly authorized before any live action
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
Greater-components can continue its own security remediation in parallel. Host M8 has no intentional greater-components contract-shape change; after merge/deploy, simulacrum can consume the updated host behavior through normal lab validation.

## Advisor-brief authorization
Not advisor-dispatched.