### PR TITLE
feat(comm): compact mailbox MCP pagination

### DIFF
--- a/cdk/go.mod
+++ b/cdk/go.mod
@@ -1,3 +1,3 @@
 module github.com/equaltoai/lesser-host/cdk
 
-go 1.26.2
+go 1.26.3

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2670,6 +2670,11 @@ paths:
         Returns bounded metadata and previews only. Full message content is fetched explicitly from the content endpoint.
         Filters are evaluated within the authenticated instance + exact agent mailbox. `query` is bounded metadata/preview
         matching only; it is not full-body search and never scans across tenants or agents.
+
+        `fields` may be used by MCP clients to request compact projected message objects. `hasMore` and `nextCursor`
+        describe the filtered result set. If bounded server-side filtering stops before exhausting broad mailbox rows,
+        `partialScan`, `scanHasMore`, and `scanCursor` expose that broad scan state separately so MCP callers do not treat
+        broad mailbox pagination as matching SMS/voice pagination.
       security:
         - instanceKeyAuth: []
       parameters:
@@ -2755,6 +2760,28 @@ paths:
             minLength: 1
             maxLength: 128
           description: Bounded metadata/preview match within the authenticated instance + exact agent mailbox.
+        - name: fields
+          in: query
+          required: false
+          schema:
+            type: string
+            minLength: 1
+            maxLength: 512
+          description: |
+            Comma-separated projection list for compact MCP responses. Supported fields are
+            `messageRef`, `deliveryId`, `messageId`, `threadId`, `direction`, `channelType`, `provider`,
+            `providerMessageId`, `status`, `from`, `to`, `subject`, `preview`, `content`, `state`, `createdAt`,
+            `updatedAt`, and nested fields such as `content.available`, `state.read`, `from.address`, and `to.number`.
+            When omitted, the legacy full metadata object is returned.
+        - name: include_raw
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: |
+            Defaults to false. Host mailbox list responses do not expose raw upstream provider payloads; when false,
+            any future raw diagnostic payload is omitted unless explicitly requested and available.
       responses:
         "200":
           description: OK

--- a/docs/lesser-body-release-contract.md
+++ b/docs/lesser-body-release-contract.md
@@ -126,6 +126,12 @@ instance-authenticated mailbox contract:
   roots, or recipients locally
 - mailbox list filters and bounded `query` are exact-agent host-side filters only; body must not implement global mailbox
   search or store durable query indexes
+- mailbox list tools should use host-side `fields` projection (for example
+  `messageRef,subject,preview,from,to,createdAt,state,content.available,threadId`) for compact MCP responses; `include_raw`
+  defaults false and body should not re-add a duplicated raw upstream message object
+- filtered mailbox `hasMore`/`nextCursor` describe matching results. If host returns `partialScan`/`scanHasMore`/
+  `scanCursor`, that is explicit broad-scan metadata and must not be surfaced to MCP callers as matching-message
+  pagination.
 - body must not persist a durable mailbox-content or read-state store of its own
 
 See `docs/soul-comm-mailbox-migration.md` for the migration order, backward-compatibility expectations, rate limits,

--- a/docs/soul-comm-mailbox-migration.md
+++ b/docs/soul-comm-mailbox-migration.md
@@ -24,7 +24,10 @@ The intent is to keep authority in one place:
 2. **Host mailbox APIs become the body contract**
    - `GET /api/v1/soul/comm/contactability/{agentId}` resolves exact-agent receive/send affordances.
   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages` lists redacted canonical messages with exact-agent filters for
-    channel, direction, read/unread, archived/deleted state, thread, and bounded metadata/preview `query`.
+    channel, direction, read/unread, archived/deleted state, thread, and bounded metadata/preview `query`. MCP callers
+    may add `fields=messageRef,subject,preview,createdAt,state,content.available` (or another supported comma-separated
+    field list) to receive compact projected message objects; `include_raw=false` is the default and host does not expose
+    raw upstream provider payloads in mailbox list responses.
   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}` returns canonical metadata for one delivery.
   - `GET /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/content` returns full content only by explicit
     messageRef fetch.
@@ -75,6 +78,10 @@ The intent is to keep authority in one place:
   byte/hash metadata, and mailbox state. Full content requires the explicit content endpoint.
 - Body should tolerate instances that have not yet generated canonical mailbox rows by returning an empty mailbox result
   or a clear capability-not-ready error rather than reconstructing mailbox state from legacy rows.
+- Filtered list pagination is matching-result pagination. Host may scan multiple bounded broad mailbox pages internally
+  to satisfy `channelType`, direction, state, and query filters. `hasMore`/`nextCursor` describe additional matching
+  messages; if host stops because the bounded broad scan budget is reached, it sets `partialScan`, `scanHasMore`, and
+  `scanCursor` separately rather than overloading MCP-facing `hasMore`.
 
 ## Auth and tenant isolation
 

--- a/docs/spec/v3/schemas/soul-comm-mailbox-list.response.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-mailbox-list.response.schema.json
@@ -4,16 +4,55 @@
   "title": "GET /api/v1/soul/comm/mailbox/{agentId}/messages response",
   "type": "object",
   "additionalProperties": false,
-  "required": ["instanceSlug", "agentId", "messages", "count", "hasMore"],
+  "required": [
+    "instanceSlug",
+    "agentId",
+    "messages",
+    "count",
+    "hasMore"
+  ],
   "properties": {
-    "instanceSlug": { "type": "string", "minLength": 1, "maxLength": 64 },
-    "agentId": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+    "instanceSlug": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "agentId": {
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]{64}$"
+    },
     "messages": {
       "type": "array",
-      "items": { "$ref": "soul-comm-mailbox-message.schema.json" }
+      "items": {
+        "$ref": "soul-comm-mailbox-message-projection.schema.json"
+      }
     },
-    "count": { "type": "integer", "minimum": 0, "maximum": 100 },
-    "hasMore": { "type": "boolean" },
-    "nextCursor": { "type": "string", "minLength": 1, "maxLength": 2048 }
+    "count": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "hasMore": {
+      "type": "boolean"
+    },
+    "nextCursor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048
+    },
+    "partialScan": {
+      "type": "boolean",
+      "description": "True when bounded server-side filtering stopped before exhausting the broad mailbox scan. MCP-facing hasMore remains filtered-result pagination, not broad scan state."
+    },
+    "scanHasMore": {
+      "type": "boolean",
+      "description": "When partialScan is true, indicates the underlying broad mailbox scan has more rows."
+    },
+    "scanCursor": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 2048,
+      "description": "Underlying broad mailbox cursor for diagnostics or explicit follow-up scans when partialScan is true."
+    }
   }
 }

--- a/docs/spec/v3/schemas/soul-comm-mailbox-message-projection.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-mailbox-message-projection.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/soul-comm-mailbox-message-projection.schema.json",
+  "title": "Soul comm mailbox projected message metadata",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "messageRef": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Opaque stable body-facing mailbox reference. In v1 this is backed by deliveryId."
+    },
+    "deliveryId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Canonical host delivery identity; exposed for diagnostics."
+    },
+    "messageId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Legacy/idempotency/provider-adjacent metadata; not the primary mailbox reference."
+    },
+    "threadId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 128
+    },
+    "direction": {
+      "type": "string",
+      "enum": [
+        "inbound",
+        "outbound"
+      ]
+    },
+    "channelType": {
+      "type": "string",
+      "enum": [
+        "email",
+        "sms",
+        "voice"
+      ]
+    },
+    "provider": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "providerMessageId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 256
+    },
+    "status": {
+      "type": "string",
+      "enum": [
+        "accepted",
+        "sent",
+        "delivered",
+        "queued",
+        "failed",
+        "bounced",
+        "dropped"
+      ]
+    },
+    "from": {
+      "$ref": "#/definitions/party"
+    },
+    "to": {
+      "$ref": "#/definitions/party"
+    },
+    "subject": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "preview": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "content": {
+      "$ref": "#/definitions/content"
+    },
+    "state": {
+      "$ref": "#/definitions/state"
+    },
+    "createdAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "updatedAt": {
+      "type": "string",
+      "format": "date-time"
+    }
+  },
+  "definitions": {
+    "party": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "address": {
+          "type": "string",
+          "maxLength": 512
+        },
+        "number": {
+          "type": "string",
+          "maxLength": 32
+        },
+        "soulAgentId": {
+          "type": "string",
+          "pattern": "^0x[0-9a-fA-F]{64}$"
+        },
+        "displayName": {
+          "type": "string",
+          "maxLength": 256
+        }
+      }
+    },
+    "content": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available": {
+          "type": "boolean"
+        },
+        "bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "mimeType": {
+          "type": "string",
+          "maxLength": 128
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{64}$"
+        },
+        "contentHref": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 512
+        }
+      }
+    },
+    "state": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "read": {
+          "type": "boolean"
+        },
+        "archived": {
+          "type": "boolean"
+        },
+        "deleted": {
+          "type": "boolean"
+        }
+      }
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/equaltoai/lesser-host
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/andybalholm/brotli v1.2.0

--- a/internal/controlplane/handlers_soul_comm_mailbox.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox.go
@@ -540,7 +540,12 @@ func (f mailboxListFilters) hasPostQueryFilters() bool {
 		f.deleted != nil ||
 		f.includeArchived != nil ||
 		f.includeDeleted ||
-		f.query != ""
+		f.query != "" ||
+		f.excludesDeletedByDefault()
+}
+
+func (f mailboxListFilters) excludesDeletedByDefault() bool {
+	return f.deleted == nil && !f.includeDeleted
 }
 
 func (f mailboxListFilters) matches(item *models.SoulCommMailboxMessage) bool {

--- a/internal/controlplane/handlers_soul_comm_mailbox.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox.go
@@ -2,11 +2,13 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
+	ddbtypes "github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
@@ -19,6 +21,8 @@ import (
 
 const mailboxContentMaxBytes int64 = 1024 * 1024
 const mailboxListQueryMaxLength = 128
+const mailboxProjectedFieldsMaxCount = 32
+const mailboxFilteredScanMaxRows = 500
 
 type soulCommMailboxListResponse struct {
 	InstanceSlug string                   `json:"instanceSlug"`
@@ -27,6 +31,21 @@ type soulCommMailboxListResponse struct {
 	Count        int                      `json:"count"`
 	HasMore      bool                     `json:"hasMore"`
 	NextCursor   string                   `json:"nextCursor,omitempty"`
+	PartialScan  bool                     `json:"partialScan,omitempty"`
+	ScanHasMore  bool                     `json:"scanHasMore,omitempty"`
+	ScanCursor   string                   `json:"scanCursor,omitempty"`
+}
+
+type soulCommMailboxProjectedListResponse struct {
+	InstanceSlug string           `json:"instanceSlug"`
+	AgentID      string           `json:"agentId"`
+	Messages     []map[string]any `json:"messages"`
+	Count        int              `json:"count"`
+	HasMore      bool             `json:"hasMore"`
+	NextCursor   string           `json:"nextCursor,omitempty"`
+	PartialScan  bool             `json:"partialScan,omitempty"`
+	ScanHasMore  bool             `json:"scanHasMore,omitempty"`
+	ScanCursor   string           `json:"scanCursor,omitempty"`
 }
 
 type soulCommMailboxGetResponse struct {
@@ -104,6 +123,22 @@ type mailboxListFilters struct {
 	includeDeleted  bool
 	threadID        string
 	query           string
+	projection      mailboxFieldProjection
+}
+
+type mailboxFieldProjection struct {
+	fields     []string
+	fieldsSet  bool
+	includeRaw bool
+}
+
+type mailboxListResult struct {
+	items       []*models.SoulCommMailboxMessage
+	hasMore     bool
+	nextCursor  string
+	partialScan bool
+	scanHasMore bool
+	scanCursor  string
 }
 
 type mailboxStateAction struct {
@@ -122,20 +157,36 @@ func (s *Server) handleSoulCommMailboxList(ctx *apptheory.Context) (*apptheory.R
 	if appErr != nil {
 		return nil, appErr
 	}
-	items, hasMore, nextCursor, listErr := s.listMailboxMessages(ctx.Context(), reqCtx.key.InstanceSlug, reqCtx.agentID, filters)
+	result, listErr := s.listMailboxMessages(ctx.Context(), reqCtx.key.InstanceSlug, reqCtx.agentID, filters)
 	if listErr != nil {
 		return nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
 	}
 
-	messages := make([]soulCommMailboxMessage, 0, len(items))
-	for _, item := range items {
-		if item == nil || !filters.matches(item) {
-			continue
+	if filters.projection.enabled() {
+		messages := make([]map[string]any, 0, len(result.items))
+		for _, item := range result.items {
+			projected, err := projectMailboxMessage(mailboxMessageJSON(item), filters.projection)
+			if err != nil {
+				return nil, apptheory.NewAppTheoryError(commCodeInternal, "internal error").WithStatusCode(http.StatusInternalServerError)
+			}
+			messages = append(messages, projected)
 		}
+		return apptheory.JSON(http.StatusOK, soulCommMailboxProjectedListResponse{
+			InstanceSlug: strings.ToLower(strings.TrimSpace(reqCtx.key.InstanceSlug)),
+			AgentID:      reqCtx.agentID,
+			Messages:     messages,
+			Count:        len(messages),
+			HasMore:      result.hasMore,
+			NextCursor:   result.nextCursor,
+			PartialScan:  result.partialScan,
+			ScanHasMore:  result.scanHasMore,
+			ScanCursor:   result.scanCursor,
+		})
+	}
+
+	messages := make([]soulCommMailboxMessage, 0, len(result.items))
+	for _, item := range result.items {
 		messages = append(messages, mailboxMessageJSON(item))
-		if len(messages) >= filters.limit {
-			break
-		}
 	}
 
 	return apptheory.JSON(http.StatusOK, soulCommMailboxListResponse{
@@ -143,8 +194,11 @@ func (s *Server) handleSoulCommMailboxList(ctx *apptheory.Context) (*apptheory.R
 		AgentID:      reqCtx.agentID,
 		Messages:     messages,
 		Count:        len(messages),
-		HasMore:      hasMore,
-		NextCursor:   nextCursor,
+		HasMore:      result.hasMore,
+		NextCursor:   result.nextCursor,
+		PartialScan:  result.partialScan,
+		ScanHasMore:  result.scanHasMore,
+		ScanCursor:   result.scanCursor,
 	})
 }
 
@@ -328,6 +382,11 @@ func parseMailboxListFilters(ctx *apptheory.Context) (mailboxListFilters, *appth
 		query:          strings.ToLower(strings.TrimSpace(queryFirst(ctx, "query"))),
 		includeDeleted: queryBool(ctx, "includeDeleted"),
 	}
+	projection, appErr := parseMailboxFieldProjection(ctx)
+	if appErr != nil {
+		return mailboxListFilters{}, appErr
+	}
+	filters.projection = projection
 	if appErr := validateMailboxListFilters(filters); appErr != nil {
 		return mailboxListFilters{}, appErr
 	}
@@ -373,6 +432,63 @@ func validateMailboxListFilters(filters mailboxListFilters) *apptheory.AppTheory
 	return nil
 }
 
+func parseMailboxFieldProjection(ctx *apptheory.Context) (mailboxFieldProjection, *apptheory.AppTheoryError) {
+	projection := mailboxFieldProjection{
+		fieldsSet:  queryPresent(ctx, "fields"),
+		includeRaw: queryBool(ctx, "include_raw"),
+	}
+	raw := strings.TrimSpace(queryFirst(ctx, "fields"))
+	if raw == "" {
+		if projection.fieldsSet {
+			return mailboxFieldProjection{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "fields is required when present").WithStatusCode(http.StatusBadRequest)
+		}
+		return projection, nil
+	}
+
+	seen := map[string]struct{}{}
+	for _, part := range strings.Split(raw, ",") {
+		field := strings.TrimSpace(part)
+		if field == "" {
+			return mailboxFieldProjection{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "fields contains an empty field").WithStatusCode(http.StatusBadRequest)
+		}
+		if !mailboxProjectionFieldAllowed(field) {
+			return mailboxFieldProjection{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "fields contains an unsupported field").WithStatusCode(http.StatusBadRequest)
+		}
+		if field == "raw" && !projection.includeRaw {
+			continue
+		}
+		if _, ok := seen[field]; ok {
+			continue
+		}
+		seen[field] = struct{}{}
+		projection.fields = append(projection.fields, field)
+		if len(projection.fields) > mailboxProjectedFieldsMaxCount {
+			return mailboxFieldProjection{}, apptheory.NewAppTheoryError(commCodeInvalidRequest, "fields contains too many fields").WithStatusCode(http.StatusBadRequest)
+		}
+	}
+
+	return projection, nil
+}
+
+func mailboxProjectionFieldAllowed(field string) bool {
+	switch strings.TrimSpace(field) {
+	case "messageRef", "deliveryId", "messageId", "threadId", "direction", "channelType",
+		"provider", "providerMessageId", "status", "from", "to", "subject", "preview",
+		"content", "state", "createdAt", "updatedAt", "raw",
+		"from.address", "from.number", "from.soulAgentId", "from.displayName",
+		"to.address", "to.number", "to.soulAgentId", "to.displayName",
+		"content.available", "content.bytes", "content.mimeType", "content.sha256", "content.contentHref",
+		"state.read", "state.archived", "state.deleted":
+		return true
+	default:
+		return false
+	}
+}
+
+func (p mailboxFieldProjection) enabled() bool {
+	return p.fieldsSet
+}
+
 func validateMailboxListCursor(cursor string) *apptheory.AppTheoryError {
 	cursor = strings.TrimSpace(cursor)
 	if cursor == "" {
@@ -400,6 +516,20 @@ func (f mailboxListFilters) queryLimit() int {
 		return scanLimit
 	}
 	return f.limit
+}
+
+func (f mailboxListFilters) filteredScanBudget() int {
+	if !f.hasPostQueryFilters() {
+		return f.limit
+	}
+	budget := f.limit * 20
+	if budget < f.queryLimit() {
+		budget = f.queryLimit()
+	}
+	if budget > mailboxFilteredScanMaxRows {
+		budget = mailboxFilteredScanMaxRows
+	}
+	return budget
 }
 
 func (f mailboxListFilters) hasPostQueryFilters() bool {
@@ -487,9 +617,99 @@ func mailboxMetadataMatchesQuery(item *models.SoulCommMailboxMessage, query stri
 	return false
 }
 
-func (s *Server) listMailboxMessages(ctx context.Context, instanceSlug string, agentID string, filters mailboxListFilters) ([]*models.SoulCommMailboxMessage, bool, string, error) {
+func (s *Server) listMailboxMessages(ctx context.Context, instanceSlug string, agentID string, filters mailboxListFilters) (mailboxListResult, error) {
 	if s == nil || s.store == nil || s.store.DB == nil {
-		return nil, false, "", fmt.Errorf("store not configured")
+		return mailboxListResult{}, fmt.Errorf("store not configured")
+	}
+	if !filters.hasPostQueryFilters() {
+		items, paged, err := s.queryMailboxMessagesPage(ctx, instanceSlug, agentID, filters, strings.TrimSpace(filters.cursor), filters.limit)
+		if err != nil {
+			return mailboxListResult{}, err
+		}
+		result := mailboxListResult{items: items}
+		if paged != nil {
+			result.hasMore = paged.HasMore
+			result.nextCursor = strings.TrimSpace(paged.NextCursor)
+		}
+		return result, nil
+	}
+	return s.listFilteredMailboxMessages(ctx, instanceSlug, agentID, filters)
+}
+
+func (s *Server) listFilteredMailboxMessages(ctx context.Context, instanceSlug string, agentID string, filters mailboxListFilters) (mailboxListResult, error) {
+	out := make([]*models.SoulCommMailboxMessage, 0, filters.limit)
+	cursor := strings.TrimSpace(filters.cursor)
+	pageLimit := filters.queryLimit()
+	scanBudget := filters.filteredScanBudget()
+	scanned := 0
+	var lastReturned *models.SoulCommMailboxMessage
+
+	for {
+		remainingBudget := scanBudget - scanned
+		if remainingBudget <= 0 {
+			return mailboxListResult{items: out, partialScan: cursor != "", scanHasMore: cursor != "", scanCursor: cursor}, nil
+		}
+		limit := pageLimit
+		if remainingBudget < limit {
+			limit = remainingBudget
+		}
+		items, paged, err := s.queryMailboxMessagesPage(ctx, instanceSlug, agentID, filters, cursor, limit)
+		if err != nil {
+			return mailboxListResult{}, err
+		}
+		scanned += len(items)
+		nextCursor, err := consumeFilteredMailboxItems(&out, items, filters, &lastReturned)
+		if err != nil {
+			return mailboxListResult{}, err
+		}
+		if nextCursor != "" {
+			return mailboxListResult{items: out, hasMore: true, nextCursor: nextCursor}, nil
+		}
+		if mailboxPageExhausted(paged) {
+			return mailboxListResult{items: out}, nil
+		}
+		cursor = strings.TrimSpace(paged.NextCursor)
+		if scanned >= scanBudget {
+			return partialMailboxScanResult(out, cursor), nil
+		}
+	}
+}
+
+func consumeFilteredMailboxItems(out *[]*models.SoulCommMailboxMessage, items []*models.SoulCommMailboxMessage, filters mailboxListFilters, lastReturned **models.SoulCommMailboxMessage) (string, error) {
+	for _, item := range items {
+		if item == nil || !filters.matches(item) {
+			continue
+		}
+		if len(*out) < filters.limit {
+			*out = append(*out, item)
+			*lastReturned = item
+			continue
+		}
+		nextCursor := encodeMailboxListCursor(*lastReturned, filters)
+		if nextCursor == "" {
+			return "", fmt.Errorf("failed to encode mailbox cursor")
+		}
+		return nextCursor, nil
+	}
+	return "", nil
+}
+
+func mailboxPageExhausted(paged *core.PaginatedResult) bool {
+	return paged == nil || !paged.HasMore || strings.TrimSpace(paged.NextCursor) == ""
+}
+
+func partialMailboxScanResult(items []*models.SoulCommMailboxMessage, cursor string) mailboxListResult {
+	return mailboxListResult{
+		items:       items,
+		partialScan: true,
+		scanHasMore: true,
+		scanCursor:  strings.TrimSpace(cursor),
+	}
+}
+
+func (s *Server) queryMailboxMessagesPage(ctx context.Context, instanceSlug string, agentID string, filters mailboxListFilters, cursor string, limit int) ([]*models.SoulCommMailboxMessage, *core.PaginatedResult, error) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return nil, nil, fmt.Errorf("store not configured")
 	}
 	items := []*models.SoulCommMailboxMessage{}
 	qb := s.store.DB.WithContext(ctx).
@@ -502,18 +722,42 @@ func (s *Server) listMailboxMessages(ctx context.Context, instanceSlug string, a
 		qb = qb.Where("PK", "=", models.SoulCommMailboxAgentPK(instanceSlug, agentID)).
 			OrderBy("SK", "DESC")
 	}
-	qb = qb.Limit(filters.queryLimit())
-	if strings.TrimSpace(filters.cursor) != "" {
-		qb = qb.Cursor(strings.TrimSpace(filters.cursor))
+	qb = qb.Limit(limit)
+	if strings.TrimSpace(cursor) != "" {
+		qb = qb.Cursor(strings.TrimSpace(cursor))
 	}
 	paged, err := qb.AllPaginated(&items)
 	if err != nil {
-		return nil, false, "", err
+		return nil, nil, err
 	}
-	if paged == nil {
-		return items, false, "", nil
+	return items, paged, nil
+}
+
+func encodeMailboxListCursor(item *models.SoulCommMailboxMessage, filters mailboxListFilters) string {
+	if item == nil {
+		return ""
 	}
-	return items, paged.HasMore, strings.TrimSpace(paged.NextCursor), nil
+	lastKey := map[string]ddbtypes.AttributeValue{
+		"PK": &ddbtypes.AttributeValueMemberS{Value: strings.TrimSpace(item.PK)},
+		"SK": &ddbtypes.AttributeValueMemberS{Value: strings.TrimSpace(item.SK)},
+	}
+	indexName := ""
+	if strings.TrimSpace(filters.threadID) != "" {
+		lastKey["gsi2PK"] = &ddbtypes.AttributeValueMemberS{Value: strings.TrimSpace(item.GSI2PK)}
+		lastKey["gsi2SK"] = &ddbtypes.AttributeValueMemberS{Value: strings.TrimSpace(item.GSI2SK)}
+		indexName = "gsi2"
+	}
+	for key, value := range lastKey {
+		member, ok := value.(*ddbtypes.AttributeValueMemberS)
+		if !ok || strings.TrimSpace(member.Value) == "" {
+			delete(lastKey, key)
+		}
+	}
+	cursor, err := theoryquery.EncodeCursor(lastKey, indexName, "DESC")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(cursor)
 }
 
 func (s *Server) loadMailboxMessage(ctx context.Context, instanceSlug string, agentID string, deliveryID string) (*models.SoulCommMailboxMessage, *apptheory.AppTheoryError) {
@@ -670,6 +914,68 @@ func mailboxMessageJSON(item *models.SoulCommMailboxMessage) soulCommMailboxMess
 		CreatedAt: formatMailboxTime(item.CreatedAt),
 		UpdatedAt: formatMailboxTime(item.UpdatedAt),
 	}
+}
+
+func projectMailboxMessage(message soulCommMailboxMessage, projection mailboxFieldProjection) (map[string]any, error) {
+	source, err := mailboxMessageMap(message)
+	if err != nil {
+		return nil, err
+	}
+	if !projection.includeRaw {
+		delete(source, "raw")
+	}
+	if !projection.enabled() {
+		return source, nil
+	}
+	out := make(map[string]any, len(projection.fields))
+	for _, field := range projection.fields {
+		copyMailboxProjectionField(source, out, strings.Split(field, "."))
+	}
+	if !projection.includeRaw {
+		delete(out, "raw")
+	}
+	return out, nil
+}
+
+func mailboxMessageMap(message soulCommMailboxMessage) (map[string]any, error) {
+	data, err := json.Marshal(message)
+	if err != nil {
+		return nil, err
+	}
+	out := map[string]any{}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func copyMailboxProjectionField(source map[string]any, dest map[string]any, path []string) {
+	if len(path) == 0 {
+		return
+	}
+	value, ok := source[path[0]]
+	if !ok {
+		return
+	}
+	if len(path) == 1 {
+		dest[path[0]] = value
+		return
+	}
+	sourceChild, ok := value.(map[string]any)
+	if !ok {
+		return
+	}
+	if existingValue, exists := dest[path[0]]; exists {
+		if _, wholeObjectSelected := existingValue.(map[string]any); !wholeObjectSelected {
+			return
+		}
+	}
+	destChild, ok := dest[path[0]].(map[string]any)
+	if !ok {
+		destChild = map[string]any{}
+		dest[path[0]] = destChild
+	}
+	copyMailboxProjectionField(sourceChild, destChild, path[1:])
 }
 
 func mailboxContentPointer(item *models.SoulCommMailboxMessage) commmailbox.ContentPointer {

--- a/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
@@ -129,6 +129,112 @@ func TestHandleSoulCommMailboxListAppliesBodyFilters(t *testing.T) {
 	require.Equal(t, match.DeliveryID, out.Messages[0].DeliveryID)
 }
 
+func TestHandleSoulCommMailboxListProjectsRequestedFields(t *testing.T) {
+	t.Parallel()
+
+	fixture := newMailboxAPITestDB()
+	expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		messages := make([]*models.SoulCommMailboxMessage, 0, 5)
+		for i := 0; i < 5; i++ {
+			msg := mailboxAPITestMessage(soulLifecycleTestAgentIDHex)
+			msg.DeliveryID = msg.DeliveryID + "-" + string(rune('a'+i))
+			msg.Subject = "Subject " + string(rune('a'+i))
+			msg.Preview = "Preview " + string(rune('a'+i))
+			messages = append(messages, msg)
+		}
+		*dest = messages
+	}).Once()
+
+	resp, err := newMailboxAPITestServer(fixture).handleSoulCommMailboxList(newMailboxAPIContext(soulLifecycleTestAgentIDHex, "", map[string][]string{
+		"limit":       {"5"},
+		"fields":      {"messageRef,subject,preview,createdAt,state,content.available"},
+		"include_raw": {"false"},
+	}))
+	require.NoError(t, err)
+	require.Less(t, len(resp.Body), 3000, "projected five-message mailbox response should stay MCP-compact")
+
+	var out soulCommMailboxProjectedListResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Equal(t, 5, out.Count)
+	require.Len(t, out.Messages, 5)
+	for _, msg := range out.Messages {
+		require.ElementsMatch(t, []string{"messageRef", "subject", "preview", "createdAt", "state", "content"}, mapKeys(msg))
+		require.NotContains(t, msg, "raw")
+		require.NotContains(t, msg, "deliveryId")
+		require.NotContains(t, msg, "from")
+		content, ok := msg["content"].(map[string]any)
+		require.True(t, ok)
+		require.ElementsMatch(t, []string{"available"}, mapKeys(content))
+		state, ok := msg["state"].(map[string]any)
+		require.True(t, ok)
+		require.ElementsMatch(t, []string{"read", "archived", "deleted"}, mapKeys(state))
+	}
+}
+
+func TestHandleSoulCommMailboxListSparseFilteredPaginationDoesNotExposeBroadHasMore(t *testing.T) {
+	t.Parallel()
+
+	fixture := newMailboxAPITestDB()
+	expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{HasMore: true, NextCursor: "broad-2"}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		*dest = []*models.SoulCommMailboxMessage{
+			mailboxAPITestMessage(soulLifecycleTestAgentIDHex),
+			mailboxAPITestMessage(soulLifecycleTestAgentIDHex),
+		}
+	}).Once()
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		*dest = []*models.SoulCommMailboxMessage{mailboxAPITestMessage(soulLifecycleTestAgentIDHex)}
+	}).Once()
+
+	resp, err := newMailboxAPITestServer(fixture).handleSoulCommMailboxList(newMailboxAPIContext(soulLifecycleTestAgentIDHex, "", map[string][]string{
+		"limit":       {"5"},
+		"channelType": {"sms"},
+	}))
+	require.NoError(t, err)
+	var out soulCommMailboxListResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Equal(t, 0, out.Count)
+	require.Empty(t, out.Messages)
+	require.False(t, out.HasMore, "filtered hasMore must not mirror broad mailbox pagination when no matching SMS rows exist")
+	require.Empty(t, out.NextCursor)
+	require.False(t, out.PartialScan)
+	require.False(t, out.ScanHasMore)
+	require.Empty(t, out.ScanCursor)
+}
+
+func TestHandleSoulCommMailboxListPartialFilteredScanExposesScanMetadata(t *testing.T) {
+	t.Parallel()
+
+	fixture := newMailboxAPITestDB()
+	expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{HasMore: true, NextCursor: "broad-2"}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		messages := make([]*models.SoulCommMailboxMessage, 0, 25)
+		for i := 0; i < 25; i++ {
+			messages = append(messages, mailboxAPITestMessage(soulLifecycleTestAgentIDHex))
+		}
+		*dest = messages
+	}).Once()
+
+	resp, err := newMailboxAPITestServer(fixture).handleSoulCommMailboxList(newMailboxAPIContext(soulLifecycleTestAgentIDHex, "", map[string][]string{
+		"limit":       {"1"},
+		"channelType": {"voice"},
+	}))
+	require.NoError(t, err)
+	var out soulCommMailboxListResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &out))
+	require.Equal(t, 0, out.Count)
+	require.False(t, out.HasMore, "filtered hasMore must not claim matching voice rows when only the broad scan has more")
+	require.Empty(t, out.NextCursor)
+	require.True(t, out.PartialScan)
+	require.True(t, out.ScanHasMore)
+	require.Equal(t, "broad-2", out.ScanCursor)
+}
+
 func TestHandleSoulCommMailboxListRejectsInvalidFilters(t *testing.T) {
 	t.Parallel()
 
@@ -142,6 +248,9 @@ func TestHandleSoulCommMailboxListRejectsInvalidFilters(t *testing.T) {
 		},
 		"long query": {
 			"query": {strings.Repeat("a", mailboxListQueryMaxLength+1)},
+		},
+		"bad projection": {
+			"fields": {"messageRef,unknown"},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -658,6 +767,14 @@ func mailboxAPITestMessage(agentID string) *models.SoulCommMailboxMessage {
 		CreatedAt:       now,
 		UpdatedAt:       now,
 	}
+}
+
+func mapKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func TestHandleSoulCommMailboxStateMutationsAreIdempotent(t *testing.T) {

--- a/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
@@ -51,7 +51,7 @@ func TestHandleSoulCommMailboxListRedactsContent(t *testing.T) {
 
 	fixture := newMailboxAPITestDB()
 	expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
-	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{HasMore: true, NextCursor: "cursor-2"}, nil).Run(func(args mock.Arguments) {
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
 		*dest = []*models.SoulCommMailboxMessage{mailboxAPITestMessage(soulLifecycleTestAgentIDHex)}
 	}).Once()
@@ -72,7 +72,7 @@ func TestHandleSoulCommMailboxListRedactsContent(t *testing.T) {
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Count != 1 || !out.HasMore || out.NextCursor != "cursor-2" {
+	if out.Count != 1 || out.HasMore || out.NextCursor != "" {
 		t.Fatalf("unexpected page metadata: %#v", out)
 	}
 	if out.Messages[0].Preview != "redacted preview" || out.Messages[0].Content.ContentHref == "" {
@@ -170,6 +170,69 @@ func TestHandleSoulCommMailboxListProjectsRequestedFields(t *testing.T) {
 		state, ok := msg["state"].(map[string]any)
 		require.True(t, ok)
 		require.ElementsMatch(t, []string{"read", "archived", "deleted"}, mapKeys(state))
+	}
+}
+
+func TestHandleSoulCommMailboxListOmitsDeletedRowsByDefault(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		query     map[string][]string
+		projected bool
+	}{
+		{
+			name: "legacy metadata response",
+			query: map[string][]string{
+				"limit": {"10"},
+			},
+		},
+		{
+			name: "projected response",
+			query: map[string][]string{
+				"limit":  {"10"},
+				"fields": {"messageRef,subject,state"},
+			},
+			projected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fixture := newMailboxAPITestDB()
+			expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
+			visible := mailboxAPITestMessage(soulLifecycleTestAgentIDHex)
+			visible.DeliveryID = "comm-delivery-visible"
+			visible.Subject = "Visible subject"
+			deleted := mailboxAPITestMessage(soulLifecycleTestAgentIDHex)
+			deleted.DeliveryID = "comm-delivery-deleted"
+			deleted.Subject = "Deleted subject"
+			deleted.Deleted = true
+			deleted.Archived = true
+			fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(func(args mock.Arguments) {
+				dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+				*dest = []*models.SoulCommMailboxMessage{visible, deleted}
+			}).Once()
+
+			resp, err := newMailboxAPITestServer(fixture).handleSoulCommMailboxList(newMailboxAPIContext(soulLifecycleTestAgentIDHex, "", tc.query))
+			require.NoError(t, err)
+			require.NotContains(t, string(resp.Body), "Deleted subject")
+
+			if tc.projected {
+				var out soulCommMailboxProjectedListResponse
+				require.NoError(t, json.Unmarshal(resp.Body, &out))
+				require.Equal(t, 1, out.Count)
+				require.Len(t, out.Messages, 1)
+				require.Equal(t, "comm-delivery-visible", out.Messages[0]["messageRef"])
+				return
+			}
+
+			var out soulCommMailboxListResponse
+			require.NoError(t, json.Unmarshal(resp.Body, &out))
+			require.Equal(t, 1, out.Count)
+			require.Len(t, out.Messages, 1)
+			require.Equal(t, "comm-delivery-visible", out.Messages[0].DeliveryID)
+		})
 	}
 }
 

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -530,6 +530,11 @@ export interface paths {
          * @description Returns bounded metadata and previews only. Full message content is fetched explicitly from the content endpoint.
          *     Filters are evaluated within the authenticated instance + exact agent mailbox. `query` is bounded metadata/preview
          *     matching only; it is not full-body search and never scans across tenants or agents.
+         *
+         *     `fields` may be used by MCP clients to request compact projected message objects. `hasMore` and `nextCursor`
+         *     describe the filtered result set. If bounded server-side filtering stops before exhausting broad mailbox rows,
+         *     `partialScan`, `scanHasMore`, and `scanCursor` expose that broad scan state separately so MCP callers do not treat
+         *     broad mailbox pagination as matching SMS/voice pagination.
          */
         get: operations["soulCommMailboxList"];
         put?: never;
@@ -1473,6 +1478,61 @@ export interface components {
             soulAgentId?: string;
             displayName?: string;
         };
+        content: {
+            available?: boolean;
+            bytes?: number;
+            mimeType?: string;
+            sha256?: string;
+            contentHref?: string;
+        };
+        state: {
+            read?: boolean;
+            archived?: boolean;
+            deleted?: boolean;
+        };
+        /** Soul comm mailbox projected message metadata */
+        "soul-comm-mailbox-message-projection.schema": {
+            /** @description Opaque stable body-facing mailbox reference. In v1 this is backed by deliveryId. */
+            messageRef?: string;
+            /** @description Canonical host delivery identity; exposed for diagnostics. */
+            deliveryId?: string;
+            /** @description Legacy/idempotency/provider-adjacent metadata; not the primary mailbox reference. */
+            messageId?: string;
+            threadId?: string;
+            /** @enum {string} */
+            direction?: "inbound" | "outbound";
+            /** @enum {string} */
+            channelType?: "email" | "sms" | "voice";
+            provider?: string;
+            providerMessageId?: string;
+            /** @enum {string} */
+            status?: "accepted" | "sent" | "delivered" | "queued" | "failed" | "bounced" | "dropped";
+            from?: components["schemas"]["party"];
+            to?: components["schemas"]["party"];
+            subject?: string;
+            preview?: string;
+            content?: components["schemas"]["content"];
+            state?: components["schemas"]["state"];
+            /** Format: date-time */
+            createdAt?: string;
+            /** Format: date-time */
+            updatedAt?: string;
+        };
+        /** GET /api/v1/soul/comm/mailbox/{agentId}/messages response */
+        "soul-comm-mailbox-list.response.schema": {
+            instanceSlug: string;
+            agentId: string;
+            messages: components["schemas"]["soul-comm-mailbox-message-projection.schema"][];
+            count: number;
+            hasMore: boolean;
+            nextCursor?: string;
+            /** @description True when bounded server-side filtering stopped before exhausting the broad mailbox scan. MCP-facing hasMore remains filtered-result pagination, not broad scan state. */
+            partialScan?: boolean;
+            /** @description When partialScan is true, indicates the underlying broad mailbox scan has more rows. */
+            scanHasMore?: boolean;
+            /** @description Underlying broad mailbox cursor for diagnostics or explicit follow-up scans when partialScan is true. */
+            scanCursor?: string;
+        };
         /** Soul comm mailbox redacted message metadata */
         "soul-comm-mailbox-message.schema": {
             /** @description Opaque stable body-facing mailbox reference. In v1 this is backed by deliveryId. */
@@ -1510,15 +1570,6 @@ export interface components {
             createdAt: string;
             /** Format: date-time */
             updatedAt?: string;
-        };
-        /** GET /api/v1/soul/comm/mailbox/{agentId}/messages response */
-        "soul-comm-mailbox-list.response.schema": {
-            instanceSlug: string;
-            agentId: string;
-            messages: components["schemas"]["soul-comm-mailbox-message.schema"][];
-            count: number;
-            hasMore: boolean;
-            nextCursor?: string;
         };
         /** GET /api/v1/soul/comm/mailbox/{agentId}/messages/{deliveryId} response */
         "soul-comm-mailbox-get.response.schema": {
@@ -3517,6 +3568,19 @@ export interface operations {
                 threadId?: string;
                 /** @description Bounded metadata/preview match within the authenticated instance + exact agent mailbox. */
                 query?: string;
+                /**
+                 * @description Comma-separated projection list for compact MCP responses. Supported fields are
+                 *     `messageRef`, `deliveryId`, `messageId`, `threadId`, `direction`, `channelType`, `provider`,
+                 *     `providerMessageId`, `status`, `from`, `to`, `subject`, `preview`, `content`, `state`, `createdAt`,
+                 *     `updatedAt`, and nested fields such as `content.available`, `state.read`, `from.address`, and `to.number`.
+                 *     When omitted, the legacy full metadata object is returned.
+                 */
+                fields?: string;
+                /**
+                 * @description Defaults to false. Host mailbox list responses do not expose raw upstream provider payloads; when false,
+                 *     any future raw diagnostic payload is omitted unless explicitly requested and available.
+                 */
+                include_raw?: boolean;
             };
             header?: never;
             path: {


### PR DESCRIPTION
## Milestone
MCP Soul + Skills M0 — compact mailbox responses and filtered pagination

Closes #259
Closes #260

## Classification
operational-reliability / API-contract / MCP payload-size / test-coverage / security-toolchain-maintenance

## Surfaces affected
- `GET /api/v1/soul/comm/mailbox/{agentId}/messages`
- Soul comm mailbox OpenAPI + v3 JSON schemas
- Generated web REST adapter
- Body-facing mailbox migration/release-contract docs
- Root and CDK Go runtime pins

## Specialist walks referenced
- Governance rubric: runtime pin updated to restore SEC-2 govulncheck pass without weakening verifier requirements.
- Provisioning / managed-update / release verification: none.
- Soul registry: none; this is soul comm mailbox, not on-chain registry state.
- Trust API / CSP / instance-auth: strict mailbox instance-key auth unchanged.
- Framework: idiomatic AppTheory/TableTheory use; no framework patch.

## Multi-tenant isolation impact
Preserved. Mailbox queries remain scoped to authenticated instance + exact agent; no cross-tenant reads or broad global mailbox scans.

## On-chain impact
None.

## Consumer impact
- `lesser-body` MCP mailbox tools can request compact `fields` projections.
- Filtered SMS/voice reads no longer treat broad mailbox pagination as matching-result pagination.
- If bounded filtering stops early, broad scan state is exposed separately as `partialScan` / `scanHasMore` / `scanCursor`.

## Tasks
- [x] #259 — add mailbox fields projection for compact MCP responses
- [x] #260 — fix filtered mailbox pagination semantics for SMS and voicemail
- [x] Security/toolchain precondition — pin Go runtime to 1.26.3 so SEC-2 scans patched stdlib

## Validation
- [x] `gofmt -l $(git ls-files '*.go')` empty
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `cd web && npm run verify:lesser-host-contracts`
- [x] `cd cdk && npm run build && npx cdk synth --context stage=lab`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29 / FAIL 0 / BLOCKED 0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete with lesser-body MCP mailbox canary reads
- [ ] Deployed to live
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
Required with `lesser-body` for MCP tool use of `fields` projection and filtered pagination interpretation.

## Advisor-brief authorization (if applicable)
Not applicable.
