### PR TITLE
fix(auth): harden invalid bearer limits and logout

### DIFF
--- a/internal/controlplane/handlers_soul_mint_conversation_instance_read.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_instance_read.go
@@ -160,19 +160,34 @@ func (s *Server) requireSoulMintInstanceReadKey(ctx *apptheory.Context) (*models
 	if token == "" {
 		return nil, soulMintInstanceReadError(soulMintInstanceReadCodeUnauthorized, "unauthorized", http.StatusUnauthorized, nil)
 	}
-
-	key, err := s.store.GetInstanceKey(ctx.Context(), sha256HexTrimmed(token))
-	if theoryErrors.IsNotFound(err) || key == nil || !key.RevokedAt.IsZero() {
-		return nil, soulMintInstanceReadError(soulMintInstanceReadCodeUnauthorized, "unauthorized", http.StatusUnauthorized, nil)
+	tokenHash := sha256HexTrimmed(token)
+	if key := soulMintConversationInstanceReadKeyFromContext(ctx); soulMintConversationInstanceReadKeyActiveForHash(key, tokenHash) {
+		s.updateSoulMintInstanceReadKeyLastUsed(ctx, key)
+		return key, nil
 	}
+
+	key, err := s.store.GetInstanceKey(ctx.Context(), tokenHash)
 	if err != nil {
+		if theoryErrors.IsNotFound(err) {
+			return nil, soulMintInstanceReadError(soulMintInstanceReadCodeUnauthorized, "unauthorized", http.StatusUnauthorized, nil)
+		}
 		return nil, soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}
+	if key == nil || !key.RevokedAt.IsZero() {
+		return nil, soulMintInstanceReadError(soulMintInstanceReadCodeUnauthorized, "unauthorized", http.StatusUnauthorized, nil)
+	}
 
+	s.updateSoulMintInstanceReadKeyLastUsed(ctx, key)
+	return key, nil
+}
+
+func (s *Server) updateSoulMintInstanceReadKeyLastUsed(ctx *apptheory.Context, key *models.InstanceKey) {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil || key == nil {
+		return
+	}
 	key.LastUsedAt = time.Now().UTC()
 	_ = key.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(key).IfExists().Update("LastUsedAt")
-	return key, nil
 }
 
 func soulMintInstanceReadErrorFromAppError(appErr *apptheory.AppError) *apptheory.AppTheoryError {

--- a/internal/controlplane/rate_limits.go
+++ b/internal/controlplane/rate_limits.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/theory-cloud/apptheory/pkg/limited"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 const (
@@ -24,7 +26,10 @@ const (
 
 	soulMintConversationInstanceReadRateLimitPrefix    = "soul-mint-read:"
 	soulMintConversationInstanceReadRateLimitAnonymous = soulMintConversationInstanceReadRateLimitPrefix + "anonymous"
+	soulMintConversationInstanceReadRateLimitInvalid   = soulMintConversationInstanceReadRateLimitPrefix + "invalid"
 	soulMintConversationInstanceReadRateLimitRouteKey  = "route_class"
+
+	ctxKeySoulMintConversationInstanceReadKey = "soul_mint.instance_read_key"
 )
 
 func (s *Server) mintConversationRateLimitMiddleware() apptheory.Middleware {
@@ -162,7 +167,7 @@ func (s *Server) mintConversationInstanceReadRateLimitMiddleware() apptheory.Mid
 			method := strings.ToUpper(strings.TrimSpace(ctx.Request.Method))
 			path := strings.TrimSpace(ctx.Request.Path)
 			if method == http.MethodGet && isSoulMintConversationInstanceReadPath(path) {
-				if resp, err := soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, method, path); resp != nil || err != nil {
+				if resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, method, path); resp != nil || err != nil {
 					return resp, err
 				}
 			}
@@ -176,22 +181,45 @@ func isSoulMintConversationInstanceReadPath(path string) bool {
 		strings.Contains(strings.TrimSpace(path), "/mint-conversations")
 }
 
-func soulMintConversationInstanceReadRateLimitIdentifier(ctx *apptheory.Context) string {
+func (s *Server) soulMintConversationInstanceReadRateLimitIdentifier(ctx *apptheory.Context) (string, *apptheory.AppTheoryError) {
 	if ctx == nil {
-		return soulMintConversationInstanceReadRateLimitAnonymous
+		return soulMintConversationInstanceReadRateLimitAnonymous, nil
 	}
-	if raw := httpx.BearerToken(ctx.Request.Headers); strings.TrimSpace(raw) != "" {
-		return soulMintConversationInstanceReadRateLimitPrefix + sha256HexTrimmed(raw)
+	raw := httpx.BearerToken(ctx.Request.Headers)
+	if strings.TrimSpace(raw) == "" {
+		return soulMintConversationInstanceReadRateLimitAnonymous, nil
 	}
-	return soulMintConversationInstanceReadRateLimitAnonymous
+	hash := sha256HexTrimmed(raw)
+	if key := soulMintConversationInstanceReadKeyFromContext(ctx); key != nil && soulMintConversationInstanceReadKeyActiveForHash(key, hash) {
+		return soulMintConversationInstanceReadRateLimitPrefix + hash, nil
+	}
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return "", soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "internal error", http.StatusInternalServerError, nil)
+	}
+	key, err := s.store.GetInstanceKey(ctx.Context(), hash)
+	if err != nil {
+		if theoryErrors.IsNotFound(err) {
+			return soulMintConversationInstanceReadRateLimitInvalid, nil
+		}
+		return "", soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "internal error", http.StatusInternalServerError, nil)
+	}
+	if key == nil || !soulMintConversationInstanceReadKeyActiveForHash(key, hash) {
+		return soulMintConversationInstanceReadRateLimitInvalid, nil
+	}
+	ctx.Set(ctxKeySoulMintConversationInstanceReadKey, key)
+	return soulMintConversationInstanceReadRateLimitPrefix + hash, nil
 }
 
-func soulMintConversationInstanceReadCheckRateLimit(ctx *apptheory.Context, limiter limited.AtomicRateLimiter, method string, path string) (*apptheory.Response, error) {
+func (s *Server) soulMintConversationInstanceReadCheckRateLimit(ctx *apptheory.Context, limiter limited.AtomicRateLimiter, method string, path string) (*apptheory.Response, error) {
 	if limiter == nil {
 		return nil, nil
 	}
+	identifier, appErr := s.soulMintConversationInstanceReadRateLimitIdentifier(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
 	decision, err := limiter.CheckAndIncrement(ctx.Context(), limited.RateLimitKey{
-		Identifier: soulMintConversationInstanceReadRateLimitIdentifier(ctx),
+		Identifier: identifier,
 		Resource:   "control-plane-api",
 		Operation:  "soul_mint_conversation_instance_read",
 		Metadata: map[string]string{
@@ -207,6 +235,21 @@ func soulMintConversationInstanceReadCheckRateLimit(ctx *apptheory.Context, limi
 		return soulMintConversationInstanceReadRateLimitResponse(ctx, decision), nil
 	}
 	return nil, nil
+}
+
+func soulMintConversationInstanceReadKeyFromContext(ctx *apptheory.Context) *models.InstanceKey {
+	if ctx == nil {
+		return nil
+	}
+	key, _ := ctx.Get(ctxKeySoulMintConversationInstanceReadKey).(*models.InstanceKey)
+	return key
+}
+
+func soulMintConversationInstanceReadKeyActiveForHash(key *models.InstanceKey, hash string) bool {
+	return key != nil &&
+		strings.TrimSpace(hash) != "" &&
+		strings.TrimSpace(key.ID) == strings.TrimSpace(hash) &&
+		key.RevokedAt.IsZero()
 }
 
 func soulMintConversationInstanceReadRateLimitRouteClass(path string) string {

--- a/internal/controlplane/rate_limits_internal_test.go
+++ b/internal/controlplane/rate_limits_internal_test.go
@@ -9,11 +9,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/theory-cloud/apptheory/pkg/limited"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
 )
 
 func TestMintConversationRateLimitMiddleware_GuardsAndBypass(t *testing.T) {
@@ -105,28 +110,43 @@ func TestMintConversationInstanceReadRateLimitMiddleware_GuardsAndPathMatch(t *t
 	}
 }
 
-func TestMintConversationInstanceReadRateLimitCheck_UsesHashedBearerAndTypedErrors(t *testing.T) {
+func TestMintConversationInstanceReadRateLimitCheck_UsesHashedBearerAndCachesKey(t *testing.T) {
 	t.Parallel()
+
+	s, qKey := newMintConversationInstanceReadRateLimitTestServer()
+	rawKey := "raw-instance-key"
+	keyHash := sha256HexTrimmed(rawKey)
+	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceKey](t, args, 0)
+		*dest = models.InstanceKey{ID: keyHash, InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()}
+	}).Once()
 
 	ctx := &apptheory.Context{
 		RequestID: "req-rate-check",
 		Request: apptheory.Request{
-			Headers: map[string][]string{mintConversationInstanceReadTestAuthHeader: {"Bearer raw-instance-key"}},
+			Headers: map[string][]string{mintConversationInstanceReadTestAuthHeader: {"Bearer " + rawKey}},
 		},
 	}
 	limiter := &mintConversationInstanceReadTestLimiter{
 		decision: &limited.LimitDecision{Allowed: true},
 	}
 
-	resp, err := soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
+	resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
 	if resp != nil || err != nil {
 		t.Fatalf("expected allowed decision to pass through, got resp=%#v err=%v", resp, err)
 	}
 	if limiter.calls != 1 {
 		t.Fatalf("expected one limiter call, got %d", limiter.calls)
 	}
-	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitPrefix+sha256HexTrimmed("raw-instance-key") {
+	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitPrefix+keyHash {
 		t.Fatalf("expected hashed bearer identifier, got %q", limiter.lastKey.Identifier)
+	}
+	if cached := soulMintConversationInstanceReadKeyFromContext(ctx); cached == nil || cached.ID != keyHash {
+		t.Fatalf("expected valid key cached for handler reuse, got %#v", cached)
+	}
+	key, appErr := s.requireSoulMintInstanceReadKey(ctx)
+	if appErr != nil || key == nil || key.ID != keyHash {
+		t.Fatalf("expected handler auth to reuse cached key, key=%#v err=%#v", key, appErr)
 	}
 	if limiter.lastKey.Metadata["method"] != http.MethodGet ||
 		limiter.lastKey.Metadata[soulMintConversationInstanceReadRateLimitRouteKey] != soulMintInstanceReadRouteList {
@@ -136,23 +156,80 @@ func TestMintConversationInstanceReadRateLimitCheck_UsesHashedBearerAndTypedErro
 		t.Fatalf("expected single route class, got %q", routeClass)
 	}
 
+	qKey.AssertExpectations(t)
+}
+
+func TestMintConversationInstanceReadRateLimitCheck_TypedErrorsAndAnonymousIdentifier(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newMintConversationInstanceReadRateLimitTestServer()
+	ctx := &apptheory.Context{RequestID: "req-rate-check"}
+	limiter := &mintConversationInstanceReadTestLimiter{}
+
 	retry := time.Second
 	limiter.decision = &limited.LimitDecision{Allowed: false, RetryAfter: &retry}
-	resp, err = soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
+	resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
 	if err != nil || resp == nil || resp.Status != http.StatusTooManyRequests {
 		t.Fatalf("expected typed 429 response, got resp=%#v err=%v", resp, err)
 	}
+	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitAnonymous {
+		t.Fatalf("expected anonymous identifier, got %q", limiter.lastKey.Identifier)
+	}
 
 	limiter.err = errors.New("rate limit store unavailable")
-	resp, err = soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
+	resp, err = s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
 	appErr := requireAppTheoryError(t, err)
 	if resp != nil || appErr.Code != soulMintInstanceReadCodeInternal || appErr.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected internal app error on limiter failure, got resp=%#v err=%#v", resp, appErr)
 	}
 
-	if id := soulMintConversationInstanceReadRateLimitIdentifier(&apptheory.Context{}); id != soulMintConversationInstanceReadRateLimitAnonymous {
+	if id, err := s.soulMintConversationInstanceReadRateLimitIdentifier(&apptheory.Context{}); err != nil || id != soulMintConversationInstanceReadRateLimitAnonymous {
 		t.Fatalf("expected anonymous identifier, got %q", id)
 	}
+}
+
+func TestMintConversationInstanceReadRateLimitCheck_InvalidBearerUsesSharedBudget(t *testing.T) {
+	t.Parallel()
+
+	s, qKey := newMintConversationInstanceReadRateLimitTestServer()
+	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := &apptheory.Context{
+		RequestID: "req-invalid-rate-check",
+		Request: apptheory.Request{
+			Headers: map[string][]string{mintConversationInstanceReadTestAuthHeader: {"Bearer invalid-instance-key"}},
+		},
+	}
+	limiter := &mintConversationInstanceReadTestLimiter{
+		decision: &limited.LimitDecision{Allowed: true},
+	}
+
+	resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
+	if resp != nil || err != nil {
+		t.Fatalf("expected invalid bearer to consume limiter then continue to auth, got resp=%#v err=%v", resp, err)
+	}
+	if limiter.calls != 1 {
+		t.Fatalf("expected one limiter call, got %d", limiter.calls)
+	}
+	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitInvalid {
+		t.Fatalf("expected invalid bearer to use shared invalid budget, got %q", limiter.lastKey.Identifier)
+	}
+	if cached := soulMintConversationInstanceReadKeyFromContext(ctx); cached != nil {
+		t.Fatalf("invalid bearer must not cache an instance key, got %#v", cached)
+	}
+	qKey.AssertExpectations(t)
+}
+
+func newMintConversationInstanceReadRateLimitTestServer() (*Server, *ttmocks.MockQuery) {
+	db := ttmocks.NewMockExtendedDB()
+	qKey := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceKey")).Return(qKey).Maybe()
+	qKey.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qKey).Maybe()
+	qKey.On("ConsistentRead").Return(qKey).Maybe()
+	qKey.On("IfExists").Return(qKey).Maybe()
+	qKey.On("Update", mock.Anything).Return(nil).Maybe()
+	return &Server{store: store.New(db)}, qKey
 }
 
 type mintConversationInstanceReadTestLimiter struct {

--- a/web/src/lib/auth/logout.test.ts
+++ b/web/src/lib/auth/logout.test.ts
@@ -27,12 +27,12 @@ describe('logout', () => {
 
 		vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
 
-		await logout();
+		await expect(logout()).rejects.toThrow('network down');
 
 		expect(get(session)).toBeNull();
 	});
 
-	it('clears the local session before the API call resolves', async () => {
+	it('waits for server-side revocation before clearing the local session', async () => {
 		const { session, setSession } = await import('src/lib/session');
 		const { logout } = await import('src/lib/auth/logout');
 
@@ -55,9 +55,10 @@ describe('logout', () => {
 			),
 		);
 
-		await logout();
+		const pendingLogout = logout();
 
-		expect(get(session)).toBeNull();
+		await Promise.resolve();
+		expect(get(session)).not.toBeNull();
 		expect(resolveLogout).toBeTypeOf('function');
 
 		resolveLogout?.(
@@ -66,5 +67,7 @@ describe('logout', () => {
 				headers: { 'content-type': 'application/json' },
 			}),
 		);
+		await pendingLogout;
+		expect(get(session)).toBeNull();
 	});
 });

--- a/web/src/lib/auth/logout.ts
+++ b/web/src/lib/auth/logout.ts
@@ -5,10 +5,11 @@ import { clearSession, session } from 'src/lib/session';
 
 export async function logout(): Promise<void> {
 	const token = get(session)?.token;
-	clearSession();
-	if (token) {
-		void authLogout(token).catch(() => {
-			// Best-effort: local session state has already been cleared.
-		});
+	try {
+		if (token) {
+			await authLogout(token);
+		}
+	} finally {
+		clearSession();
 	}
 }


### PR DESCRIPTION
## Milestone
Project 28 / issue #277 — Harden Host invalid-bearer rate limits and logout revocation semantics.

## Classification
security / trust-boundary hardening / web session correctness

## Surfaces affected
- `internal/controlplane/rate_limits.go`
- `internal/controlplane/handlers_soul_mint_conversation_instance_read.go`
- `internal/controlplane/rate_limits_internal_test.go`
- `web/src/lib/auth/logout.ts`
- `web/src/lib/auth/logout.test.ts`

## Specialist walks referenced
- Investigation: issue #277 was inspected before patching.
- Governance rubric: no verifier or rubric weakening; gov verifier passes.
- Provisioning / managed-update / release verification: not touched.
- Soul registry: no on-chain or registration mutation touched.
- Trust API / CSP / instance-auth: no trust-api route or CSP change; control-plane instance-read auth remains sha256(raw_key)-based and raw keys are neither stored nor logged.

## Multi-tenant isolation impact
No cross-tenant reads are introduced. Valid instance keys remain scoped by the existing key hash lookup and downstream instance-boundary checks. Invalid bearer attempts now share an invalid-credential rate-limit bucket instead of receiving one bucket per attacker-controlled token value.

## On-chain impact
None.

## Consumer impact
Managed instances calling the private soul mint-conversation instance-read routes keep valid per-key rate-limit isolation. Invalid/revoked bearer attempts consume the shared invalid-credential budget. Portal/operator logout waits for server-side revocation before the logout promise resolves; failed revocation still clears local state but rejects instead of reporting success.

## Tasks
- [x] host.csv:7 — invalid bearer tokens consume the instance-read rate-limit budget.
- [x] host.csv:8 — logout no longer returns success before server-side revocation completes.

## Validation
- `go test ./internal/controlplane -run 'TestMintConversationInstanceReadRateLimit|TestHandlePortalMe_OperatorMe_AndLogout'`
- `cd web && npm test -- --run src/lib/auth/logout.test.ts`
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go')` (empty)
- `git diff --check`
- `cd web && npm ci && npm run lint && npm run typecheck && npm test`
- `cd web && npm run build -- --outDir /tmp/lesser-host-web-build.<tmp>`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

Note: local default `web/dist` is currently blocked by pre-existing root-owned files, so the web build was validated with a temporary outDir. The build itself succeeds.

## Stage rollout plan (handoff after merge)
- [ ] Merged to main through review and CI.
- [ ] Deployed to lab where applicable.
- [ ] Post-deploy evidence: unauth/invalid bearer probe on the instance-read route returns the expected typed response/rate-limit behavior without raw key logging.
- [ ] Follow-up findings or conscious deferrals recorded on #277.

## Cross-repo coordination
None.

Closes #277.
