### PR TITLE
feat(auth): use AppTheory source provenance

### DIFF
--- a/internal/controlplane/audit.go
+++ b/internal/controlplane/audit.go
@@ -7,6 +7,7 @@ import (
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 
+	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -21,8 +22,20 @@ func (s *Server) tryWriteAuditLog(ctx *apptheory.Context, entry *models.AuditLog
 	if strings.TrimSpace(entry.RequestID) == "" {
 		entry.RequestID = strings.TrimSpace(ctx.RequestID)
 	}
+	applyAuditSourceProvenance(ctx, entry)
 
 	s.tryWriteAuditLogWithContext(ctx.Context(), entry)
+}
+
+func applyAuditSourceProvenance(ctx *apptheory.Context, entry *models.AuditLogEntry) {
+	if ctx == nil || entry == nil {
+		return
+	}
+	source := httpx.TrustedSourceFromContext(ctx)
+	entry.SourceIP = strings.TrimSpace(source.SourceIP)
+	entry.SourceProvider = strings.TrimSpace(source.Provider)
+	entry.SourceProvenance = strings.TrimSpace(source.Source)
+	entry.SourceValid = source.Valid
 }
 
 func (s *Server) tryWriteAuditLogWithContext(ctx context.Context, entry *models.AuditLogEntry) {

--- a/internal/controlplane/audit_internal_test.go
+++ b/internal/controlplane/audit_internal_test.go
@@ -1,0 +1,50 @@
+package controlplane
+
+import (
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestApplyAuditSourceProvenanceUsesProviderContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{
+			"x-forwarded-for": {"203.0.113.250"},
+		},
+		SourceProvenance: apptheory.SourceProvenance{
+			SourceIP: "198.51.100.77",
+			Provider: "lambda-url",
+			Source:   "provider_request_context",
+			Valid:    true,
+		},
+	}}
+	entry := &models.AuditLogEntry{}
+
+	applyAuditSourceProvenance(ctx, entry)
+
+	if !entry.SourceValid || entry.SourceIP != "198.51.100.77" || entry.SourceProvider != "lambda-url" || entry.SourceProvenance != "provider_request_context" {
+		t.Fatalf("unexpected audit source fields: %#v", entry)
+	}
+	if entry.SourceIP == "203.0.113.250" {
+		t.Fatalf("forwarded header was trusted: %#v", entry)
+	}
+}
+
+func TestApplyAuditSourceProvenanceUnknownForHeaderOnlyContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{Headers: map[string][]string{
+		"x-forwarded-for": {"198.51.100.42"},
+	}}}
+	entry := &models.AuditLogEntry{}
+
+	applyAuditSourceProvenance(ctx, entry)
+
+	if entry.SourceValid || entry.SourceIP != "" || entry.SourceProvider != commMetricUnknown || entry.SourceProvenance != commMetricUnknown {
+		t.Fatalf("expected unknown source fields, got %#v", entry)
+	}
+}

--- a/internal/controlplane/auth_operator.go
+++ b/internal/controlplane/auth_operator.go
@@ -39,6 +39,7 @@ func (s *Server) OperatorAuthHook(ctx *apptheory.Context) (string, error) {
 	if s == nil || s.store == nil || s.store.DB == nil {
 		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	httpx.SetTrustedSource(ctx)
 
 	token := httpx.BearerToken(ctx.Request.Headers)
 	if token == "" {

--- a/internal/controlplane/handlers_setup.go
+++ b/internal/controlplane/handlers_setup.go
@@ -608,6 +608,7 @@ func (s *Server) handleSetupCreateAdmin(ctx *apptheory.Context) (*apptheory.Resp
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}
@@ -654,6 +655,7 @@ func (s *Server) handleSetupFinalize(ctx *apptheory.Context) (*apptheory.Respons
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}

--- a/internal/controlplane/handlers_wallet.go
+++ b/internal/controlplane/handlers_wallet.go
@@ -89,6 +89,7 @@ func (s *Server) handleWalletLogin(ctx *apptheory.Context) (*apptheory.Response,
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}

--- a/internal/controlplane/handlers_webauthn.go
+++ b/internal/controlplane/handlers_webauthn.go
@@ -262,6 +262,7 @@ func (s *Server) handleWebAuthnRegisterFinish(ctx *apptheory.Context) (*apptheor
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}
@@ -430,6 +431,7 @@ func (s *Server) handleWebAuthnLoginFinish(ctx *apptheory.Context) (*apptheory.R
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}
@@ -572,6 +574,7 @@ func (s *Server) handleWebAuthnDeleteCredential(ctx *apptheory.Context) (*appthe
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}
@@ -627,6 +630,7 @@ func (s *Server) handleWebAuthnUpdateCredential(ctx *apptheory.Context) (*appthe
 		RequestID: ctx.RequestID,
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	if err := s.store.DB.WithContext(ctx.Context()).Model(audit).Create(); err != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to write audit log"}

--- a/internal/controlplane/rate_limits.go
+++ b/internal/controlplane/rate_limits.go
@@ -54,18 +54,9 @@ func (s *Server) mintConversationRateLimitMiddleware() apptheory.Middleware {
 
 	limiter := limited.NewDynamoRateLimiter(s.store.DB, limited.DefaultConfig(), strategy)
 	rateLimitMW := apptheory.RateLimitMiddleware(apptheory.RateLimitConfig{
-		Limiter:    limiter,
-		FailClosed: true,
-		ExtractIdentifier: func(ctx *apptheory.Context) string {
-			if ctx == nil {
-				return "anonymous"
-			}
-			id := strings.TrimSpace(ctx.AuthIdentity)
-			if id == "" {
-				return "anonymous"
-			}
-			return id
-		},
+		Limiter:           limiter,
+		FailClosed:        true,
+		ExtractIdentifier: mintConversationRateLimitIdentifier,
 	})
 
 	return func(next apptheory.Handler) apptheory.Handler {
@@ -106,17 +97,9 @@ func (s *Server) mailboxRateLimitMiddleware() apptheory.Middleware {
 	})
 	limiter := limited.NewDynamoRateLimiter(s.store.DB, limited.DefaultConfig(), strategy)
 	rateLimitMW := apptheory.RateLimitMiddleware(apptheory.RateLimitConfig{
-		Limiter:    limiter,
-		FailClosed: true,
-		ExtractIdentifier: func(ctx *apptheory.Context) string {
-			if ctx == nil {
-				return "mailbox:anonymous"
-			}
-			if raw := httpx.BearerToken(ctx.Request.Headers); strings.TrimSpace(raw) != "" {
-				return "mailbox:" + sha256HexTrimmed(raw)
-			}
-			return "mailbox:anonymous"
-		},
+		Limiter:           limiter,
+		FailClosed:        true,
+		ExtractIdentifier: mailboxRateLimitIdentifier,
 	})
 
 	return func(next apptheory.Handler) apptheory.Handler {
@@ -181,13 +164,33 @@ func isSoulMintConversationInstanceReadPath(path string) bool {
 		strings.Contains(strings.TrimSpace(path), "/mint-conversations")
 }
 
+func mintConversationRateLimitIdentifier(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return httpx.SourceRateLimitIdentifier(nil, "mint-conversation:anonymous")
+	}
+	if id := strings.TrimSpace(ctx.AuthIdentity); id != "" {
+		return id
+	}
+	return httpx.SourceRateLimitIdentifier(ctx, "mint-conversation:anonymous")
+}
+
+func mailboxRateLimitIdentifier(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return httpx.SourceRateLimitIdentifier(nil, "mailbox:anonymous")
+	}
+	if raw := httpx.BearerToken(ctx.Request.Headers); strings.TrimSpace(raw) != "" {
+		return "mailbox:" + sha256HexTrimmed(raw)
+	}
+	return httpx.SourceRateLimitIdentifier(ctx, "mailbox:anonymous")
+}
+
 func (s *Server) soulMintConversationInstanceReadRateLimitIdentifier(ctx *apptheory.Context) (string, *apptheory.AppTheoryError) {
 	if ctx == nil {
-		return soulMintConversationInstanceReadRateLimitAnonymous, nil
+		return httpx.SourceRateLimitIdentifier(nil, soulMintConversationInstanceReadRateLimitAnonymous), nil
 	}
 	raw := httpx.BearerToken(ctx.Request.Headers)
 	if strings.TrimSpace(raw) == "" {
-		return soulMintConversationInstanceReadRateLimitAnonymous, nil
+		return httpx.SourceRateLimitIdentifier(ctx, soulMintConversationInstanceReadRateLimitAnonymous), nil
 	}
 	hash := sha256HexTrimmed(raw)
 	if key := soulMintConversationInstanceReadKeyFromContext(ctx); key != nil && soulMintConversationInstanceReadKeyActiveForHash(key, hash) {
@@ -199,12 +202,12 @@ func (s *Server) soulMintConversationInstanceReadRateLimitIdentifier(ctx *appthe
 	key, err := s.store.GetInstanceKey(ctx.Context(), hash)
 	if err != nil {
 		if theoryErrors.IsNotFound(err) {
-			return soulMintConversationInstanceReadRateLimitInvalid, nil
+			return httpx.SourceRateLimitIdentifier(ctx, soulMintConversationInstanceReadRateLimitInvalid), nil
 		}
 		return "", soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}
 	if key == nil || !soulMintConversationInstanceReadKeyActiveForHash(key, hash) {
-		return soulMintConversationInstanceReadRateLimitInvalid, nil
+		return httpx.SourceRateLimitIdentifier(ctx, soulMintConversationInstanceReadRateLimitInvalid), nil
 	}
 	ctx.Set(ctxKeySoulMintConversationInstanceReadKey, key)
 	return soulMintConversationInstanceReadRateLimitPrefix + hash, nil
@@ -222,10 +225,7 @@ func (s *Server) soulMintConversationInstanceReadCheckRateLimit(ctx *apptheory.C
 		Identifier: identifier,
 		Resource:   "control-plane-api",
 		Operation:  "soul_mint_conversation_instance_read",
-		Metadata: map[string]string{
-			"method": method,
-			soulMintConversationInstanceReadRateLimitRouteKey: soulMintConversationInstanceReadRateLimitRouteClass(path),
-		},
+		Metadata:   soulMintConversationInstanceReadRateLimitMetadata(ctx, method, path),
 	})
 	if err != nil {
 		return nil, soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "internal error", http.StatusInternalServerError, nil)
@@ -235,6 +235,13 @@ func (s *Server) soulMintConversationInstanceReadCheckRateLimit(ctx *apptheory.C
 		return soulMintConversationInstanceReadRateLimitResponse(ctx, decision), nil
 	}
 	return nil, nil
+}
+
+func soulMintConversationInstanceReadRateLimitMetadata(ctx *apptheory.Context, method string, path string) map[string]string {
+	metadata := httpx.SourceRateLimitMetadata(ctx)
+	metadata["method"] = method
+	metadata[soulMintConversationInstanceReadRateLimitRouteKey] = soulMintConversationInstanceReadRateLimitRouteClass(path)
+	return metadata
 }
 
 func soulMintConversationInstanceReadKeyFromContext(ctx *apptheory.Context) *models.InstanceKey {

--- a/internal/controlplane/rate_limits_internal_test.go
+++ b/internal/controlplane/rate_limits_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -152,6 +153,9 @@ func TestMintConversationInstanceReadRateLimitCheck_UsesHashedBearerAndCachesKey
 		limiter.lastKey.Metadata[soulMintConversationInstanceReadRateLimitRouteKey] != soulMintInstanceReadRouteList {
 		t.Fatalf("expected method/path metadata, got %#v", limiter.lastKey.Metadata)
 	}
+	if limiter.lastKey.Metadata["source_valid"] != "false" || limiter.lastKey.Metadata["source_provider"] != "unknown" {
+		t.Fatalf("expected source metadata, got %#v", limiter.lastKey.Metadata)
+	}
 	if routeClass := soulMintConversationInstanceReadRateLimitRouteClass("/api/v1/soul/instance/agents/agent/mint-conversations/conv-1"); routeClass != soulMintInstanceReadRouteSingle {
 		t.Fatalf("expected single route class, got %q", routeClass)
 	}
@@ -172,7 +176,7 @@ func TestMintConversationInstanceReadRateLimitCheck_TypedErrorsAndAnonymousIdent
 	if err != nil || resp == nil || resp.Status != http.StatusTooManyRequests {
 		t.Fatalf("expected typed 429 response, got resp=%#v err=%v", resp, err)
 	}
-	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitAnonymous {
+	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitAnonymous+":source:unknown" {
 		t.Fatalf("expected anonymous identifier, got %q", limiter.lastKey.Identifier)
 	}
 
@@ -183,7 +187,7 @@ func TestMintConversationInstanceReadRateLimitCheck_TypedErrorsAndAnonymousIdent
 		t.Fatalf("expected internal app error on limiter failure, got resp=%#v err=%#v", resp, appErr)
 	}
 
-	if id, err := s.soulMintConversationInstanceReadRateLimitIdentifier(&apptheory.Context{}); err != nil || id != soulMintConversationInstanceReadRateLimitAnonymous {
+	if id, err := s.soulMintConversationInstanceReadRateLimitIdentifier(&apptheory.Context{}); err != nil || id != soulMintConversationInstanceReadRateLimitAnonymous+":source:unknown" {
 		t.Fatalf("expected anonymous identifier, got %q", id)
 	}
 }
@@ -211,13 +215,129 @@ func TestMintConversationInstanceReadRateLimitCheck_InvalidBearerUsesSharedBudge
 	if limiter.calls != 1 {
 		t.Fatalf("expected one limiter call, got %d", limiter.calls)
 	}
-	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitInvalid {
+	if limiter.lastKey.Identifier != soulMintConversationInstanceReadRateLimitInvalid+":source:unknown" {
 		t.Fatalf("expected invalid bearer to use shared invalid budget, got %q", limiter.lastKey.Identifier)
 	}
 	if cached := soulMintConversationInstanceReadKeyFromContext(ctx); cached != nil {
 		t.Fatalf("invalid bearer must not cache an instance key, got %#v", cached)
 	}
 	qKey.AssertExpectations(t)
+}
+
+func TestSourceProvenanceRateLimitIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{
+		AuthIdentity: testUsernameAlice,
+		Request: apptheory.Request{
+			Headers: map[string][]string{
+				"x-forwarded-for": {testSourceForwardedHeader},
+			},
+			SourceProvenance: testSourceProvenance(),
+		},
+	}
+	if got := mintConversationRateLimitIdentifier(ctx); got != testUsernameAlice {
+		t.Fatalf("authenticated mint identifier must remain identity-based, got %q", got)
+	}
+	if got := mailboxRateLimitIdentifier(&apptheory.Context{Request: apptheory.Request{Headers: map[string][]string{
+		"authorization": {"Bearer mailbox-key"},
+	}}}); got != "mailbox:"+sha256HexTrimmed("mailbox-key") {
+		t.Fatalf("bearer mailbox identifier must remain key-hash based, got %q", got)
+	}
+
+	ctx.AuthIdentity = ""
+	mintAnon := mintConversationRateLimitIdentifier(ctx)
+	if !strings.HasPrefix(mintAnon, "mint-conversation:anonymous"+testSourceRateLimitPrefix) || rateLimitIdentifierContainsRawSource(mintAnon) {
+		t.Fatalf("unexpected mint anonymous source identifier: %q", mintAnon)
+	}
+	mailboxAnon := mailboxRateLimitIdentifier(ctx)
+	if !strings.HasPrefix(mailboxAnon, "mailbox:anonymous"+testSourceRateLimitPrefix) || rateLimitIdentifierContainsRawSource(mailboxAnon) {
+		t.Fatalf("unexpected mailbox anonymous source identifier: %q", mailboxAnon)
+	}
+}
+
+func TestMintConversationInstanceReadRateLimitCheck_AnonymousUsesSourceProvenance(t *testing.T) {
+	t.Parallel()
+
+	s, _ := newMintConversationInstanceReadRateLimitTestServer()
+
+	ctx := newSourceRateLimitContext()
+	limiter := &mintConversationInstanceReadTestLimiter{
+		decision: &limited.LimitDecision{Allowed: true},
+	}
+
+	resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations/conv-1")
+	if resp != nil || err != nil {
+		t.Fatalf("expected anonymous request to consume limiter then continue, got resp=%#v err=%v", resp, err)
+	}
+	if !strings.HasPrefix(limiter.lastKey.Identifier, soulMintConversationInstanceReadRateLimitAnonymous+testSourceRateLimitPrefix) ||
+		rateLimitIdentifierContainsRawSource(limiter.lastKey.Identifier) {
+		t.Fatalf("unexpected anonymous source identifier: %q", limiter.lastKey.Identifier)
+	}
+	if limiter.lastKey.Metadata["source_valid"] != "true" ||
+		limiter.lastKey.Metadata["source_provider"] != testSourceProvider ||
+		limiter.lastKey.Metadata["source"] != testSourceProvenanceSource ||
+		limiter.lastKey.Metadata["source_ip_sha256"] == "" ||
+		limiter.lastKey.Metadata[soulMintConversationInstanceReadRateLimitRouteKey] != soulMintInstanceReadRouteSingle {
+		t.Fatalf("unexpected source metadata: %#v", limiter.lastKey.Metadata)
+	}
+}
+
+func TestMintConversationInstanceReadRateLimitCheck_InvalidUsesSourceProvenance(t *testing.T) {
+	t.Parallel()
+
+	s, qKey := newMintConversationInstanceReadRateLimitTestServer()
+	qKey.On("First", mock.AnythingOfType("*models.InstanceKey")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := newSourceRateLimitContext()
+	ctx.Request.Headers["authorization"] = []string{"Bearer invalid-instance-key"}
+	limiter := &mintConversationInstanceReadTestLimiter{
+		decision: &limited.LimitDecision{Allowed: true},
+	}
+
+	resp, err := s.soulMintConversationInstanceReadCheckRateLimit(ctx, limiter, "GET", "/api/v1/soul/instance/agents/agent/mint-conversations")
+	if resp != nil || err != nil {
+		t.Fatalf("expected invalid request to consume limiter then continue, got resp=%#v err=%v", resp, err)
+	}
+	if !strings.HasPrefix(limiter.lastKey.Identifier, soulMintConversationInstanceReadRateLimitInvalid+testSourceRateLimitPrefix) ||
+		rateLimitIdentifierContainsRawSource(limiter.lastKey.Identifier) {
+		t.Fatalf("unexpected invalid source identifier: %q", limiter.lastKey.Identifier)
+	}
+
+	qKey.AssertExpectations(t)
+}
+
+const (
+	testSourceIP               = "198.51.100.77"
+	testSourceForwardedHeader  = "203.0.113.250"
+	testSourceProvider         = "lambda-url"
+	testSourceProvenanceSource = "provider_request_context"
+	testSourceRateLimitPrefix  = ":source:" + testSourceProvider + ":"
+)
+
+func testSourceProvenance() apptheory.SourceProvenance {
+	return apptheory.SourceProvenance{
+		SourceIP: testSourceIP,
+		Provider: testSourceProvider,
+		Source:   testSourceProvenanceSource,
+		Valid:    true,
+	}
+}
+
+func newSourceRateLimitContext() *apptheory.Context {
+	return &apptheory.Context{
+		RequestID: "req-source-rate-check",
+		Request: apptheory.Request{
+			Headers: map[string][]string{
+				"x-forwarded-for": {testSourceForwardedHeader},
+			},
+			SourceProvenance: testSourceProvenance(),
+		},
+	}
+}
+
+func rateLimitIdentifierContainsRawSource(identifier string) bool {
+	return strings.Contains(identifier, testSourceIP) || strings.Contains(identifier, testSourceForwardedHeader)
 }
 
 func newMintConversationInstanceReadRateLimitTestServer() (*Server, *ttmocks.MockQuery) {

--- a/internal/httpx/source_provenance.go
+++ b/internal/httpx/source_provenance.go
@@ -1,0 +1,128 @@
+package httpx
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+// TrustedSourceInfo is the sanitized, provider-derived source metadata host uses
+// for audit and rate-limit context. It deliberately comes from AppTheory's
+// SourceProvenance API rather than Forwarded/X-Forwarded-* headers.
+type TrustedSourceInfo struct {
+	SourceIP string
+	Provider string
+	Source   string
+	Valid    bool
+}
+
+const trustedSourceUnknown = "unknown"
+
+// ContextKeyTrustedSource is the AppTheory context key used when auth
+// middleware has already captured trusted source provenance for downstream
+// audit/rate-limit code.
+const ContextKeyTrustedSource = "httpx.trusted_source"
+
+// TrustedSource returns provider-derived source metadata from AppTheory. It
+// does not parse or trust client-controlled forwarding headers.
+func TrustedSource(ctx *apptheory.Context) TrustedSourceInfo {
+	if ctx == nil {
+		return TrustedSourceInfo{Provider: trustedSourceUnknown, Source: trustedSourceUnknown}
+	}
+	prov := ctx.SourceProvenance()
+	return TrustedSourceInfo{
+		SourceIP: strings.TrimSpace(prov.SourceIP),
+		Provider: strings.TrimSpace(prov.Provider),
+		Source:   strings.TrimSpace(prov.Source),
+		Valid:    prov.Valid,
+	}
+}
+
+// SetTrustedSource stores trusted source metadata on the AppTheory context for
+// downstream auth/audit code. The metadata is still derived only from
+// AppTheory's provider context.
+func SetTrustedSource(ctx *apptheory.Context) TrustedSourceInfo {
+	source := TrustedSource(ctx)
+	if ctx != nil {
+		ctx.Set(ContextKeyTrustedSource, source)
+	}
+	return source
+}
+
+// TrustedSourceFromContext returns previously captured trusted source metadata
+// when present, falling back to AppTheory provider context extraction.
+func TrustedSourceFromContext(ctx *apptheory.Context) TrustedSourceInfo {
+	if ctx == nil {
+		return TrustedSource(nil)
+	}
+	if source, ok := ctx.Get(ContextKeyTrustedSource).(TrustedSourceInfo); ok {
+		return source
+	}
+	return TrustedSource(ctx)
+}
+
+// SourceIP returns the trusted provider-derived source IP convenience value.
+func SourceIP(ctx *apptheory.Context) string {
+	return TrustedSourceFromContext(ctx).SourceIP
+}
+
+// Fingerprint returns a non-secret, deterministic fingerprint for source-IP
+// based rate-limit keys so DynamoDB partition keys do not contain raw IPs.
+func (s TrustedSourceInfo) Fingerprint() string {
+	if !s.Valid || strings.TrimSpace(s.SourceIP) == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(strings.TrimSpace(s.Provider) + "\x00" + strings.TrimSpace(s.SourceIP)))
+	return hex.EncodeToString(sum[:])
+}
+
+// SourceRateLimitIdentifier returns a stable rate-limit identifier for callers
+// without a stronger authenticated identity. The identifier is derived only
+// from trusted provider context and falls back to a shared unknown bucket when
+// provider source metadata is unavailable or invalid.
+func SourceRateLimitIdentifier(ctx *apptheory.Context, prefix string) string {
+	prefix = strings.Trim(strings.TrimSpace(prefix), ":")
+	if prefix == "" {
+		prefix = "source"
+	}
+	source := TrustedSourceFromContext(ctx)
+	fp := source.Fingerprint()
+	if fp == "" {
+		return prefix + ":source:" + trustedSourceUnknown
+	}
+	provider := strings.TrimSpace(source.Provider)
+	if provider == "" {
+		provider = trustedSourceUnknown
+	}
+	return prefix + ":source:" + provider + ":" + fp
+}
+
+// SourceRateLimitMetadata returns safe source metadata for rate-limit audit
+// rows. It intentionally excludes the raw source IP; audit logs may store the
+// raw provider-derived IP, but rate-limit rows use a fingerprint only.
+func SourceRateLimitMetadata(ctx *apptheory.Context) map[string]string {
+	source := TrustedSourceFromContext(ctx)
+	provider := strings.TrimSpace(source.Provider)
+	if provider == "" {
+		provider = trustedSourceUnknown
+	}
+	sourceName := strings.TrimSpace(source.Source)
+	if sourceName == "" {
+		sourceName = trustedSourceUnknown
+	}
+	valid := "false"
+	if source.Valid {
+		valid = "true"
+	}
+	out := map[string]string{
+		"source_provider": provider,
+		"source":          sourceName,
+		"source_valid":    valid,
+	}
+	if fp := source.Fingerprint(); fp != "" {
+		out["source_ip_sha256"] = fp
+	}
+	return out
+}

--- a/internal/httpx/source_provenance_test.go
+++ b/internal/httpx/source_provenance_test.go
@@ -1,0 +1,135 @@
+package httpx
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/apptheory/testkit"
+)
+
+const (
+	testProviderLambdaURL      = "lambda-url"
+	testProviderRequestContext = "provider_request_context"
+)
+
+func TestTrustedSourceUsesAppTheoryProviderContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{
+			"x-forwarded-for": {"203.0.113.250"},
+			"forwarded":       {"for=203.0.113.251"},
+		},
+		SourceProvenance: apptheory.SourceProvenance{
+			SourceIP: "2001:db8::1",
+			Provider: testProviderLambdaURL,
+			Source:   testProviderRequestContext,
+			Valid:    true,
+		},
+	}}
+
+	source := TrustedSource(ctx)
+	if !source.Valid || source.SourceIP != "2001:db8::1" || source.Provider != testProviderLambdaURL || source.Source != testProviderRequestContext {
+		t.Fatalf("unexpected source: %#v", source)
+	}
+	if source.SourceIP == "203.0.113.250" || source.SourceIP == "203.0.113.251" {
+		t.Fatalf("forwarded header was trusted: %#v", source)
+	}
+}
+
+func TestTrustedSourceUnknownForHeaderOnlyContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{Headers: map[string][]string{
+		"x-forwarded-for": {"198.51.100.42"},
+	}}}
+	source := TrustedSource(ctx)
+	if source.Valid || source.SourceIP != "" || source.Provider != trustedSourceUnknown || source.Source != trustedSourceUnknown {
+		t.Fatalf("expected unknown source, got %#v", source)
+	}
+	if got := SourceRateLimitIdentifier(ctx, "auth"); got != "auth:source:unknown" {
+		t.Fatalf("unexpected unknown identifier: %q", got)
+	}
+}
+
+func TestSetTrustedSourceStoresProviderContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{SourceProvenance: apptheory.SourceProvenance{
+		SourceIP: "198.51.100.77",
+		Provider: testProviderLambdaURL,
+		Source:   testProviderRequestContext,
+		Valid:    true,
+	}}}
+	stored := SetTrustedSource(ctx)
+	ctx.Request.SourceProvenance = apptheory.SourceProvenance{}
+
+	fromCtx := TrustedSourceFromContext(ctx)
+	if fromCtx != stored || fromCtx.SourceIP != "198.51.100.77" || !fromCtx.Valid {
+		t.Fatalf("expected stored trusted source, got %#v stored=%#v", fromCtx, stored)
+	}
+}
+
+func TestSourceRateLimitIdentifierFingerprintsProviderSourceIP(t *testing.T) {
+	t.Parallel()
+
+	ctxA := &apptheory.Context{Request: apptheory.Request{SourceProvenance: apptheory.SourceProvenance{
+		SourceIP: "198.51.100.10",
+		Provider: testProviderLambdaURL,
+		Source:   testProviderRequestContext,
+		Valid:    true,
+	}}}
+	ctxB := &apptheory.Context{Request: apptheory.Request{SourceProvenance: apptheory.SourceProvenance{
+		SourceIP: "198.51.100.11",
+		Provider: testProviderLambdaURL,
+		Source:   testProviderRequestContext,
+		Valid:    true,
+	}}}
+
+	idA := SourceRateLimitIdentifier(ctxA, "auth")
+	idB := SourceRateLimitIdentifier(ctxB, "auth")
+	if idA == idB {
+		t.Fatalf("expected distinct identifiers, got %q", idA)
+	}
+	if !strings.HasPrefix(idA, "auth:source:lambda-url:") || strings.Contains(idA, "198.51.100.10") {
+		t.Fatalf("unexpected identifier %q", idA)
+	}
+	meta := SourceRateLimitMetadata(ctxA)
+	if meta["source_provider"] != testProviderLambdaURL || meta["source"] != testProviderRequestContext || meta["source_valid"] != "true" {
+		t.Fatalf("unexpected metadata: %#v", meta)
+	}
+	if meta["source_ip_sha256"] == "" || strings.Contains(meta["source_ip_sha256"], "198.51.100.10") {
+		t.Fatalf("expected source fingerprint metadata, got %#v", meta)
+	}
+}
+
+func TestTrustedSourceFromAppTheoryTestkitHTTPEvent(t *testing.T) {
+	t.Parallel()
+
+	env := testkit.New()
+	app := env.App()
+	app.Get("/source", func(ctx *apptheory.Context) (*apptheory.Response, error) {
+		return apptheory.MustJSON(200, TrustedSource(ctx)), nil
+	})
+
+	event := testkit.LambdaFunctionURLRequest("GET", "/source", testkit.HTTPEventOptions{
+		SourceIP: "198.51.100.88",
+		Headers: map[string]string{
+			"X-Forwarded-For": "203.0.113.10",
+		},
+	})
+	resp := env.InvokeLambdaFunctionURL(context.Background(), app, event)
+	if resp.StatusCode != 200 {
+		t.Fatalf("unexpected status: %d body=%s", resp.StatusCode, resp.Body)
+	}
+	var source TrustedSourceInfo
+	if err := json.Unmarshal([]byte(resp.Body), &source); err != nil {
+		t.Fatalf("unmarshal source: %v", err)
+	}
+	if !source.Valid || source.SourceIP != "198.51.100.88" || source.Provider != testProviderLambdaURL {
+		t.Fatalf("unexpected source: %#v", source)
+	}
+}

--- a/internal/store/models/audit_log_entry.go
+++ b/internal/store/models/audit_log_entry.go
@@ -19,6 +19,13 @@ type AuditLogEntry struct {
 	Target    string    `theorydb:"attr:target" json:"target"`
 	RequestID string    `theorydb:"attr:requestID" json:"request_id"`
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+
+	// Source provenance is provider-derived request metadata used only for
+	// audit/rate-limit context. It must never become an authorization input.
+	SourceIP         string `theorydb:"attr:sourceIP,omitempty" json:"source_ip,omitempty"`
+	SourceProvider   string `theorydb:"attr:sourceProvider,omitempty" json:"source_provider,omitempty"`
+	SourceProvenance string `theorydb:"attr:sourceProvenance,omitempty" json:"source_provenance,omitempty"`
+	SourceValid      bool   `theorydb:"attr:sourceValid,omitempty" json:"source_valid,omitempty"`
 }
 
 // TableName returns the database table name for AuditLogEntry.

--- a/internal/trust/audit.go
+++ b/internal/trust/audit.go
@@ -1,0 +1,21 @@
+package trust
+
+import (
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func applyAuditSourceProvenance(ctx *apptheory.Context, entry *models.AuditLogEntry) {
+	if ctx == nil || entry == nil {
+		return
+	}
+	source := httpx.TrustedSourceFromContext(ctx)
+	entry.SourceIP = strings.TrimSpace(source.SourceIP)
+	entry.SourceProvider = strings.TrimSpace(source.Provider)
+	entry.SourceProvenance = strings.TrimSpace(source.Source)
+	entry.SourceValid = source.Valid
+}

--- a/internal/trust/audit_internal_test.go
+++ b/internal/trust/audit_internal_test.go
@@ -1,0 +1,35 @@
+package trust
+
+import (
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestApplyAuditSourceProvenanceUsesProviderContext(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{Request: apptheory.Request{
+		Headers: map[string][]string{
+			"x-forwarded-for": {"203.0.113.250"},
+		},
+		SourceProvenance: apptheory.SourceProvenance{
+			SourceIP: "198.51.100.88",
+			Provider: "lambda-url",
+			Source:   "provider_request_context",
+			Valid:    true,
+		},
+	}}
+	entry := &models.AuditLogEntry{}
+
+	applyAuditSourceProvenance(ctx, entry)
+
+	if !entry.SourceValid || entry.SourceIP != "198.51.100.88" || entry.SourceProvider != "lambda-url" || entry.SourceProvenance != "provider_request_context" {
+		t.Fatalf("unexpected audit source fields: %#v", entry)
+	}
+	if entry.SourceIP == "203.0.113.250" {
+		t.Fatalf("forwarded header was trusted: %#v", entry)
+	}
+}

--- a/internal/trust/auth_instance.go
+++ b/internal/trust/auth_instance.go
@@ -26,6 +26,7 @@ func (s *Server) InstanceAuthHook(ctx *apptheory.Context) (string, error) {
 	if ctx == nil {
 		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	httpx.SetTrustedSource(ctx)
 
 	raw := strings.TrimSpace(httpx.BearerToken(ctx.Request.Headers))
 	if raw == "" {

--- a/internal/trust/handlers_ai_moderation.go
+++ b/internal/trust/handlers_ai_moderation.go
@@ -99,6 +99,7 @@ func (s *Server) writeAIJobAuditEntryBestEffort(ctx *apptheory.Context, instance
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: time.Now().UTC(),
 	}
+	applyAuditSourceProvenance(ctx, entry)
 	_ = entry.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(entry).Create()
 }

--- a/internal/trust/handlers_previews.go
+++ b/internal/trust/handlers_previews.go
@@ -538,6 +538,7 @@ func (s *Server) debitBudgetForPreviewRender(ctx *apptheory.Context, instanceSlu
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, auditBudget)
 	_ = auditBudget.UpdateKeys()
 
 	maxUsed := budget.IncludedCredits - linkRenderCreditCost
@@ -580,6 +581,7 @@ func (s *Server) auditPreviewRenderQueuedBestEffort(ctx *apptheory.Context, inst
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(audit).Create()
 }

--- a/internal/trust/handlers_publish_jobs.go
+++ b/internal/trust/handlers_publish_jobs.go
@@ -353,6 +353,7 @@ func (s *Server) storeLinkSafetyBasicNoLinksResult(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 
 	err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
@@ -833,6 +834,7 @@ func (s *Server) runLinkSafetyBasicJob(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, auditBudget)
 	_ = auditBudget.UpdateKeys()
 
 	auditScan := &models.AuditLogEntry{
@@ -842,6 +844,7 @@ func (s *Server) runLinkSafetyBasicJob(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, auditScan)
 	_ = auditScan.UpdateKeys()
 
 	allowOverage := strings.ToLower(strings.TrimSpace(overagePolicy)) == overagePolicyAllow

--- a/internal/trust/handlers_publish_jobs_renders.go
+++ b/internal/trust/handlers_publish_jobs_renders.go
@@ -487,6 +487,7 @@ func (s *Server) debitLinkRenderBudget(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, auditBudget)
 	_ = auditBudget.UpdateKeys()
 
 	maxUsed := budget.IncludedCredits - creditsNeededPriced
@@ -530,6 +531,7 @@ func (s *Server) queueMissingRenders(ctx *apptheory.Context, instanceSlug string
 				RequestID: strings.TrimSpace(ctx.RequestID),
 				CreatedAt: now,
 			}
+			applyAuditSourceProvenance(ctx, audit)
 			_ = audit.UpdateKeys()
 			_ = s.store.DB.WithContext(ctx.Context()).Model(audit).Create()
 		}

--- a/internal/trust/handlers_renders.go
+++ b/internal/trust/handlers_renders.go
@@ -139,6 +139,7 @@ func (s *Server) maybeServeCachedRenderRequest(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(audit).Create()
 
@@ -237,6 +238,7 @@ func (s *Server) handleCreateRender(ctx *apptheory.Context) (*apptheory.Response
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, audit)
 	_ = audit.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(audit).Create()
 
@@ -248,6 +250,7 @@ func (s *Server) handleCreateRender(ctx *apptheory.Context) (*apptheory.Response
 			RequestID: strings.TrimSpace(ctx.RequestID),
 			CreatedAt: now,
 		}
+		applyAuditSourceProvenance(ctx, auditQueue)
 		_ = auditQueue.UpdateKeys()
 		_ = s.store.DB.WithContext(ctx.Context()).Model(auditQueue).Create()
 	}
@@ -345,6 +348,7 @@ func (s *Server) debitBudgetForCreateRender(
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}
+	applyAuditSourceProvenance(ctx, auditBudget)
 	_ = auditBudget.UpdateKeys()
 
 	maxUsed := budget.IncludedCredits - linkRenderCreditCost

--- a/internal/trust/rate_limits.go
+++ b/internal/trust/rate_limits.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/theory-cloud/apptheory/pkg/limited"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/httpx"
 )
 
 const (
@@ -38,18 +40,9 @@ func (s *Server) aiRateLimitMiddleware() apptheory.Middleware {
 	limiter := limited.NewDynamoRateLimiter(s.store.DB, limited.DefaultConfig(), strategy)
 
 	rateLimitMW := apptheory.RateLimitMiddleware(apptheory.RateLimitConfig{
-		Limiter:    limiter,
-		FailClosed: true,
-		ExtractIdentifier: func(ctx *apptheory.Context) string {
-			if ctx == nil {
-				return "anonymous"
-			}
-			id := strings.TrimSpace(ctx.AuthIdentity)
-			if id == "" {
-				return "anonymous"
-			}
-			return id
-		},
+		Limiter:           limiter,
+		FailClosed:        true,
+		ExtractIdentifier: aiRateLimitIdentifier,
 	})
 
 	return func(next apptheory.Handler) apptheory.Handler {
@@ -68,4 +61,14 @@ func (s *Server) aiRateLimitMiddleware() apptheory.Middleware {
 			return next(ctx)
 		}
 	}
+}
+
+func aiRateLimitIdentifier(ctx *apptheory.Context) string {
+	if ctx == nil {
+		return httpx.SourceRateLimitIdentifier(nil, "trust-ai:anonymous")
+	}
+	if id := strings.TrimSpace(ctx.AuthIdentity); id != "" {
+		return id
+	}
+	return httpx.SourceRateLimitIdentifier(ctx, "trust-ai:anonymous")
 }

--- a/internal/trust/rate_limits_internal_test.go
+++ b/internal/trust/rate_limits_internal_test.go
@@ -2,6 +2,7 @@ package trust
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -66,4 +67,35 @@ func TestAIRateLimitMiddleware_Basic(t *testing.T) {
 	require.Equal(t, 3, called)
 
 	require.Nil(t, mw(nil))
+}
+
+func TestAIRateLimitIdentifierUsesTrustedSourceOnlyForAnonymous(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{
+		AuthIdentity: "managed-slug",
+		Request: apptheory.Request{
+			Headers: map[string][]string{
+				"x-forwarded-for": {"203.0.113.250"},
+			},
+			SourceProvenance: apptheory.SourceProvenance{
+				SourceIP: "198.51.100.88",
+				Provider: "lambda-url",
+				Source:   "provider_request_context",
+				Valid:    true,
+			},
+		},
+	}
+	require.Equal(t, "managed-slug", aiRateLimitIdentifier(ctx))
+
+	ctx.AuthIdentity = ""
+	got := aiRateLimitIdentifier(ctx)
+	require.True(t, strings.HasPrefix(got, "trust-ai:anonymous:source:lambda-url:"), got)
+	require.NotContains(t, got, "198.51.100.88")
+	require.NotContains(t, got, "203.0.113.250")
+
+	headerOnly := &apptheory.Context{Request: apptheory.Request{Headers: map[string][]string{
+		"x-forwarded-for": {"198.51.100.42"},
+	}}}
+	require.Equal(t, "trust-ai:anonymous:source:unknown", aiRateLimitIdentifier(headerOnly))
 }


### PR DESCRIPTION
## Summary
- adopt AppTheory `SourceProvenance()` as the only source of request-origin metadata for host auth/audit/rate-limit context
- add `internal/httpx` trusted-source helpers that ignore `Forwarded` / `X-Forwarded-*` headers and fingerprint source IPs for rate-limit partition keys
- enrich control-plane and trust audit entries with provider-derived source provenance, while preserving auth identity/key-hash authorization semantics
- use trusted source provenance for anonymous/invalid rate-limit buckets in control-plane and trust rate limiting

Closes #295. Refs #291.

## Trust-and-safety audit

### Proposed change
Use AppTheory provider-derived source provenance for audit and rate-limit context across auth-sensitive control-plane and trust surfaces.

### Surfaces affected
- Trust API endpoints: no route additions/removals; trust audit/rate-limit context only
- Attestation shape: unchanged
- Instance-auth mechanism: unchanged; bearer token still hashes to `sha256(raw_key)` and raw keys are never stored/logged
- CSP: unchanged; `web/` untouched
- Safety / AI-evidence services: audit metadata only, no provider/input changes

### Trust API contract impact
- Endpoint additions / modifications / removals: none
- Authentication model: preserved
- Shape / versioning: additive audit fields only
- Evidence emission: enhanced with provider-derived source context
- Rate limiting: anonymous/invalid fallback buckets now use trusted source provenance when present; authenticated identities and key hashes remain primary
- Third-party consumer impact: none

### Attestation integrity
- Shape: preserved
- Signing key: unchanged
- Signature verifiability: preserved
- Retention / revocation: unchanged

### Instance-auth correctness
- Key generation: unchanged
- Storage (`sha256` only): preserved
- Validation: preserved in `InstanceAuthHook`
- Rotation / revocation: unchanged
- Audit: source metadata is audit/rate-limit context only, never authorization

### CSP
- Headers: unchanged
- Inline script/style, unsafe-eval, third-party origins: none

### Safety / AI-evidence
- Provider changes: none
- Evidence collection shape: unchanged
- Privacy boundary: preserved; no tenant content read into host control plane

### Governance-rubric impact
- No verifier/rubric weakening.
- Gov verifier passes 29/0/0.

## Validation
- `go test ./internal/httpx ./internal/controlplane ./internal/trust ./internal/store/models`
- `go test ./...`
- `go vet ./...`
- `test -z "$(gofmt -l $(git ls-files '*.go'))"`
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Boundary confirmations
- Multi-tenant isolation preserved; source provenance is never used for tenant authorization.
- Trust API instance-auth preserved; raw instance keys are not stored, logged, or returned.
- Attestation shape/signing unchanged.
- CSP unchanged.
- On-chain / Safe / contract surfaces untouched.
- Managed provisioning and consumer release verification untouched.
