### PR TITLE
feat(soul): add hosted-bound policy vocabulary

### DIFF
--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -35,6 +35,53 @@ These two surfaces are related, but intentionally not the same thing. See `docs/
 - Suspension policy: `docs/adr/0003-suspension-policy.md`
 - Agent ID conformance vectors: `docs/spec/agent-id-test-vectors.md`
 
+## Hosted-bound-soul policy vocabulary v1
+
+Project 32 M1 introduces an explicit hosted-bound-soul policy vocabulary so `lesser-host`, `lesser`, and `lesser-body`
+do not rely on implicit channel or x402 assumptions.
+
+The v1 vocabulary names four separate concepts:
+
+1. **Anchor state**
+   - `hosted_offchain`: the soul exists as host-managed off-chain registry state and registration artifacts.
+   - `immutable_onchain`: a mint execution has been recorded on-chain and reconciled into host state.
+   - Anchor state is **assurance metadata only**. `immutable_onchain` is not a prerequisite for basic hosted-bound-soul
+     communication, and `hosted_offchain` is not a lesser capability downgrade.
+2. **Operational binding**
+   - `hosted_bound_soul`: the agent is bound to a host-managed lesser/body instance through host's domain and
+     instance-key authorization checks.
+   - Operational binding is separate from channel/capability policy; it says which managed instance may act for the
+     agent, not which operations are allowed.
+3. **Capability policy**
+   - Version: `capability-policy/v1`.
+   - Email is the default hosted-bound-soul communication capability when an active, verified, provisioned email channel
+     exists (`email.defaultAllowed=true`).
+   - Phone/SMS/voice are denied until a paid or provisioned phone entitlement exists
+     (`phone.entitlementStatus in ["provisioned","paid"]` with the relevant `smsAllowed` / `voiceAllowed` flag).
+4. **Caller access/payment policy**
+   - Version: `caller-access-payment/v1`.
+   - M1 models `publicPaidCaller` explicitly but keeps it `denied`.
+   - Public paid x402 invocation grants are intentionally deferred to M2. M1 must not grant principal/operator
+     authority to public callers.
+
+Migration path for existing souls:
+
+- Existing identities without persisted policy fields are interpreted as `hosted-bound-soul/v1` with
+  `migration.state=implicit_default_v1`.
+- The implicit default is email allowed, phone/SMS/voice not entitled, and public paid callers denied.
+- New or touched identities persist `migration.state=persisted_v1`. Email provisioning persists the default v1 policy;
+  phone provisioning persists `phone.entitlementStatus=provisioned` plus `smsAllowed=true` and `voiceAllowed=true`;
+  phone deprovisioning returns the phone policy to `not_entitled`.
+- On-chain mint execution updates `anchorState=immutable_onchain`; it does not change capability authority by itself.
+
+Body-facing contract:
+
+- `GET /api/v1/soul/comm/contactability/{agentId}` returns the effective `policy` object alongside bounded channel
+  affordances.
+- Entitlement failures use `comm.entitlement_required` with the client-safe message `channel entitlement required`.
+  The failure is produced before loading phone channel/provider details and does not reveal private reachability,
+  payment evidence, tenant data, wallet material, or provider configuration.
+
 ## Soul registry API surface (`/api/v1/soul/*`)
 
 The soul registry is served by `cmd/control-plane-api` through the `lesser.host` distribution.

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -78,6 +78,8 @@ Body-facing contract:
 
 - `GET /api/v1/soul/comm/contactability/{agentId}` returns the effective `policy` object alongside bounded channel
   affordances.
+- Public unauthenticated soul-agent reads do not expose the policy fields; the full effective capability and entitlement
+  policy is intentionally instance-key scoped to the contactability contract.
 - Entitlement failures use `comm.entitlement_required` with the client-safe message `channel entitlement required`.
   The failure is produced before loading phone channel/provider details and does not reveal private reachability,
   payment evidence, tenant data, wallet material, or provider configuration.

--- a/docs/spec/v3/fixtures/soul-comm-send.error.entitlement-required.example.json
+++ b/docs/spec/v3/fixtures/soul-comm-send.error.entitlement-required.example.json
@@ -1,0 +1,7 @@
+{
+  "error": {
+    "code": "comm.entitlement_required",
+    "message": "channel entitlement required",
+    "request_id": "req_123"
+  }
+}

--- a/docs/spec/v3/schemas/soul-agent-identity.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-identity.schema.json
@@ -59,17 +59,6 @@
     "status": { "type": "string", "minLength": 1, "maxLength": 64 },
     "mint_tx_hash": { "type": "string", "minLength": 1, "maxLength": 128 },
     "minted_at": { "type": "string", "format": "date-time" },
-    "policy_version": { "type": "string", "enum": ["hosted-bound-soul/v1"] },
-    "anchor_state": { "type": "string", "enum": ["hosted_offchain", "immutable_onchain"] },
-    "operational_binding": { "type": "string", "enum": ["hosted_bound_soul"] },
-    "capability_policy_version": { "type": "string", "enum": ["capability-policy/v1"] },
-    "caller_access_payment_policy_version": { "type": "string", "enum": ["caller-access-payment/v1"] },
-    "email_default_allowed": { "type": "boolean" },
-    "phone_entitlement_status": { "type": "string", "enum": ["not_entitled", "provisioned", "paid"] },
-    "sms_allowed": { "type": "boolean" },
-    "voice_allowed": { "type": "boolean" },
-    "public_paid_caller_access": { "type": "string", "enum": ["denied"] },
-    "policy_migration_state": { "type": "string", "enum": ["implicit_default_v1", "persisted_v1"] },
     "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/docs/spec/v3/schemas/soul-agent-identity.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-identity.schema.json
@@ -59,6 +59,17 @@
     "status": { "type": "string", "minLength": 1, "maxLength": 64 },
     "mint_tx_hash": { "type": "string", "minLength": 1, "maxLength": 128 },
     "minted_at": { "type": "string", "format": "date-time" },
+    "policy_version": { "type": "string", "enum": ["hosted-bound-soul/v1"] },
+    "anchor_state": { "type": "string", "enum": ["hosted_offchain", "immutable_onchain"] },
+    "operational_binding": { "type": "string", "enum": ["hosted_bound_soul"] },
+    "capability_policy_version": { "type": "string", "enum": ["capability-policy/v1"] },
+    "caller_access_payment_policy_version": { "type": "string", "enum": ["caller-access-payment/v1"] },
+    "email_default_allowed": { "type": "boolean" },
+    "phone_entitlement_status": { "type": "string", "enum": ["not_entitled", "provisioned", "paid"] },
+    "sms_allowed": { "type": "boolean" },
+    "voice_allowed": { "type": "boolean" },
+    "public_paid_caller_access": { "type": "string", "enum": ["denied"] },
+    "policy_migration_state": { "type": "string", "enum": ["implicit_default_v1", "persisted_v1"] },
     "updated_at": { "type": "string", "format": "date-time" }
   }
 }

--- a/docs/spec/v3/schemas/soul-comm-contactability.response.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-contactability.response.schema.json
@@ -4,13 +4,14 @@
   "title": "GET /api/v1/soul/comm/contactability/{agentId} response",
   "type": "object",
   "additionalProperties": false,
-  "required": ["instanceSlug", "agentId", "contactable", "channels", "mailbox", "availability", "firstContact", "updatedAt"],
+  "required": ["instanceSlug", "agentId", "contactable", "policy", "channels", "mailbox", "availability", "firstContact", "updatedAt"],
   "properties": {
     "instanceSlug": { "type": "string", "minLength": 1, "maxLength": 64 },
     "agentId": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
     "contactable": { "type": "boolean" },
     "preferred": { "type": "string", "enum": ["email", "phone", "sms", "voice"] },
     "fallback": { "type": "string", "enum": ["email", "phone", "sms", "voice"] },
+    "policy": { "$ref": "#/definitions/policy" },
     "channels": {
       "type": "array",
       "maxItems": 2,
@@ -22,6 +23,75 @@
     "updatedAt": { "type": "string", "format": "date-time" }
   },
   "definitions": {
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "version",
+        "anchorState",
+        "operationalBinding",
+        "capabilityPolicyVersion",
+        "callerAccessPaymentPolicyVersion",
+        "capabilities",
+        "callerAccessPayment",
+        "migration"
+      ],
+      "properties": {
+        "version": { "type": "string", "enum": ["hosted-bound-soul/v1"] },
+        "anchorState": { "type": "string", "enum": ["hosted_offchain", "immutable_onchain"] },
+        "operationalBinding": { "type": "string", "enum": ["hosted_bound_soul"] },
+        "capabilityPolicyVersion": { "type": "string", "enum": ["capability-policy/v1"] },
+        "callerAccessPaymentPolicyVersion": { "type": "string", "enum": ["caller-access-payment/v1"] },
+        "capabilities": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["email", "phone"],
+          "properties": {
+            "email": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["defaultAllowed"],
+              "properties": {
+                "defaultAllowed": { "type": "boolean" }
+              }
+            },
+            "phone": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["entitlementStatus", "smsAllowed", "voiceAllowed"],
+              "properties": {
+                "entitlementStatus": { "type": "string", "enum": ["not_entitled", "provisioned", "paid"] },
+                "smsAllowed": { "type": "boolean" },
+                "voiceAllowed": { "type": "boolean" }
+              }
+            }
+          }
+        },
+        "callerAccessPayment": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["publicPaidCaller"],
+          "properties": {
+            "publicPaidCaller": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["access"],
+              "properties": {
+                "access": { "type": "string", "enum": ["denied"] }
+              }
+            }
+          }
+        },
+        "migration": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state"],
+          "properties": {
+            "state": { "type": "string", "enum": ["implicit_default_v1", "persisted_v1"] }
+          }
+        }
+      }
+    },
     "channel": {
       "type": "object",
       "additionalProperties": false,

--- a/docs/spec/v3/schemas/soul-comm-send.error.schema.json
+++ b/docs/spec/v3/schemas/soul-comm-send.error.schema.json
@@ -22,6 +22,7 @@
             "comm.rate_limited",
             "comm.preference_violation",
             "comm.boundary_violation",
+            "comm.entitlement_required",
             "comm.insufficient_credits",
             "comm.provider_unavailable",
             "comm.provider_rejected",

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -256,6 +256,10 @@ func (s *Server) finalizeSoulProvisionEmailChannel(
 	if appErr := upsertProvisionedEmailChannel(ctx.Context(), s, agentIDHex, address, passParamName, now); appErr != nil {
 		return nil, appErr
 	}
+	applyHostedBoundSoulPolicyDefaults(identity)
+	if appErr := s.persistSoulAgentPolicyFields(ctx.Context(), identity, now); appErr != nil {
+		return nil, appErr
+	}
 
 	s.tryWriteAuditLog(ctx, &models.AuditLogEntry{
 		Action:    "soul.channel.email.provision",

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -253,6 +253,10 @@ func (s *Server) finalizeSoulProvisionPhoneChannel(
 	if appErr := upsertProvisionedPhoneChannel(ctx.Context(), s, agentIDHex, number, now); appErr != nil {
 		return nil, appErr
 	}
+	applyProvisionedPhonePolicy(identity)
+	if appErr := s.persistSoulAgentPolicyFields(ctx.Context(), identity, now); appErr != nil {
+		return nil, appErr
+	}
 
 	_ = s.store.DB.WithContext(ctx.Context()).Model(&models.AuditLogEntry{
 		Actor:     strings.TrimSpace(ctx.AuthIdentity),
@@ -338,10 +342,18 @@ func (s *Server) handleSoulDeprovisionPhoneChannel(ctx *apptheory.Context) (*app
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to update phone channel"}
 	}
 
+	return s.finalizeSoulDeprovisionPhoneChannel(ctx, agentIDHex, identity, ch, now)
+}
+
+func (s *Server) finalizeSoulDeprovisionPhoneChannel(ctx *apptheory.Context, agentIDHex string, identity *models.SoulAgentIdentity, ch *models.SoulAgentChannel, now time.Time) (*apptheory.Response, error) {
 	// Remove reverse lookup index so the number no longer resolves.
 	idx := &models.SoulPhoneAgentIndex{Phone: strings.TrimSpace(ch.Identifier), AgentID: agentIDHex}
 	_ = idx.UpdateKeys()
 	_ = s.store.DB.WithContext(ctx.Context()).Model(idx).Delete()
+	applyPhonePolicyNotEntitled(identity)
+	if appErr := s.persistSoulAgentPolicyFields(ctx.Context(), identity, now); appErr != nil {
+		return nil, appErr
+	}
 
 	// Best-effort: clear phone field from ENS resolution record (if it exists).
 	ensName := strings.TrimSpace(identity.LocalID) + ".lessersoul.eth"

--- a/internal/controlplane/handlers_soul_comm_contactability.go
+++ b/internal/controlplane/handlers_soul_comm_contactability.go
@@ -18,6 +18,7 @@ type soulCommContactabilityResponse struct {
 	Contactable  bool                               `json:"contactable"`
 	Preferred    string                             `json:"preferred,omitempty"`
 	Fallback     string                             `json:"fallback,omitempty"`
+	Policy       soulAgentEffectivePolicy           `json:"policy"`
 	Channels     []soulCommContactabilityChannel    `json:"channels"`
 	Mailbox      soulCommContactabilityMailbox      `json:"mailbox"`
 	Availability soulCommContactabilityAvailability `json:"availability"`
@@ -125,10 +126,11 @@ func buildSoulCommContactabilityResponse(
 	phone *models.SoulAgentChannel,
 ) soulCommContactabilityResponse {
 	activeIdentity := soulCommContactabilityIdentityActive(reqCtx.identity)
+	policy := effectiveSoulAgentPolicy(reqCtx.identity)
 	channels := make([]soulCommContactabilityChannel, 0, 2)
 	if activeIdentity {
-		channels = appendContactabilityChannel(channels, email)
-		channels = appendContactabilityChannel(channels, phone)
+		channels = appendContactabilityChannel(channels, policy, email)
+		channels = appendContactabilityChannel(channels, policy, phone)
 	}
 
 	contactable := false
@@ -150,6 +152,7 @@ func buildSoulCommContactabilityResponse(
 		Contactable:  contactable,
 		Preferred:    contactabilityPreference(prefs, "preferred"),
 		Fallback:     contactabilityPreference(prefs, "fallback"),
+		Policy:       policy,
 		Channels:     channels,
 		Mailbox:      contactabilityMailbox(channels),
 		Availability: contactabilityAvailability(prefs),
@@ -171,16 +174,17 @@ func soulCommContactabilityIdentityActive(identity *models.SoulAgentIdentity) bo
 
 func appendContactabilityChannel(
 	out []soulCommContactabilityChannel,
+	policy soulAgentEffectivePolicy,
 	channel *models.SoulAgentChannel,
 ) []soulCommContactabilityChannel {
-	view, ok := contactabilityChannelView(channel)
+	view, ok := contactabilityChannelView(policy, channel)
 	if !ok {
 		return out
 	}
 	return append(out, view)
 }
 
-func contactabilityChannelView(channel *models.SoulAgentChannel) (soulCommContactabilityChannel, bool) {
+func contactabilityChannelView(policy soulAgentEffectivePolicy, channel *models.SoulAgentChannel) (soulCommContactabilityChannel, bool) {
 	if !contactabilityChannelVisible(channel) {
 		return soulCommContactabilityChannel{}, false
 	}
@@ -193,8 +197,8 @@ func contactabilityChannelView(channel *models.SoulAgentChannel) (soulCommContac
 		Protocols:      append([]string(nil), channel.Protocols...),
 		Verified:       channel.Verified,
 		Status:         strings.TrimSpace(channel.Status),
-		ReceiveAllowed: contactabilityReceiveAllowed(channel),
-		SendAllowed:    contactabilitySendAllowed(channel),
+		ReceiveAllowed: contactabilityReceiveAllowed(policy, channel),
+		SendAllowed:    contactabilitySendAllowed(policy, channel),
 	}
 	switch view.ChannelType {
 	case models.SoulChannelTypeEmail:
@@ -218,23 +222,25 @@ func contactabilityChannelVisible(channel *models.SoulAgentChannel) bool {
 	return !channel.ProvisionedAt.IsZero() && channel.DeprovisionedAt.IsZero()
 }
 
-func contactabilityReceiveAllowed(channel *models.SoulAgentChannel) bool {
+func contactabilityReceiveAllowed(policy soulAgentEffectivePolicy, channel *models.SoulAgentChannel) bool {
 	switch strings.TrimSpace(channel.ChannelType) {
 	case models.SoulChannelTypeEmail:
-		return stringSliceContains(channel.Capabilities, "receive")
+		return policy.Capabilities.Email.DefaultAllowed && stringSliceContains(channel.Capabilities, "receive")
 	case models.SoulChannelTypePhone:
-		return stringSliceContains(channel.Capabilities, "sms-receive") || stringSliceContains(channel.Capabilities, "voice-receive")
+		return (policy.Capabilities.Phone.SMSAllowed && stringSliceContains(channel.Capabilities, "sms-receive")) ||
+			(policy.Capabilities.Phone.VoiceAllowed && stringSliceContains(channel.Capabilities, "voice-receive"))
 	default:
 		return false
 	}
 }
 
-func contactabilitySendAllowed(channel *models.SoulAgentChannel) bool {
+func contactabilitySendAllowed(policy soulAgentEffectivePolicy, channel *models.SoulAgentChannel) bool {
 	switch strings.TrimSpace(channel.ChannelType) {
 	case models.SoulChannelTypeEmail:
-		return stringSliceContains(channel.Capabilities, "send")
+		return policy.Capabilities.Email.DefaultAllowed && stringSliceContains(channel.Capabilities, "send")
 	case models.SoulChannelTypePhone:
-		return stringSliceContains(channel.Capabilities, "sms-send") || stringSliceContains(channel.Capabilities, "voice-send")
+		return (policy.Capabilities.Phone.SMSAllowed && stringSliceContains(channel.Capabilities, "sms-send")) ||
+			(policy.Capabilities.Phone.VoiceAllowed && stringSliceContains(channel.Capabilities, "voice-send"))
 	default:
 		return false
 	}

--- a/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_mailbox_internal_test.go
@@ -629,6 +629,13 @@ func TestSoulCommContactabilityHelpersCoverPolicyEdges(t *testing.T) {
 	require.False(t, contactabilityChannelVisible(&models.SoulAgentChannel{Identifier: "agent@example.com", Verified: true, Status: models.SoulChannelStatusActive}))
 
 	now := time.Now().UTC()
+	phonePolicy := effectiveSoulAgentPolicy(&models.SoulAgentIdentity{
+		PolicyVersion:          models.SoulPolicyVersionHostedBoundSoulV1,
+		EmailDefaultAllowed:    true,
+		PhoneEntitlementStatus: models.SoulPhoneEntitlementProvisioned,
+		SMSAllowed:             true,
+		VoiceAllowed:           true,
+	})
 	voiceOnlyPhone := &models.SoulAgentChannel{
 		ChannelType:   models.SoulChannelTypePhone,
 		Identifier:    "+15551234567",
@@ -637,13 +644,37 @@ func TestSoulCommContactabilityHelpersCoverPolicyEdges(t *testing.T) {
 		Status:        models.SoulChannelStatusActive,
 		ProvisionedAt: now,
 	}
-	view, ok := contactabilityChannelView(voiceOnlyPhone)
+	view, ok := contactabilityChannelView(phonePolicy, voiceOnlyPhone)
 	require.True(t, ok)
 	require.True(t, view.ReceiveAllowed)
 	require.False(t, view.SendAllowed)
 	require.Equal(t, "always", contactabilityAvailability(nil).Schedule)
 	require.Empty(t, contactabilityPreference(nil, "preferred"))
 	require.False(t, contactabilityMailbox(nil).ListAllowed)
+
+	defaultPolicyResp := buildSoulCommContactabilityResponse(mailboxRequestContext{
+		key:     &models.InstanceKey{InstanceSlug: commWebhookTestInstanceSlug},
+		agentID: soulLifecycleTestAgentIDHex,
+		identity: &models.SoulAgentIdentity{
+			Status:          models.SoulAgentStatusActive,
+			LifecycleStatus: models.SoulAgentStatusActive,
+			UpdatedAt:       now,
+		},
+	}, nil, nil, &models.SoulAgentChannel{
+		ChannelType:   models.SoulChannelTypePhone,
+		Identifier:    "+15551234567",
+		Capabilities:  []string{"sms-receive", "sms-send", "voice-receive", "voice-send"},
+		Verified:      true,
+		Status:        models.SoulChannelStatusActive,
+		ProvisionedAt: now,
+		UpdatedAt:     now,
+	})
+	require.Equal(t, models.SoulPolicyMigrationStateImplicitDefaultV1, defaultPolicyResp.Policy.Migration.State)
+	require.Equal(t, models.SoulPhoneEntitlementNotEntitled, defaultPolicyResp.Policy.Capabilities.Phone.EntitlementStatus)
+	require.False(t, defaultPolicyResp.Contactable)
+	require.Len(t, defaultPolicyResp.Channels, 1)
+	require.False(t, defaultPolicyResp.Channels[0].ReceiveAllowed)
+	require.False(t, defaultPolicyResp.Channels[0].SendAllowed)
 }
 
 func TestSoulCommContactabilityBuildInactiveIdentityOmitsChannels(t *testing.T) {
@@ -680,10 +711,11 @@ func TestSoulCommContactabilityChannelPolicyEdges(t *testing.T) {
 	now := time.Now().UTC()
 	require.False(t, contactabilityChannelVisible(&models.SoulAgentChannel{Identifier: "agent@example.com", Verified: false, Status: models.SoulChannelStatusActive, ProvisionedAt: now}))
 	require.False(t, contactabilityChannelVisible(&models.SoulAgentChannel{Identifier: "agent@example.com", Verified: true, Status: models.SoulChannelStatusPaused, ProvisionedAt: now}))
-	require.False(t, contactabilityReceiveAllowed(&models.SoulAgentChannel{ChannelType: models.SoulChannelTypeENS, Capabilities: []string{"receive"}}))
-	require.False(t, contactabilitySendAllowed(&models.SoulAgentChannel{ChannelType: models.SoulChannelTypeENS, Capabilities: []string{"send"}}))
+	policy := effectiveSoulAgentPolicy(&models.SoulAgentIdentity{})
+	require.False(t, contactabilityReceiveAllowed(policy, &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeENS, Capabilities: []string{"receive"}}))
+	require.False(t, contactabilitySendAllowed(policy, &models.SoulAgentChannel{ChannelType: models.SoulChannelTypeENS, Capabilities: []string{"send"}}))
 
-	ensView, ok := contactabilityChannelView(&models.SoulAgentChannel{
+	ensView, ok := contactabilityChannelView(policy, &models.SoulAgentChannel{
 		ChannelType:   models.SoulChannelTypeENS,
 		Identifier:    "agent.eth",
 		Verified:      true,
@@ -789,7 +821,17 @@ func expectMailboxAPIAccess(t *testing.T, fixture mailboxAPITestDB, agentID stri
 	}).Once()
 	fixture.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", Status: models.SoulAgentStatusActive, LifecycleStatus: models.SoulAgentStatusActive}
+		*dest = models.SoulAgentIdentity{
+			AgentID:                agentID,
+			Domain:                 "example.com",
+			Status:                 models.SoulAgentStatusActive,
+			LifecycleStatus:        models.SoulAgentStatusActive,
+			PolicyVersion:          models.SoulPolicyVersionHostedBoundSoulV1,
+			EmailDefaultAllowed:    true,
+			PhoneEntitlementStatus: models.SoulPhoneEntitlementProvisioned,
+			SMSAllowed:             true,
+			VoiceAllowed:           true,
+		}
 	}).Once()
 	fixture.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
@@ -801,7 +843,17 @@ func expectMailboxAPIIdentityAccess(t *testing.T, fixture mailboxAPITestDB, agen
 	t.Helper()
 	fixture.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", Status: models.SoulAgentStatusActive, LifecycleStatus: models.SoulAgentStatusActive}
+		*dest = models.SoulAgentIdentity{
+			AgentID:                agentID,
+			Domain:                 "example.com",
+			Status:                 models.SoulAgentStatusActive,
+			LifecycleStatus:        models.SoulAgentStatusActive,
+			PolicyVersion:          models.SoulPolicyVersionHostedBoundSoulV1,
+			EmailDefaultAllowed:    true,
+			PhoneEntitlementStatus: models.SoulPhoneEntitlementProvisioned,
+			SMSAllowed:             true,
+			VoiceAllowed:           true,
+		}
 	}).Once()
 	fixture.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)

--- a/internal/controlplane/handlers_soul_comm_send.go
+++ b/internal/controlplane/handlers_soul_comm_send.go
@@ -365,6 +365,9 @@ func (s *Server) loadSoulCommSendRoute(ctx context.Context, key *models.Instance
 	if appErr != nil {
 		return soulCommSendRoute{}, appErr
 	}
+	if policyErr := enforceSoulCommCapabilityPolicy(identity, req, metrics); policyErr != nil {
+		return soulCommSendRoute{}, policyErr
+	}
 	channel, appErr := s.loadSoulCommSendChannel(ctx, req, metrics)
 	if appErr != nil {
 		return soulCommSendRoute{}, appErr

--- a/internal/controlplane/handlers_soul_comm_send_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_internal_test.go
@@ -152,6 +152,7 @@ func TestEnforceSoulCommSendGuards_AllowsFirstContactToExternalRecipient(t *test
 			LifecycleStatus: models.SoulAgentStatusActive,
 			UpdatedAt:       time.Now().UTC(),
 		}
+		applyProvisionedPhonePolicy(dest)
 	}).Once()
 
 	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
@@ -241,6 +242,7 @@ func TestHandleSoulCommSend_SendsEmailAndRecordsStatus(t *testing.T) {
 			LifecycleStatus: models.SoulAgentStatusActive,
 			UpdatedAt:       time.Now().UTC(),
 		}
+		applyProvisionedPhonePolicy(dest)
 	}).Once()
 
 	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
@@ -373,6 +375,7 @@ func TestHandleSoulCommSend_SendsSMSAndDebitsCredits(t *testing.T) {
 			LifecycleStatus: models.SoulAgentStatusActive,
 			UpdatedAt:       time.Now().UTC(),
 		}
+		applyProvisionedPhonePolicy(dest)
 	}).Once()
 
 	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
@@ -492,6 +495,7 @@ func TestHandleSoulCommSend_StartsVoiceCallAndStoresInstruction(t *testing.T) {
 			LifecycleStatus: models.SoulAgentStatusActive,
 			UpdatedAt:       time.Now().UTC(),
 		}
+		applyProvisionedPhonePolicy(dest)
 	}).Once()
 
 	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
@@ -612,6 +616,7 @@ func TestHandleSoulCommSend_SMSInsufficientCreditsBlocksSend(t *testing.T) {
 			LifecycleStatus: models.SoulAgentStatusActive,
 			UpdatedAt:       time.Now().UTC(),
 		}
+		applyProvisionedPhonePolicy(dest)
 	}).Once()
 
 	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {

--- a/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_comm_send_more_internal_test.go
@@ -374,6 +374,34 @@ func TestHandleSoulCommSend_EmailProviderAndVoiceErrors(t *testing.T) {
 		_, err := s.handleSoulCommSend(newCommSendCtx(body, strPtr("comm-msg-prev")))
 		assertCommTheoryErrorCode(t, err, commCodeProviderUnavailable, http.StatusServiceUnavailable)
 	})
+
+	t.Run("phone entitlement required before channel details", func(t *testing.T) {
+		tdb := newSoulCommSendMoreTestDB()
+		expectCommInstanceKey(t, tdb.qKey, models.InstanceKey{ID: "k1", InstanceSlug: "inst1", CreatedAt: time.Now().Add(-time.Hour).UTC()})
+		expectCommIdentity(t, tdb.qIdentity, models.SoulAgentIdentity{
+			AgentID:         agentID,
+			Domain:          "example.com",
+			LocalID:         "agent-alice",
+			Status:          models.SoulAgentStatusActive,
+			LifecycleStatus: models.SoulAgentStatusActive,
+			UpdatedAt:       time.Now().UTC(),
+		})
+		expectCommDomain(t, tdb.qDomain, models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified})
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+
+		body := mustMarshalCommSendBody(t, map[string]any{
+			"channel": "sms",
+			"agentId": agentID,
+			"to":      "+15550143",
+			"body":    "hello",
+		})
+		_, err := s.handleSoulCommSend(newCommSendCtx(body, nil))
+		appErr := requireCommTheoryError(t, err)
+		if appErr.Code != commCodeEntitlementRequired || appErr.StatusCode != http.StatusForbidden || appErr.Message != "channel entitlement required" {
+			t.Fatalf("expected entitlement_required/403 without detail leak, got %q/%d %q", appErr.Code, appErr.StatusCode, appErr.Message)
+		}
+		tdb.qChannel.AssertNotCalled(t, "First", mock.Anything)
+	})
 }
 
 func TestHandleSoulCommSend_IdempotencyBehavior(t *testing.T) {
@@ -1648,14 +1676,18 @@ func expectCommPrefs(t *testing.T, q *ttmocks.MockQuery, prefs models.SoulAgentC
 func expectActiveCommRoute(t *testing.T, tdb soulCommSendMoreTestDB, agentID string, channelType string) {
 	t.Helper()
 
-	expectCommIdentity(t, tdb.qIdentity, models.SoulAgentIdentity{
+	identity := models.SoulAgentIdentity{
 		AgentID:         agentID,
 		Domain:          "example.com",
 		LocalID:         "agent-alice",
 		Status:          models.SoulAgentStatusActive,
 		LifecycleStatus: models.SoulAgentStatusActive,
 		UpdatedAt:       time.Now().UTC(),
-	})
+	}
+	if channelType == models.SoulChannelTypePhone {
+		applyProvisionedPhonePolicy(&identity)
+	}
+	expectCommIdentity(t, tdb.qIdentity, identity)
 	expectCommDomain(t, tdb.qDomain, models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified})
 
 	identifier := provisionTestEmailAddress

--- a/internal/controlplane/handlers_soul_config.go
+++ b/internal/controlplane/handlers_soul_config.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 type soulConfigReputationWeights struct {
@@ -24,7 +26,19 @@ type soulConfigResponse struct {
 	AdminSafeAddress        string                       `json:"admin_safe_address,omitempty"`
 	TxMode                  string                       `json:"tx_mode,omitempty"`
 	SupportedCapabilities   []string                     `json:"supported_capabilities,omitempty"`
+	PolicyVocabulary        *soulConfigPolicyVocabulary  `json:"policy_vocabulary,omitempty"`
 	ReputationWeights       *soulConfigReputationWeights `json:"reputation_weights,omitempty"`
+}
+
+type soulConfigPolicyVocabulary struct {
+	Version                           string   `json:"version"`
+	AnchorStates                      []string `json:"anchor_states"`
+	OperationalBindings               []string `json:"operational_bindings"`
+	CapabilityPolicyVersion           string   `json:"capability_policy_version"`
+	CallerAccessPaymentPolicyVersion  string   `json:"caller_access_payment_policy_version"`
+	PhoneEntitlementStatuses          []string `json:"phone_entitlement_statuses"`
+	PublicPaidCallerAccess            []string `json:"public_paid_caller_access"`
+	MissingPolicyRecordMigrationState string   `json:"missing_policy_record_migration_state"`
 }
 
 func (s *Server) requireSoulRegistryConfigured() *apptheory.AppError {
@@ -69,6 +83,27 @@ func (s *Server) handleSoulConfig(ctx *apptheory.Context) (*apptheory.Response, 
 		AdminSafeAddress:        strings.ToLower(strings.TrimSpace(s.cfg.SoulAdminSafeAddress)),
 		TxMode:                  strings.ToLower(strings.TrimSpace(s.cfg.SoulTxMode)),
 		SupportedCapabilities:   caps,
+		PolicyVocabulary: &soulConfigPolicyVocabulary{
+			Version: models.SoulPolicyVersionHostedBoundSoulV1,
+			AnchorStates: []string{
+				models.SoulAnchorStateHostedOffchain,
+				models.SoulAnchorStateImmutableOnchain,
+			},
+			OperationalBindings: []string{
+				models.SoulOperationalBindingHostedBoundSoul,
+			},
+			CapabilityPolicyVersion:          models.SoulCapabilityPolicyVersionV1,
+			CallerAccessPaymentPolicyVersion: models.SoulCallerAccessPaymentPolicyVersionV1,
+			PhoneEntitlementStatuses: []string{
+				models.SoulPhoneEntitlementNotEntitled,
+				models.SoulPhoneEntitlementProvisioned,
+				models.SoulPhoneEntitlementPaid,
+			},
+			PublicPaidCallerAccess: []string{
+				models.SoulPublicPaidCallerAccessDenied,
+			},
+			MissingPolicyRecordMigrationState: models.SoulPolicyMigrationStateImplicitDefaultV1,
+		},
 		ReputationWeights: &soulConfigReputationWeights{
 			Economic:      s.cfg.SoulReputationWeightEconomic,
 			Social:        s.cfg.SoulReputationWeightSocial,

--- a/internal/controlplane/handlers_soul_config_internal_test.go
+++ b/internal/controlplane/handlers_soul_config_internal_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 const (
@@ -157,6 +158,15 @@ func TestHandleSoulConfig_ErrorsAndSuccess(t *testing.T) {
 		require.Equal(t, testSoulSafeAddr, parsed.AdminSafeAddress)
 		require.Equal(t, "safe", parsed.TxMode)
 		require.Equal(t, []string{"a", "b"}, parsed.SupportedCapabilities)
+		require.NotNil(t, parsed.PolicyVocabulary)
+		require.Equal(t, models.SoulPolicyVersionHostedBoundSoulV1, parsed.PolicyVocabulary.Version)
+		require.Contains(t, parsed.PolicyVocabulary.AnchorStates, models.SoulAnchorStateHostedOffchain)
+		require.Contains(t, parsed.PolicyVocabulary.AnchorStates, models.SoulAnchorStateImmutableOnchain)
+		require.Equal(t, models.SoulCapabilityPolicyVersionV1, parsed.PolicyVocabulary.CapabilityPolicyVersion)
+		require.Equal(t, models.SoulCallerAccessPaymentPolicyVersionV1, parsed.PolicyVocabulary.CallerAccessPaymentPolicyVersion)
+		require.Contains(t, parsed.PolicyVocabulary.PhoneEntitlementStatuses, models.SoulPhoneEntitlementNotEntitled)
+		require.Contains(t, parsed.PolicyVocabulary.PhoneEntitlementStatuses, models.SoulPhoneEntitlementProvisioned)
+		require.Contains(t, parsed.PolicyVocabulary.PublicPaidCallerAccess, models.SoulPublicPaidCallerAccessDenied)
 		require.NotNil(t, parsed.ReputationWeights)
 		require.Equal(t, float64(1), parsed.ReputationWeights.Economic)
 		require.Equal(t, float64(2), parsed.ReputationWeights.Social)

--- a/internal/controlplane/handlers_soul_operations.go
+++ b/internal/controlplane/handlers_soul_operations.go
@@ -497,15 +497,45 @@ func (s *Server) applySoulOperationMintSideEffects(ctx context.Context, op *mode
 
 	now := time.Now().UTC()
 	update := &models.SoulAgentIdentity{
-		AgentID:         agentID,
-		Status:          status,
-		LifecycleStatus: status,
-		MintTxHash:      strings.ToLower(strings.TrimSpace(op.ExecTxHash)),
-		MintedAt:        now,
-		UpdatedAt:       now,
+		AgentID:                          agentID,
+		Status:                           status,
+		LifecycleStatus:                  status,
+		MintTxHash:                       strings.ToLower(strings.TrimSpace(op.ExecTxHash)),
+		MintedAt:                         now,
+		PolicyVersion:                    identity.PolicyVersion,
+		AnchorState:                      identity.AnchorState,
+		OperationalBinding:               identity.OperationalBinding,
+		CapabilityPolicyVersion:          identity.CapabilityPolicyVersion,
+		CallerAccessPaymentPolicyVersion: identity.CallerAccessPaymentPolicyVersion,
+		EmailDefaultAllowed:              identity.EmailDefaultAllowed,
+		PhoneEntitlementStatus:           identity.PhoneEntitlementStatus,
+		SMSAllowed:                       identity.SMSAllowed,
+		VoiceAllowed:                     identity.VoiceAllowed,
+		PublicPaidCallerAccess:           identity.PublicPaidCallerAccess,
+		PolicyMigrationState:             identity.PolicyMigrationState,
+		UpdatedAt:                        now,
 	}
+	applyHostedBoundSoulPolicyDefaults(update)
+	update.AnchorState = models.SoulAnchorStateImmutableOnchain
 	_ = update.UpdateKeys()
-	_ = s.store.DB.WithContext(ctx).Model(update).IfExists().Update("Status", "LifecycleStatus", "MintTxHash", "MintedAt", "UpdatedAt")
+	_ = s.store.DB.WithContext(ctx).Model(update).IfExists().Update(
+		"Status",
+		"LifecycleStatus",
+		"MintTxHash",
+		"MintedAt",
+		"UpdatedAt",
+		"PolicyVersion",
+		"AnchorState",
+		"OperationalBinding",
+		"CapabilityPolicyVersion",
+		"CallerAccessPaymentPolicyVersion",
+		"EmailDefaultAllowed",
+		"PhoneEntitlementStatus",
+		"SMSAllowed",
+		"VoiceAllowed",
+		"PublicPaidCallerAccess",
+		"PolicyMigrationState",
+	)
 }
 
 func (s *Server) applySoulOperationRotateWalletSideEffects(ctx context.Context, client ethRPCClient, agentID string) {

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -374,7 +374,21 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
-		*dest = models.SoulAgentIdentity{AgentID: agentID, Status: models.SoulAgentStatusActive}
+		*dest = models.SoulAgentIdentity{
+			AgentID:                          agentID,
+			Status:                           models.SoulAgentStatusActive,
+			PolicyVersion:                    models.SoulPolicyVersionHostedBoundSoulV1,
+			AnchorState:                      models.SoulAnchorStateImmutableOnchain,
+			OperationalBinding:               models.SoulOperationalBindingHostedBoundSoul,
+			CapabilityPolicyVersion:          models.SoulCapabilityPolicyVersionV1,
+			CallerAccessPaymentPolicyVersion: models.SoulCallerAccessPaymentPolicyVersionV1,
+			EmailDefaultAllowed:              true,
+			PhoneEntitlementStatus:           models.SoulPhoneEntitlementProvisioned,
+			SMSAllowed:                       true,
+			VoiceAllowed:                     true,
+			PublicPaidCallerAccess:           models.SoulPublicPaidCallerAccessDenied,
+			PolicyMigrationState:             models.SoulPolicyMigrationStatePersistedV1,
+		}
 	}).Once()
 	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
@@ -400,6 +414,23 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 	}
 	if out.Version != "1" || out.Agent.AgentID != agentID || out.Reputation == nil || out.Reputation.AgentID != agentID {
 		t.Fatalf("unexpected response: %#v", out)
+	}
+	for _, privateField := range []string{
+		"policy_version",
+		"anchor_state",
+		"operational_binding",
+		"capability_policy_version",
+		"caller_access_payment_policy_version",
+		"email_default_allowed",
+		"phone_entitlement_status",
+		"sms_allowed",
+		"voice_allowed",
+		"public_paid_caller_access",
+		"policy_migration_state",
+	} {
+		if bytes.Contains(resp.Body, []byte(privateField)) {
+			t.Fatalf("public agent response leaked private policy field %q: %s", privateField, string(resp.Body))
+		}
 	}
 }
 

--- a/internal/controlplane/handlers_soul_registry.go
+++ b/internal/controlplane/handlers_soul_registry.go
@@ -1015,7 +1015,7 @@ func buildSoulPendingAgentIdentity(
 	principalDeclaredAt string,
 	now time.Time,
 ) *models.SoulAgentIdentity {
-	return &models.SoulAgentIdentity{
+	identity := &models.SoulAgentIdentity{
 		AgentID:              reg.AgentID,
 		Domain:               reg.DomainNormalized,
 		LocalID:              reg.LocalID,
@@ -1030,6 +1030,8 @@ func buildSoulPendingAgentIdentity(
 		Status:               models.SoulAgentStatusPending,
 		UpdatedAt:            now,
 	}
+	applyHostedBoundSoulPolicyDefaults(identity)
+	return identity
 }
 
 func (s *Server) reconcileSoulPendingIdentity(

--- a/internal/controlplane/soul_policy.go
+++ b/internal/controlplane/soul_policy.go
@@ -1,0 +1,256 @@
+package controlplane
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const (
+	commMetricEntitlementRequired = "entitlement_required"
+	commCodeEntitlementRequired   = "comm.entitlement_required"
+)
+
+type soulAgentEffectivePolicy struct {
+	Version                          string                             `json:"version"`
+	AnchorState                      string                             `json:"anchorState"`
+	OperationalBinding               string                             `json:"operationalBinding"`
+	CapabilityPolicyVersion          string                             `json:"capabilityPolicyVersion"`
+	CallerAccessPaymentPolicyVersion string                             `json:"callerAccessPaymentPolicyVersion"`
+	Capabilities                     soulAgentCapabilityPolicyView      `json:"capabilities"`
+	CallerAccessPayment              soulAgentCallerAccessPolicyView    `json:"callerAccessPayment"`
+	Migration                        soulAgentPolicyMigrationPolicyView `json:"migration"`
+}
+
+type soulAgentCapabilityPolicyView struct {
+	Email soulAgentEmailCapabilityPolicyView `json:"email"`
+	Phone soulAgentPhoneCapabilityPolicyView `json:"phone"`
+}
+
+type soulAgentEmailCapabilityPolicyView struct {
+	DefaultAllowed bool `json:"defaultAllowed"`
+}
+
+type soulAgentPhoneCapabilityPolicyView struct {
+	EntitlementStatus string `json:"entitlementStatus"`
+	SMSAllowed        bool   `json:"smsAllowed"`
+	VoiceAllowed      bool   `json:"voiceAllowed"`
+}
+
+type soulAgentCallerAccessPolicyView struct {
+	PublicPaidCaller soulAgentCallerClassPolicyView `json:"publicPaidCaller"`
+}
+
+type soulAgentCallerClassPolicyView struct {
+	Access string `json:"access"`
+}
+
+type soulAgentPolicyMigrationPolicyView struct {
+	State string `json:"state"`
+}
+
+func effectiveSoulAgentPolicy(identity *models.SoulAgentIdentity) soulAgentEffectivePolicy {
+	policy := defaultSoulAgentEffectivePolicy()
+	if identity == nil {
+		return policy
+	}
+	return applySoulAgentIdentityPolicy(policy, identity)
+}
+
+func defaultSoulAgentEffectivePolicy() soulAgentEffectivePolicy {
+	return soulAgentEffectivePolicy{
+		Version:                          models.SoulPolicyVersionHostedBoundSoulV1,
+		AnchorState:                      models.SoulAnchorStateHostedOffchain,
+		OperationalBinding:               models.SoulOperationalBindingHostedBoundSoul,
+		CapabilityPolicyVersion:          models.SoulCapabilityPolicyVersionV1,
+		CallerAccessPaymentPolicyVersion: models.SoulCallerAccessPaymentPolicyVersionV1,
+		Capabilities: soulAgentCapabilityPolicyView{
+			Email: soulAgentEmailCapabilityPolicyView{DefaultAllowed: true},
+			Phone: soulAgentPhoneCapabilityPolicyView{
+				EntitlementStatus: models.SoulPhoneEntitlementNotEntitled,
+			},
+		},
+		CallerAccessPayment: soulAgentCallerAccessPolicyView{
+			PublicPaidCaller: soulAgentCallerClassPolicyView{Access: models.SoulPublicPaidCallerAccessDenied},
+		},
+		Migration: soulAgentPolicyMigrationPolicyView{State: models.SoulPolicyMigrationStateImplicitDefaultV1},
+	}
+}
+
+func applySoulAgentIdentityPolicy(policy soulAgentEffectivePolicy, identity *models.SoulAgentIdentity) soulAgentEffectivePolicy {
+	if v := strings.ToLower(strings.TrimSpace(identity.PolicyVersion)); v != "" {
+		policy.Version = v
+		policy.Migration.State = models.SoulPolicyMigrationStatePersistedV1
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.AnchorState)); v != "" {
+		policy.AnchorState = v
+	} else if soulIdentityHasOnchainAnchor(identity) {
+		policy.AnchorState = models.SoulAnchorStateImmutableOnchain
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.OperationalBinding)); v != "" {
+		policy.OperationalBinding = v
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.CapabilityPolicyVersion)); v != "" {
+		policy.CapabilityPolicyVersion = v
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.CallerAccessPaymentPolicyVersion)); v != "" {
+		policy.CallerAccessPaymentPolicyVersion = v
+	}
+	if strings.TrimSpace(identity.PolicyVersion) != "" {
+		policy.Capabilities.Email.DefaultAllowed = identity.EmailDefaultAllowed
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.PhoneEntitlementStatus)); v != "" {
+		policy.Capabilities.Phone.EntitlementStatus = v
+	}
+	entitled := soulPhoneEntitlementActive(policy.Capabilities.Phone.EntitlementStatus)
+	policy.Capabilities.Phone.SMSAllowed = identity.SMSAllowed && entitled
+	policy.Capabilities.Phone.VoiceAllowed = identity.VoiceAllowed && entitled
+	if v := strings.ToLower(strings.TrimSpace(identity.PublicPaidCallerAccess)); v != "" {
+		policy.CallerAccessPayment.PublicPaidCaller.Access = v
+	}
+	if v := strings.ToLower(strings.TrimSpace(identity.PolicyMigrationState)); v != "" {
+		policy.Migration.State = v
+	}
+	return policy
+}
+
+func soulIdentityHasOnchainAnchor(identity *models.SoulAgentIdentity) bool {
+	if identity == nil {
+		return false
+	}
+	return strings.TrimSpace(identity.MintTxHash) != "" ||
+		!identity.MintedAt.IsZero()
+}
+
+func soulPhoneEntitlementActive(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case models.SoulPhoneEntitlementProvisioned, models.SoulPhoneEntitlementPaid:
+		return true
+	default:
+		return false
+	}
+}
+
+func applyHostedBoundSoulPolicyDefaults(identity *models.SoulAgentIdentity) {
+	if identity == nil {
+		return
+	}
+	missingPolicyVersion := strings.TrimSpace(identity.PolicyVersion) == ""
+	if strings.TrimSpace(identity.PolicyVersion) == "" {
+		identity.PolicyVersion = models.SoulPolicyVersionHostedBoundSoulV1
+	}
+	if strings.TrimSpace(identity.AnchorState) == "" {
+		if soulIdentityHasOnchainAnchor(identity) {
+			identity.AnchorState = models.SoulAnchorStateImmutableOnchain
+		} else {
+			identity.AnchorState = models.SoulAnchorStateHostedOffchain
+		}
+	}
+	if strings.TrimSpace(identity.OperationalBinding) == "" {
+		identity.OperationalBinding = models.SoulOperationalBindingHostedBoundSoul
+	}
+	if strings.TrimSpace(identity.CapabilityPolicyVersion) == "" {
+		identity.CapabilityPolicyVersion = models.SoulCapabilityPolicyVersionV1
+	}
+	if strings.TrimSpace(identity.CallerAccessPaymentPolicyVersion) == "" {
+		identity.CallerAccessPaymentPolicyVersion = models.SoulCallerAccessPaymentPolicyVersionV1
+	}
+	if missingPolicyVersion {
+		identity.EmailDefaultAllowed = true
+	}
+	if strings.TrimSpace(identity.PhoneEntitlementStatus) == "" {
+		identity.PhoneEntitlementStatus = models.SoulPhoneEntitlementNotEntitled
+	}
+	if strings.TrimSpace(identity.PublicPaidCallerAccess) == "" {
+		identity.PublicPaidCallerAccess = models.SoulPublicPaidCallerAccessDenied
+	}
+	if strings.TrimSpace(identity.PolicyMigrationState) == "" {
+		identity.PolicyMigrationState = models.SoulPolicyMigrationStatePersistedV1
+	}
+}
+
+func applyProvisionedPhonePolicy(identity *models.SoulAgentIdentity) {
+	applyHostedBoundSoulPolicyDefaults(identity)
+	if identity == nil {
+		return
+	}
+	identity.PhoneEntitlementStatus = models.SoulPhoneEntitlementProvisioned
+	identity.SMSAllowed = true
+	identity.VoiceAllowed = true
+}
+
+func applyPhonePolicyNotEntitled(identity *models.SoulAgentIdentity) {
+	applyHostedBoundSoulPolicyDefaults(identity)
+	if identity == nil {
+		return
+	}
+	identity.PhoneEntitlementStatus = models.SoulPhoneEntitlementNotEntitled
+	identity.SMSAllowed = false
+	identity.VoiceAllowed = false
+}
+
+func (s *Server) persistSoulAgentPolicyFields(ctx context.Context, identity *models.SoulAgentIdentity, now time.Time) *apptheory.AppError {
+	if s == nil || s.store == nil || s.store.DB == nil || identity == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	update := &models.SoulAgentIdentity{
+		AgentID:                          identity.AgentID,
+		PolicyVersion:                    identity.PolicyVersion,
+		AnchorState:                      identity.AnchorState,
+		OperationalBinding:               identity.OperationalBinding,
+		CapabilityPolicyVersion:          identity.CapabilityPolicyVersion,
+		CallerAccessPaymentPolicyVersion: identity.CallerAccessPaymentPolicyVersion,
+		EmailDefaultAllowed:              identity.EmailDefaultAllowed,
+		PhoneEntitlementStatus:           identity.PhoneEntitlementStatus,
+		SMSAllowed:                       identity.SMSAllowed,
+		VoiceAllowed:                     identity.VoiceAllowed,
+		PublicPaidCallerAccess:           identity.PublicPaidCallerAccess,
+		PolicyMigrationState:             identity.PolicyMigrationState,
+		UpdatedAt:                        now.UTC(),
+	}
+	_ = update.UpdateKeys()
+	if err := s.store.DB.WithContext(ctx).Model(update).IfExists().Update(
+		"PolicyVersion",
+		"AnchorState",
+		"OperationalBinding",
+		"CapabilityPolicyVersion",
+		"CallerAccessPaymentPolicyVersion",
+		"EmailDefaultAllowed",
+		"PhoneEntitlementStatus",
+		"SMSAllowed",
+		"VoiceAllowed",
+		"PublicPaidCallerAccess",
+		"PolicyMigrationState",
+		"UpdatedAt",
+	); err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to persist soul policy"}
+	}
+	return nil
+}
+
+func enforceSoulCommCapabilityPolicy(identity *models.SoulAgentIdentity, req validatedSoulCommSendRequest, metrics *soulCommSendMetrics) *apptheory.AppTheoryError {
+	policy := effectiveSoulAgentPolicy(identity)
+	switch strings.TrimSpace(req.channel) {
+	case commChannelEmail:
+		if policy.Capabilities.Email.DefaultAllowed {
+			return nil
+		}
+	case commChannelSMS:
+		if policy.Capabilities.Phone.SMSAllowed {
+			return nil
+		}
+	case commChannelVoice:
+		if policy.Capabilities.Phone.VoiceAllowed {
+			return nil
+		}
+	default:
+		return nil
+	}
+	metrics.status = commMetricEntitlementRequired
+	return apptheory.NewAppTheoryError(commCodeEntitlementRequired, "channel entitlement required").WithStatusCode(http.StatusForbidden)
+}

--- a/internal/controlplane/soul_public_agent_view.go
+++ b/internal/controlplane/soul_public_agent_view.go
@@ -39,9 +39,28 @@ const (
 )
 
 type soulPublicAgentView struct {
-	models.SoulAgentIdentity
-	ENSName string                `json:"ens_name,omitempty"`
-	Avatar  *soulPublicAvatarView `json:"avatar,omitempty"`
+	AgentID                string                `json:"agent_id,omitempty"`
+	Domain                 string                `json:"domain,omitempty"`
+	LocalID                string                `json:"local_id,omitempty"`
+	ENSName                string                `json:"ens_name,omitempty"`
+	Wallet                 string                `json:"wallet,omitempty"`
+	TokenID                string                `json:"token_id,omitempty"`
+	MetaURI                string                `json:"meta_uri,omitempty"`
+	Avatar                 *soulPublicAvatarView `json:"avatar,omitempty"`
+	Capabilities           []string              `json:"capabilities,omitempty"`
+	PrincipalAddress       string                `json:"principal_address,omitempty"`
+	PrincipalSignature     string                `json:"principal_signature,omitempty"`
+	PrincipalDeclaration   string                `json:"principal_declaration,omitempty"`
+	PrincipalDeclaredAt    string                `json:"principal_declared_at,omitempty"`
+	SelfDescriptionVersion int                   `json:"self_description_version,omitempty"`
+	LifecycleStatus        string                `json:"lifecycle_status,omitempty"`
+	LifecycleReason        string                `json:"lifecycle_reason,omitempty"`
+	SuccessorAgentID       string                `json:"successor_agent_id,omitempty"`
+	PredecessorAgentID     string                `json:"predecessor_agent_id,omitempty"`
+	Status                 string                `json:"status,omitempty"`
+	MintTxHash             string                `json:"mint_tx_hash,omitempty"`
+	MintedAt               time.Time             `json:"minted_at,omitempty"`
+	UpdatedAt              time.Time             `json:"updated_at,omitempty"`
 }
 
 type soulPublicAvatarView struct {
@@ -87,7 +106,7 @@ func (s *Server) buildSoulPublicAgentView(ctx context.Context, identity *models.
 		return view
 	}
 
-	view.SoulAgentIdentity = *identity
+	view = buildSoulPublicAgentIdentityView(identity)
 	if strings.TrimSpace(identity.LocalID) != "" {
 		if ensName, err := s.loadSoulPublicAgentENSName(ctx, identity.AgentID); err == nil {
 			view.ENSName = ensName
@@ -100,6 +119,34 @@ func (s *Server) buildSoulPublicAgentView(ctx context.Context, identity *models.
 	}
 
 	return view
+}
+
+func buildSoulPublicAgentIdentityView(identity *models.SoulAgentIdentity) soulPublicAgentView {
+	if identity == nil {
+		return soulPublicAgentView{}
+	}
+	return soulPublicAgentView{
+		AgentID:                identity.AgentID,
+		Domain:                 identity.Domain,
+		LocalID:                identity.LocalID,
+		Wallet:                 identity.Wallet,
+		TokenID:                identity.TokenID,
+		MetaURI:                identity.MetaURI,
+		Capabilities:           append([]string(nil), identity.Capabilities...),
+		PrincipalAddress:       identity.PrincipalAddress,
+		PrincipalSignature:     identity.PrincipalSignature,
+		PrincipalDeclaration:   identity.PrincipalDeclaration,
+		PrincipalDeclaredAt:    identity.PrincipalDeclaredAt,
+		SelfDescriptionVersion: identity.SelfDescriptionVersion,
+		LifecycleStatus:        identity.LifecycleStatus,
+		LifecycleReason:        identity.LifecycleReason,
+		SuccessorAgentID:       identity.SuccessorAgentID,
+		PredecessorAgentID:     identity.PredecessorAgentID,
+		Status:                 identity.Status,
+		MintTxHash:             identity.MintTxHash,
+		MintedAt:               identity.MintedAt,
+		UpdatedAt:              identity.UpdatedAt,
+	}
 }
 
 func (s *Server) loadSoulPublicAgentENSName(ctx context.Context, agentIDHex string) (string, error) {

--- a/internal/store/models/models_test.go
+++ b/internal/store/models/models_test.go
@@ -372,14 +372,22 @@ func TestModels_UpdateKeysAndDefaults(t *testing.T) {
 		t.Parallel()
 
 		a := &SoulAgentIdentity{
-			AgentID:    " 0xABC ",
-			Domain:     " Example.COM ",
-			LocalID:    " @Alice/ ",
-			Wallet:     " 0xDEF ",
-			TokenID:    " 0x123 ",
-			MetaURI:    " https://example.com/agent.json ",
-			Status:     "",
-			MintTxHash: " 0xBEEF ",
+			AgentID:                          " 0xABC ",
+			Domain:                           " Example.COM ",
+			LocalID:                          " @Alice/ ",
+			Wallet:                           " 0xDEF ",
+			TokenID:                          " 0x123 ",
+			MetaURI:                          " https://example.com/agent.json ",
+			Status:                           "",
+			MintTxHash:                       " 0xBEEF ",
+			PolicyVersion:                    " HOSTED-BOUND-SOUL/V1 ",
+			AnchorState:                      " HOSTED_OFFCHAIN ",
+			OperationalBinding:               " HOSTED_BOUND_SOUL ",
+			CapabilityPolicyVersion:          " CAPABILITY-POLICY/V1 ",
+			CallerAccessPaymentPolicyVersion: " CALLER-ACCESS-PAYMENT/V1 ",
+			PhoneEntitlementStatus:           " PROVISIONED ",
+			PublicPaidCallerAccess:           " DENIED ",
+			PolicyMigrationState:             " PERSISTED_V1 ",
 		}
 		require.NoError(t, a.BeforeCreate())
 		require.Equal(t, "SOUL#AGENT#0xabc", a.PK)
@@ -392,6 +400,14 @@ func TestModels_UpdateKeysAndDefaults(t *testing.T) {
 		require.Equal(t, "https://example.com/agent.json", a.MetaURI)
 		require.Equal(t, SoulAgentStatusPending, a.Status)
 		require.Equal(t, "0xbeef", a.MintTxHash)
+		require.Equal(t, SoulPolicyVersionHostedBoundSoulV1, a.PolicyVersion)
+		require.Equal(t, SoulAnchorStateHostedOffchain, a.AnchorState)
+		require.Equal(t, SoulOperationalBindingHostedBoundSoul, a.OperationalBinding)
+		require.Equal(t, SoulCapabilityPolicyVersionV1, a.CapabilityPolicyVersion)
+		require.Equal(t, SoulCallerAccessPaymentPolicyVersionV1, a.CallerAccessPaymentPolicyVersion)
+		require.Equal(t, SoulPhoneEntitlementProvisioned, a.PhoneEntitlementStatus)
+		require.Equal(t, SoulPublicPaidCallerAccessDenied, a.PublicPaidCallerAccess)
+		require.Equal(t, SoulPolicyMigrationStatePersistedV1, a.PolicyMigrationState)
 		require.False(t, a.UpdatedAt.IsZero())
 	})
 

--- a/internal/store/models/soul_agent_identity.go
+++ b/internal/store/models/soul_agent_identity.go
@@ -17,6 +17,27 @@ const (
 	SoulAgentStatusBurned        = "burned"
 )
 
+// Soul policy vocabulary constants define the hosted-bound-soul v1 policy contract.
+//
+// The names intentionally separate immutable anchor assurance from operational
+// binding, capability policy, and caller access/payment policy. They are
+// persisted on SoulAgentIdentity so existing souls can migrate in place without
+// a new on-chain action.
+const (
+	SoulPolicyVersionHostedBoundSoulV1        = "hosted-bound-soul/v1"
+	SoulAnchorStateHostedOffchain             = "hosted_offchain"
+	SoulAnchorStateImmutableOnchain           = "immutable_onchain"
+	SoulOperationalBindingHostedBoundSoul     = "hosted_bound_soul"
+	SoulCapabilityPolicyVersionV1             = "capability-policy/v1"
+	SoulCallerAccessPaymentPolicyVersionV1    = "caller-access-payment/v1"
+	SoulPhoneEntitlementNotEntitled           = "not_entitled"
+	SoulPhoneEntitlementProvisioned           = "provisioned"
+	SoulPhoneEntitlementPaid                  = "paid"
+	SoulPublicPaidCallerAccessDenied          = "denied"
+	SoulPolicyMigrationStateImplicitDefaultV1 = "implicit_default_v1"
+	SoulPolicyMigrationStatePersistedV1       = "persisted_v1"
+)
+
 // SoulAgentIdentity stores the off-chain identity record for a soul agent.
 //
 // Keys:
@@ -57,6 +78,21 @@ type SoulAgentIdentity struct {
 	MintTxHash string    `theorydb:"attr:mintTxHash" json:"mint_tx_hash,omitempty"`
 	MintedAt   time.Time `theorydb:"attr:mintedAt" json:"minted_at,omitempty"`
 	UpdatedAt  time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
+
+	// hosted-bound-soul v1 policy vocabulary. These fields are off-chain policy
+	// state; they do not grant on-chain authority and must not be interpreted as
+	// replacing contract ownership or Safe-governed mutations.
+	PolicyVersion                    string `theorydb:"attr:policyVersion" json:"policy_version,omitempty"`
+	AnchorState                      string `theorydb:"attr:anchorState" json:"anchor_state,omitempty"`
+	OperationalBinding               string `theorydb:"attr:operationalBinding" json:"operational_binding,omitempty"`
+	CapabilityPolicyVersion          string `theorydb:"attr:capabilityPolicyVersion" json:"capability_policy_version,omitempty"`
+	CallerAccessPaymentPolicyVersion string `theorydb:"attr:callerAccessPaymentPolicyVersion" json:"caller_access_payment_policy_version,omitempty"`
+	EmailDefaultAllowed              bool   `theorydb:"attr:emailDefaultAllowed" json:"email_default_allowed,omitempty"`
+	PhoneEntitlementStatus           string `theorydb:"attr:phoneEntitlementStatus" json:"phone_entitlement_status,omitempty"`
+	SMSAllowed                       bool   `theorydb:"attr:smsAllowed" json:"sms_allowed,omitempty"`
+	VoiceAllowed                     bool   `theorydb:"attr:voiceAllowed" json:"voice_allowed,omitempty"`
+	PublicPaidCallerAccess           string `theorydb:"attr:publicPaidCallerAccess" json:"public_paid_caller_access,omitempty"`
+	PolicyMigrationState             string `theorydb:"attr:policyMigrationState" json:"policy_migration_state,omitempty"`
 }
 
 // TableName returns the database table name for SoulAgentIdentity.
@@ -170,6 +206,14 @@ func (a *SoulAgentIdentity) UpdateKeys() error {
 	a.PredecessorAgentID = strings.ToLower(strings.TrimSpace(a.PredecessorAgentID))
 	a.Status = strings.ToLower(strings.TrimSpace(a.Status))
 	a.MintTxHash = strings.ToLower(strings.TrimSpace(a.MintTxHash))
+	a.PolicyVersion = strings.ToLower(strings.TrimSpace(a.PolicyVersion))
+	a.AnchorState = strings.ToLower(strings.TrimSpace(a.AnchorState))
+	a.OperationalBinding = strings.ToLower(strings.TrimSpace(a.OperationalBinding))
+	a.CapabilityPolicyVersion = strings.ToLower(strings.TrimSpace(a.CapabilityPolicyVersion))
+	a.CallerAccessPaymentPolicyVersion = strings.ToLower(strings.TrimSpace(a.CallerAccessPaymentPolicyVersion))
+	a.PhoneEntitlementStatus = strings.ToLower(strings.TrimSpace(a.PhoneEntitlementStatus))
+	a.PublicPaidCallerAccess = strings.ToLower(strings.TrimSpace(a.PublicPaidCallerAccess))
+	a.PolicyMigrationState = strings.ToLower(strings.TrimSpace(a.PolicyMigrationState))
 
 	a.PK = fmt.Sprintf("SOUL#AGENT#%s", a.AgentID)
 	a.SK = "IDENTITY"

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -1413,6 +1413,25 @@ export interface components {
             mint_tx_hash?: string;
             /** Format: date-time */
             minted_at?: string;
+            /** @enum {string} */
+            policy_version?: "hosted-bound-soul/v1";
+            /** @enum {string} */
+            anchor_state?: "hosted_offchain" | "immutable_onchain";
+            /** @enum {string} */
+            operational_binding?: "hosted_bound_soul";
+            /** @enum {string} */
+            capability_policy_version?: "capability-policy/v1";
+            /** @enum {string} */
+            caller_access_payment_policy_version?: "caller-access-payment/v1";
+            email_default_allowed?: boolean;
+            /** @enum {string} */
+            phone_entitlement_status?: "not_entitled" | "provisioned" | "paid";
+            sms_allowed?: boolean;
+            voice_allowed?: boolean;
+            /** @enum {string} */
+            public_paid_caller_access?: "denied";
+            /** @enum {string} */
+            policy_migration_state?: "implicit_default_v1" | "persisted_v1";
             /** Format: date-time */
             updated_at?: string;
             $defs: {
@@ -1490,7 +1509,7 @@ export interface components {
         "soul-comm-send.error.schema": {
             error: {
                 /** @enum {string} */
-                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.preference_violation" | "comm.boundary_violation" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.idempotency_conflict" | "comm.internal";
+                code: "comm.invalid_request" | "comm.unauthorized" | "comm.agent_not_active" | "comm.channel_not_provisioned" | "comm.channel_unverified" | "comm.rate_limited" | "comm.preference_violation" | "comm.boundary_violation" | "comm.entitlement_required" | "comm.insufficient_credits" | "comm.provider_unavailable" | "comm.provider_rejected" | "comm.idempotency_conflict" | "comm.internal";
                 message: string;
                 status_code?: number;
                 /** @description Optional structured, client-safe metadata. For comm.boundary_violation caused by an invalid reply/conversation reference, Host returns field=inReplyTo, boundary=conversation, and a reason such as no_prior_conversation. */
@@ -1539,6 +1558,39 @@ export interface components {
                 request_id?: string;
             };
         };
+        policy: {
+            /** @enum {string} */
+            version: "hosted-bound-soul/v1";
+            /** @enum {string} */
+            anchorState: "hosted_offchain" | "immutable_onchain";
+            /** @enum {string} */
+            operationalBinding: "hosted_bound_soul";
+            /** @enum {string} */
+            capabilityPolicyVersion: "capability-policy/v1";
+            /** @enum {string} */
+            callerAccessPaymentPolicyVersion: "caller-access-payment/v1";
+            capabilities: {
+                email: {
+                    defaultAllowed: boolean;
+                };
+                phone: {
+                    /** @enum {string} */
+                    entitlementStatus: "not_entitled" | "provisioned" | "paid";
+                    smsAllowed: boolean;
+                    voiceAllowed: boolean;
+                };
+            };
+            callerAccessPayment: {
+                publicPaidCaller: {
+                    /** @enum {string} */
+                    access: "denied";
+                };
+            };
+            migration: {
+                /** @enum {string} */
+                state: "implicit_default_v1" | "persisted_v1";
+            };
+        };
         channel: {
             /** @enum {string} */
             channelType: "email" | "phone";
@@ -1583,6 +1635,7 @@ export interface components {
             preferred?: "email" | "phone" | "sms" | "voice";
             /** @enum {string} */
             fallback?: "email" | "phone" | "sms" | "voice";
+            policy: components["schemas"]["policy"];
             channels: components["schemas"]["channel"][];
             mailbox: components["schemas"]["mailbox"];
             availability: components["schemas"]["availability"];

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -1413,25 +1413,6 @@ export interface components {
             mint_tx_hash?: string;
             /** Format: date-time */
             minted_at?: string;
-            /** @enum {string} */
-            policy_version?: "hosted-bound-soul/v1";
-            /** @enum {string} */
-            anchor_state?: "hosted_offchain" | "immutable_onchain";
-            /** @enum {string} */
-            operational_binding?: "hosted_bound_soul";
-            /** @enum {string} */
-            capability_policy_version?: "capability-policy/v1";
-            /** @enum {string} */
-            caller_access_payment_policy_version?: "caller-access-payment/v1";
-            email_default_allowed?: boolean;
-            /** @enum {string} */
-            phone_entitlement_status?: "not_entitled" | "provisioned" | "paid";
-            sms_allowed?: boolean;
-            voice_allowed?: boolean;
-            /** @enum {string} */
-            public_paid_caller_access?: "denied";
-            /** @enum {string} */
-            policy_migration_state?: "implicit_default_v1" | "persisted_v1";
             /** Format: date-time */
             updated_at?: string;
             $defs: {


### PR DESCRIPTION
## Summary

Project 32 M1 host work for #312 and #313.

- adds the `hosted-bound-soul/v1` policy vocabulary to `SoulAgentIdentity`, separating anchor assurance, operational binding, capability policy, and caller access/payment policy
- persists policy defaults on new/touched hosted-bound souls, marks mint receipts as `immutable_onchain`, and preserves channel entitlement authority during mint reconciliation
- makes email an explicit default policy while requiring provisioned/paid phone entitlement for SMS/voice before channel/provider lookup
- returns `comm.entitlement_required` with a client-safe message when phone entitlement is absent
- exposes the effective policy in the soul comm contactability contract, updates schemas/fixtures/generated adapter, and documents the migration path

Closes #312.
Closes #313.

## Stewardship / safety notes

- **On-chain:** off-chain policy vocabulary only. No Solidity, deployment artifact, Safe payload, mint-signer, or new on-chain transaction path. Mint reconciliation only records `anchorState=immutable_onchain` after an existing mint receipt.
- **Multi-tenant:** preserves existing domain + instance-key authorization boundaries; no cross-tenant reads and no tenant content enters host.
- **Trust / comm safety:** phone entitlement denial happens before phone channel/provider load, so private reachability/provider/payment details are not revealed. Instance-auth semantics are unchanged.
- **Release verification:** no managed provisioning or consumer-release-verification path changes.
- **CSP / web:** generated adapter update only; no CSP loosening, inline script/style, third-party origin, or eval.
- **M1 boundary:** public paid caller/x402 authority remains modeled as `denied`; no public x402 grant is introduced.

## Validation

- `git diff --check`
- `go test ./internal/controlplane ./internal/store/models`
- `go test ./...`
- `go vet ./...`
- `gofmt -l .`
- `cd web && npm ci && npm run verify:lesser-host-contracts`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → PASS (29 pass, 0 fail, 0 blocked)

## Rollout

No deploy in this PR. Standard path after review/merge is `lab` soak before any `live` deployment if/when Aron authorizes rollout.
