### PR TITLE
[codex] Upload Body auxiliary assets with tenant profile

### DIFF
--- a/cdk/lib/provision-runner/helpers.sh
+++ b/cdk/lib/provision-runner/helpers.sh
@@ -183,9 +183,9 @@ upload_lesser_body_auxiliary_assets() {
     object_key="$body_asset_prefix/$s3_key"
     echo "Uploading lesser-body auxiliary asset $id to s3://$body_asset_bucket/$object_key"
     if [ -n "$content_type" ]; then
-      aws s3 cp "$body_release_dir/$path" "s3://$body_asset_bucket/$object_key" --content-type "$content_type"
+      AWS_PROFILE=managed aws s3 cp "$body_release_dir/$path" "s3://$body_asset_bucket/$object_key" --content-type "$content_type"
     else
-      aws s3 cp "$body_release_dir/$path" "s3://$body_asset_bucket/$object_key"
+      AWS_PROFILE=managed aws s3 cp "$body_release_dir/$path" "s3://$body_asset_bucket/$object_key"
     fi
   done
 }

--- a/cdk/test/provision-runner-buildspec.test.ts
+++ b/cdk/test/provision-runner-buildspec.test.ts
@@ -27,6 +27,7 @@ test('RUN_MODE=lesser-body uses the release helper instead of a source checkout'
 	assert.match(buildCommands, /body-failure\.json/);
 	assert.match(buildCommands, /prepare_lesser_body_auxiliary_assets/);
 	assert.match(buildCommands, /upload_lesser_body_auxiliary_assets "\$BODY_RELEASE_DIR" "\$BODY_ASSET_BUCKET" "\$BODY_ASSET_PREFIX"/);
+	assert.match(buildCommands, /AWS_PROFILE=managed aws s3 cp "\$body_release_dir\/\$path" "s3:\/\/\$body_asset_bucket\/\$object_key"/);
 	assert.match(buildCommands, /managed_auxiliary_assets_v1/);
 	assert.match(buildCommands, /BODY_ASSET_BUCKET="cdk-hnb659fds-assets-\$TARGET_ACCOUNT_ID-\$TARGET_REGION"/);
 	assert.doesNotMatch(buildCommands, /lesser-body-src/);


### PR DESCRIPTION
## Summary

Fixes the lab managed Body update failure observed after PR #273.

- Uses the assumed tenant `managed` AWS profile when uploading schema-2 Body auxiliary assets to the tenant CDK asset bucket.
- Keeps the existing checksum/byte verification and prefix-relative object key behavior unchanged.
- Adds a provision-runner buildspec regression so auxiliary uploads cannot silently fall back to the host CodeBuild role.

## Root cause

The runner assumed the tenant role during `PRE_BUILD`, but `upload_lesser_body_auxiliary_assets` used plain `aws s3 cp`. That ran as the host CodeBuild service role and was denied by the tenant asset bucket:

`AccessDenied ... not authorized to perform: s3:PutObject ... cdk-hnb659fds-assets-209468748504-us-east-1/...`

The deploy helper already runs with `AWS_PROFILE=managed`; auxiliary asset upload needed the same tenant-profile boundary.

## Validation

- `bash -n cdk/lib/provision-runner/helpers.sh cdk/lib/provision-runner/build-lesser-body.sh cdk/lib/provision-runner/build.sh`
- `git diff --check`
- `go test ./internal/provisionworker`
- `go test ./...`
- `cd cdk && npm ci && npm test`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS 29 / 0 / 0

## Rollout

After review/merge, deploy to lab with the canonical AppTheory contract and rerun the Body update for `simulacrum` / Body `v0.3.3`.