### PR TITLE
[codex] Harden governance verifiers and sanitize remediation docs

### DIFF
--- a/docs/roadmap-codex-security-remediation-2026-04-28.md
+++ b/docs/roadmap-codex-security-remediation-2026-04-28.md
@@ -1,246 +1,115 @@
-# Roadmap: Host Security Hardening — Codex Findings 2026-04-28
+# Roadmap: Host Security Remediation Coordination — 2026-04-28
 
 ## Goal
 
-Remediate the 69 new Codex Security findings reported in `.theory/codex-security-findings-2026-04-28T21-19-20.568Z.csv` without weakening host's governance rubric, multi-tenant isolation, on-chain integrity, consumer release verification, trust/API auth posture, or strict CSP. Done means every finding is either fixed with regression coverage and evidence, explicitly marked stale/not-applicable with repository evidence, or routed to a documented external/sibling coordination item; lab soak and live rollout are completed under normal host deployment discipline.
+Coordinate remediation of the 2026-04-28 Codex security report without weakening host's governance rubric,
+multi-tenant isolation, on-chain integrity, consumer release verification, trust/API auth posture, or strict CSP. Done
+means each reported item is fixed with regression coverage and evidence, resolved as stale/not-applicable with repository
+evidence, or routed to a documented external/sibling coordination item. Deployment remains a separate operator phase.
+
+## Public disclosure boundary
+
+This public roadmap intentionally omits unresolved finding titles, exploit narratives, exact affected paths, and raw
+scanner output. Those details are tracked in review records only as needed for maintainers to reproduce and fix a finding.
+Public documentation should describe remediation sequencing, governance gates, and rollout discipline without becoming a
+live attack map.
+
+When a finding is closed, the merged PR body is the public record that maps the finding reference to the concrete fix,
+regression coverage, and verification commands. Until then, this roadmap stays cluster-level.
 
 ## Classification
 
-Security / tenant-isolation / on-chain-integrity / governance / provisioning / managed-update / soul-registry / trust-API / CSP / operational-reliability / bug-fix / test-coverage / docs.
+Security / tenant-isolation / on-chain-integrity / governance / provisioning / managed-update / soul-registry /
+trust-API / CSP / operational-reliability / bug-fix / test-coverage / docs.
 
-## Source findings
+## Source and tracking
 
-- Report: `.theory/codex-security-findings-2026-04-28T21-19-20.568Z.csv`
-- GitHub Project: [#26 — Host Security Hardening — Codex Findings 2026-04-28](https://github.com/orgs/equaltoai/projects/26)
-- Parent issues: [#181](https://github.com/equaltoai/lesser-host/issues/181) through [#186](https://github.com/equaltoai/lesser-host/issues/186); cluster issues [#187](https://github.com/equaltoai/lesser-host/issues/187) through [#211](https://github.com/equaltoai/lesser-host/issues/211)
-- Current investigation commit: `ecbc94340825c6c346f3bf637561bdd27cd816c3`
-- Finding count: 69 total — 13 high, 34 medium, 13 low, 9 informational
-- Confirmed live high-risk clusters: mailbox content overwrite, public soul chain fanout, unauthenticated comm webhooks/voice billing, SES spoofed sender trust, email/channel/ENS takeover, unbound soul operation tx recording, public dispute evidence exposure, unpinned `latest` provisioning, forced remote-agent enablement.
-- Stale/partially obsolete: high finding "Unverified lesser-body tarball executed in privileged runner" is materially changed on current HEAD because lesser-body named release assets are checksum-verified before execution; residual risk remains through `latest` defaults and certification gates.
+- Source report date: 2026-04-28.
+- Detailed report artifacts: not committed to public docs.
+- Program tracking: GitHub Project [#26 — Host Security Hardening — Codex Findings 2026-04-28](https://github.com/orgs/equaltoai/projects/26).
+- Closure record: merged PR bodies and evidence artifacts, not unresolved public-path inventories.
 
-## Surfaces affected
-
-- `cmd/control-plane-api`, `internal/controlplane`: public soul APIs, comm webhooks, portal instance/update APIs, channel provisioning, operation recording, billing/metering, public dispute/validation surfaces.
-- `cmd/email-ingress`, `internal/emailingress`: SES inbound bridge and sender/authentication verdict handling.
-- `cmd/comm-worker`, `internal/commworker`, `internal/commmailbox`: inbound routing, mailbox capture/content storage, preview/listing, queue/status, sender enrichment.
-- `cmd/provision-worker`, `internal/provisionworker`, `cdk/lib/provision-runner/*`: managed provisioning, managed update, release verification, lesser-body certification, instance-key secrets, trust verification.
-- `internal/store/models`: soul identity/channel/index/mailbox/operation models and TableTheory registration.
-- `contracts/`: SoulRegistry, TipSplitter, OffchainResolver contract issues.
-- `scripts/managed-release-certification`, `scripts/managed-release-readiness`: release evidence/certification semantics.
-- `gov-infra/verifiers`: CMP-4 verifier semantic hardening.
-- `web/`: MarkdownRenderer sanitization and portal update UX correctness.
-- `cdk/`: CodeBuild runner, CloudFront/trust routing/IAM, webhook base URLs.
-- `app-theory/app.json`: AppTheory deployment contract command interpolation.
-
-## Sibling-repo coordination
-
-- lesser: required for managed provisioning behavior validation and canary managed-instance rollout expectations; no immediate lesser code edit planned.
-- body: required for comm/mailbox API compatibility and lesser-body release certification expectations; no immediate body code edit planned unless host-side contract changes require body adaptation.
-- soul: awareness required for public soul namespace semantics, channel ownership/index invariants, and public privacy posture; no namespace URL change planned.
-- greater: awareness only if MarkdownRenderer fix needs upstream greater-components alignment; host's local web consumption must remain CSP-safe.
-- sim: required for integration validation of portal/trust/soul/comm tightened behavior.
-
-## Framework coordination
-
-- AppTheory: required for finding #24 if safe deploy-command interpolation belongs in the framework rather than host's app contract; otherwise host must consume the framework idiomatically without local patches.
-- TableTheory: possible if conditional create/update ownership semantics need framework support; default path is host-side conditional reads/writes, not local framework patches.
-- FaceTheory: possible only if MarkdownRenderer sanitization belongs upstream; no local CSP loosening.
-
-## External-vendor coordination
-
-- Stripe / billing: no Stripe change expected; voice billing idempotency must preserve ledger correctness.
-- SES / email vendors: SES receipt verdicts, Migadu mailbox conflict behavior, and forwarding idempotency need vendor-aware handling.
-- Telnyx: webhook signature validation and canonical base URL handling required.
-- AI providers: OpenAI mint stream token cap / cost guard hardening.
-- eth_rpc provider: public soul read fanout must be bounded/cached to protect provider availability and cost.
-- Safe multisig signers: required only if contract changes progress beyond Sepolia to mainnet.
-
-## Phases
+## Remediation phases
 
 ### Phase 0: Evidence baseline and project triage
 
-- Items: all findings #1–#69.
-- Dependencies: none.
-- Risks:
-  - False positives or stale findings consume security bandwidth.
-  - Fixing without reproducer coverage can hide regressions.
-- Deliverables:
-  - Finding ledger in issue bodies with status: confirmed / stale / fixed / not-applicable.
-  - Minimal reproducer or code evidence for every high and medium finding.
-  - Priority labels and owner surfaces assigned.
+- Assign each report item to a remediation cluster.
+- Record whether it is confirmed, stale/not-applicable, or assigned for verification.
+- Require a reproducer, code evidence, or explicit not-applicable rationale before closure.
 
-### Phase 1: P0 public ingress, comm, mailbox, and privacy blockers
+### Phase 1: Public ingress, comm, mailbox, and privacy blockers
 
-- Items: #1, #3, #4, #7, #8, #9, #10, #11, #14, #19, #20, #21, #23, #26, #29, #30, #39, #41, #43, #48, #49, #58, #59, #61, #62, #67.
-- Dependencies: Phase 0 triage for exact repro/acceptance; `audit-trust-and-safety` walk.
-- Risks:
-  - Tightening webhook auth can interrupt inbound email/SMS/voice delivery if vendor signatures are mis-modeled.
-  - Mailbox content immutability must not create ghost rows or cross-agent reads.
-  - Public privacy fixes must preserve intentionally public soul read semantics.
-- Deliverables:
-  - Provider-authenticated comm webhook handling with replay/idempotency controls.
-  - SES SPF/DKIM/DMARC verdict gating before sender identity enrichment.
-  - Mailbox content write reservation/immutability and digest consistency.
-  - Email/phone/ENS/channel uniqueness and ownership guards.
-  - Public dispute/validation/channel/search responses redacted, bounded, or authenticated as appropriate.
-  - Header/log injection and mailbox preview/normalization DoS fixes.
+- Harden inbound provider trust, replay/idempotency handling, and sender/verdict treatment.
+- Preserve tenant boundaries and bounded mailbox semantics.
+- Redact or bound public surfaces where stored evidence or validation material would otherwise be overexposed.
+- Keep instance-auth strict and logs sanitized.
 
 ### Phase 2: Soul registry and on-chain operation integrity
 
-- Items: #6, #22, #28, #31, #32, #33, #34, #38, #40, #44, #45, #68.
-- Dependencies: `evolve-soul-registry` walk; contract changes require Hardhat tests, Slither, solhint, Sepolia evidence before mainnet Safe-ready payloads.
-- Risks:
-  - On-chain operation side effects are irreversible if tx receipts remain unbound.
-  - Contract changes can require forward-fix deploys rather than rollback.
-  - Signature canonicalization must align web and Go exactly.
-- Deliverables:
-  - Tx receipt validation bound to expected contract, calldata/event logs, value, and agent-specific state transition before status/side effects.
-  - Mint/rotation/lifecycle signature replay controls and canonicalization fixes.
-  - Public relationship/endorsement merge bounds.
-  - Contract fixes or explicit not-applicable evidence for OffchainResolver, SoulRegistry, and TipSplitter findings.
+- Validate operation execution against expected on-chain state transitions before recording irreversible side effects.
+- Preserve canonical signature/domain separation across soul lifecycle operations.
+- Treat contract changes with the full Slither, solhint, Hardhat, Sepolia, and Safe-ready mainnet discipline.
 
 ### Phase 3: Managed provisioning, release verification, and managed-update supply chain
 
-- Items: #5, #12, #13, #15, #16, #17, #18, #47, #51, #52, #53, #54, #55, #60, #63, #64, #65.
-- Dependencies: `provision-managed-instance` walk; release-verification discipline; canary managed instance selected before live broad rollout.
-- Risks:
-  - Removing `latest` defaults changes operator workflows and may block misconfigured deploys immediately.
-  - Release verification changes can stop managed provisioning if manifests are incomplete.
-  - Instance-key secret stage isolation touches tenant trust/auth and must not expose raw keys.
-- Deliverables:
-  - Explicit pinned release requirements or operator-approved resolution flow; no silent `latest` default in managed provisioning.
-  - `git_sha` validation as immutable 40-hex commit SHA where source checkout is required.
-  - lesser-body template certification enabled by default where safety requires it, with truthful evidence status.
-  - Stage-scoped instance key secret names and authenticated trust verification restored.
-  - Body-only/update metadata semantics corrected, including portal/operator blank-version config and key-rotation actions.
-  - Tip config validation prevents deploy-wedging configuration.
+- Remove ambiguous or floating managed-release inputs from provisioning paths.
+- Preserve checksum-based consumer release verification for lesser and body artifacts.
+- Keep instance-key handling stage-scoped and hash-only.
+- Exercise managed update semantics without weakening rollback or per-slug isolation.
 
 ### Phase 4: Public read scalability, web/CSP, governance, reputation, and model registration
 
-- Items: #2, #24, #25, #27, #35, #36, #37, #42, #46, #50, #56, #57, #66, #69.
-- Dependencies: `audit-trust-and-safety` for CSP/web and public reads; `maintain-governance-rubric` for CMP-4; possible `coordinate-framework-feedback` if TableTheory model registration friction is framework-level.
-- Risks:
-  - CSP must not be loosened to accommodate Markdown rendering.
-  - Public read bounding must not break legitimate registry discovery.
-  - Governance verifier fixes must tighten semantics without creating flaky CI.
-- Deliverables:
-  - Public soul reads bounded/cached/paginated with rate/cost awareness.
-  - MarkdownRenderer sanitization is mandatory for untrusted content; no `unsafe-inline`, no `unsafe-eval`.
-  - CMP-4 verifier validates semantics, not keyword presence.
-  - Reputation and model registration fixes with tests.
-  - AppTheory deploy-command interpolation finding routed to a safe host contract change or framework-feedback issue.
+- Bound public reads and expensive enrichment paths.
+- Keep the web UI CSP-safe; do not introduce inline script/style, eval, or third-party script origins.
+- Tighten governance verifiers where scanner findings show keyword-only or parser-only blind spots.
+- Add regression coverage for reputation/model-registration behavior changes.
 
 ### Phase 4.5: Lesser M9 structured init-admin consent alignment
 
-- Items: [#217](https://github.com/equaltoai/lesser-host/issues/217),
-  [#218](https://github.com/equaltoai/lesser-host/issues/218),
-  [#219](https://github.com/equaltoai/lesser-host/issues/219),
-  [#220](https://github.com/equaltoai/lesser-host/issues/220),
-  [#221](https://github.com/equaltoai/lesser-host/issues/221).
-- Dependencies: Phase 4 merged; `provision-managed-instance` walk; lesser PR
-  [#901](https://github.com/equaltoai/lesser/pull/901) before final release certification/canary evidence.
-- Risks:
-  - host currently transports provisioning consent but must emit the structured JSON that Lesser M9 accepts.
-  - Any whitespace trimming or reserialization between wallet signing, `ProvisionJob`, CodeBuild, `provision.json`, and
-    `lesser init-admin` invalidates signature/replay semantics.
-  - Certifying M9 before exact published release assets exist would weaken consumer release verification.
-- Deliverables:
-  - host-generated `consent_message` is compact JSON with `kind=lesser.init_admin_consent.v1`, managed stage `instance`,
-    `username`, `nonce`, and `expires_at` only.
-  - Exact signed bytes are preserved through portal verification, stored job state, CodeBuild environment transport, and
-    `provision.json`.
-  - Managed provisioning docs and Lesser release contract document M9 consent shape, instance-stage domain derivation,
-    CORS sequencing, and no-bypass release-certification expectations.
-  - M9 consumption remains gated on checksum-verified exact published assets, managed-release certification/readiness,
-    lab dry-run, and canary evidence before live/default rollout.
+- Preserve exact signed consent bytes through portal verification, stored job state, CodeBuild transport, and
+  `provision.json`.
+- Keep M9 consumption gated on checksum-verified exact published lesser artifacts, managed-release certification,
+  readiness checks, lab dry-run, and canary evidence before live/default rollout.
 
 ### Phase 5: Regression evidence, docs, and staged rollout
 
-- Items: all fixed findings.
-- Dependencies: Phases 1–4.5 fixes merged through PR with gov-infra verifiers.
-- Risks:
-  - Evidence gaps can make a fix unreviewable.
-  - Lab-only success may not cover live vendor/provider behavior.
-- Deliverables:
-  - Tests for each finding cluster.
-  - Updated docs/runbooks where behavior changes operator or customer flows.
-  - `gov-infra/evidence/` updated by verifiers where applicable.
-  - Lab deployment and soak evidence.
-  - Live deploy authorization checklist and post-deploy monitoring notes.
-- M5 repository-owned records:
-  - Evidence package: `docs/security/codex-security-m5-evidence-2026-04-29.md`
-  - Rollout checklist: `docs/security/codex-security-m5-rollout-checklist-2026-04-29.md`
-  - Release notes: `docs/security/codex-security-release-notes-2026-04-29.md`
+- Link each closed finding to tests, verifier output, or evidence-backed not-applicable rationale.
+- Update operator-facing docs only after behavior changes are merged.
+- Produce lab evidence and a live authorization checklist for the operator-managed deployment phase.
 
-## Stage rollout plan (host's own service)
+## Rollout discipline
 
-### Lab
+### Repository gates
 
-- Command: `theory app up --stage lab`
-- Soak duration: at least one business day for non-critical phases; compressed but not skipped for P0 hotfixes.
-- Soak criteria:
-  - `go test ./...`, web lint/typecheck/tests as applicable, CDK synth, gov-infra rubric pass.
-  - Public soul endpoints return bounded/redacted responses with expected cache/rate behavior.
-  - Comm webhook tests pass with valid/invalid/replayed provider signatures.
-  - SES ingress test events handle authentication verdicts correctly.
-  - Managed provisioning dry-run/test slug succeeds with pinned release and checksum verification.
-  - Soul tx receipt validation tested against Sepolia receipts.
+- `go test ./...`
+- applicable web/CDK/contract gates for touched surfaces
+- `bash gov-infra/verifiers/gov-verify-rubric.sh`
+- PR body maps report references to fixes, tests, and verification output
 
-### Live
+### Host service deployment
 
-- Command: `theory app up --stage live`
-- Authorization: explicit operator approval after lab soak.
-- Post-deploy monitoring:
-  - CloudWatch error rate per Lambda.
-  - CloudFront 4xx/5xx by route family.
-  - comm-worker queue depth and DLQ.
-  - SES ingress failures and verdict rejects.
-  - Telnyx/Migadu webhook success/failure rates.
-  - provisioning-worker SQS depth and CodeBuild failures.
-  - trust/API instance-auth failure rate.
-  - eth_rpc latency/error rates.
-  - soul operation record-execution rejects and successful validated receipts.
-  - gov-infra evidence freshness.
+Deployment is operator-owned and follows normal host discipline:
 
-## On-chain rollout plan
+1. Merge through PR with governance verifiers green.
+2. Deploy to `lab` via the AppTheory contract.
+3. Soak and collect evidence for affected surfaces.
+4. Deploy to `live` only with explicit operator authorization.
+5. Monitor CloudWatch, CloudFront, queue depth, provider callbacks, provisioning jobs, trust/API auth failures, and
+   on-chain operation outcomes as applicable.
 
-- Sepolia deploy: required for any `contracts/` fix; include deploy tx, Etherscan verification, Slither/solhint/Hardhat output.
-- Safe-ready payload: prepare only after Sepolia evidence and review.
-- Mainnet execution: Safe multisig only; never single-signer.
-- Post-deploy verification: bytecode/source match, contract addresses recorded under `docs/deployments/`, evidence committed.
-- Off-chain reconciliation: update contract config/DynamoDB references only through normal deploy/config process.
+### On-chain rollout
 
-## Managed-instance rollout plan
+Contract-affecting work requires Sepolia first, source verification, Slither/solhint/Hardhat output, Safe-ready mainnet
+payloads for non-trivial mutations, and post-deploy bytecode/source verification.
 
-- Dry-run target: lab test slug first.
-- Canary customer: one managed instance selected by Aron/operator after lab dry-run.
-- Broader rollout: staged by managed instance; pause on first provisioning/update regression.
-- Per-slug rollback: rollback/remediation runbook per affected slug; release verification remains mandatory.
+### Managed-instance rollout
 
-## Release artifact plan
+Provisioning-affecting work requires lab dry-run, a selected canary managed instance, per-slug rollback/remediation
+planning, and no bypass of consumer release verification.
 
-- GitHub Release: normal host release after fixed phases merge to `main`.
-- Release notes: call out webhook authentication requirements, public API redaction/bounds, managed provisioning pinning, and any on-chain/contract updates.
-- Managed-consumer impact: host consumes lesser/body artifacts; no unverified artifact deployment permitted.
-
-## Rollback plan
-
-- Lambda-version rollback: revert commit and redeploy through AppTheory/CDK; do not delete rollback versions.
-- CDK stack rollback: revert commit + `theory app up --stage <stage>`; no destructive stack operations.
-- On-chain rollback: not rollbackable; forward-fix via new on-chain transaction/Safe governance.
-- Governance-rubric rollback: avoid unless verifier is proven wrong; any rollback is a governance event.
-- Managed-update per-slug rollback: remediate per slug; do not bypass release verification.
-
-## AGPL posture
+## AGPL and framework posture
 
 - No proprietary blobs.
-- New dependencies require AGPL-compatible license vetting.
-- No vendored closed-source security tooling.
-
-## Open questions
-
-1. Which live managed instance, if any, should be the provisioning canary after lab dry-run?
-2. Which public soul fields are intentionally public versus redacted by default for dispute/validation/channel evidence?
-3. Which Telnyx/Migadu/SES signature/verdict headers are present in current live provider payloads?
-4. Which contract findings require Solidity changes versus off-chain guardrails/not-applicable evidence?
-5. Should this initiative cut one release after all phases, or multiple hotfix releases after P0/P1 and provisioning phases?
+- New dependencies require license compatibility review.
+- Framework awkwardness is routed to the relevant Theory Cloud steward instead of local framework patching.
+- Public docs remain useful for governance and rollout review without exposing unresolved attack detail.

--- a/docs/security/codex-findings-2026-04-28-ledger.md
+++ b/docs/security/codex-findings-2026-04-28-ledger.md
@@ -1,117 +1,58 @@
 # Codex Security Finding Ledger — 2026-04-28
 
-This ledger is the M0 evidence baseline for GitHub Project [#26](https://github.com/orgs/equaltoai/projects/26), tracking the Codex Security report at `.theory/codex-security-findings-2026-04-28T21-19-20.568Z.csv`. The CSV itself is not committed; this document records the repository-safe triage index, owner milestone, and disposition for every finding.
+This ledger is the repository-safe public index for the 2026-04-28 Codex security report. It intentionally does not
+publish unresolved finding titles, exploit narratives, exact affected paths, raw request shapes, tokens, credentials,
+or private scanner output.
+
+## Public disclosure boundary
+
+- Detailed scanner output is not committed to public docs.
+- Unresolved findings are tracked by reference ID, severity, remediation cluster, and closure state only.
+- Merged PR bodies become the public per-finding record after they include the concrete fix, regression coverage, and
+  verification evidence.
+- If a finding is stale or not applicable, the closing PR/issue must include code evidence and reviewer rationale without
+  exposing unnecessary exploit detail.
 
 ## Disposition meanings
 
-- **confirmed-static** — M0 directly inspected current code and the reported vulnerable shape is present.
-- **partially-stale/residual-risk** — current code has changed enough that the original wording is no longer fully accurate, but a related security risk remains assigned.
-- **assigned-for-verification** — finding is in-mission and assigned to an implementation cluster; the owning milestone must add a reproducer or evidence-backed not-applicable disposition before closing.
+- **assigned-for-verification** — in mission and assigned to a remediation cluster; closure still requires tests or
+  evidence-backed rationale.
+- **fixed** — merged PR linked the reference to code/docs changes and verification output.
+- **stale/not-applicable** — reviewed against current code and closed with repository evidence.
+- **external-coordination** — requires sibling-repo, framework, vendor, or operator coordination before closure.
 
-## Findings
+## Cluster index
 
-| ID | Severity | Disposition | Owner | Title | Relevant paths |
-|---:|---|---|---|---|---|
-| 1 | high | confirmed-static | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Mailbox content can be overwritten via Message-ID replay | internal/commworker/mailbox_capture.go<br>internal/commmailbox/content_store.go<br>internal/commworker/store.go<br>internal/store/models/soul_comm_mailbox.go |
-| 2 | high | confirmed-static | M4 / [#204](https://github.com/equaltoai/lesser-host/issues/204) | Unauthenticated soul lookups trigger expensive on-chain RPC fanout | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_public.go<br>internal/controlplane/handlers_soul_discovery_v3.go<br>internal/controlplane/soul_public_agent_view.go |
-| 3 | high | confirmed-static | M1 / [#189](https://github.com/equaltoai/lesser-host/issues/189) | SES email ingress trusts spoofable From identity | cdk/lib/lesser-host-stack.ts<br>internal/emailingress/server.go<br>internal/commworker/server.go |
-| 4 | high | confirmed-static | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Email provisioning can hijack existing mailboxes | internal/controlplane/handlers_soul_channels_email_provision.go<br>internal/controlplane/deps_migadu.go<br>internal/controlplane/handlers_soul_update_registration.go |
-| 5 | high | confirmed-static | M3 / [#198](https://github.com/equaltoai/lesser-host/issues/198) | Managed provisioning now defaults to unpinned `latest` releases | cdk/cdk.json<br>cdk/lib/lesser-host-stack.ts<br>internal/controlplane/handlers_provisioning.go<br>internal/provisionworker/server.go |
-| 6 | high | confirmed-static | M2 / [#194](https://github.com/equaltoai/lesser-host/issues/194) | Mint execution endpoint accepts arbitrary tx hashes | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_agent_mint_operation.go<br>internal/controlplane/handlers_soul_operations.go |
-| 7 | high | confirmed-static | M1 / [#190](https://github.com/equaltoai/lesser-host/issues/190) | Voice webhook enables unauthenticated credit-drain billing abuse | internal/controlplane/handlers_comm_webhooks.go<br>internal/controlplane/server.go |
-| 8 | high | confirmed-static | M1 / [#189](https://github.com/equaltoai/lesser-host/issues/189) | Unauthenticated webhooks allow forged inbound comm injection | internal/controlplane/server.go<br>internal/controlplane/handlers_comm_webhooks.go<br>internal/commworker/message.go<br>internal/commworker/server.go |
-| 9 | high | confirmed-static | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Email provisioning allows arbitrary lessersoul.ai address claims | internal/controlplane/handlers_soul_channels_email_provision.go<br>internal/controlplane/deps_migadu.go |
-| 10 | high | confirmed-static | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | V3 channel index writes allow email/phone/ENS takeover | internal/controlplane/handlers_soul_update_registration.go<br>internal/store/models/soul_agent_channel_index_items.go<br>internal/store/models/soul_agent_ens_resolution.go |
-| 11 | high | confirmed-static | M1 / [#192](https://github.com/equaltoai/lesser-host/issues/192) | Unauthenticated public exposure of dispute evidence data | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_sovereignty.go<br>internal/store/models/soul_agent_dispute.go |
-| 12 | high | confirmed-static | M3 / [#203](https://github.com/equaltoai/lesser-host/issues/203) | Provisioning now force-enables open remote agent registration | cdk/lib/lesser-host-stack.ts |
-| 13 | high | partially-stale/residual-risk | M3 / [#198](https://github.com/equaltoai/lesser-host/issues/198) | Unverified lesser-body tarball executed in privileged runner | cdk/lib/lesser-host-stack.ts<br>internal/store/models/instance.go<br>internal/controlplane/handlers_instances.go |
-| 14 | medium | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Mailbox reply endpoint enables RFC5322 header injection | internal/controlplane/handlers_soul_comm_mailbox_reply.go<br>internal/controlplane/handlers_soul_comm_send.go<br>internal/commworker/mailbox_capture.go |
-| 15 | medium | assigned-for-verification | M3 / [#198](https://github.com/equaltoai/lesser-host/issues/198) | Unvalidated git_sha allows mutable source ref checkout | cdk/lib/provision-runner/helpers.sh |
-| 16 | medium | assigned-for-verification | M3 / [#199](https://github.com/equaltoai/lesser-host/issues/199) | Lesser-body template certification silently disabled by default | cdk/lib/provision-runner-buildspec.ts<br>internal/provisionworker/update_jobs.go |
-| 17 | medium | assigned-for-verification | M3 / [#200](https://github.com/equaltoai/lesser-host/issues/200) | Canary token can leak to arbitrary or plaintext base URLs | github/workflows/managed-release-canary.yml<br>scripts/managed-release-certification/main.go |
-| 18 | medium | assigned-for-verification | M3 / [#201](https://github.com/equaltoai/lesser-host/issues/201) | Instance key secret names lost stage isolation | internal/provisionworker/server.go<br>internal/provisionworker/managed_instance_key_secrets.go |
-| 19 | medium | assigned-for-verification | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Phone notifications can forge recipient addresses | internal/commworker/server.go<br>internal/controlplane/handlers_soul_update_registration.go |
-| 20 | medium | assigned-for-verification | M1 / [#189](https://github.com/equaltoai/lesser-host/issues/189) | Telnyx webhook can be set from request Host | internal/controlplane/handlers_soul_channels_phone_provision.go<br>internal/controlplane/handlers_comm_voice_outbound.go<br>internal/controlplane/deps_telnyx.go<br>cdk/lib/lesser-host-stack.ts |
-| 21 | medium | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Unescaped inbound message IDs allow log injection | internal/commworker/server.go<br>internal/commworker/message.go<br>internal/controlplane/server.go<br>internal/controlplane/handlers_comm_webhooks.go |
-| 22 | medium | assigned-for-verification | M2 / [#194](https://github.com/equaltoai/lesser-host/issues/194) | Rotation execution accepts unrelated transaction hashes | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_agent_rotation_operation.go<br>internal/controlplane/handlers_soul_operations.go |
-| 23 | medium | assigned-for-verification | M1 / [#193](https://github.com/equaltoai/lesser-host/issues/193) | First-contact preferences ignore email CC/BCC recipients | internal/controlplane/handlers_soul_comm_send.go |
-| 24 | medium | confirmed-static | M4 / [#211](https://github.com/equaltoai/lesser-host/issues/211) | Unsafe eval in deploy command enables shell command injection | app-theory/app.json<br>cdk/bin/lesser-host.ts |
-| 25 | medium | assigned-for-verification | M4 / [#204](https://github.com/equaltoai/lesser-host/issues/204) | Authenticated DoS via conflict-path GitHub release resolution | internal/controlplane/handlers_portal_updates.go<br>internal/controlplane/lesser_releases.go |
-| 26 | medium | assigned-for-verification | M1 / [#190](https://github.com/equaltoai/lesser-host/issues/190) | Unauthenticated voice webhooks permit reply/status spoofing | internal/controlplane/server.go<br>internal/controlplane/handlers_comm_voice_outbound.go |
-| 27 | medium | assigned-for-verification | M4 / [#205](https://github.com/equaltoai/lesser-host/issues/205) | Communication score can be inflated without any actual responses | internal/soulreputationworker/server.go<br>internal/soulreputation/v0.go<br>internal/config/config.go |
-| 28 | medium | assigned-for-verification | M2 / [#197](https://github.com/equaltoai/lesser-host/issues/197) | CCIP callback lacks target binding, allowing proof replay | contracts/contracts/OffchainResolver.sol |
-| 29 | medium | assigned-for-verification | M1 / [#193](https://github.com/equaltoai/lesser-host/issues/193) | Outbound email boundary check bypass via unvalidated inReplyTo | internal/controlplane/handlers_soul_comm_send.go |
-| 30 | medium | assigned-for-verification | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Unauthenticated channel resolution leaks and trusts unverified claims | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_discovery_v3.go<br>internal/controlplane/handlers_soul_update_registration.go |
-| 31 | medium | assigned-for-verification | M2 / [#195](https://github.com/equaltoai/lesser-host/issues/195) | Mint finalize can publish pending agents as active | internal/controlplane/handlers_soul_mint_conversation.go |
-| 32 | medium | assigned-for-verification | M2 / [#195](https://github.com/equaltoai/lesser-host/issues/195) | Lifecycle signatures are replayable for up to 10 years | internal/controlplane/handlers_soul_lifecycle.go |
-| 33 | medium | assigned-for-verification | M2 / [#195](https://github.com/equaltoai/lesser-host/issues/195) | Principal signature can be replayed across soul agents | internal/controlplane/handlers_soul_registry.go<br>internal/soul/registration_v2.go |
-| 34 | medium | assigned-for-verification | M2 / [#195](https://github.com/equaltoai/lesser-host/issues/195) | V2 registration can bypass existing version history | internal/controlplane/handlers_soul_update_registration.go<br>internal/controlplane/soul_registration_publish_v2.go |
-| 35 | medium | assigned-for-verification | M4 / [#204](https://github.com/equaltoai/lesser-host/issues/204) | Public versions endpoint now performs unbounded DB reads | internal/controlplane/handlers_soul_versions.go |
-| 36 | medium | assigned-for-verification | M4 / [#204](https://github.com/equaltoai/lesser-host/issues/204) | Public soul search now enables unbounded DB-scan DoS | internal/controlplane/handlers_soul_public.go |
-| 37 | medium | assigned-for-verification | M4 / [#205](https://github.com/equaltoai/lesser-host/issues/205) | OpenAI mint stream lacks output token cap enabling DoS/cost abuse | internal/controlplane/handlers_soul_mint_conversation.go<br>internal/ai/llm/mint_conversation_stream.go |
-| 38 | medium | assigned-for-verification | M2 / [#196](https://github.com/equaltoai/lesser-host/issues/196) | Unbounded endorsement merge enables public read DoS | internal/controlplane/handlers_soul_relationships.go |
-| 39 | medium | assigned-for-verification | M1 / [#192](https://github.com/equaltoai/lesser-host/issues/192) | Opt-in endpoint lets non-operators finalize challenge results | internal/controlplane/handlers_soul_sovereignty.go<br>internal/controlplane/handlers_soul_validation.go<br>internal/controlplane/server.go |
-| 40 | medium | assigned-for-verification | M2 / [#197](https://github.com/equaltoai/lesser-host/issues/197) | Burned Soul IDs can be reminted and reassigned by owner | contracts/contracts/SoulRegistry.sol |
-| 41 | medium | assigned-for-verification | M1 / [#192](https://github.com/equaltoai/lesser-host/issues/192) | Validation responses are exposed through public API | internal/controlplane/handlers_soul_validation.go<br>internal/store/models/soul_agent_validation_record.go<br>internal/controlplane/server.go<br>internal/controlplane/handlers_soul_public.go |
-| 42 | medium | assigned-for-verification | M4 / [#205](https://github.com/equaltoai/lesser-host/issues/205) | Suspended agents retain stale public reputation | internal/soulreputationworker/server.go<br>internal/controlplane/handlers_soul_public.go |
-| 43 | medium | assigned-for-verification | M1 / [#192](https://github.com/equaltoai/lesser-host/issues/192) | Public validation API leaks raw challenge transcripts | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_public.go<br>internal/store/models/soul_agent_validation_record.go |
-| 44 | medium | assigned-for-verification | M2 / [#194](https://github.com/equaltoai/lesser-host/issues/194) | Soul operation receipts are accepted without validation | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_operations.go |
-| 45 | medium | assigned-for-verification | M2 / [#197](https://github.com/equaltoai/lesser-host/issues/197) | Wallet rotations leave pending funds at old addresses | contracts/contracts/TipSplitter.sol |
-| 46 | medium | assigned-for-verification | M4 / [#205](https://github.com/equaltoai/lesser-host/issues/205) | Portal users can self-enable Soul provisioning | internal/controlplane/server.go<br>internal/controlplane/handlers_portal_instances.go<br>internal/controlplane/handlers_instances.go |
-| 47 | medium | assigned-for-verification | M3 / [#201](https://github.com/equaltoai/lesser-host/issues/201) | Trust verification skips key auth when AI is disabled | internal/provisionworker/update_jobs.go |
-| 48 | low | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Mailbox preview exposes full short message content | internal/controlplane/handlers_soul_comm_mailbox.go<br>internal/store/models/soul_comm_mailbox.go<br>internal/controlplane/comm_mailbox_capture.go<br>internal/commworker/mailbox_capture.go |
-| 49 | low | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Unbounded preview normalization can cause memory/CPU DoS | internal/store/models/soul_comm_mailbox.go |
-| 50 | low | assigned-for-verification | M4 / [#206](https://github.com/equaltoai/lesser-host/issues/206) | CMP-4 verifier can be bypassed with insecure wording | gov-infra/verifiers/gov-verify-rubric.sh |
-| 51 | low | assigned-for-verification | M3 / [#199](https://github.com/equaltoai/lesser-host/issues/199) | Readiness check accepts mismatched lesser-body evidence | scripts/managed-release-readiness/main.go |
-| 52 | low | assigned-for-verification | M3 / [#199](https://github.com/equaltoai/lesser-host/issues/199) | Lesser-body evidence can report pass when deployment failed | scripts/managed-release-certification/main.go |
-| 53 | low | assigned-for-verification | M3 / [#200](https://github.com/equaltoai/lesser-host/issues/200) | Untrusted issue comment marker can DoS readiness sync | scripts/managed-release-readiness/main.go<br>github/workflows/managed-release-canary.yml |
-| 54 | low | assigned-for-verification | M3 / [#198](https://github.com/equaltoai/lesser-host/issues/198) | Prerelease tags bypass new managed minimum-version check | internal/provisionworker/release_compatibility.go<br>internal/controlplane/handlers_portal_updates.go<br>internal/controlplane/lesser_releases.go |
-| 55 | low | assigned-for-verification | M3 / [#202](https://github.com/equaltoai/lesser-host/issues/202) | Body-only updates can overwrite recorded LesserVersion without deploy | internal/controlplane/handlers_portal_updates.go<br>internal/provisionworker/update_jobs.go |
-| 56 | low | confirmed-static | M4 / [#207](https://github.com/equaltoai/lesser-host/issues/207) | MarkdownRenderer allows sanitization bypass (XSS risk) | web/src/lib/greater/content/components/MarkdownRenderer.svelte |
-| 57 | low | assigned-for-verification | M4 / [#204](https://github.com/equaltoai/lesser-host/issues/204) | Public ENS cache allows unbounded memory DoS via random names | internal/trust/server.go<br>internal/trust/handlers_ens_gateway.go |
-| 58 | low | assigned-for-verification | M1 / [#193](https://github.com/equaltoai/lesser-host/issues/193) | Rejected claim-level updates still overwrite public S3 metadata | internal/controlplane/handlers_soul_update_registration.go<br>internal/controlplane/handlers_soul_capabilities.go |
-| 59 | low | assigned-for-verification | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Unverified domains can enumerate Soul agents | internal/controlplane/server.go<br>internal/controlplane/handlers_soul_mine.go<br>internal/controlplane/handlers_portal_instances.go<br>internal/controlplane/handlers_soul_registry.go |
-| 60 | low | assigned-for-verification | M3 / [#202](https://github.com/equaltoai/lesser-host/issues/202) | Tip config can wedge managed deploys | internal/controlplane/handlers_instances.go<br>internal/provisionworker/server.go<br>internal/provisionworker/update_jobs.go<br>cdk/lib/lesser-host-stack.ts |
-| 61 | informational | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | Queue listing can miss valid queued messages | internal/controlplane/handlers_soul_comm_portal.go |
-| 62 | informational | assigned-for-verification | M1 / [#188](https://github.com/equaltoai/lesser-host/issues/188) | One-shot S3 init error causes persistent mailbox write DoS | internal/commmailbox/content_store.go |
-| 63 | informational | assigned-for-verification | M3 / [#199](https://github.com/equaltoai/lesser-host/issues/199) | Template-cert check can report pass on body phase failures | scripts/managed-release-certification/main.go<br>cdk/lib/provision-runner-buildspec.ts |
-| 64 | informational | assigned-for-verification | M3 / [#202](https://github.com/equaltoai/lesser-host/issues/202) | Managed Lesser deploys now depend on missing metadata file | cdk/lib/provision-runner-buildspec.ts |
-| 65 | informational | confirmed-static | M3 / [#202](https://github.com/equaltoai/lesser-host/issues/202) | Blank version validation breaks config and key update buttons | web/src/lib/utils/versionTags.ts<br>web/src/pages/portal/InstanceDetail.svelte<br>web/src/pages/operator/InstanceSupport.svelte<br>internal/controlplane/handlers_portal_updates.go |
-| 66 | informational | assigned-for-verification | M4 / [#208](https://github.com/equaltoai/lesser-host/issues/208) | Trust soul update route added without required infra permissions | cdk/lib/lesser-host-stack.ts<br>internal/trust/server.go<br>internal/controlplane/handlers_soul_update_registration.go |
-| 67 | informational | assigned-for-verification | M1 / [#191](https://github.com/equaltoai/lesser-host/issues/191) | Email/phone index keys permit contact-to-agent mapping takeover | internal/store/models/soul_agent_channel_index_items.go |
-| 68 | informational | assigned-for-verification | M2 / [#195](https://github.com/equaltoai/lesser-host/issues/195) | Timestamp canonicalization breaks signed soul write requests | web/src/pages/portal/SoulAgentDetail.svelte<br>internal/controlplane/handlers_soul_continuity.go<br>internal/controlplane/handlers_soul_relationships.go |
-| 69 | informational | confirmed-static | M4 / [#208](https://github.com/equaltoai/lesser-host/issues/208) | Soul models are not registered with TableTheory | internal/store/db.go<br>internal/store/models/soul_agent_identity.go<br>internal/store/models/soul_operation.go<br>internal/store/models/soul_agent_index_items.go<br>internal/store/models/soul_agent_reputation.go<br>internal/store/models/soul_agent_validation_record.go<br>internal/store/models/soul_agent_endorsement.go |
+| Cluster | Scope | Closure evidence |
+| --- | --- | --- |
+| M1 | Public ingress, comm, mailbox, and privacy blockers | Provider/auth regression tests, privacy/redaction assertions, sanitized logs, and trust/API auth checks. |
+| M2 | Soul registry and on-chain operation integrity | Go regression tests, contract tests where applicable, Slither/solhint/Hardhat output for Solidity changes, and Sepolia/Safe-ready evidence when deployment is required. |
+| M3 | Managed provisioning, release verification, and managed-update supply chain | Release-certification/readiness tests, pinned-artifact verification evidence, provisioning dry-run or canary notes, and instance-key isolation checks. |
+| M4 | Public read scalability, web/CSP, governance, reputation, and model registration | Bounded-read tests, CSP-safe web checks, governance verifier output, and model/reputation regression tests. |
+| M4.5 | Structured managed-provisioning consent alignment | Exact-byte consent preservation tests and checksum-verified release certification evidence before rollout. |
+| M5 | Regression evidence, documentation, and rollout preparation | PR mapping, verifier output, lab evidence, and operator live-deploy checklist. |
 
-## M0 direct-confirmation notes
+## Finding-status register
 
-- **#1**: Mailbox content write happens before conditional row insert; S3 PutObject is unconditional and duplicate row insert condition failure is suppressed.
-- **#2**: Public soul agent read calls per-request on-chain avatar enrichment, including EVM dial and unbounded renderer log scan.
-- **#3**: SES ingress parses and trusts sender identity without M0-observed verdict gating before comm-worker enqueue.
-- **#4**: Email provisioning accepts caller-supplied local part and proceeds through Migadu mailbox/forwarding path.
-- **#5**: CDK defaults contain `managedLesserDefaultVersion` and `managedLesserBodyDefaultVersion` set to `latest`; runner resolves latest dynamically.
-- **#6**: Soul operation execution recording only validates hash shape and successful receipt before status/side-effect update.
-- **#7**: Voice webhook route is public and metering reads request-provided duration/call fields.
-- **#8**: Comm webhook routes are public and accept normalized inbound payloads before enqueue without M0-observed provider signature validation.
-- **#9**: Provisioned email address can be constructed from caller-supplied local part.
-- **#10**: Email/phone/ENS indexes use global identifier keys and CreateOrUpdate semantics.
-- **#11**: Public dispute handlers return stored dispute objects including evidence/statement/resolution fields.
-- **#12**: Provision runner `enable_agents` force-sets agent registration and remote-agent options.
-- **#13**: Current HEAD verifies named lesser-body release assets before executing deploy script, making the original tarball wording stale; residual deterministic-release/certification risks remain in M3.
-- **#24**: AppTheory app contract uses shell `eval` with templated profile substitution; owning issue must determine safe host contract change vs framework feedback.
-- **#56**: MarkdownRenderer exposes optional sanitization around a raw HTML sink; current usages do not pass `sanitize=false`, but the component-level footgun is real.
-- **#65**: Web validation rejects blank release versions while backend supports blank version for config/key-rotation update actions.
-- **#69**: Store Lambda init registration is an explicit allowlist; the reported soul models are not all present in the registration list on current HEAD.
+The register below keeps only the minimum public state needed to audit closure. Detailed descriptions live in the owning
+PR once the fix is ready for review.
 
-## Milestone owner summary
-
-- **M1**: findings #1, #14, #21, #48, #49, #61, #62, #3, #8, #20, #26, #7, #4, #9, #10, #19, #30, #59, #67, #11, #39, #41, #43, #23, #29, #58
-- **M2**: findings #6, #22, #44, #31, #32, #33, #34, #68, #38, #28, #40, #45
-- **M3**: findings #5, #13, #15, #54, #16, #51, #52, #63, #17, #53, #18, #47, #55, #60, #64, #65, #12
-- **M4**: findings #2, #25, #35, #36, #57, #27, #37, #42, #46, #50, #56, #66, #69, #24
-- **M4.5**: cross-repo lesser M9 structured `init-admin` consent alignment — [#217](https://github.com/equaltoai/lesser-host/issues/217)
-  through [#221](https://github.com/equaltoai/lesser-host/issues/221). This is not a new Codex CSV finding; it is the
-  managed-provisioning handoff needed before host consumes/certifies lesser M9 after the original remediation project.
+| Reference range | Severity mix | Current public state | Remediation cluster |
+| --- | --- | --- | --- |
+| 1–14 | high/medium | Assigned or merged through cluster PRs; see merged PR bodies for closed references. | M1/M2/M3 |
+| 15–30 | medium | Assigned or merged through cluster PRs; see merged PR bodies for closed references. | M1/M2/M3/M4 |
+| 31–47 | medium | Assigned or merged through cluster PRs; see merged PR bodies for closed references. | M1/M2/M3/M4 |
+| 48–60 | low | Assigned or merged through cluster PRs; see merged PR bodies for closed references. | M1/M3/M4 |
+| 61–69 | informational | Assigned or merged through cluster PRs; see merged PR bodies for closed references. | M1/M2/M3/M4 |
+| M4.5 follow-up | cross-repo alignment | Tracked separately from the 2026-04-28 scanner output; closure requires exact published-artifact certification. | M4.5 |
 
 ## Closure rule
 
-A finding may leave this ledger only when the owning issue links a merged PR with regression/evidence, or records a reviewed not-applicable/stale disposition with code evidence. High and medium findings should not be closed from source review alone unless the finding is demonstrably stale on current HEAD.
+A finding leaves the active register only when its owning PR or issue records one of the following:
+
+1. a merged fix with regression coverage and verification output;
+2. a reviewed stale/not-applicable disposition with code evidence; or
+3. an explicit external-coordination handoff with the remaining host-side risk bounded.
+
+Public docs must not be used as live inventories of unresolved attack detail. Keep unresolved detail in scoped review
+threads and move only the closure evidence into public PR records.

--- a/gov-infra/pack.json
+++ b/gov-infra/pack.json
@@ -1,14 +1,14 @@
 {
   "$schema": "https://gov.pai.dev/schemas/pack.schema.json",
   "schemaVersion": 1,
-  "packVersion": "2026.04.30-m6",
-  "packDigest": "506c5bee3285c5d902ea39f0070bd8bfe753a51a91147c06d2e0d658be963d8d",
+  "packVersion": "2026.05.14-m7.2",
+  "packDigest": "c326dfb8a5827ab1d48e156cd1cdf7f04e4cd47e92bb0185bce7320723fdf8cb",
   "domain": "custom",
   "projectSlug": "lesser-host",
-  "generatedAt": "2026-04-30T15:30:00Z",
+  "generatedAt": "2026-05-14T21:49:27Z",
   "source": {
     "commitSha": "UNKNOWN",
-    "branch": "codex/host-security-m6-prelive-hardening"
+    "branch": "codex/issue-285-gov-docs-isolation"
   },
   "artifacts": {
     "planning": [

--- a/gov-infra/planning/lesser-host-10of10-rubric.md
+++ b/gov-infra/planning/lesser-host-10of10-rubric.md
@@ -67,7 +67,7 @@ Enforcement rule (anti-drift):
 | --- | ---: | --- | --- |
 | SEC-1 | 3 | Static security scan green (pinned version) | `golangci-lint run --timeout=10m` with `gosec` enabled + `slither` on `contracts` (implemented in verifier; see `gov-infra/evidence/SEC-1-output.log`). |
 | SEC-2 | 3 | Dependency vulnerability scan green | `govulncheck -mode=binary` on shipped `cmd/*` binaries (implemented in verifier; see `gov-infra/evidence/SEC-2-output.log`). |
-| SEC-3 | 2 | Supply-chain verification green | GitHub Actions must be pinned by commit SHA (no `uses: ...@vN`); Node lifecycle hooks scanned with scripts-disabled installs; Go/Python metadata scans (implemented in verifier; see `gov-infra/evidence/SEC-3-output.log`) |
+| SEC-3 | 2 | Supply-chain verification green | GitHub Actions must be pinned by full commit SHA (no tag, branch, SemVer, or expression refs in `uses:`); the verifier self-tests normal step, quoted-key, flow-mapping, and reusable-workflow syntax; Node lifecycle hooks scanned with scripts-disabled installs; Go/Python metadata scans (implemented in verifier; see `gov-infra/evidence/SEC-3-output.log`) |
 | SEC-4 | 2 | Domain-specific P0 regression tests (security critical paths) | Run `TestP0_*` regression suite (bootstrap/authz invariants, SSRF defense, instance auth) (implemented in verifier; see `gov-infra/evidence/SEC-4-output.log`). |
 
 SEC-1 note: Slither runs from a repo-local Python venv under `gov-infra/.tools/` (created/managed by the verifier); do not rely on a system-wide Slither install.
@@ -80,7 +80,7 @@ SEC-1 note: Slither runs from a repo-local Python venv under `gov-infra/.tools/`
 | CMP-1 | 3 | Controls matrix exists and is current | File exists: `gov-infra/planning/lesser-host-controls-matrix.md` |
 | CMP-2 | 2 | Evidence plan exists and is reproducible | File exists: `gov-infra/planning/lesser-host-evidence-plan.md` |
 | CMP-3 | 2 | Threat model exists and is current | File exists: `gov-infra/planning/lesser-host-threat-model.md` |
-| CMP-4 | 3 | Bounded soul comm mailbox controls are explicit | `bash gov-infra/verifiers/gov-verify-rubric.sh` checks ADR 0005, the soul surface, roadmap, threat model, controls matrix, and evidence plan for retention, encryption, access audit, list/content split, no semantic-memory role, hash-only instance auth, write-once audit/events, protected identity/provenance fields, and body/lesser non-authority. |
+| CMP-4 | 3 | Bounded soul comm mailbox controls are explicit | `bash gov-infra/verifiers/gov-verify-rubric.sh` checks ADR 0005, the soul surface, roadmap, threat model, controls matrix, and evidence plan for retention, encryption, access audit, list/content split, no semantic-memory role, hash-only instance auth, write-once audit/events, protected identity/provenance fields, and body/lesser non-authority. The gate rejects explicit insecure variants (optional retention/encryption/audit, full-content list responses, raw-key/plaintext fallback, and cross-tenant mailbox search/analytics) instead of relying on positive keyword presence alone. |
 
 **10/10 definition:** CMP-1 through CMP-4 pass.
 

--- a/gov-infra/planning/lesser-host-evidence-plan.md
+++ b/gov-infra/planning/lesser-host-evidence-plan.md
@@ -58,7 +58,7 @@ Legend:
 | Completeness | COM-6 | Logging/operational standards checks run | `gov-infra/evidence/COM-6-output.log` |
 | Security | SEC-1 | Static security scan runs with pinned tooling (Go + Solidity) | `gov-infra/evidence/SEC-1-output.log` |
 | Security | SEC-2 | Dependency vulnerability scan runs with pinned tooling | `gov-infra/evidence/SEC-2-output.log` |
-| Security | SEC-3 | Supply-chain verification gates run (Actions pinning + dependency lifecycle scan) | `gov-infra/evidence/SEC-3-output.log` |
+| Security | SEC-3 | Supply-chain verification gates run (full-SHA Actions pinning with syntax self-tests + dependency lifecycle scan) | `gov-infra/evidence/SEC-3-output.log` |
 | Security | SEC-4 | Domain-specific P0 security regression tests run | `gov-infra/evidence/SEC-4-output.log` |
 | Compliance readiness | CMP-1 | Controls matrix exists and is readable | (presence check) + `gov-infra/evidence/CMP-1-output.log` |
 | Compliance readiness | CMP-2 | Evidence plan exists and is readable | (presence check) + `gov-infra/evidence/CMP-2-output.log` |

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -446,57 +446,203 @@ scan_python_supply_chain() {
 }
 
 check_supply_chain_actions_pinned() {
-  # Enforces integrity pinning for GitHub Actions. External actions must pin
-  # either a full 40-character commit SHA or a full SemVer release tag
-  # (vX.Y.Z). Floating refs such as @v4, @v4.1, @main, @master, and branch
-  # names are rejected.
-  local wf_dir="${REPO_ROOT}/.github/workflows"
+  # Enforces integrity pinning for GitHub Actions. External actions must pin a
+  # full 40-character commit SHA. Floating refs such as @v4, @v4.1.0, @main,
+  # @master, branch names, and expression-derived refs are rejected. Local
+  # in-repo actions are allowed; docker:// actions must pin an immutable image
+  # digest.
+  local wf_dir="${1:-${REPO_ROOT}/.github/workflows}"
   if [[ ! -d "${wf_dir}" ]]; then
     echo "GitHub Actions pin check: no workflows detected; skipping."
     return 0
   fi
 
-  local failures=""
-  local line file lineno value action ref
-  while IFS= read -r line; do
-    file="${line%%:*}"
-    local rest="${line#*:}"
-    lineno="${rest%%:*}"
-    value="${rest#*:}"
-    value="$(printf '%s' "${value}" | sed -E 's/^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*//; s/[[:space:]]+#.*$//; s/^[\"'\\'' ]+//; s/[\"'\\'' ]+$//')"
-    [[ -n "${value}" ]] || continue
+  local output ec
+  set +e
+  output="$(python3 - "${wf_dir}" "${REPO_ROOT}" <<'PY' 2>&1
+import pathlib
+import re
+import sys
 
-    # Local reusable actions and docker image actions do not use owner/repo@ref.
-    if [[ "${value}" == ./* ]] || [[ "${value}" == docker://* ]]; then
-      continue
-    fi
+wf_dir = pathlib.Path(sys.argv[1])
+repo_root = pathlib.Path(sys.argv[2])
+workflow_files = sorted(
+    p for p in wf_dir.rglob("*") if p.is_file() and p.suffix in {".yml", ".yaml"}
+)
 
-    if [[ "${value}" != *@* ]]; then
-      failures+="${file}:${lineno}: ${value} (missing @ref)"$'\n'
-      continue
-    fi
+line_uses = re.compile(
+    r"^\s*(?:-\s*)?(?:['\"]?uses['\"]?)\s*:\s*(?P<value>.+?)\s*$",
+    re.IGNORECASE,
+)
+flow_uses = re.compile(
+    r"(?P<prefix>[{,])\s*(?:['\"]?uses['\"]?)\s*:\s*(?P<value>[^,}]+)",
+    re.IGNORECASE,
+)
+sha_ref = re.compile(r"^[0-9a-fA-F]{40}$")
+docker_digest = re.compile(r"^docker://.+@sha256:[0-9a-fA-F]{64}$")
 
-    action="${value%@*}"
-    ref="${value##*@}"
-    if [[ -z "${action}" || -z "${ref}" ]]; then
-      failures+="${file}:${lineno}: ${value} (malformed uses ref)"$'\n'
-      continue
-    fi
 
-    if [[ "${ref}" =~ ^[0-9a-fA-F]{40}$ ]] || [[ "${ref}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-      continue
-    fi
+def display_path(path):
+    try:
+        return str(path.relative_to(repo_root))
+    except ValueError:
+        return str(path)
 
-    failures+="${file}:${lineno}: ${value} (ref must be 40-char SHA or vX.Y.Z)"$'\n'
-  done < <(grep -R --include='*.yml' --include='*.yaml' -nE '^[[:space:]]*(-[[:space:]]*)?uses:[[:space:]]*' "${wf_dir}" 2>/dev/null || true)
 
-  if [[ -n "${failures}" ]]; then
-    echo "FAIL: unpinned GitHub Action detected"
-    printf '%s' "${failures}"
+def strip_yaml_comment(value):
+    quote = ""
+    escape = False
+    for idx, ch in enumerate(value):
+        if escape:
+            escape = False
+            continue
+        if ch == "\\":
+            escape = True
+            continue
+        if quote:
+            if ch == quote:
+                quote = ""
+            continue
+        if ch in {"'", '"'}:
+            quote = ch
+            continue
+        if ch == "#" and (idx == 0 or value[idx - 1].isspace()):
+            return value[:idx].strip()
+    return value.strip()
+
+
+def normalize_scalar(value):
+    value = strip_yaml_comment(value).strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1]
+    return value.strip()
+
+
+def iter_uses(path):
+    for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        match = line_uses.match(raw_line)
+        if match:
+            yield lineno, normalize_scalar(match.group("value"))
+            continue
+        for match in flow_uses.finditer(raw_line):
+            yield lineno, normalize_scalar(match.group("value"))
+
+
+def pin_failure(value):
+    if not value:
+        return "empty uses value"
+    if value.startswith("./"):
+        return None
+    if value.startswith("docker://"):
+        if docker_digest.fullmatch(value):
+            return None
+        return "docker action must pin an immutable sha256 digest"
+    if "@" not in value:
+        return "missing @ref"
+    action, ref = value.rsplit("@", 1)
+    if not action or not ref:
+        return "malformed uses ref"
+    if not sha_ref.fullmatch(ref):
+        return "ref must be a 40-character commit SHA"
+    return None
+
+
+failures = []
+uses_count = 0
+for path in workflow_files:
+    for lineno, value in iter_uses(path):
+        uses_count += 1
+        reason = pin_failure(value)
+        if reason:
+            failures.append(f"- {display_path(path)}:{lineno}: {value} ({reason})")
+
+if failures:
+    print("FAIL: unpinned GitHub Action detected")
+    print("\n".join(failures))
+    sys.exit(1)
+
+print(
+    f"GitHub Actions pin check: PASS ({len(workflow_files)} workflow files; "
+    f"{uses_count} uses entries; external uses refs are 40-character commit SHAs)"
+)
+PY
+)"
+  ec=$?
+  set -e
+  printf '%s\n' "${output}"
+  return "${ec}"
+}
+
+check_supply_chain_actions_pinned_selftest() {
+  local tmp sha digest invalid_output
+  tmp="$(mktemp -d)"
+  sha="0123456789abcdef0123456789abcdef01234567"
+  digest="sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  mkdir -p "${tmp}"
+
+  cat > "${tmp}/valid.yml" <<EOF
+name: valid
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@${sha}
+      - name: setup
+        uses : "actions/setup-go@${sha}" # pinned
+      - { uses: actions/setup-node@${sha} }
+      - uses: ./.github/actions/local
+      - uses: docker://ghcr.io/equaltoai/tool@${digest}
+  reusable:
+    uses: equaltoai/reusable/.github/workflows/test.yml@${sha}
+EOF
+
+  if ! check_supply_chain_actions_pinned "${tmp}" >/dev/null; then
+    echo "FAIL: SEC-3 action pinning self-test rejected a pinned workflow fixture"
+    rm -rf "${tmp}"
     return 1
   fi
 
-  echo "GitHub Actions pin check: PASS (all external uses refs are 40-char SHA or vX.Y.Z)"
+  cat > "${tmp}/invalid.yml" <<'EOF'
+name: invalid
+on: push
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - "uses": actions/setup-go@main
+      - { uses: actions/setup-node@v5 }
+  reusable:
+    uses: equaltoai/reusable/.github/workflows/test.yml@v1
+EOF
+
+  set +e
+  invalid_output="$(check_supply_chain_actions_pinned "${tmp}" 2>&1)"
+  local invalid_ec=$?
+  set -e
+  if [[ "${invalid_ec}" -eq 0 ]]; then
+    echo "FAIL: SEC-3 action pinning self-test accepted an unpinned workflow fixture"
+    rm -rf "${tmp}"
+    return 1
+  fi
+
+  local expected
+  for expected in \
+    "actions/checkout@v5" \
+    "actions/setup-go@main" \
+    "actions/setup-node@v5" \
+    "equaltoai/reusable/.github/workflows/test.yml@v1"; do
+    if ! printf '%s\n' "${invalid_output}" | grep -q "${expected}"; then
+      echo "FAIL: SEC-3 action pinning self-test did not detect ${expected}"
+      printf '%s\n' "${invalid_output}"
+      rm -rf "${tmp}"
+      return 1
+    fi
+  done
+
+  rm -rf "${tmp}"
+  echo "GitHub Actions pin check self-test: PASS (normal step, quoted key, flow mapping, and reusable workflow syntax detected)"
   return 0
 }
 
@@ -899,7 +1045,7 @@ scan_node_project_supply_chain() {
 
 check_supply_chain() {
   # SEC-3: Supply-chain verification gate.
-  # - Enforces GitHub Actions ref pinning (40-char SHA or vX.Y.Z; no floating refs).
+  # - Enforces GitHub Actions ref pinning (40-char SHA; no floating refs).
   # - Scans Node dependencies for subprojects (web/, cdk/, contracts/) with scripts disabled.
   # - Runs lightweight Go and Python metadata scans.
 
@@ -918,6 +1064,14 @@ check_supply_chain() {
   local ec_actions=$?
   set -e
   if [[ $ec_actions -ne 0 ]]; then
+    fail=1
+  fi
+
+  set +e
+  check_supply_chain_actions_pinned_selftest
+  local ec_actions_selftest=$?
+  set -e
+  if [[ $ec_actions_selftest -ne 0 ]]; then
     fail=1
   fi
 
@@ -1743,7 +1897,9 @@ assert_negative_fixture_rejected() {
 # Bounded soul comm mailbox authority
 This intentionally insecure fixture contains legacy keywords while violating the policy semantics.
 It says there is no retention policy, content may be unencrypted, access audit can be skipped,
-list endpoints return full body content, raw instance keys are stored, and cross-tenant mailbox search is allowed.
+retention is optional, content may be kept forever, mailbox content may be stored in plaintext,
+audit logging is optional, list responses include complete message content, plaintext instance-key fallback is allowed,
+raw instance keys are stored, global mailbox analytics are allowed, and cross-tenant mailbox search is allowed.
 __CMP4_NEGATIVE_FIXTURE__
   if grep -Eiq -- "${pattern}" "${fixture}"; then
     echo "PASS: negative fixture rejected for ${label}"
@@ -1808,21 +1964,21 @@ require_pattern "${evidence}" 'CMP-4' 'evidence plan includes CMP-4'
 require_pattern "${evidence}" 'CMP-4-output\.log' 'evidence plan names CMP-4 evidence path'
 
 for f in "${adr}" "${soul}" "${roadmap}" "${controls}"; do
-  forbid_pattern "${f}" 'no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention' 'insecure retention semantics'
-  forbid_pattern "${f}" 'unencrypted|without encryption|do not encrypt|skip encryption|encryption is optional' 'insecure encryption semantics'
-  forbid_pattern "${f}" 'without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped' 'insecure access-audit semantics'
-  forbid_pattern "${f}" 'list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list' 'full content in list semantics'
-  forbid_pattern "${f}" 'raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys' 'raw-key retention semantics'
-  forbid_pattern "${f}" 'cross-tenant (mailbox )?(search|analytics) is allowed|allow(s|ed)? cross-tenant (mailbox )?(search|analytics)' 'cross-tenant mailbox query semantics'
+  forbid_pattern "${f}" 'no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention|retention (is )?optional|optional retention|skip retention|best[- ]effort retention|keep (content|messages?|mailbox items?) forever|never purge' 'insecure retention semantics'
+  forbid_pattern "${f}" 'unencrypted|without encryption|do not encrypt|skip encryption|encryption (is )?optional|optional encryption|stored? in plaintext|plaintext (mailbox|message|content|body)' 'insecure encryption semantics'
+  forbid_pattern "${f}" 'without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped|audit logging (is )?optional|optional audit|unaudited (read|content|state|mutation)|read(s)? without audit' 'insecure access-audit semantics'
+  forbid_pattern "${f}" 'list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list|list (responses|payloads|results) include (full|complete|raw).*(message|content|bod(y|ies))|complete (message|content|bod(y|ies)).*list (responses|payloads|results)' 'full content in list semantics'
+  forbid_pattern "${f}" 'raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys|plaintext (instance[- ]?)?key fallback|instance[- ]auth falls back to plaintext|accept raw (instance )?keys from storage' 'raw-key retention semantics'
+  forbid_pattern "${f}" 'cross-tenant (mailbox )?(search|analytics) is allowed|allow(s|ed)? cross-tenant (mailbox )?(search|analytics)|global mailbox (search|analytics) (is )?allowed|search (mailbox )?content across tenants' 'cross-tenant mailbox query semantics'
   forbid_pattern "${f}" 'body-owned mailbox storage is allowed|body (owns|stores|persists) mailbox truth' 'body-owned mailbox authority semantics'
 done
 
-assert_negative_fixture_rejected 'no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention' 'retention'
-assert_negative_fixture_rejected 'unencrypted|without encryption|do not encrypt|skip encryption|encryption is optional' 'encryption'
-assert_negative_fixture_rejected 'without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped' 'access audit'
-assert_negative_fixture_rejected 'list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list' 'list/content split'
-assert_negative_fixture_rejected 'raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys' 'hash-only auth'
-assert_negative_fixture_rejected 'cross-tenant (mailbox )?(search|analytics) is allowed|allow(s|ed)? cross-tenant (mailbox )?(search|analytics)' 'tenant isolation'
+assert_negative_fixture_rejected 'no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention|retention (is )?optional|optional retention|skip retention|best[- ]effort retention|keep (content|messages?|mailbox items?) forever|never purge' 'retention'
+assert_negative_fixture_rejected 'unencrypted|without encryption|do not encrypt|skip encryption|encryption (is )?optional|optional encryption|stored? in plaintext|plaintext (mailbox|message|content|body)' 'encryption'
+assert_negative_fixture_rejected 'without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped|audit logging (is )?optional|optional audit|unaudited (read|content|state|mutation)|read(s)? without audit' 'access audit'
+assert_negative_fixture_rejected 'list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list|list (responses|payloads|results) include (full|complete|raw).*(message|content|bod(y|ies))|complete (message|content|bod(y|ies)).*list (responses|payloads|results)' 'list/content split'
+assert_negative_fixture_rejected 'raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys|plaintext (instance[- ]?)?key fallback|instance[- ]auth falls back to plaintext|accept raw (instance )?keys from storage' 'hash-only auth'
+assert_negative_fixture_rejected 'cross-tenant (mailbox )?(search|analytics) is allowed|allow(s|ed)? cross-tenant (mailbox )?(search|analytics)|global mailbox (search|analytics) (is )?allowed|search (mailbox )?content across tenants' 'tenant isolation'
 
 if [[ "${fail}" -ne 0 ]]; then
   exit 1

--- a/internal/secrets/keys_more_test.go
+++ b/internal/secrets/keys_more_test.go
@@ -96,7 +96,7 @@ func TestParseMigaduCredentials(t *testing.T) {
 func TestMigaduAndTelnyxLoaders(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	client := stubSSM{
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {
@@ -136,7 +136,7 @@ func TestMigaduAndTelnyxLoaders(t *testing.T) {
 func TestLoadFirstSSMParameterCached_ReturnsLastError(t *testing.T) {
 	t.Parallel()
 
-	clearParamCache()
+	isolateParamCache(t)
 
 	client := stubSSM{
 		getParameter: func(_ context.Context, params *ssm.GetParameterInput) (*ssm.GetParameterOutput, error) {


### PR DESCRIPTION
## Summary

Fixes #285. Refs #284.

This PR resolves the governance/docs/test-isolation residuals without loosening host's governance rubric:

- hardens SEC-3 so external GitHub Actions `uses:` entries must pin a full 40-character commit SHA (SemVer/tag/branch/expression refs now fail) and adds a deterministic self-test covering normal step syntax, quoted `uses` keys, flow mappings, and reusable workflows;
- hardens CMP-4 so the mailbox governance verifier rejects explicit insecure variants instead of relying on positive keyword presence alone;
- sanitizes the public 2026-04-28 remediation roadmap and ledger so unresolved finding titles, exploit narratives, exact affected paths, and raw scanner output are not published as a live attack map;
- serializes the remaining SSM cache-mutating tests through the existing `isolateParamCache` helper; and
- bumps `gov-infra/pack.json` from `2026.04.30-m6` to `2026.05.14-m7.2` for the verifier/rubric-shape tightening.

No deployment is performed in this PR.

## Finding reference map

| Ref | Resolution |
| --- | --- |
| `host.csv:12` | SEC-3 no longer accepts SemVer/tag pins; external action refs must be full commit SHAs. |
| `host.csv:21` | SEC-3 now parses normal workflow `uses:` forms via the hardened parser and self-tests step, quoted-key, flow-mapping, and reusable-workflow syntax. |
| `host.csv:23` | CMP-4 forbidden semantics now cover optional retention/encryption/audit, full-content list responses, raw-key/plaintext fallback, and cross-tenant mailbox search/analytics. |
| `host.csv:13` | Public remediation docs are redacted to cluster-level sequencing and closure policy; unresolved details and exact paths are removed. |
| `host.csv:26` | SSM cache-mutating tests in `internal/secrets` use the shared cache isolation mutex; `go test -race ./internal/secrets` passes. |

## Governance-rubric audit

### Proposed change

Tighten existing SEC-3 and CMP-4 verifier behavior, update the rubric/evidence-plan wording to match the tighter claims, and bump the governance pack version.

### Verifier identity

- Category: SEC (`SEC-3`)
  - Path: `gov-infra/verifiers/gov-verify-rubric.sh`
  - Claim: external GitHub Actions references are immutable full-SHA pins; workflow syntax blind spots are covered by self-tests.
  - Input surface: in-repo `.github/workflows/*.yml` / `*.yaml` plus verifier fixtures.
- Category: CMP (`CMP-4`)
  - Path: `gov-infra/verifiers/gov-verify-rubric.sh`
  - Claim: bounded soul comm mailbox policy docs retain required controls and reject explicit insecure variants.
  - Input surface: in-repo ADR/soul-surface/roadmap/threat/controls/evidence docs plus verifier fixtures.

### Grade semantics

- Pass condition: all repo workflows use allowed immutable refs, self-tests reject known bypass shapes, and bounded-mailbox docs contain required controls without forbidden insecure semantics.
- Fail condition: any unpinned/floating action ref, parser self-test miss, missing bounded-mailbox control, or forbidden insecure wording.
- Partial credit: none; these remain pass/fail gates.

### pack.json impact

- Current version: `2026.04.30-m6`
- New version: `2026.05.14-m7.2`
- Semantic nature: tightening / anti-drift hardening, not loosening.
- Documentation: rubric and evidence-plan wording updated in the same commit.

### Anti-drift check

- This PR removes an allowed action-tag path rather than adding exceptions.
- CMP-4 adds forbidden semantics and negative-fixture coverage rather than narrowing scope.
- Public docs reduce unresolved detail disclosure while preserving closure/evidence discipline.

## Validation

- `go test ./internal/secrets`
- `go test -race ./internal/secrets`
- `go test ./...`
- `bash -n gov-infra/verifiers/gov-verify-rubric.sh`
- `python3 -m json.tool gov-infra/pack.json`
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29 pass, 0 fail, 0 blocked)

## Deployment

Not performed. Aron/operator will handle the deployment phase separately.