### PR TITLE
refactor(api): pilot AppTheory typed request binding

### DIFF
--- a/internal/controlplane/handlers_operator_reviews.go
+++ b/internal/controlplane/handlers_operator_reviews.go
@@ -352,9 +352,9 @@ func (s *Server) handlePortalCreateExternalInstanceRegistration(ctx *apptheory.C
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 
-	var req externalInstanceRegistrationRequest
-	if err := httpx.ParseJSON(ctx, &req); err != nil {
-		return nil, err
+	req, parseErr := httpx.BindJSON[externalInstanceRegistrationRequest](ctx)
+	if parseErr != nil {
+		return nil, parseErr
 	}
 
 	slug := strings.ToLower(strings.TrimSpace(req.Slug))

--- a/internal/controlplane/handlers_operator_reviews_internal_test.go
+++ b/internal/controlplane/handlers_operator_reviews_internal_test.go
@@ -192,3 +192,63 @@ func TestPortalExternalInstanceRegistrationLifecycle(t *testing.T) {
 		t.Fatalf("reject: resp=%#v err=%v", resp, err)
 	}
 }
+
+func TestPortalExternalInstanceRegistrationTypedBinding(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		body        []byte
+		wantMessage string
+	}{
+		{
+			name:        "empty body",
+			body:        nil,
+			wantMessage: "empty body",
+		},
+		{
+			name:        "malformed json",
+			body:        []byte("{"),
+			wantMessage: "invalid JSON",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tdb := newOperatorReviewsTestDB()
+			s := &Server{store: store.New(tdb.db)}
+			_, err := s.handlePortalCreateExternalInstanceRegistration(&apptheory.Context{
+				AuthIdentity: "alice",
+				RequestID:    "r1",
+				Request:      apptheory.Request{Body: tc.body},
+			})
+			appErr, ok := err.(*apptheory.AppError)
+			if !ok {
+				t.Fatalf("expected AppError, got %T (%v)", err, err)
+			}
+			if appErr.Code != appErrCodeBadRequest || appErr.Message != tc.wantMessage {
+				t.Fatalf("unexpected error: %#v", appErr)
+			}
+		})
+	}
+
+	t.Run("unknown fields are ignored", func(t *testing.T) {
+		t.Parallel()
+
+		tdb := newOperatorReviewsTestDB()
+		s := &Server{store: store.New(tdb.db)}
+
+		tdb.qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+		tdb.qReg.On("Create").Return(nil).Once()
+		tdb.qAudit.On("Create").Return(nil).Once()
+
+		resp, err := s.handlePortalCreateExternalInstanceRegistration(&apptheory.Context{
+			AuthIdentity: "alice",
+			RequestID:    "r1",
+			Request:      apptheory.Request{Body: []byte(`{"slug":"demo","note":"hello","extra":true}`)},
+		})
+		if err != nil || resp.Status != 201 {
+			t.Fatalf("unknown field create: resp=%#v err=%v", resp, err)
+		}
+	})
+}

--- a/internal/httpx/http_helpers.go
+++ b/internal/httpx/http_helpers.go
@@ -11,6 +11,33 @@ import (
 const maxRequestBodySize = 1 << 20
 
 func ParseJSON(ctx *apptheory.Context, dest any) error {
+	if err := validateJSONBody(ctx); err != nil {
+		return err
+	}
+	if err := json.Unmarshal(ctx.Request.Body, dest); err != nil {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid JSON"}
+	}
+	return nil
+}
+
+// BindJSON uses AppTheory typed request binding for JSON bodies while
+// preserving host's existing ParseJSON request-size and error semantics.
+func BindJSON[Req any](ctx *apptheory.Context) (Req, error) {
+	var zero Req
+	if err := validateJSONBody(ctx); err != nil {
+		return zero, err
+	}
+
+	req, err := apptheory.BindRequest(ctx, apptheory.BindConfig[Req]{
+		Body: true,
+	})
+	if err != nil {
+		return zero, &apptheory.AppError{Code: "app.bad_request", Message: "invalid JSON"}
+	}
+	return req, nil
+}
+
+func validateJSONBody(ctx *apptheory.Context) error {
 	if ctx == nil {
 		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid request"}
 	}
@@ -19,9 +46,6 @@ func ParseJSON(ctx *apptheory.Context, dest any) error {
 	}
 	if len(ctx.Request.Body) > maxRequestBodySize {
 		return &apptheory.AppError{Code: "app.bad_request", Message: "request body too large"}
-	}
-	if err := json.Unmarshal(ctx.Request.Body, dest); err != nil {
-		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid JSON"}
 	}
 	return nil
 }

--- a/internal/httpx/http_helpers_test.go
+++ b/internal/httpx/http_helpers_test.go
@@ -38,6 +38,37 @@ func TestParseJSON(t *testing.T) {
 	}
 }
 
+func TestBindJSON(t *testing.T) {
+	t.Parallel()
+
+	type bindRequest struct {
+		Value string `json:"value"`
+	}
+
+	if _, err := BindJSON[bindRequest](nil); err == nil {
+		t.Fatalf("expected error for nil ctx")
+	}
+
+	ctx := &apptheory.Context{}
+	if _, err := BindJSON[bindRequest](ctx); err == nil {
+		t.Fatalf("expected error for empty body")
+	}
+
+	ctx.Request.Body = []byte("{")
+	if _, err := BindJSON[bindRequest](ctx); err == nil {
+		t.Fatalf("expected error for invalid json")
+	}
+
+	ctx.Request.Body = []byte(`{"value":"x","unknown":true}`)
+	req, err := BindJSON[bindRequest](ctx)
+	if err != nil {
+		t.Fatalf("BindJSON: %v", err)
+	}
+	if req.Value != "x" {
+		t.Fatalf("expected typed bound value, got %#v", req)
+	}
+}
+
 func TestBearerToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Milestone
Phase 4 — maintainability pilot for AppTheory typed request binding (#297)

## Classification
Maintainability / framework consumption / test coverage.

## Surfaces affected
- `internal/httpx`: adds `BindJSON` typed-binding helper that delegates JSON binding to AppTheory while preserving host's existing body-size and bad-request semantics.
- `internal/controlplane`: external instance registration create path uses the typed helper.
- Tests for `httpx` typed binding and external instance registration empty/malformed/unknown-field behavior.

## Specialist walks referenced
- Governance rubric: no rubric/verifier changes; gov verifier PASS 29/0/0 locally.
- Provisioning / managed-update / release verification: not touched.
- Soul registry: not touched.
- Trust API / CSP / instance-auth: not touched.
- Framework: idiomatic AppTheory `BindRequest` / `BindConfig`; no local framework patch.

## Multi-tenant isolation impact
None. This only changes request decoding for external instance registration metadata and does not add cross-tenant reads/writes.

## On-chain impact
None.

## Consumer impact
Portal customers creating external instance registrations; status/error semantics remain unchanged for empty and malformed bodies, while unknown JSON fields remain tolerated as before.

## Tasks
- [x] #297 Pilot AppTheory typed request binding

## Validation
- `go test ./internal/httpx ./internal/controlplane`
- `go test ./...`
- `go vet ./...`
- `test -z "$(gofmt -l $(git ls-files '*.go'))"`
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete
- [ ] Deployed to live
- [ ] Post-deploy monitoring verified

## Cross-repo coordination
None for this PR.

## Advisor-brief authorization (if applicable)
Not advisor-dispatched.
