### PR TITLE
feat(soul): expose anchor assurance metadata

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -303,6 +303,56 @@ components:
     SoulAgentIdentity:
       $ref: "../spec/v3/schemas/soul-agent-identity.schema.json"
 
+    SoulAnchorEvidence:
+      type: object
+      additionalProperties: false
+      required: [kind]
+      properties:
+        kind:
+          type: string
+          enum: [host_registry_record, mint_transaction]
+        tx_hash:
+          type: string
+          pattern: "^0x[0-9a-fA-F]{64}$"
+        operation_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+        token_id:
+          type: string
+          minLength: 1
+          maxLength: 256
+        chain_id:
+          type: integer
+          minimum: 1
+        recorded_at:
+          type: string
+          format: date-time
+
+    SoulAnchorAssurance:
+      type: object
+      additionalProperties: false
+      required: [state, source, capability_gate, mutable, revocable]
+      properties:
+        state:
+          type: string
+          enum: [hosted_offchain, immutable_onchain]
+        source:
+          type: string
+          enum: [host_record, onchain_receipt]
+        capability_gate:
+          type: boolean
+          enum: [false]
+        mutable:
+          type: boolean
+        revocable:
+          type: boolean
+        evidence:
+          type: array
+          maxItems: 8
+          items:
+            $ref: "#/components/schemas/SoulAnchorEvidence"
+
     SoulResolveResponse:
       type: object
       additionalProperties: false
@@ -734,6 +784,8 @@ components:
           type: string
         conversation_id:
           type: string
+        anchor_assurance:
+          $ref: "#/components/schemas/SoulAnchorAssurance"
         promotion:
           $ref: "#/components/schemas/SoulAgentPromotion"
 

--- a/docs/soul-agent-first-client-contract.md
+++ b/docs/soul-agent-first-client-contract.md
@@ -39,6 +39,12 @@ Important fields include:
 - declaration metadata: `principal_address`, `principal_signature`, `principal_declaration`, `principal_declared_at`
 - lifecycle metadata: `status`, `lifecycle_status`, `lifecycle_reason`, `successor_agent_id`, `predecessor_agent_id`
 - publication metadata: `self_description_version`, `mint_tx_hash`, `minted_at`, `updated_at`
+- anchor assurance metadata under `anchor_assurance`
+  - `state`: `hosted_offchain` or `immutable_onchain`
+  - `source`: `host_record` or `onchain_receipt`
+  - `capability_gate`: always `false`; assurance is a trust/display signal, not default capability authority
+  - `mutable` / `revocable`: display hints for the assurance tier, not permission decisions
+  - `evidence[]`: host-registry or mint-transaction evidence (`tx_hash`, `operation_id`, `chain_id`, timestamps when known)
 - on-chain avatar metadata under `avatar`
   - `current_style_id`
   - `current_style_name`
@@ -48,6 +54,11 @@ Important fields include:
 
 Clients should prefer these structured fields directly. Fetching `meta_uri` for token metadata should be treated as a
 fallback for older records, not the primary integration path.
+
+Anchor assurance is deliberately separate from capability and caller-access policy. Hosted/off-chain souls may still use
+their allowed capabilities, x402 caller grants, and communication channels when their policy permits it. Promotion to
+`immutable_onchain` adds trust evidence; it must not create a second agent namespace, rotate `agent_id`, or silently
+change capability/access policy.
 
 ## Authentication
 
@@ -316,6 +327,7 @@ Each event includes:
 - `event_type`
 - `summary`
 - `occurred_at`
+- optional `anchor_assurance` for transitions that add anchor evidence, especially `mint_executed`
 - optional linkage fields:
   - `request_id`
   - `operation_id`
@@ -346,6 +358,12 @@ These are the most important contract-level failure cases for clients to handle 
     closed
 - expected version mismatch
   - finalize/update publication can reject stale clients that try to publish against an outdated version chain
+- anchor promotion failure / rollback
+  - failed or unrecorded mint execution leaves the identity in its existing hosted/off-chain assurance state
+  - retry the same promotion/mint operation or record a verified execution receipt; do not create a replacement
+    `agent_id` or parallel namespace
+  - if off-chain reconciliation cannot verify an `immutable_onchain` marker, treat the assurance evidence as incomplete
+    and surface a repair state; do not revoke ordinary capabilities unless the explicit capability/access policy changed
 
 Clients should surface these as explicit workflow states instead of retrying blindly.
 

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -122,6 +122,11 @@ The soul registry is served by `cmd/control-plane-api` through the `lesser.host`
 - `GET /api/v1/soul/agents/{agentId}/validations` (paginated)
 - `GET /api/v1/soul/search?q=...&capability=...`
 
+`GET /api/v1/soul/agents/{agentId}` includes `anchor_assurance` as public trust/display metadata. The assurance state
+is `hosted_offchain` or `immutable_onchain`, includes host-record or mint-transaction evidence when available, and
+sets `capability_gate: false` to make the contract explicit: capability authorization remains controlled by the
+agent's capability/access policy, not by whether the soul has already been promoted on-chain.
+
 #### `GET /api/v1/soul/search` query semantics
 
 The soul search endpoint is intentionally fail-closed and does not perform an unbounded cross-domain local-ID scan.

--- a/docs/spec/v3/schemas/soul-agent-identity.schema.json
+++ b/docs/spec/v3/schemas/soul-agent-identity.schema.json
@@ -32,6 +32,36 @@
           "maxItems": 16
         }
       }
+    },
+    "anchor_evidence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": { "type": "string", "enum": ["host_registry_record", "mint_transaction"] },
+        "tx_hash": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+        "operation_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "token_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "chain_id": { "type": "integer", "minimum": 1 },
+        "recorded_at": { "type": "string", "format": "date-time" }
+      }
+    },
+    "anchor_assurance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["state", "source", "capability_gate", "mutable", "revocable"],
+      "properties": {
+        "state": { "type": "string", "enum": ["hosted_offchain", "immutable_onchain"] },
+        "source": { "type": "string", "enum": ["host_record", "onchain_receipt"] },
+        "capability_gate": { "type": "boolean", "const": false },
+        "mutable": { "type": "boolean" },
+        "revocable": { "type": "boolean" },
+        "evidence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/anchor_evidence" },
+          "maxItems": 8
+        }
+      }
     }
   },
   "properties": {
@@ -43,6 +73,7 @@
     "token_id": { "type": "string", "minLength": 1, "maxLength": 256 },
     "meta_uri": { "type": "string", "format": "uri" },
     "avatar": { "$ref": "#/$defs/avatar" },
+    "anchor_assurance": { "$ref": "#/$defs/anchor_assurance" },
     "capabilities": {
       "type": "array",
       "items": { "type": "string", "minLength": 1, "maxLength": 128 }

--- a/internal/controlplane/handlers_soul_operations.go
+++ b/internal/controlplane/handlers_soul_operations.go
@@ -293,10 +293,13 @@ func (s *Server) syncMintPromotionAfterOperationExecution(ctx context.Context, u
 	}
 	if success && (previous == nil || !strings.EqualFold(strings.TrimSpace(previous.ReadinessStatus), models.SoulAgentPromotionReadinessReadyForConversation)) {
 		if appErr := s.saveSoulAgentPromotionLifecycleEvent(ctx, buildSoulAgentPromotionLifecycleEvent(promotion, soulAgentPromotionLifecycleEventInput{
-			EventType:   models.SoulAgentPromotionEventTypeMintExecuted,
-			RequestID:   strings.TrimSpace(requestID),
-			OperationID: update.OperationID,
-			OccurredAt:  now,
+			EventType:        models.SoulAgentPromotionEventTypeMintExecuted,
+			RequestID:        strings.TrimSpace(requestID),
+			OperationID:      update.OperationID,
+			AnchorState:      models.SoulAnchorStateImmutableOnchain,
+			AnchorTxHash:     update.ExecTxHash,
+			AnchorEvidenceAt: now,
+			OccurredAt:       now,
 		})); appErr != nil {
 			return appErr
 		}

--- a/internal/controlplane/handlers_soul_operations_internal_test.go
+++ b/internal/controlplane/handlers_soul_operations_internal_test.go
@@ -132,7 +132,7 @@ func latestPromotionLifecycleEventModelCall(t *testing.T, db *ttmocks.MockExtend
 
 	for i := len(db.Calls) - 1; i >= 0; i-- {
 		call := db.Calls[i]
-		if call.Method != "Model" || len(call.Arguments) == 0 {
+		if call.Method != modelCallMethod || len(call.Arguments) == 0 {
 			continue
 		}
 		event, ok := call.Arguments.Get(0).(*models.SoulAgentPromotionLifecycleEvent)
@@ -143,6 +143,25 @@ func latestPromotionLifecycleEventModelCall(t *testing.T, db *ttmocks.MockExtend
 		return &copy
 	}
 	t.Fatalf("expected lifecycle event model call")
+	return nil
+}
+
+func latestSoulAgentIdentityUpdateModelCall(t *testing.T, db *ttmocks.MockExtendedDB) *models.SoulAgentIdentity {
+	t.Helper()
+
+	for i := len(db.Calls) - 1; i >= 0; i-- {
+		call := db.Calls[i]
+		if call.Method != modelCallMethod || len(call.Arguments) == 0 {
+			continue
+		}
+		identity, ok := call.Arguments.Get(0).(*models.SoulAgentIdentity)
+		if !ok || identity == nil || strings.TrimSpace(identity.MintTxHash) == "" {
+			continue
+		}
+		copy := *identity
+		return &copy
+	}
+	t.Fatalf("expected soul identity update model call")
 	return nil
 }
 
@@ -299,6 +318,7 @@ func TestSyncMintPromotionAfterOperationExecution_EmitsLifecycleEvent(t *testing
 		Kind:        models.SoulOperationKindMint,
 		AgentID:     agentID,
 		Status:      models.SoulOperationStatusExecuted,
+		ExecTxHash:  "0x" + strings.Repeat("ab", 32),
 	}, "rid-1", now, true)
 	if appErr != nil {
 		t.Fatalf("unexpected appErr: %#v", appErr)
@@ -313,6 +333,64 @@ func TestSyncMintPromotionAfterOperationExecution_EmitsLifecycleEvent(t *testing
 	}
 	if event.ReadinessStatus != models.SoulAgentPromotionReadinessReadyForConversation {
 		t.Fatalf("expected ready-for-conversation snapshot, got %#v", event)
+	}
+	if event.AnchorState != models.SoulAnchorStateImmutableOnchain ||
+		event.AnchorEvidenceTxHash != "0x"+strings.Repeat("ab", 32) ||
+		!event.AnchorEvidenceAt.Equal(now) {
+		t.Fatalf("expected immutable anchor evidence on mint event, got %#v", event)
+	}
+}
+
+func TestApplySoulOperationMintSideEffectsPreservesAgentIDAndPolicy(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulOperationsTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	agentID := "0x" + strings.Repeat("77", 32)
+	txHash := "0x" + strings.Repeat("ef", 32)
+	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
+		*dest = models.SoulAgentIdentity{
+			AgentID:                          agentID,
+			Status:                           models.SoulAgentStatusActive,
+			LifecycleStatus:                  models.SoulAgentStatusActive,
+			PolicyVersion:                    models.SoulPolicyVersionHostedBoundSoulV1,
+			AnchorState:                      models.SoulAnchorStateHostedOffchain,
+			OperationalBinding:               models.SoulOperationalBindingHostedBoundSoul,
+			CapabilityPolicyVersion:          models.SoulCapabilityPolicyVersionV1,
+			CallerAccessPaymentPolicyVersion: models.SoulCallerAccessPaymentPolicyVersionV1,
+			EmailDefaultAllowed:              true,
+			PhoneEntitlementStatus:           models.SoulPhoneEntitlementProvisioned,
+			SMSAllowed:                       true,
+			VoiceAllowed:                     true,
+			PublicPaidCallerAccess:           models.SoulPublicPaidCallerAccessGrantable,
+			PolicyMigrationState:             models.SoulPolicyMigrationStatePersistedV1,
+		}
+	}).Once()
+	tdb.qID.On("Update", mock.Anything).Return(nil).Once()
+
+	s.applySoulOperationMintSideEffects(context.Background(), &models.SoulOperation{
+		Kind:       models.SoulOperationKindMint,
+		AgentID:    agentID,
+		ExecTxHash: txHash,
+	}, agentID)
+
+	update := latestSoulAgentIdentityUpdateModelCall(t, tdb.db)
+	if update.AgentID != agentID || update.MintTxHash != txHash || update.AnchorState != models.SoulAnchorStateImmutableOnchain {
+		t.Fatalf("unexpected mint side-effect identity update: %#v", update)
+	}
+	if update.PolicyVersion != models.SoulPolicyVersionHostedBoundSoulV1 ||
+		update.OperationalBinding != models.SoulOperationalBindingHostedBoundSoul ||
+		update.CapabilityPolicyVersion != models.SoulCapabilityPolicyVersionV1 ||
+		update.CallerAccessPaymentPolicyVersion != models.SoulCallerAccessPaymentPolicyVersionV1 ||
+		!update.EmailDefaultAllowed ||
+		update.PhoneEntitlementStatus != models.SoulPhoneEntitlementProvisioned ||
+		!update.SMSAllowed ||
+		!update.VoiceAllowed ||
+		update.PublicPaidCallerAccess != models.SoulPublicPaidCallerAccessGrantable ||
+		update.PolicyMigrationState != models.SoulPolicyMigrationStatePersistedV1 {
+		t.Fatalf("mint side effect churned capability/access policy: %#v", update)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_promotion_events.go
+++ b/internal/controlplane/handlers_soul_promotion_events.go
@@ -13,14 +13,15 @@ import (
 )
 
 type soulAgentPromotionLifecycleEventView struct {
-	EventID        string                 `json:"event_id"`
-	EventType      string                 `json:"event_type"`
-	Summary        string                 `json:"summary,omitempty"`
-	OccurredAt     time.Time              `json:"occurred_at"`
-	RequestID      string                 `json:"request_id,omitempty"`
-	OperationID    string                 `json:"operation_id,omitempty"`
-	ConversationID string                 `json:"conversation_id,omitempty"`
-	Promotion      soulAgentPromotionView `json:"promotion"`
+	EventID         string                   `json:"event_id"`
+	EventType       string                   `json:"event_type"`
+	Summary         string                   `json:"summary,omitempty"`
+	OccurredAt      time.Time                `json:"occurred_at"`
+	RequestID       string                   `json:"request_id,omitempty"`
+	OperationID     string                   `json:"operation_id,omitempty"`
+	ConversationID  string                   `json:"conversation_id,omitempty"`
+	AnchorAssurance *soulAnchorAssuranceView `json:"anchor_assurance,omitempty"`
+	Promotion       soulAgentPromotionView   `json:"promotion"`
 }
 
 type soulAgentPromotionLifecycleEventListResponse struct {
@@ -32,12 +33,15 @@ type soulAgentPromotionLifecycleEventListResponse struct {
 }
 
 type soulAgentPromotionLifecycleEventInput struct {
-	EventType      string
-	Summary        string
-	RequestID      string
-	OperationID    string
-	ConversationID string
-	OccurredAt     time.Time
+	EventType        string
+	Summary          string
+	RequestID        string
+	OperationID      string
+	ConversationID   string
+	AnchorState      string
+	AnchorTxHash     string
+	AnchorEvidenceAt time.Time
+	OccurredAt       time.Time
 }
 
 func cloneSoulAgentPromotion(promotion *models.SoulAgentPromotion) *models.SoulAgentPromotion {
@@ -76,6 +80,9 @@ func buildSoulAgentPromotionLifecycleEvent(promotion *models.SoulAgentPromotion,
 		MintOperationID:          promotion.MintOperationID,
 		MintOperationStatus:      promotion.MintOperationStatus,
 		PrincipalAddress:         promotion.PrincipalAddress,
+		AnchorState:              strings.TrimSpace(input.AnchorState),
+		AnchorEvidenceTxHash:     strings.TrimSpace(input.AnchorTxHash),
+		AnchorEvidenceAt:         input.AnchorEvidenceAt,
 		LatestConversationID:     promotion.LatestConversationID,
 		LatestConversationStatus: promotion.LatestConversationStatus,
 		LatestReviewSHA256:       promotion.LatestReviewSHA256,
@@ -200,15 +207,20 @@ func (s *Server) buildSoulAgentPromotionLifecycleEventView(event *models.SoulAge
 	if event == nil {
 		return soulAgentPromotionLifecycleEventView{}
 	}
+	chainID := int64(0)
+	if s != nil {
+		chainID = s.cfg.SoulChainID
+	}
 	return soulAgentPromotionLifecycleEventView{
-		EventID:        strings.TrimSpace(event.EventID),
-		EventType:      strings.TrimSpace(event.EventType),
-		Summary:        strings.TrimSpace(event.Summary),
-		OccurredAt:     event.OccurredAt,
-		RequestID:      strings.TrimSpace(event.RequestID),
-		OperationID:    strings.TrimSpace(event.OperationID),
-		ConversationID: strings.TrimSpace(event.ConversationID),
-		Promotion:      s.buildSoulAgentPromotionView(promotionFromLifecycleEvent(event)),
+		EventID:         strings.TrimSpace(event.EventID),
+		EventType:       strings.TrimSpace(event.EventType),
+		Summary:         strings.TrimSpace(event.Summary),
+		OccurredAt:      event.OccurredAt,
+		RequestID:       strings.TrimSpace(event.RequestID),
+		OperationID:     strings.TrimSpace(event.OperationID),
+		ConversationID:  strings.TrimSpace(event.ConversationID),
+		AnchorAssurance: buildSoulAnchorAssuranceFromLifecycleEvent(event, chainID),
+		Promotion:       s.buildSoulAgentPromotionView(promotionFromLifecycleEvent(event)),
 	}
 }
 

--- a/internal/controlplane/handlers_soul_promotion_events_internal_test.go
+++ b/internal/controlplane/handlers_soul_promotion_events_internal_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +84,9 @@ func TestHandleSoulListMyPromotionLifecycleEvents_ReturnsPagedViews(t *testing.T
 				ApprovalStatus:           models.SoulAgentPromotionApprovalStatusApproved,
 				ReadinessStatus:          models.SoulAgentPromotionReadinessReadyForFinalize,
 				MintOperationID:          "op-1",
+				AnchorState:              models.SoulAnchorStateImmutableOnchain,
+				AnchorEvidenceTxHash:     "0x" + strings.Repeat("cd", 32),
+				AnchorEvidenceAt:         time.Date(2026, 3, 28, 17, 55, 0, 0, time.UTC),
 				ConversationID:           "conv-1",
 				PublishedVersion:         0,
 				CreatedAt:                time.Date(2026, 3, 28, 17, 0, 0, 0, time.UTC),
@@ -115,6 +119,22 @@ func TestHandleSoulListMyPromotionLifecycleEvents_ReturnsPagedViews(t *testing.T
 	}
 	if out.Events[0].Promotion.NextActions[0] != testSoulPromotionActionBeginFinalize {
 		t.Fatalf("expected finalize next action, got %#v", out.Events[0].Promotion)
+	}
+	assertSoulPromotionEventAnchorAssurance(t, out.Events[0].AnchorAssurance)
+}
+
+func assertSoulPromotionEventAnchorAssurance(t *testing.T, assurance *soulAnchorAssuranceView) {
+	t.Helper()
+
+	if assurance == nil {
+		t.Fatalf("expected mint event anchor assurance evidence")
+	}
+	if assurance.State != models.SoulAnchorStateImmutableOnchain ||
+		assurance.Source != soulAnchorAssuranceSourceOnchainReceipt ||
+		assurance.CapabilityGate ||
+		len(assurance.Evidence) != 1 ||
+		assurance.Evidence[0].Kind != soulAnchorEvidenceKindMintTransaction {
+		t.Fatalf("expected mint event anchor assurance evidence, got %#v", assurance)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -367,7 +367,7 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 	tdb := newSoulPublicTestDB()
 	s := &Server{
 		store: store.New(tdb.db),
-		cfg:   config.Config{SoulEnabled: true},
+		cfg:   config.Config{SoulEnabled: true, SoulChainID: 1},
 	}
 
 	agentID := "0x" + strings.Repeat("11", 32)
@@ -388,6 +388,8 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 			VoiceAllowed:                     true,
 			PublicPaidCallerAccess:           models.SoulPublicPaidCallerAccessDenied,
 			PolicyMigrationState:             models.SoulPolicyMigrationStatePersistedV1,
+			MintTxHash:                       "0x" + strings.Repeat("ab", 32),
+			MintedAt:                         time.Date(2026, 5, 17, 1, 2, 3, 0, time.UTC),
 		}
 	}).Once()
 	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
@@ -415,6 +417,35 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 	if out.Version != "1" || out.Agent.AgentID != agentID || out.Reputation == nil || out.Reputation.AgentID != agentID {
 		t.Fatalf("unexpected response: %#v", out)
 	}
+	assertSoulPublicAgentOnchainAnchorAssurance(t, out.Agent.AnchorAssurance)
+	assertSoulPublicAgentPolicyFieldsNotLeaked(t, resp.Body)
+}
+
+func assertSoulPublicAgentOnchainAnchorAssurance(t *testing.T, assurance *soulAnchorAssuranceView) {
+	t.Helper()
+
+	if assurance == nil {
+		t.Fatalf("expected anchor assurance metadata")
+	}
+	if assurance.State != models.SoulAnchorStateImmutableOnchain ||
+		assurance.Source != soulAnchorAssuranceSourceOnchainReceipt ||
+		assurance.CapabilityGate ||
+		assurance.Mutable ||
+		assurance.Revocable {
+		t.Fatalf("unexpected anchor assurance: %#v", assurance)
+	}
+	if len(assurance.Evidence) != 1 ||
+		assurance.Evidence[0].Kind != soulAnchorEvidenceKindMintTransaction ||
+		assurance.Evidence[0].TxHash == "" ||
+		assurance.Evidence[0].ChainID != 1 ||
+		assurance.Evidence[0].RecordedAt == nil {
+		t.Fatalf("unexpected anchor evidence: %#v", assurance.Evidence)
+	}
+}
+
+func assertSoulPublicAgentPolicyFieldsNotLeaked(t *testing.T, body []byte) {
+	t.Helper()
+
 	for _, privateField := range []string{
 		"policy_version",
 		"anchor_state",
@@ -428,8 +459,8 @@ func TestHandleSoulPublicGetAgent_Success(t *testing.T) {
 		"public_paid_caller_access",
 		"policy_migration_state",
 	} {
-		if bytes.Contains(resp.Body, []byte(privateField)) {
-			t.Fatalf("public agent response leaked private policy field %q: %s", privateField, string(resp.Body))
+		if bytes.Contains(body, []byte(privateField)) {
+			t.Fatalf("public agent response leaked private policy field %q: %s", privateField, string(body))
 		}
 	}
 }

--- a/internal/controlplane/handlers_soul_x402_grants_internal_test.go
+++ b/internal/controlplane/handlers_soul_x402_grants_internal_test.go
@@ -114,6 +114,7 @@ func expectX402Identity(t *testing.T, q *ttmocks.MockQuery, access string) {
 			Status:                           models.SoulAgentStatusActive,
 			LifecycleStatus:                  models.SoulAgentStatusActive,
 			PolicyVersion:                    models.SoulPolicyVersionHostedBoundSoulV1,
+			AnchorState:                      models.SoulAnchorStateHostedOffchain,
 			CallerAccessPaymentPolicyVersion: models.SoulCallerAccessPaymentPolicyVersionV1,
 			PublicPaidCallerAccess:           access,
 			UpdatedAt:                        time.Now().UTC(),
@@ -207,6 +208,24 @@ func TestP0_HandleSoulX402IssueInvocationGrant_SuccessMinimizesPaymentEvidence(t
 	resp, err := s.handleSoulX402IssueInvocationGrant(&apptheory.Context{Request: apptheory.Request{Body: x402IssueBody(t, nil)}})
 	out := requireX402IssueResponse(t, resp, err)
 	assertX402IssueMinimized(t, resp, out, *captured)
+}
+
+func TestHandleSoulX402IssueInvocationGrant_HostedAnchorIsNotCapabilityGate(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulX402GrantTestDB()
+	expectX402Identity(t, tdb.qIdentity, models.SoulPublicPaidCallerAccessGrantable)
+	captured := expectX402GrantCreateCapture(t, tdb)
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+	resp, err := s.handleSoulX402IssueInvocationGrant(&apptheory.Context{Request: apptheory.Request{Body: x402IssueBody(t, nil)}})
+	out := requireX402IssueResponse(t, resp, err)
+	if !out.TokenReturned || out.Grant.PolicyVersion != models.SoulCallerAccessPaymentPolicyVersionV1 {
+		t.Fatalf("expected hosted/offchain grantable policy to issue scoped grant, got %#v", out)
+	}
+	if *captured == nil || (*captured).PolicyVersion != models.SoulCallerAccessPaymentPolicyVersionV1 {
+		t.Fatalf("expected hosted/offchain grant persisted without immutable anchor requirement, got %#v", *captured)
+	}
 }
 
 func TestHandleSoulX402IssueInvocationGrant_DeniedPolicyReturnsGenericUnavailable(t *testing.T) {

--- a/internal/controlplane/soul_anchor_assurance.go
+++ b/internal/controlplane/soul_anchor_assurance.go
@@ -1,0 +1,146 @@
+package controlplane
+
+import (
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const (
+	soulAnchorAssuranceSourceHostRecord     = "host_record"
+	soulAnchorAssuranceSourceOnchainReceipt = "onchain_receipt"
+	soulAnchorEvidenceKindHostRecord        = "host_registry_record"
+	soulAnchorEvidenceKindMintTransaction   = "mint_transaction"
+)
+
+type soulAnchorAssuranceView struct {
+	State          string                   `json:"state"`
+	Source         string                   `json:"source"`
+	CapabilityGate bool                     `json:"capability_gate"`
+	Mutable        bool                     `json:"mutable"`
+	Revocable      bool                     `json:"revocable"`
+	Evidence       []soulAnchorEvidenceView `json:"evidence,omitempty"`
+}
+
+type soulAnchorEvidenceView struct {
+	Kind        string     `json:"kind"`
+	TxHash      string     `json:"tx_hash,omitempty"`
+	OperationID string     `json:"operation_id,omitempty"`
+	TokenID     string     `json:"token_id,omitempty"`
+	ChainID     int64      `json:"chain_id,omitempty"`
+	RecordedAt  *time.Time `json:"recorded_at,omitempty"`
+}
+
+func buildSoulAnchorAssuranceFromIdentity(identity *models.SoulAgentIdentity, chainID int64) soulAnchorAssuranceView {
+	policy := effectiveSoulAgentPolicy(identity)
+	if identity == nil {
+		return buildSoulAnchorAssurance(policy.AnchorState, "", "", "", time.Time{}, chainID, time.Time{})
+	}
+	return buildSoulAnchorAssurance(
+		policy.AnchorState,
+		identity.MintTxHash,
+		"",
+		identity.TokenID,
+		identity.MintedAt,
+		chainID,
+		identity.UpdatedAt,
+	)
+}
+
+func buildSoulAnchorAssuranceFromLifecycleEvent(event *models.SoulAgentPromotionLifecycleEvent, chainID int64) *soulAnchorAssuranceView {
+	if event == nil {
+		return nil
+	}
+	state := strings.TrimSpace(event.AnchorState)
+	txHash := strings.TrimSpace(event.AnchorEvidenceTxHash)
+	if state == "" && txHash == "" && event.AnchorEvidenceAt.IsZero() {
+		return nil
+	}
+	view := buildSoulAnchorAssurance(
+		state,
+		txHash,
+		event.OperationID,
+		"",
+		event.AnchorEvidenceAt,
+		chainID,
+		event.OccurredAt,
+	)
+	return &view
+}
+
+func buildSoulAnchorAssurance(state string, txHash string, operationID string, tokenID string, evidenceAt time.Time, chainID int64, hostRecordedAt time.Time) soulAnchorAssuranceView {
+	state = normalizeSoulAnchorAssuranceState(state)
+	txHash = strings.ToLower(strings.TrimSpace(txHash))
+	operationID = strings.TrimSpace(operationID)
+	tokenID = strings.TrimSpace(tokenID)
+
+	view := soulAnchorAssuranceView{
+		State:          state,
+		Source:         soulAnchorAssuranceSourceHostRecord,
+		CapabilityGate: false,
+		Mutable:        true,
+		Revocable:      true,
+	}
+	if state == models.SoulAnchorStateImmutableOnchain {
+		view.Mutable = false
+		view.Revocable = false
+		if txHash != "" {
+			view.Source = soulAnchorAssuranceSourceOnchainReceipt
+		}
+	}
+
+	if txHash != "" {
+		view.Evidence = append(view.Evidence, soulAnchorEvidenceView{
+			Kind:        soulAnchorEvidenceKindMintTransaction,
+			TxHash:      txHash,
+			OperationID: operationID,
+			TokenID:     tokenID,
+			ChainID:     positiveInt64OrZero(chainID),
+			RecordedAt:  timePtrIfNonZero(evidenceAt),
+		})
+		return view
+	}
+
+	view.Evidence = append(view.Evidence, soulAnchorEvidenceView{
+		Kind:        soulAnchorEvidenceKindHostRecord,
+		OperationID: operationID,
+		TokenID:     tokenID,
+		ChainID:     positiveInt64OrZero(chainID),
+		RecordedAt:  timePtrIfNonZero(firstNonZeroTime(evidenceAt, hostRecordedAt)),
+	})
+	return view
+}
+
+func normalizeSoulAnchorAssuranceState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case models.SoulAnchorStateImmutableOnchain:
+		return models.SoulAnchorStateImmutableOnchain
+	default:
+		return models.SoulAnchorStateHostedOffchain
+	}
+}
+
+func firstNonZeroTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func timePtrIfNonZero(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	out := value.UTC()
+	return &out
+}
+
+func positiveInt64OrZero(value int64) int64 {
+	if value > 0 {
+		return value
+	}
+	return 0
+}

--- a/internal/controlplane/soul_policy_internal_test.go
+++ b/internal/controlplane/soul_policy_internal_test.go
@@ -1,0 +1,50 @@
+package controlplane
+
+import (
+	"testing"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestEffectiveSoulAgentPolicyDoesNotGateCapabilitiesOnAnchorState(t *testing.T) {
+	t.Parallel()
+
+	for _, anchorState := range []string{
+		models.SoulAnchorStateHostedOffchain,
+		models.SoulAnchorStateImmutableOnchain,
+	} {
+		t.Run(anchorState, func(t *testing.T) {
+			t.Parallel()
+
+			identity := &models.SoulAgentIdentity{
+				AgentID:                soulLifecycleTestAgentIDHex,
+				Status:                 models.SoulAgentStatusActive,
+				PolicyVersion:          models.SoulPolicyVersionHostedBoundSoulV1,
+				AnchorState:            anchorState,
+				EmailDefaultAllowed:    true,
+				PhoneEntitlementStatus: models.SoulPhoneEntitlementProvisioned,
+				SMSAllowed:             true,
+				VoiceAllowed:           true,
+				PublicPaidCallerAccess: models.SoulPublicPaidCallerAccessGrantable,
+			}
+
+			policy := effectiveSoulAgentPolicy(identity)
+			if policy.AnchorState != anchorState {
+				t.Fatalf("expected anchor state %q, got %#v", anchorState, policy)
+			}
+			if !policy.Capabilities.Email.DefaultAllowed ||
+				!policy.Capabilities.Phone.SMSAllowed ||
+				!policy.Capabilities.Phone.VoiceAllowed ||
+				policy.CallerAccessPayment.PublicPaidCaller.Access != models.SoulPublicPaidCallerAccessGrantable {
+				t.Fatalf("anchor assurance changed capability/access policy: %#v", policy)
+			}
+
+			for _, channel := range []string{commChannelEmail, commChannelSMS, commChannelVoice} {
+				metrics := newSoulCommSendMetrics("lab", "inst1")
+				if err := enforceSoulCommCapabilityPolicy(identity, validatedSoulCommSendRequest{channel: channel}, metrics); err != nil {
+					t.Fatalf("anchor state %q should not block %s capability: %v", anchorState, channel, err)
+				}
+			}
+		})
+	}
+}

--- a/internal/controlplane/soul_public_agent_view.go
+++ b/internal/controlplane/soul_public_agent_view.go
@@ -39,28 +39,29 @@ const (
 )
 
 type soulPublicAgentView struct {
-	AgentID                string                `json:"agent_id,omitempty"`
-	Domain                 string                `json:"domain,omitempty"`
-	LocalID                string                `json:"local_id,omitempty"`
-	ENSName                string                `json:"ens_name,omitempty"`
-	Wallet                 string                `json:"wallet,omitempty"`
-	TokenID                string                `json:"token_id,omitempty"`
-	MetaURI                string                `json:"meta_uri,omitempty"`
-	Avatar                 *soulPublicAvatarView `json:"avatar,omitempty"`
-	Capabilities           []string              `json:"capabilities,omitempty"`
-	PrincipalAddress       string                `json:"principal_address,omitempty"`
-	PrincipalSignature     string                `json:"principal_signature,omitempty"`
-	PrincipalDeclaration   string                `json:"principal_declaration,omitempty"`
-	PrincipalDeclaredAt    string                `json:"principal_declared_at,omitempty"`
-	SelfDescriptionVersion int                   `json:"self_description_version,omitempty"`
-	LifecycleStatus        string                `json:"lifecycle_status,omitempty"`
-	LifecycleReason        string                `json:"lifecycle_reason,omitempty"`
-	SuccessorAgentID       string                `json:"successor_agent_id,omitempty"`
-	PredecessorAgentID     string                `json:"predecessor_agent_id,omitempty"`
-	Status                 string                `json:"status,omitempty"`
-	MintTxHash             string                `json:"mint_tx_hash,omitempty"`
-	MintedAt               time.Time             `json:"minted_at,omitempty"`
-	UpdatedAt              time.Time             `json:"updated_at,omitempty"`
+	AgentID                string                   `json:"agent_id,omitempty"`
+	Domain                 string                   `json:"domain,omitempty"`
+	LocalID                string                   `json:"local_id,omitempty"`
+	ENSName                string                   `json:"ens_name,omitempty"`
+	Wallet                 string                   `json:"wallet,omitempty"`
+	TokenID                string                   `json:"token_id,omitempty"`
+	MetaURI                string                   `json:"meta_uri,omitempty"`
+	Avatar                 *soulPublicAvatarView    `json:"avatar,omitempty"`
+	AnchorAssurance        *soulAnchorAssuranceView `json:"anchor_assurance,omitempty"`
+	Capabilities           []string                 `json:"capabilities,omitempty"`
+	PrincipalAddress       string                   `json:"principal_address,omitempty"`
+	PrincipalSignature     string                   `json:"principal_signature,omitempty"`
+	PrincipalDeclaration   string                   `json:"principal_declaration,omitempty"`
+	PrincipalDeclaredAt    string                   `json:"principal_declared_at,omitempty"`
+	SelfDescriptionVersion int                      `json:"self_description_version,omitempty"`
+	LifecycleStatus        string                   `json:"lifecycle_status,omitempty"`
+	LifecycleReason        string                   `json:"lifecycle_reason,omitempty"`
+	SuccessorAgentID       string                   `json:"successor_agent_id,omitempty"`
+	PredecessorAgentID     string                   `json:"predecessor_agent_id,omitempty"`
+	Status                 string                   `json:"status,omitempty"`
+	MintTxHash             string                   `json:"mint_tx_hash,omitempty"`
+	MintedAt               time.Time                `json:"minted_at,omitempty"`
+	UpdatedAt              time.Time                `json:"updated_at,omitempty"`
 }
 
 type soulPublicAvatarView struct {
@@ -106,7 +107,11 @@ func (s *Server) buildSoulPublicAgentView(ctx context.Context, identity *models.
 		return view
 	}
 
-	view = buildSoulPublicAgentIdentityView(identity)
+	chainID := int64(0)
+	if s != nil {
+		chainID = s.cfg.SoulChainID
+	}
+	view = buildSoulPublicAgentIdentityView(identity, chainID)
 	if strings.TrimSpace(identity.LocalID) != "" {
 		if ensName, err := s.loadSoulPublicAgentENSName(ctx, identity.AgentID); err == nil {
 			view.ENSName = ensName
@@ -121,10 +126,11 @@ func (s *Server) buildSoulPublicAgentView(ctx context.Context, identity *models.
 	return view
 }
 
-func buildSoulPublicAgentIdentityView(identity *models.SoulAgentIdentity) soulPublicAgentView {
+func buildSoulPublicAgentIdentityView(identity *models.SoulAgentIdentity, chainID int64) soulPublicAgentView {
 	if identity == nil {
 		return soulPublicAgentView{}
 	}
+	anchorAssurance := buildSoulAnchorAssuranceFromIdentity(identity, chainID)
 	return soulPublicAgentView{
 		AgentID:                identity.AgentID,
 		Domain:                 identity.Domain,
@@ -132,6 +138,7 @@ func buildSoulPublicAgentIdentityView(identity *models.SoulAgentIdentity) soulPu
 		Wallet:                 identity.Wallet,
 		TokenID:                identity.TokenID,
 		MetaURI:                identity.MetaURI,
+		AnchorAssurance:        &anchorAssurance,
 		Capabilities:           append([]string(nil), identity.Capabilities...),
 		PrincipalAddress:       identity.PrincipalAddress,
 		PrincipalSignature:     identity.PrincipalSignature,

--- a/internal/controlplane/soul_public_agent_view_internal_test.go
+++ b/internal/controlplane/soul_public_agent_view_internal_test.go
@@ -350,6 +350,36 @@ func TestBuildSoulPublicAgentViewHandlesNilAndStrictIntegrity(t *testing.T) {
 	}
 }
 
+func TestBuildSoulPublicAgentViewIncludesHostedAnchorAssurance(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := time.Date(2026, 5, 17, 2, 0, 0, 0, time.UTC)
+	s := &Server{cfg: config.Config{SoulChainID: 11155111}}
+	view := s.buildSoulPublicAgentView(context.Background(), &models.SoulAgentIdentity{
+		AgentID:     "0x" + strings.Repeat("44", 32),
+		Status:      models.SoulAgentStatusActive,
+		AnchorState: models.SoulAnchorStateHostedOffchain,
+		UpdatedAt:   updatedAt,
+	})
+	if view.AnchorAssurance == nil {
+		t.Fatalf("expected anchor assurance: %#v", view)
+	}
+	if view.AnchorAssurance.State != models.SoulAnchorStateHostedOffchain ||
+		view.AnchorAssurance.Source != soulAnchorAssuranceSourceHostRecord ||
+		view.AnchorAssurance.CapabilityGate ||
+		!view.AnchorAssurance.Mutable ||
+		!view.AnchorAssurance.Revocable {
+		t.Fatalf("unexpected hosted anchor assurance: %#v", view.AnchorAssurance)
+	}
+	if len(view.AnchorAssurance.Evidence) != 1 ||
+		view.AnchorAssurance.Evidence[0].Kind != soulAnchorEvidenceKindHostRecord ||
+		view.AnchorAssurance.Evidence[0].ChainID != 11155111 ||
+		view.AnchorAssurance.Evidence[0].RecordedAt == nil ||
+		!view.AnchorAssurance.Evidence[0].RecordedAt.Equal(updatedAt) {
+		t.Fatalf("unexpected hosted anchor evidence: %#v", view.AnchorAssurance.Evidence)
+	}
+}
+
 func TestLoadSoulPublicAgentAvatarGuardClauses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/models/soul_agent_promotion_lifecycle_event.go
+++ b/internal/store/models/soul_agent_promotion_lifecycle_event.go
@@ -60,6 +60,10 @@ type SoulAgentPromotionLifecycleEvent struct {
 	MintOperationStatus string `theorydb:"attr:mintOperationStatus" json:"mint_operation_status,omitempty"`
 	PrincipalAddress    string `theorydb:"attr:principalAddress" json:"principal_address,omitempty"`
 
+	AnchorState          string    `theorydb:"attr:anchorState" json:"anchor_state,omitempty"`
+	AnchorEvidenceTxHash string    `theorydb:"attr:anchorEvidenceTxHash" json:"anchor_evidence_tx_hash,omitempty"`
+	AnchorEvidenceAt     time.Time `theorydb:"attr:anchorEvidenceAt" json:"anchor_evidence_at,omitempty"`
+
 	LatestConversationID     string `theorydb:"attr:latestConversationId" json:"latest_conversation_id,omitempty"`
 	LatestConversationStatus string `theorydb:"attr:latestConversationStatus" json:"latest_conversation_status,omitempty"`
 	LatestReviewSHA256       string `theorydb:"attr:latestReviewSha256" json:"latest_review_sha256,omitempty"`
@@ -138,6 +142,8 @@ func (e *SoulAgentPromotionLifecycleEvent) UpdateKeys() error {
 	e.MintOperationID = strings.TrimSpace(e.MintOperationID)
 	e.MintOperationStatus = strings.ToLower(strings.TrimSpace(e.MintOperationStatus))
 	e.PrincipalAddress = strings.TrimSpace(e.PrincipalAddress)
+	e.AnchorState = strings.ToLower(strings.TrimSpace(e.AnchorState))
+	e.AnchorEvidenceTxHash = strings.ToLower(strings.TrimSpace(e.AnchorEvidenceTxHash))
 	e.LatestConversationID = strings.TrimSpace(e.LatestConversationID)
 	e.LatestConversationStatus = strings.ToLower(strings.TrimSpace(e.LatestConversationStatus))
 	e.LatestReviewSHA256 = strings.ToLower(strings.TrimSpace(e.LatestReviewSHA256))

--- a/internal/store/models/soul_agent_promotion_lifecycle_event_test.go
+++ b/internal/store/models/soul_agent_promotion_lifecycle_event_test.go
@@ -9,10 +9,12 @@ func TestSoulAgentPromotionLifecycleEventBeforeCreateSetsKeys(t *testing.T) {
 	t.Parallel()
 
 	event := &SoulAgentPromotionLifecycleEvent{
-		AgentID:     " 0xABC ",
-		EventType:   SoulAgentPromotionEventTypeFinalizeReady,
-		RequestedBy: " alice ",
-		OccurredAt:  time.Date(2026, 3, 28, 19, 0, 0, 0, time.UTC),
+		AgentID:              " 0xABC ",
+		EventType:            SoulAgentPromotionEventTypeFinalizeReady,
+		RequestedBy:          " alice ",
+		AnchorState:          " IMMUTABLE_ONCHAIN ",
+		AnchorEvidenceTxHash: " 0xBEEF ",
+		OccurredAt:           time.Date(2026, 3, 28, 19, 0, 0, 0, time.UTC),
 	}
 	if err := event.BeforeCreate(); err != nil {
 		t.Fatalf("BeforeCreate: %v", err)
@@ -25,6 +27,9 @@ func TestSoulAgentPromotionLifecycleEventBeforeCreateSetsKeys(t *testing.T) {
 	}
 	if event.EventID == "" || event.SK == "" || event.GSI1SK == "" {
 		t.Fatalf("expected generated event keys, got %#v", event)
+	}
+	if event.AnchorState != SoulAnchorStateImmutableOnchain || event.AnchorEvidenceTxHash != "0xbeef" {
+		t.Fatalf("expected normalized anchor evidence fields, got %#v", event)
 	}
 }
 

--- a/web/src/lib/api/soul.ts
+++ b/web/src/lib/api/soul.ts
@@ -190,6 +190,9 @@ export interface SoulSearchResponse {
 	next_cursor?: string;
 }
 
+export type SoulAnchorEvidence = components['schemas']['SoulAnchorEvidence'];
+export type SoulAnchorAssurance = components['schemas']['SoulAnchorAssurance'];
+
 export function soulPublicSearch(input: {
 	q?: string;
 	domain?: string;
@@ -235,6 +238,7 @@ export interface SoulAgentIdentity {
 			selected?: boolean;
 		}>;
 	};
+	anchor_assurance?: SoulAnchorAssurance;
 	capabilities?: string[];
 	status: string;
 	lifecycle_status?: string;
@@ -398,6 +402,7 @@ export interface SoulAgentPromotionLifecycleEvent {
 	request_id?: string;
 	operation_id?: string;
 	conversation_id?: string;
+	anchor_assurance?: SoulAnchorAssurance;
 	promotion: SoulAgentPromotion;
 }
 

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -948,6 +948,27 @@ export interface components {
         SoulAgentChannelPreferencesResponse: components["schemas"]["soul-agent-channel-preferences.response.schema"];
         SoulAgentChannelPreferencesRequest: components["schemas"]["soul-agent-channel-preferences.request.schema"];
         SoulAgentIdentity: components["schemas"]["soul-agent-identity.schema"];
+        SoulAnchorEvidence: {
+            /** @enum {string} */
+            kind: "host_registry_record" | "mint_transaction";
+            tx_hash?: string;
+            operation_id?: string;
+            token_id?: string;
+            chain_id?: number;
+            /** Format: date-time */
+            recorded_at?: string;
+        };
+        SoulAnchorAssurance: {
+            /** @enum {string} */
+            state: "hosted_offchain" | "immutable_onchain";
+            /** @enum {string} */
+            source: "host_record" | "onchain_receipt";
+            /** @enum {boolean} */
+            capability_gate: false;
+            mutable: boolean;
+            revocable: boolean;
+            evidence?: components["schemas"]["SoulAnchorEvidence"][];
+        };
         SoulResolveResponse: {
             /** @enum {string} */
             version: "1";
@@ -1132,6 +1153,7 @@ export interface components {
             request_id?: string;
             operation_id?: string;
             conversation_id?: string;
+            anchor_assurance?: components["schemas"]["SoulAnchorAssurance"];
             promotion: components["schemas"]["SoulAgentPromotion"];
         };
         SoulAgentPromotionLifecycleEventListResponse: {
@@ -1441,6 +1463,16 @@ export interface components {
             renderer_address?: string;
             image?: string;
         };
+        anchor_evidence: {
+            /** @enum {string} */
+            kind: "host_registry_record" | "mint_transaction";
+            tx_hash?: string;
+            operation_id?: string;
+            token_id?: string;
+            chain_id?: number;
+            /** Format: date-time */
+            recorded_at?: string;
+        };
         avatar: {
             token_uri?: string;
             image?: string;
@@ -1448,6 +1480,17 @@ export interface components {
             current_style_name?: string;
             current_renderer_address?: string;
             styles?: components["schemas"]["avatar_style"][];
+        };
+        anchor_assurance: {
+            /** @enum {string} */
+            state: "hosted_offchain" | "immutable_onchain";
+            /** @enum {string} */
+            source: "host_record" | "onchain_receipt";
+            /** @constant */
+            capability_gate: false;
+            mutable: boolean;
+            revocable: boolean;
+            evidence?: components["schemas"]["anchor_evidence"][];
         };
         /** Soul agent identity */
         "soul-agent-identity.schema": {
@@ -1460,6 +1503,7 @@ export interface components {
             /** Format: uri */
             meta_uri?: string;
             avatar?: components["schemas"]["avatar"];
+            anchor_assurance?: components["schemas"]["anchor_assurance"];
             capabilities?: string[];
             principal_address?: string;
             principal_signature?: string;
@@ -1490,6 +1534,27 @@ export interface components {
                     current_style_name?: string;
                     current_renderer_address?: string;
                     styles?: components["schemas"]["avatar_style"][];
+                };
+                anchor_evidence: {
+                    /** @enum {string} */
+                    kind: "host_registry_record" | "mint_transaction";
+                    tx_hash?: string;
+                    operation_id?: string;
+                    token_id?: string;
+                    chain_id?: number;
+                    /** Format: date-time */
+                    recorded_at?: string;
+                };
+                anchor_assurance: {
+                    /** @enum {string} */
+                    state: "hosted_offchain" | "immutable_onchain";
+                    /** @enum {string} */
+                    source: "host_record" | "onchain_receipt";
+                    /** @constant */
+                    capability_gate: false;
+                    mutable: boolean;
+                    revocable: boolean;
+                    evidence?: components["schemas"]["anchor_evidence"][];
                 };
             };
         };


### PR DESCRIPTION
## Summary

Closes #315.
Closes #316.

Implements the Project 32 M3 Host batch:

- adds public `anchor_assurance` metadata to soul agent views and generated REST/types contracts
- records immutable/on-chain anchor evidence on promotion lifecycle `mint_executed` events
- keeps `agentId` stable and preserves hosted-bound-soul capability/access policy while changing only anchor assurance to `immutable_onchain` after verified mint execution
- documents hosted/off-chain vs immutable/on-chain assurance semantics and rollback/failure behavior without namespace churn

## Stewardship notes

### Soul-registry audit

- Solidity/contracts: not touched; no Slither/Hardhat-triggering contract change.
- Real on-chain operations: none performed.
- On-chain-reaching Go: no new chain call path; evidence is recorded only after the existing verified mint execution path has already accepted a receipt.
- Off-chain state: additive optional lifecycle-event fields (`anchorState`, `anchorEvidenceTxHash`, `anchorEvidenceAt`) and additive public metadata view.
- Safe-ready payloads / mint-signer handling: unchanged.
- Agent namespace: `agentId` remains the identity key throughout hosted→onchain promotion.

### Trust/safety posture

- Trust API (`/.well-known/*`, `/attestations/*`): not touched.
- Instance API key auth and `sha256(raw_key)` matching: unchanged.
- CSP/web security headers: unchanged.
- Anchor assurance is explicit metadata (`capability_gate: false`), not a capability authorization gate.

## Tests / verification

- `go test ./internal/controlplane ./internal/store/models`
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go')`
- `cd web && npm run generate:lesser-host-api`
- `cd web && npm run verify:lesser-host-contracts`
- `cd web && npm run typecheck`
- `cd web && npm run lint`
- `cd web && npm test`
- `cd cdk && npm ci && npm run synth`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29 pass / 0 fail / 0 blocked)

No deploy, provisioning, migration, or real on-chain operation was run.
