### PR TITLE
fix(contracts): harden TipSplitter pre-live safety

### DIFF
--- a/contracts/contracts/TipSplitter.sol
+++ b/contracts/contracts/TipSplitter.sol
@@ -308,8 +308,8 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
 
     // ========= Withdrawals =========
 
-    /// @notice Withdraw pending balance. Withdrawals can be paused independently.
-    function withdraw(address token) external nonReentrant {
+    /// @notice Withdraw pending balance. Global pause and withdrawalsPaused both freeze withdrawals.
+    function withdraw(address token) external nonReentrant whenNotPaused {
         require(!withdrawalsPaused, "TipSplitter: withdrawals paused");
         if (token == address(0)) {
             uint256 ethAmount = pendingETH[msg.sender];
@@ -430,17 +430,17 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
         emit AgentIdentityRegistryUpdated(old, registry);
     }
 
-    /// @notice Pause tipping and other state-changing operations (owner only).
+    /// @notice Pause tipping, batch tipping, agent tipping, and withdrawals (owner only).
     function pause() external onlyOwner {
         _pause();
     }
 
-    /// @notice Unpause tipping and other state-changing operations (owner only).
+    /// @notice Unpause tipping, batch tipping, agent tipping, and withdrawals unless withdrawalsPaused is still set.
     function unpause() external onlyOwner {
         _unpause();
     }
 
-    /// @notice Pause or unpause withdrawals independently from tips.
+    /// @notice Pause or unpause withdrawals independently from the global pause.
     function setWithdrawalsPaused(bool paused_) external onlyOwner {
         withdrawalsPaused = paused_;
         emit WithdrawalsPausedSet(paused_);

--- a/contracts/contracts/TipSplitter.sol
+++ b/contracts/contracts/TipSplitter.sol
@@ -64,11 +64,6 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
 
     mapping(address => uint256) private _hostWalletRefCount; // wallet => number of hosts using it
 
-    // recipient => list of tokens with a non-zero pending balance for that recipient.
-    // Maintained to make migrations bounded to the recipient's active tokens (instead of a global ever-allowed list).
-    mapping(address => address[]) private _recipientTokenList;
-    mapping(address => mapping(address => uint256)) private _recipientTokenIndex; // recipient => token => index in _recipientTokenList (1-based)
-
     /// @notice Per-token max tip amount (0 = unlimited). Use address(0) key for ETH.
     mapping(address => uint256) public maxTipAmount;
     /// @notice Per-token min tip amount (0 = MIN_TIP_AMOUNT unless hasCustomMinTipAmount is true). Use address(0) key for ETH.
@@ -103,8 +98,6 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
     event TokenAllowedSet(address indexed token, bool allowed);
     /// @notice Emitted when the Lesser wallet is updated.
     event LesserWalletUpdated(address indexed oldWallet, address indexed newWallet);
-    /// @notice Emitted when pending balances are migrated during a wallet rotation.
-    event PendingMigrated(address indexed oldWallet, address indexed newWallet, uint256 ethAmount, uint256 tokenCount);
     /// @notice Emitted when a token's maximum tip amount is updated.
     event MaxTipAmountSet(address indexed token, uint256 amount);
     /// @notice Emitted when a token's minimum tip amount is updated.
@@ -335,7 +328,6 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
         uint256 tokenAmount = pendingToken[token][msg.sender];
         require(tokenAmount > 0, "TipSplitter: no pending");
         pendingToken[token][msg.sender] = 0;
-        _removeRecipientToken(msg.sender, token);
         totalPendingToken[token] -= tokenAmount;
 
         IERC20(token).safeTransfer(msg.sender, tokenAmount);
@@ -357,6 +349,7 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
     }
 
     /// @notice Update a host configuration (owner only).
+    /// @dev Existing pending balances stay with the wallet they were credited to; rotations affect future tips only.
     function updateHost(bytes32 hostId, address wallet, uint16 feeBps) external onlyOwner {
         require(hosts[hostId].wallet != address(0), "TipSplitter: host missing");
         require(wallet != address(0), "TipSplitter: invalid wallet");
@@ -365,12 +358,8 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
 
         address oldWallet = hosts[hostId].wallet;
         if (oldWallet != wallet) {
-            uint256 oldRefCount = _hostWalletRefCount[oldWallet];
-            _hostWalletRefCount[oldWallet] = oldRefCount - 1;
+            _hostWalletRefCount[oldWallet]--;
             _hostWalletRefCount[wallet]++;
-            if (oldRefCount == 1) {
-                _migratePending(oldWallet, wallet);
-            }
         }
         hosts[hostId].wallet = wallet;
         hosts[hostId].feeBps = feeBps;
@@ -421,13 +410,13 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
     // ========= Admin =========
 
     /// @notice Update the Lesser wallet address (owner only).
+    /// @dev Existing pending balances stay with the wallet they were credited to; rotations affect future tips only.
     function setLesserWallet(address newWallet) external onlyOwner {
         require(newWallet != address(0), "TipSplitter: invalid wallet");
         require(newWallet != lesserWallet, "TipSplitter: no-op");
         require(_hostWalletRefCount[newWallet] == 0, "TipSplitter: wallet is a host wallet");
         address old = lesserWallet;
         lesserWallet = newWallet;
-        _migratePending(old, newWallet);
         emit LesserWalletUpdated(old, newWallet);
     }
 
@@ -529,59 +518,8 @@ contract TipSplitter is Ownable2Step, Pausable, ReentrancyGuard {
         if (amount == 0) {
             return;
         }
-        if (_recipientTokenIndex[recipient][token] == 0) {
-            _recipientTokenList[recipient].push(token);
-            _recipientTokenIndex[recipient][token] = _recipientTokenList[recipient].length; // 1-based
-        }
         pendingToken[token][recipient] += amount;
         totalPendingToken[token] += amount;
-    }
-
-    function _removeRecipientToken(address recipient, address token) internal {
-        uint256 idx = _recipientTokenIndex[recipient][token];
-        if (idx == 0) {
-            return;
-        }
-        uint256 last = _recipientTokenList[recipient].length;
-        if (idx != last) {
-            address lastToken = _recipientTokenList[recipient][last - 1];
-            _recipientTokenList[recipient][idx - 1] = lastToken;
-            _recipientTokenIndex[recipient][lastToken] = idx;
-        }
-        _recipientTokenList[recipient].pop();
-        delete _recipientTokenIndex[recipient][token];
-    }
-
-    function _migratePending(address oldWallet, address newWallet) internal {
-        if (oldWallet == newWallet) {
-            return;
-        }
-
-        uint256 ethAmount = pendingETH[oldWallet];
-        if (ethAmount > 0) {
-            pendingETH[oldWallet] = 0;
-            pendingETH[newWallet] += ethAmount;
-        }
-
-        uint256 tokenCount = 0;
-        while (_recipientTokenList[oldWallet].length > 0) {
-            address token = _recipientTokenList[oldWallet][_recipientTokenList[oldWallet].length - 1];
-            uint256 amount = pendingToken[token][oldWallet];
-            pendingToken[token][oldWallet] = 0;
-            _removeRecipientToken(oldWallet, token);
-            if (amount > 0) {
-                if (_recipientTokenIndex[newWallet][token] == 0) {
-                    _recipientTokenList[newWallet].push(token);
-                    _recipientTokenIndex[newWallet][token] = _recipientTokenList[newWallet].length; // 1-based
-                }
-                pendingToken[token][newWallet] += amount;
-                tokenCount++;
-            }
-        }
-
-        if (ethAmount > 0 || tokenCount > 0) {
-            emit PendingMigrated(oldWallet, newWallet, ethAmount, tokenCount);
-        }
     }
 
     function _split(uint16 hostFeeBps, uint256 amount)

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -15,6 +15,7 @@
     "deploy:sepolia:soul-attestations": "hardhat run --network sepolia scripts/deploy-soul-attestations.js",
     "deploy:sepolia:soul-renderers": "hardhat run --network sepolia scripts/deploy-soul-renderers.js",
     "lint": "solhint \"contracts/**/*.sol\"",
+    "slither": "slither contracts/TipSplitter.sol --config-file slither.config.json",
     "test": "hardhat compile && node --test test/*.test.js"
   },
   "devDependencies": {

--- a/contracts/test/TipSplitter.test.js
+++ b/contracts/test/TipSplitter.test.js
@@ -601,6 +601,18 @@ describe("TipSplitter — tipToken", () => {
       /amount exceeds max/,
     );
   });
+
+  it("reverts when paused", async () => {
+    const { splitter, tokenAddr, actor, tipper, owner, HOST_ID, CONTENT_HASH } =
+      await deploy();
+    await splitter.connect(owner).pause();
+    await assert.rejects(
+      splitter
+        .connect(tipper)
+        .tipToken(tokenAddr, HOST_ID, actor.address, MIN_TIP, CONTENT_HASH),
+      /EnforcedPause/,
+    );
+  });
 });
 
 // ======================================================================
@@ -694,7 +706,7 @@ describe("TipSplitter — Withdrawals", () => {
     );
   });
 
-  it("allows withdrawals when paused", async () => {
+  it("reverts ETH withdrawals when globally paused", async () => {
     const { splitter, actor, tipper, owner, HOST_ID, CONTENT_HASH } =
       await deploy();
     const amount = ethers.parseEther("1");
@@ -702,7 +714,26 @@ describe("TipSplitter — Withdrawals", () => {
       .connect(tipper)
       .tipETH(HOST_ID, actor.address, CONTENT_HASH, { value: amount });
     await splitter.connect(owner).pause();
+    await assert.rejects(
+      splitter.connect(actor).withdraw(ethers.ZeroAddress),
+      /EnforcedPause/,
+    );
+    await splitter.connect(owner).unpause();
     await splitter.connect(actor).withdraw(ethers.ZeroAddress);
+  });
+
+  it("reverts ERC-20 withdrawals when globally paused", async () => {
+    const { splitter, tokenAddr, actor, tipper, owner, HOST_ID, CONTENT_HASH } =
+      await deploy();
+    const amount = ethers.parseEther("10");
+    await splitter
+      .connect(tipper)
+      .tipToken(tokenAddr, HOST_ID, actor.address, amount, CONTENT_HASH);
+    await splitter.connect(owner).pause();
+    await assert.rejects(
+      splitter.connect(actor).withdraw(tokenAddr),
+      /EnforcedPause/,
+    );
   });
 
   it("reverts when withdrawals are paused", async () => {
@@ -1102,6 +1133,23 @@ describe("TipSplitter — Pause / Unpause", () => {
       splitter.connect(tipper).setWithdrawalsPaused(true),
       /OwnableUnauthorizedAccount/,
     );
+  });
+
+  it("keeps owner admin controls available during a global pause", async () => {
+    const { splitter, owner, other, tokenAddr, HOST_ID } = await deploy();
+    await splitter.connect(owner).pause();
+
+    await splitter.connect(owner).setHostActive(HOST_ID, false);
+    await splitter.connect(owner).updateHost(HOST_ID, other.address, 200);
+    await splitter.connect(owner).setTokenAllowed(tokenAddr, false);
+    await splitter.connect(owner).setWithdrawalsPaused(true);
+
+    const [wallet, feeBps, isActive] = await splitter.hosts(HOST_ID);
+    assert.equal(wallet, other.address);
+    assert.equal(feeBps, 200n);
+    assert.equal(isActive, false);
+    assert.equal(await splitter.allowedTokens(tokenAddr), false);
+    assert.equal(await splitter.withdrawalsPaused(), true);
   });
 });
 

--- a/contracts/test/TipSplitter.test.js
+++ b/contracts/test/TipSplitter.test.js
@@ -889,7 +889,7 @@ describe("TipSplitter — setLesserWallet", () => {
     assert.equal(await splitter.lesserWallet(), other.address);
   });
 
-  it("migrates pending ETH and token balances to the new lesser wallet", async () => {
+  it("leaves pending ETH and token balances at the credited lesser wallet", async () => {
     const {
       splitter,
       token,
@@ -917,18 +917,24 @@ describe("TipSplitter — setLesserWallet", () => {
 
     await splitter.connect(owner).setLesserWallet(other.address);
 
-    assert.equal(await splitter.pendingETH(lesserWallet.address), 0n);
-    assert.equal(await splitter.pendingETH(other.address), ethSplit.lesserShare);
-    assert.equal(await splitter.pendingToken(tokenAddr, lesserWallet.address), 0n);
     assert.equal(
-      await splitter.pendingToken(tokenAddr, other.address),
+      await splitter.pendingETH(lesserWallet.address),
+      ethSplit.lesserShare,
+    );
+    assert.equal(await splitter.pendingETH(other.address), 0n);
+    assert.equal(
+      await splitter.pendingToken(tokenAddr, lesserWallet.address),
       tokenSplit.lesserShare,
     );
+    assert.equal(await splitter.pendingToken(tokenAddr, other.address), 0n);
     assert.equal(await splitter.totalPendingToken(tokenAddr), tokenAmount);
 
-    await splitter.connect(other).withdraw(ethers.ZeroAddress);
-    await splitter.connect(other).withdraw(tokenAddr);
-    assert.equal(await token.balanceOf(other.address), tokenSplit.lesserShare);
+    await splitter.connect(lesserWallet).withdraw(ethers.ZeroAddress);
+    await splitter.connect(lesserWallet).withdraw(tokenAddr);
+    assert.equal(
+      await token.balanceOf(lesserWallet.address),
+      tokenSplit.lesserShare,
+    );
   });
 
   it("rejects zero address", async () => {
@@ -1300,10 +1306,18 @@ describe("TipSplitter — setLesserWallet host collision", () => {
   });
 });
 
-describe("TipSplitter — host wallet rotation pending migration", () => {
-  it("migrates pending host ETH when the last host reference rotates", async () => {
-    const { splitter, owner, hostWallet, actor, tipper, other, HOST_ID, CONTENT_HASH } =
-      await deploy();
+describe("TipSplitter — wallet rotation pending isolation", () => {
+  it("does not move pending host ETH when a host wallet rotates", async () => {
+    const {
+      splitter,
+      owner,
+      hostWallet,
+      actor,
+      tipper,
+      other,
+      HOST_ID,
+      CONTENT_HASH,
+    } = await deploy();
     const amount = ethers.parseEther("1");
     const split = expectedSplit(amount);
 
@@ -1313,8 +1327,64 @@ describe("TipSplitter — host wallet rotation pending migration", () => {
 
     await splitter.connect(owner).updateHost(HOST_ID, other.address, HOST_FEE_BPS);
 
-    assert.equal(await splitter.pendingETH(hostWallet.address), 0n);
-    assert.equal(await splitter.pendingETH(other.address), split.hostShare);
+    assert.equal(await splitter.pendingETH(hostWallet.address), split.hostShare);
+    assert.equal(await splitter.pendingETH(other.address), 0n);
+  });
+
+  it("does not move unrelated actor ETH when a host wallet rotates", async () => {
+    const {
+      splitter,
+      owner,
+      hostWallet,
+      actor,
+      tipper,
+      other,
+      HOST_ID,
+      CONTENT_HASH,
+    } = await deploy();
+    const secondHostId = ethers.id("second.host");
+    await splitter.connect(owner).registerHost(secondHostId, actor.address, 200);
+
+    const amount = ethers.parseEther("1");
+    const split = expectedSplit(amount, 200n);
+    await splitter
+      .connect(tipper)
+      .tipETH(secondHostId, hostWallet.address, CONTENT_HASH, {
+        value: amount,
+      });
+
+    await splitter.connect(owner).updateHost(HOST_ID, other.address, HOST_FEE_BPS);
+
+    assert.equal(await splitter.pendingETH(hostWallet.address), split.actorShare);
+    assert.equal(await splitter.pendingETH(other.address), 0n);
+  });
+
+  it("does not move pending host ERC-20 balances when a host wallet rotates", async () => {
+    const {
+      splitter,
+      tokenAddr,
+      owner,
+      hostWallet,
+      actor,
+      tipper,
+      other,
+      HOST_ID,
+      CONTENT_HASH,
+    } = await deploy();
+    const amount = ethers.parseEther("10");
+    const split = expectedSplit(amount);
+
+    await splitter
+      .connect(tipper)
+      .tipToken(tokenAddr, HOST_ID, actor.address, amount, CONTENT_HASH);
+
+    await splitter.connect(owner).updateHost(HOST_ID, other.address, HOST_FEE_BPS);
+
+    assert.equal(
+      await splitter.pendingToken(tokenAddr, hostWallet.address),
+      split.hostShare,
+    );
+    assert.equal(await splitter.pendingToken(tokenAddr, other.address), 0n);
   });
 });
 

--- a/docs/runbook-sepolia-contract-deploy.md
+++ b/docs/runbook-sepolia-contract-deploy.md
@@ -126,6 +126,45 @@ cd contracts
 SOUL_REGISTRY_ADDRESS=0x... npm run deploy:sepolia:soul-renderers
 ```
 
+### Standalone TipSplitter redeploy (M9 hardening path)
+
+If only `TipSplitter.sol` changes, do **not** redeploy the full soul-registry set by default. For the M9 pre-live
+hardening rollout, deploy a fresh TipSplitter that points at the already-active Sepolia SoulRegistry:
+
+```bash
+cd contracts
+npm ci
+npm test
+npm run lint
+# `bash ../gov-infra/verifiers/gov-verify-rubric.sh` creates the pinned Slither venv; use an equivalent pinned Slither
+# environment if running this command before the full verifier.
+PATH="../gov-infra/.tools/python/venv-sec-1-slither/bin:$PATH" npm run slither
+
+LESSER_WALLET=<current lesser_wallet from docs/deployments/sepolia/latest.json> \
+INITIAL_OWNER=<current owner_safe from docs/deployments/sepolia/latest.json> \
+AGENT_IDENTITY_REGISTRY=<current SoulRegistry address from docs/deployments/sepolia/latest.json> \
+npm run deploy:sepolia
+```
+
+After deployment:
+
+1. Run read-only checks against the new address:
+   - `owner() == INITIAL_OWNER`
+   - `lesserWallet() == LESSER_WALLET`
+   - `agentIdentityRegistry() == AGENT_IDENTITY_REGISTRY`
+   - `paused() == false`
+   - `withdrawalsPaused() == false`
+2. Update `docs/deployments/sepolia/latest.json`:
+   - `contracts.TipSplitter.address`
+   - `contracts.TipSplitter.deployment_tx_hash`
+   - `lesser_host.cdk_context.tipContractAddressLab`
+3. Update local CDK context for lab to the new `tipContractAddressLab` and deploy host lab through
+   `theory app up --stage lab` in a separate deployment step.
+4. Validate `/api/v1/tip-registry/config` returns the new TipSplitter address before using `simulacrum` as the canary.
+
+Because M9 is pre-live and there are no live tips to preserve, this path intentionally avoids any live-funds migration.
+Mainnet Safe execution remains deferred until a future live-readiness authorization.
+
 ### Phase 3 — Mint signer setup
 
 The portal mint flow uses `selfMintSoul`: the control plane signs an EIP-712 self-mint attestation with a hot key (stored in SSM), and the Safe (or user) submits the transaction (paying gas + mint fee).

--- a/docs/security/host-security-round2-prelive-rollout.md
+++ b/docs/security/host-security-round2-prelive-rollout.md
@@ -43,3 +43,20 @@ not receive that high-privilege role. Before a managed provisioning or managed-u
 now ensures the per-instance `MANAGED_INSTANCE_ROLE_NAME` trust policy includes the concrete
 `MANAGED_PROVISION_RUNNER_ROLE_ARN`. Existing lab tenant accounts (`theory` first, `simulacrum` canary second) should be
 migrated by the normal managed-update path; do not restore org-vending-role access to the deploy runner as a shortcut.
+
+## M9 Sepolia TipSplitter handoff
+
+M9 hardens the pre-live TipSplitter contract before any live/mainnet tipping is enabled:
+
+- wallet rotations no longer migrate recipient-keyed pending balances; pending liabilities remain with the credited
+  wallet, and rotations affect future tips only
+- `pause()` is the emergency global freeze for both new tips and withdrawals
+- `setWithdrawalsPaused(true)` remains available for withdrawal-only freezes and is still required, together with
+  `pause()`, before stray-balance sweep operations
+
+Post-merge, deploy a fresh TipSplitter to Sepolia using the standalone TipSplitter redeploy path in
+`docs/runbook-sepolia-contract-deploy.md`. Update `docs/deployments/sepolia/latest.json` and lab CDK context with the new
+TipSplitter address only after the Sepolia deployment transaction is confirmed and read-only constructor checks pass.
+
+Mainnet Safe execution remains deferred until a future live-readiness authorization. Do not prepare or execute a mainnet
+TipSplitter Safe transaction as part of this round-2 pre-live milestone.

--- a/docs/tip-registry.md
+++ b/docs/tip-registry.md
@@ -23,17 +23,41 @@ Emergency owner-only methods (intended for incident response; not normal registr
   - callable only when both `paused()` and `withdrawalsPaused` are true
   - sweeps only untracked token balance (`balanceOf(this) - totalPendingToken[token]`) to `lesserWallet`
 
+## TipSplitter safety semantics
+
+### Wallet rotations
+
+`setLesserWallet` and `updateHost` affect **future** tips only. Existing `pendingETH` and `pendingToken` liabilities
+remain credited to the wallet that originally received them and must be withdrawn by that credited wallet. The contract
+does not perform automatic pending-balance migrations during wallet rotations because the public pending ledgers are
+recipient-keyed and can include multiple roles (Lesser share, host share, actor share) for the same address.
+
+If a future live deployment needs to move already-accrued liabilities, that must be handled as an explicit governance
+migration with role-scoped accounting and transaction evidence. It is not part of the normal host registry update path.
+
+### Pause controls
+
+`pause()` is the emergency global freeze:
+
+- deposit/split paths (`tipETH`, `batchTipETH`, `tipToken`, `batchTipToken`, `tipAgentETH`, `tipAgentToken`) revert while
+  paused
+- withdrawals revert while paused
+- owner/admin controls remain available so the Safe can correct configuration and prepare recovery actions
+
+`setWithdrawalsPaused(true)` is an additional withdrawal-only freeze. It can block withdrawals without blocking new tips,
+and it remains in effect after `unpause()` until the owner calls `setWithdrawalsPaused(false)`.
+
 ## Emergency runbook (operator)
 
 Use this only during incident response. The contract owner is expected to be the admin Safe.
 
 ### 1) Freeze movement
 
-1. Execute `pause()`.
-2. Execute `setWithdrawalsPaused(true)`.
+1. Execute `pause()` to freeze both new tips and withdrawals.
+2. If untracked-balance sweep operations may be needed, also execute `setWithdrawalsPaused(true)`.
 3. Verify:
    - `paused() == true`
-   - `withdrawalsPaused == true`
+   - `withdrawalsPaused == true` when sweep operations are planned
 
 ### 2) Sweep untracked stray balances
 


### PR DESCRIPTION
## Milestone
M9 — Pre-live Sepolia TipSplitter hardening

## Classification
security / on-chain-integrity / host-contracts / operational-reliability / docs

## Surfaces affected
- `contracts/contracts/TipSplitter.sol`
- `contracts/test/TipSplitter.test.js`
- `contracts/package.json`
- `docs/tip-registry.md`
- `docs/runbook-sepolia-contract-deploy.md`
- `docs/security/host-security-round2-prelive-rollout.md`

## Specialist walks referenced
- Governance rubric: no rubric weakening; local gov-infra verifier PASS 29/0/0
- Provisioning / managed-update / release verification: not affected
- Soul registry / on-chain: `evolve-soul-registry` applied; Solidity-only TipSplitter hardening, Sepolia redeploy deferred to post-merge handoff, mainnet Safe execution deferred
- Trust API / CSP / instance-auth: not affected
- Framework: not affected

## Multi-tenant isolation impact
None. This milestone is on-chain TipSplitter accounting/operational safety; it does not read tenant data or cross tenant boundaries.

## On-chain impact
Solidity contract behavior changes for future TipSplitter deployments. No Sepolia transaction, mainnet transaction, or Safe payload is executed by this implementation PR. Post-merge Sepolia redeploy is documented as a separate operator action.

## Consumer impact
- Managed operators: safer pre-live TipSplitter behavior before lab/Sepolia rollout
- Customers / live users: none; no live tipping has occurred and live deployment is deferred
- External on-chain callers: future TipSplitter deployments no longer auto-migrate pending balances during wallet rotations; global pause freezes withdrawals

## Tasks
- [x] #248 — Isolate TipSplitter pending balance migrations
- [x] #249 — Decide and enforce pre-live TipSplitter pause semantics
- [x] #250 — Prepare Sepolia redeploy handoff and evidence path (deployment/record update remains separate after merge)

## Validation
- [x] `gofmt -l .` (empty)
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `cd contracts && npm test`
- [x] `cd contracts && npm run lint` (existing OffchainResolver warnings only; 0 errors)
- [x] `cd contracts && PATH="../gov-infra/.tools/python/venv-sec-1-slither/bin:$PATH" npm run slither` (0 medium+ findings; informational costly-loop only)
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29 / FAIL 0 / BLOCKED 0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deploy hardened TipSplitter to Sepolia using `docs/runbook-sepolia-contract-deploy.md` standalone M9 path
- [ ] Update `docs/deployments/sepolia/latest.json` with the new TipSplitter address + tx hash
- [ ] Update lab CDK context for `tipContractAddressLab`
- [ ] Deploy host lab via `theory app up --stage lab`
- [ ] Validate `/api/v1/tip-registry/config` returns the new TipSplitter
- [ ] `theory` validation complete
- [ ] `simulacrum` canary complete where relevant
- [ ] Mainnet Safe-ready execution explicitly deferred until future live-readiness authorization

## Cross-repo coordination
None required for this PR. Greater-components / simulacrum integration can proceed after host and greater security remediation converge.

## Advisor-brief authorization
Not advisor-dispatched.

Closes #248
Closes #249
Refs #229
Refs #250
