### PR TITLE
feat(store): harden Lambda runtime reliability

### DIFF
--- a/internal/renderworker/server.go
+++ b/internal/renderworker/server.go
@@ -281,7 +281,7 @@ func (s *Server) storeRenderError(ctx context.Context, renderID string, normaliz
 	return s.store.PutRenderArtifact(ctx, item)
 }
 
-func (s *Server) handleRetentionSweep(ctx *apptheory.EventContext, _ events.EventBridgeEvent) (any, error) {
+func (s *Server) handleRetentionSweep(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
 	if s == nil || s.store == nil {
 		return nil, fmt.Errorf("store not initialized")
 	}
@@ -292,6 +292,7 @@ func (s *Server) handleRetentionSweep(ctx *apptheory.EventContext, _ events.Even
 		return nil, fmt.Errorf("event context is nil")
 	}
 
+	workload := apptheory.NormalizeEventBridgeScheduledWorkload(ctx, event)
 	now := time.Now().UTC()
 	deleted := 0
 
@@ -317,8 +318,25 @@ func (s *Server) handleRetentionSweep(ctx *apptheory.EventContext, _ events.Even
 	}
 
 	return map[string]any{
-		"deleted": deleted,
+		"deleted":  deleted,
+		"workload": retentionSweepWorkloadSummary(workload),
 	}, nil
+}
+
+func retentionSweepWorkloadSummary(summary apptheory.EventBridgeScheduledWorkloadSummary) map[string]any {
+	return map[string]any{
+		"correlation_id":     summary.CorrelationID,
+		"correlation_source": summary.CorrelationSource,
+		"deadline_unix_ms":   summary.DeadlineUnixMS,
+		"detail_type":        summary.DetailType,
+		"event_id":           summary.EventID,
+		"idempotency_key":    summary.IdempotencyKey,
+		"kind":               summary.Kind,
+		"remaining_ms":       summary.RemainingMS,
+		"run_id":             summary.RunID,
+		"scheduled_time":     summary.ScheduledTime,
+		"source":             summary.Source,
+	}
 }
 
 func sqsQueueNameFromURL(raw string) string {

--- a/internal/renderworker/server_test.go
+++ b/internal/renderworker/server_test.go
@@ -206,6 +206,63 @@ func TestRetentionSweepDeletesExpiredArtifacts(t *testing.T) {
 	}
 }
 
+func TestRetentionSweepReturnsScheduledWorkloadSummary(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(config.Config{}, &fakeRenderStore{items: map[string]*models.RenderArtifact{}}, &fakeArtifactStore{})
+	scheduledAt := time.Date(2026, 5, 16, 12, 0, 0, 0, time.UTC)
+	event := testkit.EventBridgeEvent(testkit.EventBridgeEventOptions{
+		ID: "retention-evt-1",
+		Detail: map[string]any{
+			"run_id":          "retention-run-1",
+			"idempotency_key": "retention/sweep/1",
+			"correlation_id":  "retention-corr-1",
+		},
+		Time: scheduledAt,
+	})
+
+	out, err := srv.handleRetentionSweep(&apptheory.EventContext{RequestID: "req-retention", RemainingMS: 6000}, event)
+	if err != nil {
+		t.Fatalf("handleRetentionSweep: %v", err)
+	}
+
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map output, got %T", out)
+	}
+	workload, ok := m["workload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected workload summary map, got %#v", m["workload"])
+	}
+
+	want := map[string]any{
+		"kind":               "scheduled",
+		"run_id":             "retention-run-1",
+		"idempotency_key":    "retention/sweep/1",
+		"correlation_id":     "retention-corr-1",
+		"correlation_source": "detail.correlation_id",
+		"event_id":           "retention-evt-1",
+		"source":             "aws.events",
+		"detail_type":        "Scheduled Event",
+		"remaining_ms":       6000,
+		"scheduled_time":     scheduledAt.Format(time.RFC3339),
+	}
+	for key, expected := range want {
+		if got := workload[key]; got != expected {
+			t.Fatalf("workload[%s] = %#v, want %#v (full workload %#v)", key, got, expected, workload)
+		}
+	}
+	if deadline, ok := workload["deadline_unix_ms"].(int64); !ok || deadline <= 0 {
+		t.Fatalf("expected positive deadline_unix_ms, got %#v", workload["deadline_unix_ms"])
+	}
+	if _, leaked := workload["detail"]; leaked {
+		t.Fatalf("workload summary must not expose raw event detail: %#v", workload)
+	}
+	if _, leaked := workload["resources"]; leaked {
+		t.Fatalf("workload summary must not expose raw event resources: %#v", workload)
+	}
+}
+
 func containsString(haystack []string, needle string) bool {
 	needle = strings.TrimSpace(needle)
 	for _, s := range haystack {

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -1,14 +1,21 @@
 package store
 
 import (
+	"time"
+
 	"github.com/theory-cloud/tabletheory"
 
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
+// lambdaTimeoutBuffer is the cold-start TableTheory buffer host leaves before
+// the Lambda hard deadline so handlers can return structured errors instead
+// of timing out mid-DynamoDB operation.
+const lambdaTimeoutBuffer = 1500 * time.Millisecond
+
 // LambdaInit initializes the database connection and registers all models.
 func LambdaInit() (DB, error) {
-	return tabletheory.LambdaInit(
+	db, err := tabletheory.LambdaInit(
 		&models.AIJob{},
 		&models.AIResult{},
 		&models.Attestation{},
@@ -77,4 +84,8 @@ func LambdaInit() (DB, error) {
 		&models.SoulRelationshipFromIndex{},
 		&models.SoulAgentDispute{},
 	)
+	if err != nil {
+		return nil, err
+	}
+	return db.WithLambdaTimeoutConfig(tabletheory.LambdaTimeoutConfig{Buffer: lambdaTimeoutBuffer}), nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -3,8 +3,8 @@ package store
 import (
 	"context"
 
+	"github.com/theory-cloud/tabletheory"
 	"github.com/theory-cloud/tabletheory/pkg/core"
-
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 )
 
@@ -21,7 +21,85 @@ type Store struct {
 
 // New constructs a new Store.
 func New(db DB) *Store {
-	return &Store{DB: db}
+	return &Store{DB: lambdaTimeoutGuardDB(db)}
+}
+
+// lambdaTimeoutGuardDB returns a DB wrapper that applies TableTheory's
+// Lambda-deadline-aware guard only for invocation contexts that actually carry
+// a deadline. Tests, local tooling, and non-Lambda contexts keep the original
+// mock/non-Lambda DB path unchanged.
+func lambdaTimeoutGuardDB(db DB) DB {
+	if db == nil {
+		return nil
+	}
+	if _, ok := db.(*lambdaTimeoutDB); ok {
+		return db
+	}
+	return &lambdaTimeoutDB{db: db}
+}
+
+type lambdaTimeoutDB struct {
+	db DB
+}
+
+func (d *lambdaTimeoutDB) Model(model any) core.Query {
+	return d.db.Model(model)
+}
+
+func (d *lambdaTimeoutDB) Transaction(fn func(tx *core.Tx) error) error {
+	return d.db.Transaction(fn)
+}
+
+func (d *lambdaTimeoutDB) Migrate() error {
+	return d.db.Migrate()
+}
+
+func (d *lambdaTimeoutDB) AutoMigrate(models ...any) error {
+	return d.db.AutoMigrate(models...)
+}
+
+func (d *lambdaTimeoutDB) Close() error {
+	return d.db.Close()
+}
+
+func (d *lambdaTimeoutDB) WithContext(ctx context.Context) core.DB {
+	return applyLambdaTimeoutGuard(ctx, d.db).WithContext(ctx)
+}
+
+func (d *lambdaTimeoutDB) TransactWrite(ctx context.Context, fn func(core.TransactionBuilder) error) error {
+	return applyLambdaTimeoutGuard(ctx, d.db).TransactWrite(ctx, fn)
+}
+
+func applyLambdaTimeoutGuard(ctx context.Context, db DB) DB {
+	if db == nil || ctx == nil {
+		return db
+	}
+	if _, ok := ctx.Deadline(); !ok {
+		return db
+	}
+
+	// tabletheory.LambdaDB exposes the preferred typed helper preserving Lambda
+	// caches, model registration, and TransactWrite support.
+	if lambdaDB, ok := db.(interface {
+		WithLambdaTimeout(context.Context) *tabletheory.LambdaDB
+	}); ok {
+		if guarded := lambdaDB.WithLambdaTimeout(ctx); guarded != nil {
+			return guarded
+		}
+	}
+
+	// Test doubles and lower-level TableTheory implementations expose the
+	// core.ExtendedDB shape. Only use the result when it still satisfies host's
+	// Store DB contract, including TransactWrite.
+	if extended, ok := db.(interface {
+		WithLambdaTimeout(context.Context) core.DB
+	}); ok {
+		if guarded, ok := extended.WithLambdaTimeout(ctx).(DB); ok && guarded != nil {
+			return guarded
+		}
+	}
+
+	return db
 }
 
 // IsNotFound reports whether an error represents a not-found condition.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,7 +2,9 @@ package store
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -22,6 +24,55 @@ func TestIsNotFound(t *testing.T) {
 	if !IsNotFound(theoryErrors.ErrItemNotFound) {
 		t.Fatalf("expected true")
 	}
+}
+
+func TestStore_LambdaTimeoutGuard_NoOpsWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db := ttmocks.NewMockExtendedDBStrict()
+
+	db.On("WithContext", ctx).Return(db).Once()
+
+	st := New(db)
+	got := st.DB.WithContext(ctx)
+	if got != db {
+		t.Fatalf("expected original DB for non-deadline context, got %T", got)
+	}
+
+	db.AssertNotCalled(t, "WithLambdaTimeout", mock.Anything)
+	db.AssertExpectations(t)
+}
+
+func TestStore_LambdaTimeoutGuard_AppliesDeadlineAndPreservesTransactWrite(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Minute))
+	defer cancel()
+
+	base := ttmocks.NewMockExtendedDBStrict()
+	guarded := ttmocks.NewMockExtendedDBStrict()
+	expectedErr := errors.New("transaction delegated")
+
+	base.On("WithLambdaTimeout", ctx).Return(guarded).Once()
+	guarded.On("WithContext", ctx).Return(guarded).Once()
+
+	st := New(base)
+	got := st.DB.WithContext(ctx)
+	if got != guarded {
+		t.Fatalf("expected guarded DB for deadline context, got %T", got)
+	}
+
+	base.On("WithLambdaTimeout", ctx).Return(guarded).Once()
+	guarded.On("TransactWrite", ctx, mock.Anything).Return(expectedErr).Once()
+
+	err := st.DB.TransactWrite(ctx, nil)
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("expected delegated TransactWrite error %v, got %v", expectedErr, err)
+	}
+
+	base.AssertExpectations(t)
+	guarded.AssertExpectations(t)
 }
 
 func TestStore_DBHelpers(t *testing.T) {


### PR DESCRIPTION
## Milestone
Project 31 Phase 2 — runtime reliability hardening with TableTheory Lambda timeout guards and an AppTheory scheduled-workload pilot.

Closes #294.
Closes #296.
Refs #291.

## Classification
Operational reliability, framework-consumption, worker reliability, governance-preserving maintenance.

## Surfaces affected
- Store/runtime guard: `internal/store/db.go`, `internal/store/store.go`, `internal/store/store_test.go`
- Scheduled worker pilot: `internal/renderworker/server.go`, `internal/renderworker/server_test.go`

## Specialist walks referenced
- Governance rubric: no verifier/rubric weakening; gov verifier passes 29/0/0.
- Provisioning / managed-update / release verification: no provisioning runner, managed-update execution, or consumer-release-verification behavior changes.
- Soul registry: no Solidity/source/deploy/Safe-ready payload changes.
- Trust API / CSP / instance-auth: no trust route, raw-key, attestation, CSP, or instance-auth changes.
- Framework: idiomatic local consumption of TableTheory `WithLambdaTimeout` / `WithLambdaTimeoutConfig` and AppTheory `NormalizeEventBridgeScheduledWorkload`. No local framework patches.

## Multi-tenant isolation impact
None. The Store wrapper preserves existing keying/query behavior and only derives DB timeout behavior from the invocation context deadline. No tenant boundary traversal or cross-tenant query is introduced.

## On-chain impact
None. No Solidity or on-chain-reaching transaction code changed.

## Consumer impact
- Host Lambda DynamoDB calls through `Store.DB.WithContext(ctx)` / `TransactWrite(ctx, ...)` now use TableTheory's Lambda-deadline-aware guard when an invocation context carries a deadline, reducing hard-timeout risk.
- Non-Lambda/local/test contexts remain on the original DB path.
- Render retention sweep output includes a safe AppTheory scheduled workload summary (run/idempotency/correlation/deadline metadata) without raw EventBridge detail/resources and without changing sweep deletion semantics.

## Tasks
- [x] #294 Apply TableTheory Lambda timeout guards
- [x] #296 Pilot AppTheory scheduled workload normalization

## Validation
- `go test ./internal/store ./internal/renderworker` — pass
- `go test ./internal/store ./internal/renderworker ./internal/provisionworker ./internal/soulreputationworker ./internal/aiworker ./internal/commworker ./internal/controlplane ./internal/trust` — pass
- `go test ./...` — pass
- `go vet ./...` — pass
- `test -z "$(gofmt -l $(git ls-files '*.go'))"` — pass
- `git diff --check` — pass
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — pass (29 pass / 0 fail / 0 blocked)

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab via `theory app up --stage lab`
- [ ] Lab soak complete: control-plane/trust smoke, render retention-sweep observation, CloudWatch error scan
- [ ] Deployed to live only with explicit operator authorization
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None required. Framework feedback remains tracked separately in #299.

## Advisor-brief authorization
Arch approved Phase 2 in PR #300 after Phase 1 landed. This PR will be sent back to Arch for review before any Phase 3 work starts.
