### PR TITLE
[codex] Clarify comm send/reply boundary contract

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -2559,6 +2559,15 @@ paths:
     post:
       operationId: soulCommSend
       summary: Send an outbound comm message
+      description: |
+        Sends a new outbound comm through host. Host always generates the outgoing `messageId`, `messageRef`, and
+        `deliveryId`; callers must not use this endpoint to supply outbound message identity.
+
+        `inReplyTo`, when present, is a reply/conversation boundary reference rather than an identity override. Host
+        checks it against prior host/provider conversation state for every recipient and fails closed with HTTP 403
+        `comm.boundary_violation` plus `error.details.field=inReplyTo` when the reference is invalid. Canonical mailbox
+        replies should use `POST /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/reply`, which derives
+        recipient, thread, and provider reply headers from host's mailbox state.
       security:
         - instanceKeyAuth: []
       requestBody:
@@ -2582,6 +2591,12 @@ paths:
                 $ref: "#/components/schemas/SoulCommSendErrorEnvelope"
         "401":
           description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulCommSendErrorEnvelope"
+        "403":
+          description: Boundary or preference violation
           content:
             application/json:
               schema:

--- a/docs/lesser-body-release-contract.md
+++ b/docs/lesser-body-release-contract.md
@@ -124,6 +124,12 @@ instance-authenticated mailbox contract:
 - read/unread/archive/delete tools mutate host's canonical mailbox state
 - reply tools call host's canonical mailbox reply endpoint so body does not reconstruct provider reply headers, thread
   roots, or recipients locally
+- send tools must treat host-generated message identity as response-only. Host `POST /api/v1/soul/comm/send` does not
+  accept caller-supplied outgoing `messageId`; its optional `inReplyTo` is a reply/conversation boundary reference that
+  must match prior host/provider state for every recipient. Invalid refs fail closed as HTTP 403
+  `comm.boundary_violation` with `error.details.field=inReplyTo`. Body should remove, rename, or prevalidate any
+  `email_send.messageId`-style argument rather than forwarding it as Host `inReplyTo`; mailbox replies should use
+  `email_reply` / Host's mailbox reply endpoint.
 - mailbox list filters and bounded `query` are exact-agent host-side filters only; body must not implement global mailbox
   search or store durable query indexes
 - mailbox list tools should use host-side `fields` projection (for example

--- a/docs/soul-comm-mailbox-migration.md
+++ b/docs/soul-comm-mailbox-migration.md
@@ -60,6 +60,15 @@ The intent is to keep authority in one place:
 
 - `POST /api/v1/soul/comm/send` and `GET /api/v1/soul/comm/status/{messageId}` remain available for existing outbound
   send/status callers.
+- `POST /api/v1/soul/comm/send` is not an outgoing-message-identity API. Host always generates the outbound
+  `messageId`, `messageRef`, and `deliveryId` returned in the response. Its optional `inReplyTo` request field is a
+  reply/conversation boundary reference for legacy callers only: if present, it must match prior host/provider
+  conversation state for every recipient. Arbitrary caller-supplied refs fail closed with HTTP 403
+  `comm.boundary_violation` and structured details naming `field: "inReplyTo"`.
+- New mailbox replies should use `POST /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/reply`; host derives
+  the recipient, thread, and provider reply headers from canonical mailbox state. Body should not map an MCP
+  `email_send.messageId` argument into Host `inReplyTo`; reply-oriented MCP flows should call the mailbox reply
+  endpoint instead.
 - Body-facing mailbox responses return `messageRef` as the canonical opaque reference. In v1 `messageRef` is backed by
   `deliveryId`; `deliveryId` remains exposed for diagnostics. `messageId` remains legacy/idempotency/provider metadata,
   not the primary public body reference.

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -125,6 +125,10 @@ ADR 0005 defines the bounded mailbox authority decision for soul communications.
   content, content identity, and read/unread/archive/delete state.
 - Body-facing APIs use `messageRef` as the canonical opaque mailbox reference, backed by `deliveryId` in v1. Legacy
   `messageId` values are accepted only when unambiguous within the authenticated instance + exact agent mailbox.
+- Outbound `POST /api/v1/soul/comm/send` never accepts caller-supplied outgoing message identity. Host generates
+  `messageId`/`messageRef`/`deliveryId`; the request `inReplyTo` field is only a reply/conversation boundary reference
+  and fails closed with `comm.boundary_violation` when it does not match prior conversation state for every recipient.
+  Canonical replies should use the mailbox reply endpoint so host derives recipient/thread/provider context.
 - `lesser` receives notification summaries/projections for UX/activity only; it is not authoritative mailbox state.
 - `lesser-body` remains the MCP facade and exposes tools over host's API contract. It must not persist mailbox truth.
 - List endpoints must return redacted previews/metadata only. Full content requires an explicit content/read call and

--- a/docs/spec/v3/fixtures/soul-comm-send.error.boundary-violation.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.error.boundary-violation.example.json
@@ -1,0 +1,13 @@
+{
+  "error": {
+    "code": "comm.boundary_violation",
+    "message": "inReplyTo does not match a prior conversation with every recipient",
+    "status_code": 403,
+    "details": {
+      "boundary": "conversation",
+      "field": "inReplyTo",
+      "reason": "no_prior_conversation"
+    },
+    "request_id": "req_123"
+  }
+}

--- a/docs/spec/v3/fixtures/soul-comm-send.request.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.request.example.json
@@ -2,8 +2,7 @@
   "channel": "email",
   "agentId": "0x2222222222222222222222222222222222222222222222222222222222222222",
   "to": "alice@example.com",
-  "subject": "Re: Project collaboration",
-  "body": "Hi Alice,\\n\\nYes — happy to collaborate.\\n",
-  "inReplyTo": "comm-msg-001",
+  "subject": "Project collaboration",
+  "body": "Hi Alice,\\n\\nStarting a new thread about the collaboration.\\n",
   "idempotencyKey": "mcp-email-send-6a4b7a70-0c4d-4b1d-8e18-7b6f55f3f3e5"
 }

--- a/docs/spec/v3/fixtures/soul-comm-send.request.reply-boundary.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.request.reply-boundary.example.json
@@ -1,0 +1,9 @@
+{
+  "channel": "email",
+  "agentId": "0x2222222222222222222222222222222222222222222222222222222222222222",
+  "to": "alice@example.com",
+  "subject": "Re: Project collaboration",
+  "body": "Hi Alice,\\n\\nYes — happy to collaborate.\\n",
+  "inReplyTo": "comm-msg-001",
+  "idempotencyKey": "mcp-email-reply-boundary-6a4b7a70-0c4d-4b1d-8e18-7b6f55f3f3e5"
+}

--- a/docs/spec/v3/schemas/soul-comm-send.error.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.error.schema.json
@@ -21,13 +21,26 @@
             "comm.channel_unverified",
             "comm.rate_limited",
             "comm.preference_violation",
+            "comm.boundary_violation",
             "comm.insufficient_credits",
             "comm.provider_unavailable",
             "comm.provider_rejected",
+            "comm.idempotency_conflict",
             "comm.internal"
           ]
         },
         "message": { "type": "string", "minLength": 1, "maxLength": 2048 },
+        "status_code": { "type": "integer", "minimum": 400, "maximum": 599 },
+        "details": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Optional structured, client-safe metadata. For comm.boundary_violation caused by an invalid reply/conversation reference, Host returns field=inReplyTo, boundary=conversation, and a reason such as no_prior_conversation.",
+          "properties": {
+            "boundary": { "type": "string", "enum": ["conversation"] },
+            "field": { "type": "string", "enum": ["inReplyTo", "to"] },
+            "reason": { "type": "string", "enum": ["no_prior_conversation", "missing_recipient", "reply_boundary_violation"] }
+          }
+        },
         "request_id": { "type": "string", "minLength": 1, "maxLength": 128 }
       }
     }

--- a/docs/spec/v3/schemas/soul-comm-send.request.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.request.schema.json
@@ -2,6 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://lesser.host/spec/v3/schemas/soul-comm-send.request.schema.json",
   "title": "POST /api/v1/soul/comm/send request",
+  "description": "Sends a new outbound comm. Host always generates the outgoing messageId/messageRef; callers must not supply outgoing message identity. The optional inReplyTo field is only a reply/conversation boundary reference for legacy send callers and must match prior host/provider conversation state for every recipient. Canonical mailbox replies should use POST /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/reply instead.",
   "type": "object",
   "additionalProperties": false,
   "required": ["channel", "agentId", "to", "body"],
@@ -20,7 +21,12 @@
     "replyTo": { "type": "string", "format": "email" },
     "subject": { "type": "string", "minLength": 1, "maxLength": 998 },
     "body": { "type": "string", "minLength": 1 },
-    "inReplyTo": { "type": ["string", "null"], "minLength": 1, "maxLength": 128 },
+    "inReplyTo": {
+      "type": ["string", "null"],
+      "minLength": 1,
+      "maxLength": 128,
+      "description": "Optional reply/conversation boundary reference, not an outgoing message identity. If present, it must match a prior conversation with every recipient; invalid refs fail closed with 403 comm.boundary_violation and error.details.field=inReplyTo. Prefer the canonical mailbox reply endpoint for replies."
+    },
     "idempotencyKey": { "type": "string", "minLength": 1, "maxLength": 256 }
   },
   "allOf": [

--- a/docs/spec/v3/schemas/soul-comm-send.response.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.response.schema.json
@@ -19,7 +19,8 @@
     "messageId": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "description": "Host-generated outbound send/status identifier. Callers cannot supply this value on POST /api/v1/soul/comm/send."
     },
     "status": {
       "type": "string",
@@ -69,7 +70,8 @@
     "deliveryId": {
       "type": "string",
       "minLength": 1,
-      "maxLength": 128
+      "maxLength": 128,
+      "description": "Host-generated canonical mailbox delivery identifier; v1 also backs messageRef."
     },
     "threadId": {
       "type": "string",

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -55,6 +55,15 @@ const (
 	commCodePreferenceViolation = "comm.preference_violation"
 	commCodeBoundaryViolation   = "comm.boundary_violation"
 	commCodeIdempotencyConflict = "comm.idempotency_conflict"
+
+	commReplyBoundaryDetailBoundary = "boundary"
+	commReplyBoundaryDetailField    = "field"
+	commReplyBoundaryDetailReason   = "reason"
+	commReplyBoundaryFieldInReplyTo = "inReplyTo"
+	commReplyBoundaryConversation   = "conversation"
+
+	commReplyBoundaryReasonDefault             = "reply_boundary_violation"
+	commReplyBoundaryReasonNoPriorConversation = "no_prior_conversation"
 )
 
 type soulCommSendRequest struct {
@@ -593,7 +602,7 @@ func (s *Server) enforceSoulCommReplyBoundary(ctx *apptheory.Context, req valida
 	}
 	for _, recipient := range recipients {
 		if !soulCommReplyBoundaryMatchesRecipient(activities, req.channel, recipient, req.inReplyTo) {
-			return s.denySoulCommReplyBoundary(ctx, req, recipient, now, metrics, "inReplyTo", "no_prior_conversation", "inReplyTo does not match a prior conversation with every recipient")
+			return s.denySoulCommReplyBoundary(ctx, req, recipient, now, metrics, commReplyBoundaryFieldInReplyTo, commReplyBoundaryReasonNoPriorConversation, "inReplyTo does not match a prior conversation with every recipient")
 		}
 	}
 	return nil
@@ -751,25 +760,25 @@ func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedS
 func (s *Server) denySoulCommReplyBoundary(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, field string, reason string, message string) *apptheory.AppTheoryError {
 	metrics.status = commMetricBoundaryViolation
 	appErr := s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckViolated, commCodeBoundaryViolation, message)
-	if appErr != nil {
-		appErr.WithDetails(soulCommReplyBoundaryErrorDetails(field, reason))
+	if appErr == nil {
+		return nil
 	}
-	return appErr
+	return appErr.WithDetails(soulCommReplyBoundaryErrorDetails(field, reason))
 }
 
 func soulCommReplyBoundaryErrorDetails(field string, reason string) map[string]any {
 	field = strings.TrimSpace(field)
 	if field == "" {
-		field = "inReplyTo"
+		field = commReplyBoundaryFieldInReplyTo
 	}
 	reason = strings.TrimSpace(reason)
 	if reason == "" {
-		reason = "reply_boundary_violation"
+		reason = commReplyBoundaryReasonDefault
 	}
 	return map[string]any{
-		"boundary": "conversation",
-		"field":    field,
-		"reason":   reason,
+		commReplyBoundaryDetailBoundary: commReplyBoundaryConversation,
+		commReplyBoundaryDetailField:    field,
+		commReplyBoundaryDetailReason:   reason,
 	}
 }
 

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -584,7 +584,7 @@ func (s *Server) enforceSoulCommReplyBoundary(ctx *apptheory.Context, req valida
 	}
 	recipients := soulCommBoundaryRecipients(req)
 	if len(recipients) == 0 {
-		return s.denySoulCommReplyBoundary(ctx, req, req.to, now, metrics, "reply boundary requires a recipient")
+		return s.denySoulCommReplyBoundary(ctx, req, req.to, now, metrics, "to", "missing_recipient", "reply boundary requires a recipient")
 	}
 	activities, err := s.listSoulCommReplyBoundaryActivities(ctx.Context(), req.agentIDHex, req.channel, 500)
 	if err != nil {
@@ -593,7 +593,7 @@ func (s *Server) enforceSoulCommReplyBoundary(ctx *apptheory.Context, req valida
 	}
 	for _, recipient := range recipients {
 		if !soulCommReplyBoundaryMatchesRecipient(activities, req.channel, recipient, req.inReplyTo) {
-			return s.denySoulCommReplyBoundary(ctx, req, recipient, now, metrics, "inReplyTo does not match a prior conversation with every recipient")
+			return s.denySoulCommReplyBoundary(ctx, req, recipient, now, metrics, "inReplyTo", "no_prior_conversation", "inReplyTo does not match a prior conversation with every recipient")
 		}
 	}
 	return nil
@@ -748,9 +748,29 @@ func (s *Server) denySoulCommFirstContact(ctx *apptheory.Context, req validatedS
 	return s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckSkipped, commCodePreferenceViolation, message)
 }
 
-func (s *Server) denySoulCommReplyBoundary(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, message string) *apptheory.AppTheoryError {
+func (s *Server) denySoulCommReplyBoundary(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, field string, reason string, message string) *apptheory.AppTheoryError {
 	metrics.status = commMetricBoundaryViolation
-	return s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckViolated, commCodeBoundaryViolation, message)
+	appErr := s.recordSoulCommGuardViolation(ctx, req, recipient, now, metrics, models.SoulCommBoundaryCheckViolated, commCodeBoundaryViolation, message)
+	if appErr != nil {
+		appErr.WithDetails(soulCommReplyBoundaryErrorDetails(field, reason))
+	}
+	return appErr
+}
+
+func soulCommReplyBoundaryErrorDetails(field string, reason string) map[string]any {
+	field = strings.TrimSpace(field)
+	if field == "" {
+		field = "inReplyTo"
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "reply_boundary_violation"
+	}
+	return map[string]any{
+		"boundary": "conversation",
+		"field":    field,
+		"reason":   reason,
+	}
 }
 
 func (s *Server) recordSoulCommGuardViolation(ctx *apptheory.Context, req validatedSoulCommSendRequest, recipient string, now time.Time, metrics *soulCommSendMetrics, boundaryCheck string, code string, message string) *apptheory.AppTheoryError {

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -1103,6 +1103,9 @@ func TestEnforceSoulCommSendGuards_InReplyToRequiresRecipientThread(t *testing.T
 		if appErr.Code != commCodeBoundaryViolation || appErr.StatusCode != http.StatusForbidden {
 			t.Fatalf("expected %s/403, got %q/%d", commCodeBoundaryViolation, appErr.Code, appErr.StatusCode)
 		}
+		if appErr.Details["field"] != "inReplyTo" || appErr.Details["reason"] != "no_prior_conversation" || appErr.Details["boundary"] != "conversation" {
+			t.Fatalf("expected structured inReplyTo boundary details, got %#v", appErr.Details)
+		}
 	})
 
 	t.Run("cc recipient must be part of thread", func(t *testing.T) {

--- a/internal/specv3/contracts_test.go
+++ b/internal/specv3/contracts_test.go
@@ -35,9 +35,12 @@ func TestV3ContractFixturesValidate(t *testing.T) {
 			fixtures: []string{filepath.Join(fixturesDir, "communication-outbound-notification.email.example.json")},
 		},
 		{
-			name:     "soul_comm_send_request",
-			schema:   filepath.Join(schemasDir, "soul-comm-send.request.schema.json"),
-			fixtures: []string{filepath.Join(fixturesDir, "soul-comm-send.request.example.json")},
+			name:   "soul_comm_send_request",
+			schema: filepath.Join(schemasDir, "soul-comm-send.request.schema.json"),
+			fixtures: []string{
+				filepath.Join(fixturesDir, "soul-comm-send.request.example.json"),
+				filepath.Join(fixturesDir, "soul-comm-send.request.reply-boundary.example.json"),
+			},
 		},
 		{
 			name:     "soul_comm_send_response",
@@ -45,9 +48,12 @@ func TestV3ContractFixturesValidate(t *testing.T) {
 			fixtures: []string{filepath.Join(fixturesDir, "soul-comm-send.response.example.json")},
 		},
 		{
-			name:     "soul_comm_send_error",
-			schema:   filepath.Join(schemasDir, "soul-comm-send.error.schema.json"),
-			fixtures: []string{filepath.Join(fixturesDir, "soul-comm-send.error.preference-violation.example.json")},
+			name:   "soul_comm_send_error",
+			schema: filepath.Join(schemasDir, "soul-comm-send.error.schema.json"),
+			fixtures: []string{
+				filepath.Join(fixturesDir, "soul-comm-send.error.preference-violation.example.json"),
+				filepath.Join(fixturesDir, "soul-comm-send.error.boundary-violation.example.json"),
+			},
 		},
 		{
 			name:     "soul_agent_channels_response",

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -472,7 +472,17 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /** Send an outbound comm message */
+        /**
+         * Send an outbound comm message
+         * @description Sends a new outbound comm through host. Host always generates the outgoing `messageId`, `messageRef`, and
+         *     `deliveryId`; callers must not use this endpoint to supply outbound message identity.
+         *
+         *     `inReplyTo`, when present, is a reply/conversation boundary reference rather than an identity override. Host
+         *     checks it against prior host/provider conversation state for every recipient and fails closed with HTTP 403
+         *     `comm.boundary_violation` plus `error.details.field=inReplyTo` when the reference is invalid. Canonical mailbox
+         *     replies should use `POST /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/reply`, which derives
+         *     recipient, thread, and provider reply headers from host's mailbox state.
+         */
         post: operations["soulCommSend"];
         delete?: never;
         options?: never;
@@ -1347,7 +1357,10 @@ export interface components {
             has_more: boolean;
             next_cursor?: string;
         };
-        /** POST /api/v1/soul/comm/send request */
+        /**
+         * POST /api/v1/soul/comm/send request
+         * @description Sends a new outbound comm. Host always generates the outgoing messageId/messageRef; callers must not supply outgoing message identity. The optional inReplyTo field is only a reply/conversation boundary reference for legacy send callers and must match prior host/provider conversation state for every recipient. Canonical mailbox replies should use POST /api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/reply instead.
+         */
         "soul-comm-send.request.schema": {
             /** @enum {string} */
             channel: "email" | "sms" | "voice";
@@ -1359,11 +1372,13 @@ export interface components {
             replyTo?: string;
             subject?: string;
             body: string;
+            /** @description Optional reply/conversation boundary reference, not an outgoing message identity. If present, it must match a prior conversation with every recipient; invalid refs fail closed with 403 comm.boundary_violation and error.details.field=inReplyTo. Prefer the canonical mailbox reply endpoint for replies. */
             inReplyTo?: string | null;
             idempotencyKey?: string;
         } & (unknown & unknown & unknown);
         /** POST /api/v1/soul/comm/send response */
         "soul-comm-send.response.schema": {
+            /** @description Host-generated outbound send/status identifier. Callers cannot supply this value on POST /api/v1/soul/comm/send. */
             messageId: string;
             /** @enum {string} */
             status: "accepted" | "sent" | "failed";
@@ -1377,6 +1392,7 @@ export interface components {
             createdAt: string;
             /** @description Opaque stable body-facing mailbox reference for the created outbound delivery; v1 equals deliveryId. */
             messageRef: string;
+            /** @description Host-generated canonical mailbox delivery identifier; v1 also backs messageRef. */
             deliveryId: string;
             threadId: string;
         };
@@ -1384,8 +1400,20 @@ export interface components {
         "soul-comm-send.error.schema": {
             error: {
                 /** @enum {string} */
-                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.preference_violation" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.internal";
+                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.preference_violation" | "comm.boundary_violation" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.idempotency_conflict" | "comm.internal";
                 message: string;
+                status_code?: number;
+                /** @description Optional structured, client-safe metadata. For comm.boundary_violation caused by an invalid reply/conversation reference, Host returns field=inReplyTo, boundary=conversation, and a reason such as no_prior_conversation. */
+                details?: {
+                    /** @enum {string} */
+                    boundary?: "conversation";
+                    /** @enum {string} */
+                    field?: "inReplyTo" | "to";
+                    /** @enum {string} */
+                    reason?: "no_prior_conversation" | "missing_recipient" | "reply_boundary_violation";
+                } & {
+                    [key: string]: unknown;
+                };
                 request_id?: string;
             };
         };
@@ -3445,6 +3473,15 @@ export interface operations {
             };
             /** @description Unauthorized */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["soul-comm-send.error.schema"];
+                };
+            };
+            /** @description Boundary or preference violation */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## Summary

Closes #262.

This clarifies Host's soul comm send/reply boundary contract without weakening fail-closed conversation-boundary enforcement.

- Document that `POST /api/v1/soul/comm/send` always generates outbound `messageId`, `messageRef`, and `deliveryId`; callers must not supply outgoing message identity.
- Define `inReplyTo` as a reply/conversation boundary reference for legacy send callers, not an identity override.
- Add structured `comm.boundary_violation` details for invalid reply refs: `boundary=conversation`, `field=inReplyTo`, `reason=no_prior_conversation`.
- Update v3 JSON Schemas, fixtures, OpenAPI, and the generated web REST adapter.
- Update Body-facing docs to coordinate with equaltoai/lesser-body#172: Body should not forward `email_send.messageId` as Host `inReplyTo`; mailbox replies should use Host's canonical mailbox reply endpoint.

## Root cause

Ops' Project 21 M0 probe showed Body's MCP `email_send.messageId` footgun reaching Host as `inReplyTo` and correctly failing closed as `403 comm.boundary_violation`. Host enforcement was correct, but the contract surface did not clearly distinguish generated message identity from boundary-checked reply refs.

## Validation

- `go test ./internal/controlplane ./internal/specv3`
- `go test ./...`
- `go vet ./...`
- `cd web && npm run verify:lesser-host-contracts`
- `git diff --check`

## Governance / safety notes

- Boundary enforcement remains fail-closed.
- No tenant-data access expansion.
- No provisioning, on-chain, CSP, or trust-API changes.
- No Body repo changes included; Aron is coordinating Body #172 separately.