### PR TITLE
fix(soul): add reputation phase diagnostics

### DIFF
--- a/internal/soulreputationworker/server.go
+++ b/internal/soulreputationworker/server.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"math"
 	"math/big"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -52,6 +54,8 @@ type Server struct {
 	dialTip tipLogDialer
 	now     func() time.Time
 	attest  *attestations.KMSService
+
+	logPhaseFailure func(ctx *apptheory.EventContext, phase string)
 }
 
 // NewServer constructs a soul reputation worker Server.
@@ -63,6 +67,8 @@ func NewServer(cfg config.Config, st *store.Store, packs soulPackStore) *Server 
 		dialTip: dialTipLogClient,
 		now:     time.Now,
 		attest:  attestations.NewKMSService(cfg.AttestationSigningKeyID, cfg.AttestationPublicKeyIDs),
+
+		logPhaseFailure: logRecomputePhaseFailure,
 	}
 }
 
@@ -99,7 +105,7 @@ type reputationSnapshotSignaturePayload struct {
 
 func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBridgeEvent) (any, error) {
 	if err := s.requireRecomputePrereqs(ctx); err != nil {
-		return nil, err
+		return nil, s.recomputePhaseError(ctx, "prereqs", err)
 	}
 
 	rpcURL, contractAddr, skip := s.tipRecomputeConfig()
@@ -109,24 +115,24 @@ func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBrid
 
 	client, err := s.dialTip(ctx.Context(), rpcURL)
 	if err != nil {
-		return nil, fmt.Errorf("failed to dial tip rpc: %w", err)
+		return nil, s.recomputePhaseError(ctx, "dial_tip_rpc", fmt.Errorf("failed to dial tip rpc: %w", err))
 	}
 	defer client.Close()
 
 	blockRef, err := client.BlockNumber(ctx.Context())
 	if err != nil {
-		return nil, fmt.Errorf("failed to read head block: %w", err)
+		return nil, s.recomputePhaseError(ctx, "read_head_block", fmt.Errorf("failed to read head block: %w", err))
 	}
 
 	fromBlock, chunkSize := s.tipIngestRange(blockRef)
 	tipCounts, err := fetchAgentTipCounts(ctx.Context(), client, contractAddr, fromBlock, blockRef, chunkSize)
 	if err != nil {
-		return nil, fmt.Errorf("failed to ingest tips: %w", err)
+		return nil, s.recomputePhaseError(ctx, "ingest_tips", fmt.Errorf("failed to ingest tips: %w", err))
 	}
 
 	identities, err := s.listAgentIdentities(ctx.Context())
 	if err != nil {
-		return nil, fmt.Errorf("failed to list identities: %w", err)
+		return nil, s.recomputePhaseError(ctx, "list_identities", fmt.Errorf("failed to list identities: %w", err))
 	}
 	sort.Slice(identities, func(i, j int) bool { return soulIdentitySortKey(identities[i]) < soulIdentitySortKey(identities[j]) })
 
@@ -135,7 +141,7 @@ func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBrid
 
 	reps, updated, skippedSuspended, err := s.computeAndPersistReputations(ctx.Context(), identities, blockRef, now, v0cfg, tipCounts)
 	if err != nil {
-		return nil, err
+		return nil, s.recomputePhaseError(ctx, "compute_and_persist_reputations", err)
 	}
 	totalTipEvents := sumTipEvents(tipCounts)
 
@@ -153,12 +159,12 @@ func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBrid
 
 	body, err := json.Marshal(snapshot)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal snapshot: %w", err)
+		return nil, s.recomputePhaseError(ctx, "marshal_snapshot", fmt.Errorf("failed to marshal snapshot: %w", err))
 	}
 
 	key := reputationSnapshotS3Key(s.cfg.TipChainID, blockRef)
 	if err := s.packs.PutObject(ctx.Context(), key, body, "application/json", "no-store"); err != nil {
-		return nil, fmt.Errorf("failed to write snapshot: %w", err)
+		return nil, s.recomputePhaseError(ctx, "write_snapshot", fmt.Errorf("failed to write snapshot: %w", err))
 	}
 
 	sigKey := ""
@@ -173,17 +179,17 @@ func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBrid
 			ComputedAt:     now,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to marshal snapshot signature payload: %w", err)
+			return nil, s.recomputePhaseError(ctx, "marshal_snapshot_signature_payload", fmt.Errorf("failed to marshal snapshot signature payload: %w", err))
 		}
 
 		jws, _, err := s.attest.SignPayloadJWS(ctx.Context(), payloadBytes)
 		if err != nil {
-			return nil, fmt.Errorf("failed to sign snapshot signature payload: %w", err)
+			return nil, s.recomputePhaseError(ctx, "sign_snapshot_signature_payload", fmt.Errorf("failed to sign snapshot signature payload: %w", err))
 		}
 
 		sigKey = reputationSnapshotSignatureS3Key(key)
 		if err := s.packs.PutObject(ctx.Context(), sigKey, []byte(jws), "application/jose", "no-store"); err != nil {
-			return nil, fmt.Errorf("failed to write snapshot signature: %w", err)
+			return nil, s.recomputePhaseError(ctx, "write_snapshot_signature", fmt.Errorf("failed to write snapshot signature: %w", err))
 		}
 	}
 
@@ -199,6 +205,51 @@ func (s *Server) handleRecompute(ctx *apptheory.EventContext, _ events.EventBrid
 		"tip_agents_with_tips": len(tipCounts),
 		"tip_events_total":     totalTipEvents,
 	}, nil
+}
+
+var soulReputationPhaseLogger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+func (s *Server) recomputePhaseError(ctx *apptheory.EventContext, phase string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if s != nil && s.logPhaseFailure != nil {
+		s.logPhaseFailure(ctx, phase)
+	}
+	return fmt.Errorf("soul reputation recompute phase %s failed: %w", normalizeRecomputePhase(phase), err)
+}
+
+func logRecomputePhaseFailure(ctx *apptheory.EventContext, phase string) {
+	requestID := ""
+	if ctx != nil {
+		requestID = strings.TrimSpace(ctx.RequestID)
+	}
+
+	soulReputationPhaseLogger.Error(
+		"soul_reputation_recompute.phase_failed",
+		slog.String("service", ServiceName),
+		slog.String("request_id", requestID),
+		slog.String("phase", normalizeRecomputePhase(phase)),
+	)
+}
+
+func normalizeRecomputePhase(phase string) string {
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "prereqs",
+		"dial_tip_rpc",
+		"read_head_block",
+		"ingest_tips",
+		"list_identities",
+		"compute_and_persist_reputations",
+		"marshal_snapshot",
+		"write_snapshot",
+		"marshal_snapshot_signature_payload",
+		"sign_snapshot_signature_payload",
+		"write_snapshot_signature":
+		return strings.ToLower(strings.TrimSpace(phase))
+	default:
+		return "unknown"
+	}
 }
 
 func (s *Server) requireRecomputePrereqs(ctx *apptheory.EventContext) error {

--- a/internal/soulreputationworker/server_more_internal_test.go
+++ b/internal/soulreputationworker/server_more_internal_test.go
@@ -2,6 +2,7 @@ package soulreputationworker
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -86,4 +87,35 @@ func TestTipIngestRange_ClampsAndDefaults(t *testing.T) {
 	from, chunk := srv.tipIngestRange(20)
 	require.Equal(t, uint64(20), from)
 	require.Equal(t, uint64(5000), chunk)
+}
+
+func TestRecomputePhaseError_LogsOnlySanitizedPhase(t *testing.T) {
+	t.Parallel()
+
+	const rawAgentID = "0x00000000000000000000000000000000000000000000000000000000000000aa"
+	var logged []string
+	srv := &Server{
+		logPhaseFailure: func(ctx *apptheory.EventContext, phase string) {
+			require.Equal(t, "rid", ctx.RequestID)
+			logged = append(logged, phase)
+		},
+	}
+
+	err := srv.recomputePhaseError(
+		&apptheory.EventContext{RequestID: "rid"},
+		"compute_and_persist_reputations",
+		errors.New("failed to persist reputation for "+rawAgentID),
+	)
+	require.Error(t, err)
+	require.ErrorContains(t, err, rawAgentID)
+	require.Equal(t, []string{"compute_and_persist_reputations"}, logged)
+	require.NotContains(t, logged[0], rawAgentID)
+}
+
+func TestNormalizeRecomputePhase(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "list_identities", normalizeRecomputePhase(" LIST_IDENTITIES "))
+	require.Equal(t, "unknown", normalizeRecomputePhase("list_identities\nextra"))
+	require.Equal(t, "unknown", normalizeRecomputePhase(""))
 }


### PR DESCRIPTION
## Milestone
Project 31 / host#306 — investigate lab soul-reputation-worker scheduled failures.

Refs #306.

## Classification
Soul registry / operational-reliability / bug-fix diagnostic instrumentation.

## Surfaces affected
- `internal/soulreputationworker/server.go`
- `internal/soulreputationworker/server_more_internal_test.go`

## Specialist walks referenced
- Advisor brief: Pilot assignment received and acknowledged under Aron's standing authorization for Pilot-assigned milestones.
- Issue investigation: lab scheduled invocations fail behind AppTheory safe error wrapping; public lab probes and other Lambdas were healthy.
- Soul registry: off-chain reputation aggregation only; no Solidity, Safe payload, mint-signer, or on-chain transaction change.
- Governance rubric: verifier run remained PASS; no rubric/pack/verifier changes.
- Provisioning / release verification: not touched.
- Trust API / CSP / instance-auth: not touched.
- Framework: no local framework patch.

## Investigation note

### Reported symptom
Lab `lesser-host-lab-soul-reputation-worker` scheduled EventBridge recompute invocations fail repeatedly, while logs only show the AppTheory safe wrapper event `apptheory: event workload failed` / `app.internal`.

### What is definitely true
- Lab config has soul/tip enabled and redacted required parameters present (`TIP_CHAIN_ID`, contract address, RPC SSM parameter, attestation key IDs).
- CloudWatch showed scheduled EventBridge invocations failing with retry attempts, but without a worker-internal phase.
- CloudTrail showed successful SSM/KMS reads around invocations and a DynamoDB `ListTables` access denied from TableTheory Lambda pre-warm behavior; that looks like safe-to-ignore prewarm noise rather than a confirmed recompute phase failure.
- Earlier read-only probes confirmed the Sepolia RPC parameter can answer `eth_blockNumber`, first `eth_getLogs` chunk returned OK, and local read phases can list identities and run validation/integrity/communication reads.

### Fix-locus verdict
Host-side observability gap in the off-chain soul reputation worker. The exact failing runtime phase still needs lab deploy/soak of this diagnostic patch to identify safely.

### Hypotheses ranked
1. Lambda-only failure after early read phases: reputation persistence, S3 snapshot write, or KMS signing. Evidence: local read-only phases passed; CloudWatch has no phase detail today.
2. Lambda runtime/RPC behavior differs from local probes. Evidence: lab invokes under Lambda network/runtime and redacted SSM configuration.
3. TableTheory `ListTables` denied prewarm is correlated but not causal. Evidence: TableTheory prewarm ignores the error; no DynamoDB operation failure has yet surfaced in current safe logs.

## What changed
- Wrapped each scheduled recompute phase with `recomputePhaseError`.
- Emitted a sanitized JSON log event, `soul_reputation_recompute.phase_failed`, containing only:
  - `service`
  - `request_id`
  - whitelisted `phase`
- Kept raw RPC URLs, wallet material, tenant data, private keys, agent IDs, signed payloads, and raw error text out of the diagnostic log.
- Added regression coverage that injected errors containing raw-looking agent IDs are not forwarded into the diagnostic log value.

## Multi-tenant isolation impact
None. This change does not read tenant content, traverse tenant accounts, alter instance-key handling, or add cross-tenant queries. It only logs a whitelisted worker phase name for host's own lab worker failure diagnosis.

## On-chain impact
None. No Solidity, no Safe payload, no contract call shape change, no transaction signing/sending, and no deploy action.

## Consumer impact
Managed operators get safer lab diagnosis for the scheduled soul reputation worker. No customer portal, managed provisioning, or instance API behavior changes.

## Tasks
- [x] Add safe phase-level diagnostics to the scheduled soul reputation recompute path.
- [x] Add targeted tests for diagnostic redaction and phase normalization.
- [x] Run host validation locally.

## Validation
- `git ls-files '*.go' | xargs gofmt -l` — empty
- `go test ./internal/soulreputationworker` — pass
- `go test ./...` — pass
- `go vet ./...` — pass
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29 pass, 0 fail, 0 blocked)

Not run because surfaces are untouched:
- CDK synth (no CDK changes)
- Web lint/typecheck/tests (no `web/` changes)
- Hardhat / Slither / solhint (no Solidity changes)

## Stage rollout plan (handoff after merge)
- [ ] Merge through required review and CI/gov-infra checks.
- [ ] Operator-authorized deploy to `lab`; do not deploy to `live` from this PR.
- [ ] Let the next scheduled lab EventBridge invocation run.
- [ ] Inspect only the sanitized `soul_reputation_recompute.phase_failed` event for the failing phase.
- [ ] File or implement the narrow follow-up fix for the identified phase.
- [ ] Keep live deployment gated on successful lab diagnosis and soak.

## Cross-repo coordination
None required. This is host-only off-chain worker observability.

## Advisor-brief authorization
Pilot assignment was received as a direct active assignment for Project 31 / host#306 and acknowledged under Aron's standing authorization for Pilot-assigned work in this session.