### PR TITLE
fix(soul): bind registration principals to verified policy

### DIFF
--- a/internal/controlplane/constants.go
+++ b/internal/controlplane/constants.go
@@ -16,6 +16,7 @@ const (
 	appErrCodeBadRequest   = "app.bad_request"
 	appErrCodeForbidden    = "app.forbidden"
 	appErrCodeUnauthorized = "app.unauthorized"
+	appErrCodeConflict     = "app.conflict"
 
 	cacheControlNoStore = "no-store"
 )

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -177,6 +178,9 @@ func (s *Server) completeSoulAgentRegistrationUpdate(
 	if appErr != nil {
 		return nil, appErr
 	}
+	if bindingErr := s.validateSoulUpdateRegistrationPrincipalBinding(identity, regV2, regV3); bindingErr != nil {
+		return nil, bindingErr
+	}
 
 	now := time.Now().UTC()
 	claimLevels := extractCapabilityClaimLevels(reg)
@@ -250,6 +254,55 @@ func (s *Server) requireSoulUpdateRegistrationInstancePrereqs(instanceSlug strin
 	}
 	if s.soulPacks == nil {
 		return &apptheory.AppError{Code: "app.conflict", Message: "soul registry bucket is not configured"}
+	}
+	return nil
+}
+
+func (s *Server) validateSoulUpdateRegistrationPrincipalBinding(identity *models.SoulAgentIdentity, regV2 *soul.RegistrationFileV2, regV3 *soul.RegistrationFileV3) *apptheory.AppError {
+	if regV2 == nil && regV3 == nil {
+		return nil
+	}
+	if identity == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	var principal *soul.PrincipalDeclarationV2
+	if regV2 != nil {
+		principal = &regV2.Principal
+	}
+	if regV3 != nil {
+		principal = &regV3.Principal
+	}
+	if principal == nil {
+		return nil
+	}
+
+	binding := soul.PrincipalDeclarationBindingV2{
+		Identifier:  strings.TrimSpace(identity.PrincipalAddress),
+		Declaration: strings.TrimSpace(identity.PrincipalDeclaration),
+		Signature:   strings.TrimSpace(identity.PrincipalSignature),
+		DeclaredAt:  strings.TrimSpace(identity.PrincipalDeclaredAt),
+	}
+	if err := principal.ValidateVerifiedBinding(binding); err != nil {
+		code := appErrCodeBadRequest
+		if errors.Is(err, soul.ErrPrincipalBindingMissing) {
+			code = appErrCodeConflict
+		}
+		return &apptheory.AppError{Code: code, Message: err.Error()}
+	}
+
+	verifiedRegistration := &models.SoulAgentRegistration{
+		AgentID:          strings.TrimSpace(identity.AgentID),
+		Wallet:           strings.TrimSpace(identity.Wallet),
+		DomainNormalized: strings.TrimSpace(identity.Domain),
+		LocalID:          strings.TrimSpace(identity.LocalID),
+	}
+	digest, appErr := s.computeSoulPrincipalDeclarationDigest(verifiedRegistration, binding.Identifier, binding.Declaration, binding.DeclaredAt)
+	if appErr != nil {
+		return appErr
+	}
+	if err := verifyEthereumSignatureBytes(binding.Identifier, digest, binding.Signature); err != nil {
+		return &apptheory.AppError{Code: appErrCodeConflict, Message: "verified principal binding is invalid; re-verify agent principal"}
 	}
 	return nil
 }

--- a/internal/controlplane/handlers_soul_update_registration_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_internal_test.go
@@ -52,6 +52,9 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 		t.Fatalf("generate key: %v", err)
 	}
 	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	principalDeclaration := boundaryTestPrincipalDeclaration
+	principalSigHex := signSoulUpdateRegistrationPrincipalForTest(t, key, principalDeclaration)
+	verifiedPrincipalSigHex := signSoulUpdateRegistrationVerifiedPrincipalForTest(t, s, key, agentIDHex, wallet, principalDeclaration)
 
 	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
@@ -64,7 +67,7 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{
+		identity := models.SoulAgentIdentity{
 			AgentID:   agentIDHex,
 			Domain:    "example.com",
 			LocalID:   "agent-alice",
@@ -72,6 +75,8 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 			Status:    models.SoulAgentStatusActive,
 			UpdatedAt: time.Now().Add(-time.Minute).UTC(),
 		}
+		applySoulUpdateRegistrationPrincipalForTest(&identity, wallet, principalDeclaration, verifiedPrincipalSigHex)
+		*dest = identity
 	}).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -93,14 +98,6 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 	}}
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) { return client, nil }
 
-	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
-	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
-	if err != nil {
-		t.Fatalf("principal Sign: %v", err)
-	}
-	principalSigHex := "0x" + hex.EncodeToString(principalSig)
-
 	unsigned := map[string]any{
 		"version": "2",
 		"agentId": agentIDHex,
@@ -114,7 +111,7 @@ func TestHandleSoulAgentUpdateRegistration_V2_FirstVersion_AllowsNullPreviousVer
 			"contactUri":  "https://example.com/alice",
 			"declaration": principalDeclaration,
 			"signature":   principalSigHex,
-			"declaredAt":  "2026-03-01T00:00:00Z",
+			"declaredAt":  soulUpdateRegistrationPrincipalDeclaredAtForTest,
 		},
 		"selfDescription": map[string]any{
 			"purpose":    "I summarize documents for humans.",
@@ -235,6 +232,9 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 		t.Fatalf("generate key: %v", err)
 	}
 	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	principalDeclaration := boundaryTestPrincipalDeclaration
+	principalSigHex := signSoulUpdateRegistrationPrincipalForTest(t, key, principalDeclaration)
+	verifiedPrincipalSigHex := signSoulUpdateRegistrationVerifiedPrincipalForTest(t, s, key, agentIDHex, wallet, principalDeclaration)
 
 	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
@@ -247,7 +247,7 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{
+		identity := models.SoulAgentIdentity{
 			AgentID:   agentIDHex,
 			Domain:    "example.com",
 			LocalID:   "agent-alice",
@@ -255,6 +255,8 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 			Status:    models.SoulAgentStatusActive,
 			UpdatedAt: time.Now().Add(-time.Minute).UTC(),
 		}
+		applySoulUpdateRegistrationPrincipalForTest(&identity, wallet, principalDeclaration, verifiedPrincipalSigHex)
+		*dest = identity
 	}).Once()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qVersion.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -279,14 +281,6 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 	}}
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) { return client, nil }
 
-	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
-	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
-	if err != nil {
-		t.Fatalf("principal Sign: %v", err)
-	}
-	principalSigHex := "0x" + hex.EncodeToString(principalSig)
-
 	unsigned := map[string]any{
 		"version": "3",
 		"agentId": agentIDHex,
@@ -300,7 +294,7 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 			"contactUri":  "https://example.com/alice",
 			"declaration": principalDeclaration,
 			"signature":   principalSigHex,
-			"declaredAt":  "2026-03-01T00:00:00Z",
+			"declaredAt":  soulUpdateRegistrationPrincipalDeclaredAtForTest,
 		},
 		"selfDescription": map[string]any{
 			"purpose":    "I summarize documents for humans.",
@@ -435,6 +429,9 @@ func TestHandleSoulAgentUpdateRegistration_V2_RequiresPreviousVersionURI_ForSubs
 		t.Fatalf("generate key: %v", err)
 	}
 	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	principalDeclaration := boundaryTestPrincipalDeclaration
+	principalSigHex := signSoulUpdateRegistrationPrincipalForTest(t, key, principalDeclaration)
+	verifiedPrincipalSigHex := signSoulUpdateRegistrationVerifiedPrincipalForTest(t, s, key, agentIDHex, wallet, principalDeclaration)
 
 	// No existing record for version 2 (target).
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Once()
@@ -455,7 +452,7 @@ func TestHandleSoulAgentUpdateRegistration_V2_RequiresPreviousVersionURI_ForSubs
 	tdb.qWalletIdx.On("First", mock.AnythingOfType("*models.WalletIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{
+		identity := models.SoulAgentIdentity{
 			AgentID:                agentIDHex,
 			Domain:                 "example.com",
 			LocalID:                "agent-alice",
@@ -464,6 +461,8 @@ func TestHandleSoulAgentUpdateRegistration_V2_RequiresPreviousVersionURI_ForSubs
 			SelfDescriptionVersion: 1,
 			UpdatedAt:              time.Now().Add(-time.Minute).UTC(),
 		}
+		applySoulUpdateRegistrationPrincipalForTest(&identity, wallet, principalDeclaration, verifiedPrincipalSigHex)
+		*dest = identity
 	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 
@@ -482,14 +481,6 @@ func TestHandleSoulAgentUpdateRegistration_V2_RequiresPreviousVersionURI_ForSubs
 
 	prevURI := "s3://bucket/" + soulRegistrationVersionedS3Key(agentIDHex, 1)
 
-	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
-	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
-	if err != nil {
-		t.Fatalf("principal Sign: %v", err)
-	}
-	principalSigHex := "0x" + hex.EncodeToString(principalSig)
-
 	unsigned := map[string]any{
 		"version": "2",
 		"agentId": agentIDHex,
@@ -501,7 +492,7 @@ func TestHandleSoulAgentUpdateRegistration_V2_RequiresPreviousVersionURI_ForSubs
 			"identifier":  wallet,
 			"declaration": principalDeclaration,
 			"signature":   principalSigHex,
-			"declaredAt":  "2026-03-01T00:00:00Z",
+			"declaredAt":  soulUpdateRegistrationPrincipalDeclaredAtForTest,
 		},
 		"selfDescription": map[string]any{
 			"purpose":    "I summarize documents for humans.",

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -391,10 +391,13 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 		t.Fatalf("generate key: %v", err)
 	}
 	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	principalDeclaration := boundaryTestPrincipalDeclaration
+	principalSigHex := signSoulUpdateRegistrationPrincipalForTest(t, key, principalDeclaration)
+	verifiedPrincipalSigHex := signSoulUpdateRegistrationVerifiedPrincipalForTest(t, s, key, agentIDHex, wallet, principalDeclaration)
 
 	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{
+		identity := models.SoulAgentIdentity{
 			AgentID:   agentIDHex,
 			Domain:    "example.com",
 			LocalID:   "agent-alice",
@@ -402,6 +405,8 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 			Status:    models.SoulAgentStatusActive,
 			UpdatedAt: time.Now().Add(-time.Minute).UTC(),
 		}
+		applySoulUpdateRegistrationPrincipalForTest(&identity, wallet, principalDeclaration, verifiedPrincipalSigHex)
+		*dest = identity
 	}).Once()
 	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
@@ -429,13 +434,6 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}}
 	s.dialEVM = func(ctx context.Context, rpcURL string) (ethRPCClient, error) { return client, nil }
 
-	principalDeclaration := boundaryTestPrincipalDeclaration
-	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
-	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
-	if err != nil {
-		t.Fatalf("principal sign: %v", err)
-	}
-
 	unsigned := map[string]any{
 		"version": "3",
 		"agentId": agentIDHex,
@@ -448,8 +446,8 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 			"displayName": "Alice",
 			"contactUri":  "https://example.com/alice",
 			"declaration": principalDeclaration,
-			"signature":   "0x" + hex.EncodeToString(principalSig),
-			"declaredAt":  "2026-03-01T00:00:00Z",
+			"signature":   principalSigHex,
+			"declaredAt":  soulUpdateRegistrationPrincipalDeclaredAtForTest,
 		},
 		"selfDescription": map[string]any{
 			"purpose":    "I summarize documents for humans.",

--- a/internal/controlplane/handlers_soul_update_registration_principal_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_principal_internal_test.go
@@ -1,0 +1,108 @@
+package controlplane
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/crypto"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const soulUpdateRegistrationPrincipalDeclaredAtForTest = "2026-03-01T00:00:00Z"
+
+func signSoulUpdateRegistrationPrincipalForTest(t *testing.T, key *ecdsa.PrivateKey, principalDeclaration string) string {
+	t.Helper()
+
+	principalDigest := crypto.Keccak256([]byte(principalDeclaration))
+	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
+	if err != nil {
+		t.Fatalf("principal sign: %v", err)
+	}
+	return "0x" + hex.EncodeToString(principalSig)
+}
+
+func signSoulUpdateRegistrationVerifiedPrincipalForTest(t *testing.T, s *Server, key *ecdsa.PrivateKey, agentIDHex string, wallet string, principalDeclaration string) string {
+	t.Helper()
+
+	principalDigest, appErr := s.computeSoulPrincipalDeclarationDigest(&models.SoulAgentRegistration{
+		AgentID:          agentIDHex,
+		Wallet:           wallet,
+		DomainNormalized: "example.com",
+		LocalID:          "agent-alice",
+	}, wallet, principalDeclaration, soulUpdateRegistrationPrincipalDeclaredAtForTest)
+	if appErr != nil {
+		t.Fatalf("principal digest: %v", appErr)
+	}
+	principalSig, err := crypto.Sign(accounts.TextHash(principalDigest), key)
+	if err != nil {
+		t.Fatalf("verified principal sign: %v", err)
+	}
+	return "0x" + hex.EncodeToString(principalSig)
+}
+
+func applySoulUpdateRegistrationPrincipalForTest(identity *models.SoulAgentIdentity, wallet string, principalDeclaration string, principalSigHex string) {
+	identity.PrincipalAddress = wallet
+	identity.PrincipalDeclaration = principalDeclaration
+	identity.PrincipalSignature = principalSigHex
+	identity.PrincipalDeclaredAt = soulUpdateRegistrationPrincipalDeclaredAtForTest
+}
+
+func TestValidateSoulUpdateRegistrationPrincipalBinding(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{SoulChainID: 1, SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001"}}
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	verifiedSig := signSoulUpdateRegistrationVerifiedPrincipalForTest(t, s, key, soulLifecycleTestAgentIDHex, wallet, boundaryTestPrincipalDeclaration)
+	principal := soul.PrincipalDeclarationV2{
+		Identifier:  wallet,
+		Declaration: boundaryTestPrincipalDeclaration,
+		DeclaredAt:  soulUpdateRegistrationPrincipalDeclaredAtForTest,
+	}
+	identity := &models.SoulAgentIdentity{
+		AgentID:              soulLifecycleTestAgentIDHex,
+		Domain:               "example.com",
+		LocalID:              "agent-alice",
+		Wallet:               wallet,
+		PrincipalAddress:     wallet,
+		PrincipalDeclaration: boundaryTestPrincipalDeclaration,
+		PrincipalSignature:   verifiedSig,
+		PrincipalDeclaredAt:  soulUpdateRegistrationPrincipalDeclaredAtForTest,
+	}
+
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(identity, &soul.RegistrationFileV2{Principal: principal}, nil); appErr != nil {
+		t.Fatalf("expected v2 binding to validate: %v", appErr)
+	}
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(identity, nil, &soul.RegistrationFileV3{Principal: principal}); appErr != nil {
+		t.Fatalf("expected v3 binding to validate: %v", appErr)
+	}
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(identity, nil, nil); appErr != nil {
+		t.Fatalf("expected legacy registration to skip principal binding: %v", appErr)
+	}
+
+	replayed := *identity
+	replayed.PrincipalSignature = signSoulUpdateRegistrationPrincipalForTest(t, key, boundaryTestPrincipalDeclaration)
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(&replayed, &soul.RegistrationFileV2{Principal: principal}, nil); appErr == nil || appErr.Code != appErrCodeConflict {
+		t.Fatalf("expected replayed unbound principal signature conflict, got %#v", appErr)
+	}
+
+	mismatch := principal
+	mismatch.Identifier = "0x0000000000000000000000000000000000000001"
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(identity, &soul.RegistrationFileV2{Principal: mismatch}, nil); appErr == nil || appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected principal mismatch bad_request, got %#v", appErr)
+	}
+
+	missingBinding := &models.SoulAgentIdentity{PrincipalAddress: identity.PrincipalAddress}
+	if appErr := s.validateSoulUpdateRegistrationPrincipalBinding(missingBinding, &soul.RegistrationFileV2{Principal: principal}, nil); appErr == nil || appErr.Code != appErrCodeConflict {
+		t.Fatalf("expected missing verified principal conflict, got %#v", appErr)
+	}
+}

--- a/internal/controlplane/test_consts_internal_test.go
+++ b/internal/controlplane/test_consts_internal_test.go
@@ -1,9 +1,8 @@
 package controlplane
 
 const (
-	appErrCodeConflict = "app.conflict"
-	testNope           = "nope"
-	testNotAnAddress   = "not-an-address"
+	testNope         = "nope"
+	testNotAnAddress = "not-an-address"
 
 	testEthAddress1 = "0x0000000000000000000000000000000000000001"
 	testEthAddress2 = "0x0000000000000000000000000000000000000002"

--- a/internal/soul/registration_v2.go
+++ b/internal/soul/registration_v2.go
@@ -59,6 +59,20 @@ type PrincipalDeclarationV2 struct {
 	DeclaredAt  string `json:"declaredAt"`
 }
 
+var ErrPrincipalBindingMissing = errors.New("verified principal binding is missing")
+
+// PrincipalDeclarationBindingV2 carries the host-verified principal fields that
+// were accepted during the registration proof flow. The registration file leaf
+// validator remains compatible with the v2 public schema, while host publication
+// uses this binding to prevent a valid principal declaration from being replayed
+// into another agent's registration.
+type PrincipalDeclarationBindingV2 struct {
+	Identifier  string
+	Declaration string
+	Signature   string
+	DeclaredAt  string
+}
+
 type SelfDescriptionV2 struct {
 	Purpose      string `json:"purpose"`
 	Constraints  string `json:"constraints,omitempty"`
@@ -286,6 +300,31 @@ func (p *PrincipalDeclarationV2) Validate() error {
 	}
 	if err := validateRFC3339(p.DeclaredAt); err != nil {
 		return fmt.Errorf("declaredAt: %w", err)
+	}
+	return nil
+}
+
+func (p *PrincipalDeclarationV2) ValidateVerifiedBinding(binding PrincipalDeclarationBindingV2) error {
+	if p == nil {
+		return errors.New("principal is required")
+	}
+	if strings.TrimSpace(binding.Identifier) == "" ||
+		strings.TrimSpace(binding.Declaration) == "" ||
+		strings.TrimSpace(binding.Signature) == "" ||
+		strings.TrimSpace(binding.DeclaredAt) == "" {
+		return ErrPrincipalBindingMissing
+	}
+	// The stored signature is intentionally presence-only here. A v2 public
+	// registration can carry the schema's declaration-only signature while host
+	// stores the domain-separated proof signature accepted during registration.
+	if !strings.EqualFold(strings.TrimSpace(p.Identifier), strings.TrimSpace(binding.Identifier)) {
+		return errors.New("principal does not match verified agent principal")
+	}
+	if strings.TrimSpace(p.Declaration) != strings.TrimSpace(binding.Declaration) {
+		return errors.New("principal does not match verified agent principal")
+	}
+	if strings.TrimSpace(p.DeclaredAt) != strings.TrimSpace(binding.DeclaredAt) {
+		return errors.New("principal does not match verified agent principal")
 	}
 	return nil
 }

--- a/internal/soul/registration_v2_test.go
+++ b/internal/soul/registration_v2_test.go
@@ -3,6 +3,7 @@ package soul
 import (
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -177,6 +178,33 @@ func TestRegistrationFileV2_ParseAndValidate(t *testing.T) {
 				t.Fatalf("expected validation error")
 			}
 		})
+	}
+}
+
+func TestPrincipalDeclarationV2ValidateVerifiedBinding(t *testing.T) {
+	t.Parallel()
+
+	valid := validPrincipalV2(t)
+	binding := PrincipalDeclarationBindingV2{
+		Identifier:  strings.ToLower(valid.Identifier),
+		Declaration: "  " + valid.Declaration + "  ",
+		Signature:   "  " + valid.Signature + "  ",
+		DeclaredAt:  "  " + valid.DeclaredAt + "  ",
+	}
+	if err := valid.ValidateVerifiedBinding(binding); err != nil {
+		t.Fatalf("expected binding to validate case-insensitive identifier and trimmed fields: %v", err)
+	}
+
+	missing := binding
+	missing.Identifier = " "
+	if err := valid.ValidateVerifiedBinding(missing); !errors.Is(err, ErrPrincipalBindingMissing) {
+		t.Fatalf("expected missing binding sentinel, got %v", err)
+	}
+
+	mismatched := binding
+	mismatched.Identifier = common.HexToAddress("0x0000000000000000000000000000000000000001").Hex()
+	if err := valid.ValidateVerifiedBinding(mismatched); err == nil || !strings.Contains(err.Error(), "verified agent principal") {
+		t.Fatalf("expected principal mismatch, got %v", err)
 	}
 }
 

--- a/internal/trust/handlers_ai_moderation_internal_test.go
+++ b/internal/trust/handlers_ai_moderation_internal_test.go
@@ -7,7 +7,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/mock"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/equaltoai/lesser-host/internal/ai"
 	"github.com/equaltoai/lesser-host/internal/artifacts"
@@ -109,6 +112,57 @@ func TestHandleAIModerationImage_DisabledShortCircuitsFetch(t *testing.T) {
 	}
 	if out.Contract.Module != ai.ModerationImageLLMModule || out.Contract.InputsHash == "" {
 		t.Fatalf("expected image moderation contract, got %#v", out.Contract)
+	}
+}
+
+func TestHandleAIModerationImage_BudgetPrecheckShortCircuitsFetch(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInstance := new(ttmocks.MockQuery)
+	qBudget := new(ttmocks.MockQuery)
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(qBudget).Maybe()
+	qInstance.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInstance).Maybe()
+	qBudget.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qBudget).Maybe()
+	qBudget.On("ConsistentRead").Return(qBudget).Maybe()
+
+	enabled := true
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest, ok := args.Get(0).(*models.Instance)
+		if !ok {
+			t.Fatalf("expected *models.Instance mock destination")
+		}
+		*dest = models.Instance{
+			Slug:              testBudgetInstanceSlug,
+			AIEnabled:         &enabled,
+			ModerationEnabled: &enabled,
+			ModerationTrigger: moderationTriggerAlways,
+		}
+	}).Once()
+	qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	st := store.New(db)
+	s := &Server{store: st, ai: ai.NewService(st), artifacts: artifacts.New("bucket")}
+	body, _ := json.Marshal(aiModerationImageRequest{URL: "https://example.com/image.png"})
+	resp, err := s.handleAIModerationImage(&apptheory.Context{
+		AuthIdentity: testBudgetInstanceSlug,
+		Request:      apptheory.Request{Body: body},
+	})
+	if err != nil {
+		t.Fatalf("expected budget precheck response before url fetch, got err: %v", err)
+	}
+	if resp.Status != 200 {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out aiModerationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Status != statusNotCheckedBudget || out.ErrorCode != statusNotCheckedBudget || out.Budget.Reason != budgetReasonNotConfigured {
+		t.Fatalf("expected not_checked_budget precheck response before fetch, got %#v", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Bind v2/v3 soul registration publication to the host-verified principal proof stored on the agent identity, including a domain-separated signature check against agent/domain/local-id/wallet/chain/contract context.
- Keep the public v2 principal leaf validator schema-compatible while adding host-side verified binding enforcement so declaration-only signatures cannot be replayed into another agent registration.
- Add regression coverage that image URL moderation returns disabled/budget-precheck responses before URL fetch/storage work.

## Finding map
- `host.csv:6` / arbitrary post attestations: current code already binds publish-job subjects to `ctx.AuthIdentity` via `normalizeInstanceAttestationSubject`, derives attestation IDs with `InstanceAttestationID(instanceSlug, ...)`, requires `instance_slug` on public lookup, and hides legacy unbound attestation records. Existing trust tests cover owned subjects and instance-bound lookup.
- `host.csv:16` / lifecycle signature replay: current lifecycle parsing uses `parseSoulSignedTimestamp` with 15-minute max age and 5-minute future skew; existing continuity tests verify stale timestamp rejection.
- `host.csv:17` / principal signature replay: this PR adds the missing publication-time binding for v2/v3 registration files, rejects missing/invalid stored verified principal proofs, and covers replayed declaration-only signatures.
- `host.csv:18` / v2 version-history bypass: current publish path requires `previousVersionUri` for existing history via `ensureNoSoulRegistrationVersionHistory` and validates expected previous versions; existing tests cover the conflict path.
- `host.csv:22` / image URL ingest before policy/budget: current image moderation already performs disabled/policy and budget prechecks before `prepareModerationImageInputs`; this PR adds explicit budget-precheck short-circuit coverage for URL requests.

## Validation
- `go test ./internal/soul ./internal/controlplane ./internal/trust`
- `go test ./...`
- `go vet ./...`
- `gov-infra/.tools/bin/golangci-lint run --timeout=10m`
- `test -z "$(gofmt -l $(git ls-files '*.go'))"`
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS 29 / FAIL 0 / BLOCKED 0

## Deployment
- Not performed. Aron will handle the deployment phase.

Closes #283
