### PR TITLE
fix(soul): harden Project 21 mailbox and mint logs

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -1028,11 +1028,17 @@ export class LesserHostStack extends cdk.Stack {
 			? { throttlingRateLimit: 500, throttlingBurstLimit: 1000 }
 			: { throttlingRateLimit: 100, throttlingBurstLimit: 200 };
 
+		const controlPlaneIntegration = new apigwv2Integrations.HttpLambdaIntegration(
+			'ControlPlaneIntegration', controlPlaneFn,
+		);
 		const controlPlaneApi = new apigwv2.HttpApi(this, 'ControlPlaneHttpApi', {
 			apiName: `${namePrefix}-control-plane`,
-			defaultIntegration: new apigwv2Integrations.HttpLambdaIntegration(
-				'ControlPlaneIntegration', controlPlaneFn,
-			),
+			defaultIntegration: controlPlaneIntegration,
+		});
+		controlPlaneApi.addRoutes({
+			path: '/api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}',
+			methods: [apigwv2.HttpMethod.GET],
+			integration: controlPlaneIntegration,
 		});
 		// AppTheory can stream SSE correctly through API Gateway REST proxy responses, but not via HttpApi.
 		// Keep the main control plane on HttpApi and route only the soul mint conversation subtree to REST.
@@ -1102,7 +1108,11 @@ export class LesserHostStack extends cdk.Stack {
 					ip: '$context.identity.sourceIp',
 					requestTime: '$context.requestTime',
 					method: '$context.httpMethod',
-					path: '$context.path',
+					// HTTP API access logs cannot transform path parameters. Persist the
+					// route key instead of the raw path so private mint-conversation
+					// identifiers never land in API Gateway access logs; Lambda request
+					// logs retain sanitized path correlation.
+					path: '$context.routeKey',
 					protocol: '$context.protocol',
 					status: '$context.status',
 					responseLength: '$context.responseLength',

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -41,6 +41,14 @@ function findResources(template: SynthesizedTemplate, type: string): Array<Recor
 		.map((resource) => resource?.Properties ?? {});
 }
 
+function parseAccessLogFormat(stage: Record<string, unknown>): Record<string, unknown> {
+	const accessLogSettings = stage.AccessLogSettings;
+	assert.ok(accessLogSettings && typeof accessLogSettings === 'object', 'expected stage access log settings');
+	const format = (accessLogSettings as { Format?: unknown }).Format;
+	assert.equal(typeof format, 'string', 'expected access log format string');
+	return JSON.parse(format as string) as Record<string, unknown>;
+}
+
 test('state table exposes the active update recovery index', () => {
 	const template = synthTemplate();
 	const tables = findResources(template, 'AWS::DynamoDB::Table');
@@ -74,6 +82,28 @@ test('stack schedules the managed update sweep every five minutes', () => {
 	});
 
 	assert.ok(matchingRule, 'expected managed update sweep EventBridge rule');
+});
+
+test('control-plane HTTP API access logs do not persist raw request paths', () => {
+	const template = synthTemplate();
+	const stages = findResources(template, 'AWS::ApiGatewayV2::Stage');
+	const controlPlaneStage = stages.find((stage) => stage.StageName === '$default');
+	assert.ok(controlPlaneStage, 'expected control-plane HTTP API default stage');
+	const format = parseAccessLogFormat(controlPlaneStage);
+
+	assert.equal(format.path, '$context.routeKey');
+	assert.equal(format.routeKey, '$context.routeKey');
+	assert.notEqual(format.path, '$context.path');
+});
+
+test('private mint-conversation instance read route has a templated HTTP API route key', () => {
+	const template = synthTemplate();
+	const routes = findResources(template, 'AWS::ApiGatewayV2::Route');
+	const matching = routes.find((route) => {
+		return route.RouteKey === 'GET /api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}';
+	});
+
+	assert.ok(matching, 'expected private mint-conversation single-read route to have a non-raw route key');
 });
 
 function findLambdaByFunctionName(template: SynthesizedTemplate, namePart: string): Record<string, unknown> | undefined {

--- a/internal/controlplane/handlers_soul_comm_mailbox.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox.go
@@ -722,6 +722,7 @@ func (s *Server) queryMailboxMessagesPage(ctx context.Context, instanceSlug stri
 	if strings.TrimSpace(filters.threadID) != "" {
 		qb = qb.Index("gsi2").
 			Where("gsi2PK", "=", models.SoulCommMailboxThreadPK(instanceSlug, agentID, filters.threadID)).
+			Where("gsi2SK", "BEGINS_WITH", "MSG#").
 			OrderBy("gsi2SK", "DESC")
 	} else {
 		qb = qb.Where("PK", "=", models.SoulCommMailboxAgentPK(instanceSlug, agentID)).

--- a/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
@@ -83,6 +83,27 @@ func TestHandleSoulCommMailboxListRedactsContent(t *testing.T) {
 	}
 }
 
+func TestHandleSoulCommMailboxListThreadQueryRestrictsToMessageRows(t *testing.T) {
+	t.Parallel()
+
+	fixture := newMailboxAPITestDB()
+	expectMailboxAPIAccess(t, fixture, soulLifecycleTestAgentIDHex)
+	fixture.qMsg.On("AllPaginated", mock.AnythingOfType("*[]*models.SoulCommMailboxMessage")).Return(&core.PaginatedResult{}, nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulCommMailboxMessage](t, args, 0)
+		*dest = []*models.SoulCommMailboxMessage{mailboxAPITestMessage(soulLifecycleTestAgentIDHex)}
+	}).Once()
+
+	_, err := newMailboxAPITestServer(fixture).handleSoulCommMailboxList(newMailboxAPIContext(soulLifecycleTestAgentIDHex, "", map[string][]string{
+		"threadId": {"comm-thread-1"},
+		"limit":    {"10"},
+	}))
+	require.NoError(t, err)
+
+	fixture.qMsg.AssertCalled(t, "Index", "gsi2")
+	fixture.qMsg.AssertCalled(t, "Where", "gsi2PK", "=", models.SoulCommMailboxThreadPK("inst1", soulLifecycleTestAgentIDHex, "comm-thread-1"))
+	fixture.qMsg.AssertCalled(t, "Where", "gsi2SK", "BEGINS_WITH", "MSG#")
+}
+
 func TestHandleSoulCommMailboxListAppliesBodyFilters(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -918,7 +918,7 @@ func (s *Server) updateMintConversationMessages(ctx context.Context, agentIDHex 
 	}
 	_ = conv.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx).Model(conv).IfExists().Update("Messages"); err != nil {
-		log.Printf("controlplane: update mint conversation messages failed: agent=%s conversation=%s err=%v", conv.AgentID, conv.ConversationID, err)
+		log.Printf("controlplane: update mint conversation messages failed: agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(conv.AgentID), soulMintInstanceReadAuditHash(conv.ConversationID), err)
 	}
 }
 
@@ -964,7 +964,7 @@ func (s *Server) updateMintConversationTurn(ctx context.Context, agentIDHex stri
 	}
 	_ = conv.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx).Model(conv).IfExists().Update("Messages", "Usage"); err != nil {
-		log.Printf("controlplane: update mint conversation turn failed: agent=%s conversation=%s err=%v", conv.AgentID, conv.ConversationID, err)
+		log.Printf("controlplane: update mint conversation turn failed: agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(conv.AgentID), soulMintInstanceReadAuditHash(conv.ConversationID), err)
 	}
 }
 
@@ -984,7 +984,7 @@ func (s *Server) updateMintConversationStatus(ctx context.Context, agentIDHex st
 	}
 	_ = conv.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx).Model(conv).IfExists().Update("Messages", "ProducedDeclarations", "Status", "CompletedAt"); err != nil {
-		log.Printf("controlplane: update mint conversation status failed: agent=%s conversation=%s status=%s err=%v", conv.AgentID, conv.ConversationID, conv.Status, err)
+		log.Printf("controlplane: update mint conversation status failed: agent_hash=%s conversation_hash=%s status=%s err=%v", soulMintInstanceReadAuditHash(conv.AgentID), soulMintInstanceReadAuditHash(conv.ConversationID), conv.Status, err)
 	}
 }
 

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -47,6 +47,7 @@ func New(service string) apptheory.ObservabilityHooks {
 			)
 		},
 		Metric: func(rec apptheory.MetricRecord) {
+			tags := SanitizeMetricTags(rec.Tags)
 			logger.Log(
 				context.Background(),
 				slog.LevelInfo,
@@ -54,7 +55,7 @@ func New(service string) apptheory.ObservabilityHooks {
 				slog.String("service", service),
 				slog.String("name", rec.Name),
 				slog.Int("value", rec.Value),
-				slog.Any("tags", rec.Tags),
+				slog.Any("tags", tags),
 			)
 		},
 	}

--- a/internal/observability/observability.go
+++ b/internal/observability/observability.go
@@ -21,6 +21,7 @@ func New(service string) apptheory.ObservabilityHooks {
 
 	return apptheory.ObservabilityHooks{
 		Log: func(rec apptheory.LogRecord) {
+			rec.Path = SanitizeLogPath(rec.Path)
 			emitTrustProxy503BestEffort(service, rec)
 			emitCommWebhookMetricsBestEffort(service, rec)
 

--- a/internal/observability/observability_more_test.go
+++ b/internal/observability/observability_more_test.go
@@ -1,6 +1,7 @@
 package observability
 
 import (
+	"strings"
 	"testing"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -24,6 +25,51 @@ func TestObservabilityHelpers_Coverage(t *testing.T) {
 	emitCommWebhookMetricsBestEffort("control-plane-api", apptheory.LogRecord{Path: "/webhooks/comm/voice/inbound", Status: 503})
 	emitCommWebhookMetricsBestEffort("control-plane-api", apptheory.LogRecord{Path: "/webhooks/comm/voice/status", Status: 503})
 	emitCommWebhookMetricsBestEffort("control-plane-api", apptheory.LogRecord{Path: "/webhooks/comm/other", Status: 503})
+}
+
+func TestSanitizeLogPathRedactsPrivateMintConversationIDs(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		in             string
+		rawSecret      string
+		wantPrefix     string
+		wantSuffixGone string
+	}{
+		"host instance single read": {
+			in:             "/api/v1/soul/instance/agents/0xabc/mint-conversations/conv-private-1?cursor=raw-cursor",
+			rawSecret:      "conv-private-1",
+			wantPrefix:     "/api/v1/soul/instance/agents/0xabc/mint-conversations/conversation-sha256:",
+			wantSuffixGone: "raw-cursor",
+		},
+		"lesser self scope proxy": {
+			in:             "/api/v1/souls/bound/me/mint-conversations/lesser-private-conv#frag",
+			rawSecret:      "lesser-private-conv",
+			wantPrefix:     "/api/v1/souls/bound/me/mint-conversations/conversation-sha256:",
+			wantSuffixGone: "frag",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			got := SanitizeLogPath(tc.in)
+			if !strings.HasPrefix(got, tc.wantPrefix) {
+				t.Fatalf("expected sanitized path prefix %q, got %q", tc.wantPrefix, got)
+			}
+			if strings.Contains(got, tc.rawSecret) || strings.Contains(got, tc.wantSuffixGone) {
+				t.Fatalf("sanitized path leaked private path/query data: %q", got)
+			}
+		})
+	}
+}
+
+func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	path := "/api/v1/soul/instance/agents/0xabc/mint-conversations?limit=20"
+	if got := SanitizeLogPath(path); got != path {
+		t.Fatalf("expected list path unchanged, got %q", got)
+	}
 }
 
 func TestCommWebhookProviderAndChannel(t *testing.T) {

--- a/internal/observability/observability_more_test.go
+++ b/internal/observability/observability_more_test.go
@@ -72,6 +72,47 @@ func TestSanitizeLogPathLeavesOtherRoutesUnchanged(t *testing.T) {
 	}
 }
 
+func TestSanitizeMetricTagsRedactsPathWithoutMutatingInput(t *testing.T) {
+	t.Parallel()
+
+	rawPath := "/api/v1/soul/instance/agents/0xabc/mint-conversations/conv-private-1?cursor=raw-cursor"
+	tags := map[string]string{
+		"method": "GET",
+		"path":   rawPath,
+		"status": "200",
+	}
+
+	got := SanitizeMetricTags(tags)
+	if got == nil {
+		t.Fatal("expected sanitized tags")
+	}
+	if got["method"] != "GET" || got["status"] != "200" {
+		t.Fatalf("expected non-path tags preserved, got %#v", got)
+	}
+	if !strings.HasPrefix(got["path"], "/api/v1/soul/instance/agents/0xabc/mint-conversations/conversation-sha256:") {
+		t.Fatalf("expected sanitized metric path, got %q", got["path"])
+	}
+	if strings.Contains(got["path"], "conv-private-1") || strings.Contains(got["path"], "raw-cursor") {
+		t.Fatalf("sanitized metric path leaked private path/query data: %q", got["path"])
+	}
+	if tags["path"] != rawPath {
+		t.Fatalf("expected input tags to remain unchanged, got %q", tags["path"])
+	}
+}
+
+func TestSanitizeMetricTagsLeavesPathlessTagsUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tags := map[string]string{"method": "GET", "status": "200"}
+	got := SanitizeMetricTags(tags)
+	if got["method"] != "GET" || got["status"] != "200" {
+		t.Fatalf("expected pathless tags preserved, got %#v", got)
+	}
+	if _, ok := got["path"]; ok {
+		t.Fatalf("expected no path tag, got %#v", got)
+	}
+}
+
 func TestCommWebhookProviderAndChannel(t *testing.T) {
 	t.Parallel()
 

--- a/internal/observability/path_redaction.go
+++ b/internal/observability/path_redaction.go
@@ -26,6 +26,24 @@ func SanitizeLogPath(raw string) string {
 	return strings.TrimSpace(raw)
 }
 
+// SanitizeMetricTags copies framework metric tags and normalizes any request
+// path tag before generic metric logs persist it. AppTheory emits the raw
+// request path in MetricRecord.Tags["path"] independently from LogRecord.Path,
+// so Host must apply the same redaction at the metric hook boundary.
+func SanitizeMetricTags(tags map[string]string) map[string]string {
+	if len(tags) == 0 {
+		return tags
+	}
+	sanitized := make(map[string]string, len(tags))
+	for key, value := range tags {
+		sanitized[key] = value
+	}
+	if path, ok := sanitized["path"]; ok {
+		sanitized["path"] = SanitizeLogPath(path)
+	}
+	return sanitized
+}
+
 func splitLogPathSuffix(raw string) (path string, suffix string) {
 	for i, r := range raw {
 		if r == '?' || r == '#' {

--- a/internal/observability/path_redaction.go
+++ b/internal/observability/path_redaction.go
@@ -1,0 +1,91 @@
+package observability
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+const redactedPathHashPrefix = "sha256:"
+
+// SanitizeLogPath normalizes private route path segments before generic
+// request logs persist them. Dedicated audit records carry their own hashed
+// identifiers; this is the defense-in-depth layer for framework/API access
+// style logs that otherwise receive only a raw request path.
+func SanitizeLogPath(raw string) string {
+	path, _ := splitLogPathSuffix(strings.TrimSpace(raw))
+	if path == "" {
+		return strings.TrimSpace(raw)
+	}
+	if sanitized, ok := sanitizeSoulMintInstanceConversationPath(path); ok {
+		return sanitized
+	}
+	if sanitized, ok := sanitizeLesserSelfScopeMintConversationPath(path); ok {
+		return sanitized
+	}
+	return strings.TrimSpace(raw)
+}
+
+func splitLogPathSuffix(raw string) (path string, suffix string) {
+	for i, r := range raw {
+		if r == '?' || r == '#' {
+			return raw[:i], raw[i:]
+		}
+	}
+	return raw, ""
+}
+
+func sanitizeSoulMintInstanceConversationPath(path string) (string, bool) {
+	segments, leadingSlash := splitPathSegments(path)
+	if len(segments) != 8 ||
+		segments[0] != "api" ||
+		segments[1] != "v1" ||
+		segments[2] != "soul" ||
+		segments[3] != "instance" ||
+		segments[4] != "agents" ||
+		segments[6] != "mint-conversations" ||
+		strings.TrimSpace(segments[5]) == "" ||
+		strings.TrimSpace(segments[7]) == "" {
+		return "", false
+	}
+	segments[7] = "conversation-" + shortLogHash(segments[7])
+	return joinPathSegments(segments, leadingSlash), true
+}
+
+func sanitizeLesserSelfScopeMintConversationPath(path string) (string, bool) {
+	segments, leadingSlash := splitPathSegments(path)
+	if len(segments) != 7 ||
+		segments[0] != "api" ||
+		segments[1] != "v1" ||
+		segments[2] != "souls" ||
+		segments[3] != "bound" ||
+		segments[4] != "me" ||
+		segments[5] != "mint-conversations" ||
+		strings.TrimSpace(segments[6]) == "" {
+		return "", false
+	}
+	segments[6] = "conversation-" + shortLogHash(segments[6])
+	return joinPathSegments(segments, leadingSlash), true
+}
+
+func splitPathSegments(path string) ([]string, bool) {
+	leadingSlash := strings.HasPrefix(path, "/")
+	trimmed := strings.Trim(path, "/")
+	if trimmed == "" {
+		return nil, leadingSlash
+	}
+	return strings.Split(trimmed, "/"), leadingSlash
+}
+
+func joinPathSegments(segments []string, leadingSlash bool) string {
+	joined := strings.Join(segments, "/")
+	if leadingSlash {
+		return "/" + joined
+	}
+	return joined
+}
+
+func shortLogHash(raw string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(raw)))
+	return redactedPathHashPrefix + hex.EncodeToString(sum[:])[:16]
+}


### PR DESCRIPTION
## Summary

Project 21 residual cleanup for Host issues #264 and #275.

### #264 — Thread-scoped mailbox duplicate sparse rows

Root cause: thread-scoped mailbox reads query `gsi2` by thread partition only. Mailbox state-change event rows intentionally share the thread `gsi2PK` for audit/history, but their `gsi2SK` starts with `EVENT#`, so they could be hydrated through the message model as sparse duplicate same-delivery rows after read/unread/reply mutations.

Fix:

- constrain thread-scoped mailbox message queries to `gsi2SK BEGINS_WITH MSG#`
- add regression coverage asserting the thread query uses the message-row sort-key prefix

### #275 — Private mint-conversation generic route/access log hardening

Fix:

- add `observability.SanitizeLogPath` for private mint-conversation single-read paths:
  - Host instance route: `/api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}`
  - Lesser self-scope proxy-shaped path if it ever passes through Host logging: `/api/v1/souls/bound/me/mint-conversations/{conversationId}`
- hash-normalize the private `conversationId` segment and drop query/fragment suffixes on those private single-read paths so raw cursors/fragments are not persisted with the sanitized path
- apply path sanitization before Host generic AppTheory request logs, AppTheory metric `tags.path` logs, and derived EMF metric details
- change control-plane HTTP API access logs to persist `$context.routeKey` instead of raw `$context.path`
- add an explicit templated HTTP API route for the Host private single-read route so API Gateway access logs preserve route class without raw `conversationId`
- keep dedicated Host instance-read audit behavior unchanged: hashed actor/instance/agent/conversation identifiers only
- hash agent/conversation identifiers in mint-conversation update-failure log lines

Sibling scope:

- The Lesser self-scope proxy route is not Host-owned. I created equaltoai/lesser#955 and linked it from #275 rather than expanding Host scope silently.

## Validation

- `go test ./internal/observability`
- `go test ./internal/controlplane ./internal/observability`
- `go test ./...`
- `cd cdk && npm test`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS 29 / FAIL 0 / BLOCKED 0

Notes: `cd cdk && npm test` still emits existing CloudFront `S3Origin` deprecation warnings and existing Lightning CSS `:global(...)` warnings from the web build; tests pass.

## Ops probe steps

- For #264: reproduce self-send → read/unread → reply → `email_read(threadId=...)`; expected result is one row per delivery, no same-delivery sparse duplicates with empty subject/body.
- For #275: call the Host instance route `/api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}` and verify:
  - Host generic Lambda request logs contain a sanitized path with `conversation-sha256:<16hex>` rather than the raw conversation ID
  - Host generic AppTheory metric logs contain sanitized `tags.path` with `conversation-sha256:<16hex>` rather than the raw conversation ID
  - control-plane HTTP API access logs use the templated route key, not raw `$context.path`
  - dedicated `soul_mint_instance_read` audit/access logs continue to show hashed identifiers only

Closes #264
Closes #275
