### PR TITLE
[codex] update AppTheory and Greater pins

### DIFF
--- a/app-theory/app.json
+++ b/app-theory/app.json
@@ -3,7 +3,7 @@
   "frameworks": {
     "apptheory": {
       "module": "github.com/theory-cloud/apptheory",
-      "version": "v1.6.0",
+      "version": "v1.7.0",
       "docs": [
         "docs/getting-started.md",
         "docs/migration/from-lift.md"

--- a/app-theory/init.md
+++ b/app-theory/init.md
@@ -21,19 +21,19 @@ This section defines the **pinned destination frameworks**. These values are **c
 (do not guess; do not write UNKNOWN).
 
 ### AppTheory (pinned)
-- Go module: `github.com/theory-cloud/apptheory@v1.6.0`
+- Go module: `github.com/theory-cloud/apptheory@v1.7.0`
 - Go runtime import: `github.com/theory-cloud/apptheory/runtime`
-- Docs entrypoints (for tag `v1.6.0`):
+- Docs entrypoints (for tag `v1.7.0`):
   - `docs/getting-started.md`
   - `docs/migration/from-lift.md`
 - Copy/paste dependency command:
-  - `go get github.com/theory-cloud/apptheory@v1.6.0`
+  - `go get github.com/theory-cloud/apptheory@v1.7.0`
 - Recommended pinned docs links:
-  - `https://github.com/theory-cloud/AppTheory/blob/v1.6.0/docs/getting-started.md`
-  - `https://github.com/theory-cloud/AppTheory/blob/v1.6.0/docs/migration/from-lift.md`
+  - `https://github.com/theory-cloud/AppTheory/blob/v1.7.0/docs/getting-started.md`
+  - `https://github.com/theory-cloud/AppTheory/blob/v1.7.0/docs/migration/from-lift.md`
 - Recommended pinned CDK docs links:
-  - `https://github.com/theory-cloud/AppTheory/blob/v1.6.0/cdk/docs/getting-started.md`
-  - `https://github.com/theory-cloud/AppTheory/blob/v1.6.0/cdk/docs/api-reference.md`
+  - `https://github.com/theory-cloud/AppTheory/blob/v1.7.0/cdk/docs/getting-started.md`
+  - `https://github.com/theory-cloud/AppTheory/blob/v1.7.0/cdk/docs/api-reference.md`
 
 ### TableTheory (pinned)
 - Go module: `github.com/theory-cloud/tabletheory@v1.8.3`

--- a/cdk/lib/provision-runner-buildspec.ts
+++ b/cdk/lib/provision-runner-buildspec.ts
@@ -27,12 +27,18 @@ function assembleBuildScript(): string {
 
 	// Strip shebangs — CodeBuild already runs under bash.
 	const stripShebang = (s: string) => s.replace(/^#!\/usr\/bin\/env bash\n/, '');
+	const stripAnyShebang = (s: string) => s.replace(/^#!.*\n/, '');
 
 	// Replace ### INLINE: <file> ### markers with the actual script content.
+	//
+	// Use replacement callbacks so shell literals containing `$'`, `$&`, or
+	// similar sequences are inserted verbatim. Passing raw script text as the
+	// replacement string lets JavaScript's String.replace expand replacement
+	// tokens, which can corrupt the rendered CodeBuild shell script.
 	let assembled = dispatcher;
-	assembled = assembled.replace(/^.*### INLINE: build-lesser-body\.sh ###.*$/m, body.replace(/^#!.*\n/, ''));
-	assembled = assembled.replace(/^.*### INLINE: build-lesser\.sh ###.*$/m, lesser.replace(/^#!.*\n/, ''));
-	assembled = assembled.replace(/^.*### INLINE: build-lesser-mcp\.sh ###.*$/m, mcp.replace(/^#!.*\n/, ''));
+	assembled = assembled.replace(/^.*### INLINE: build-lesser-body\.sh ###.*$/m, () => stripAnyShebang(body));
+	assembled = assembled.replace(/^.*### INLINE: build-lesser\.sh ###.*$/m, () => stripAnyShebang(lesser));
+	assembled = assembled.replace(/^.*### INLINE: build-lesser-mcp\.sh ###.*$/m, () => stripAnyShebang(mcp));
 
 	return [stripShebang(helpers), stripShebang(assembled)].join('\n');
 }

--- a/cdk/test/provision-runner-buildspec.test.ts
+++ b/cdk/test/provision-runner-buildspec.test.ts
@@ -1,9 +1,20 @@
 import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
 import test from 'node:test';
 
 import { renderProvisionRunnerBuildCommands } from '../lib/provision-runner-buildspec';
 
 const buildCommands = renderProvisionRunnerBuildCommands();
+
+test('rendered provision runner build script is valid bash', () => {
+	const result = spawnSync('bash', ['-n'], {
+		encoding: 'utf8',
+		input: buildCommands,
+	});
+
+	assert.ifError(result.error);
+	assert.equal(result.status, 0, result.stderr || result.stdout);
+});
 
 test('RUN_MODE=lesser uses the CLI binary with --release-dir', () => {
 	assert.match(buildCommands, /prepare_lesser_release_dir "\$LESSER_RELEASE_DIR"/);

--- a/docs/framework-feedback-signals-2026-05-16.md
+++ b/docs/framework-feedback-signals-2026-05-16.md
@@ -2,7 +2,10 @@
 
 This record closes Phase 6 of the lesser-host Theory Cloud adoption roadmap. It
 captures framework-level feedback surfaced while adopting AppTheory `v1.6.0`,
-TableTheory `v1.8.3`, and Greater Components `greater-v0.8.11`.
+TableTheory `v1.8.3`, and Greater Components `greater-v0.8.11`. The 2026-05-18
+AppTheory `v1.7.0` / Greater `greater-v0.8.14` refresh consumed the upstream
+LightningCSS selector cleanup while preserving the remaining strict-CSP markdown
+feedback.
 
 These are feedback signals only. They do **not** authorize local framework
 patches, CSP loosening, trust-API auth changes, provisioning changes, or managed
@@ -14,7 +17,7 @@ release-verification changes.
 | --- | --- | --- |
 | AppTheory SES event-source dispatch | AppTheory framework steward via Aron / Arch review | Prepared below; this host endpoint has no contactable AppTheory mailbox, so it is routed through Aron with this PR and the Arch review handoff. |
 | Greater/FaceTheory fail-closed markdown rendering | Greater Components steward; FaceTheory pattern owner via Greater/Aron | Prepared below and sent to `greater.equaltoai@theorymcp.ai`; delivery ID recorded after send. |
-| Greater/FaceTheory LightningCSS-safe global selectors | Greater Components steward; FaceTheory pattern owner via Greater/Aron | Prepared below and sent to `greater.equaltoai@theorymcp.ai`; delivery ID recorded after send. |
+| Greater/FaceTheory LightningCSS-safe global selectors | Greater Components steward; FaceTheory pattern owner via Greater/Aron | Prepared below and sent to `greater.equaltoai@theorymcp.ai`; delivery ID recorded after send. Consumed in host on 2026-05-18 via Greater `greater-v0.8.14` primitive CSS refresh. |
 
 Related TableTheory release-state feedback is already recorded in
 `docs/tabletheory-release-state-assessment.md`; it should be routed as a
@@ -209,6 +212,10 @@ patterns.
 Greater Components `greater-v0.8.11` / commit
 `0abcb00d4466b425473476dd1b38ba628118091c`.
 
+2026-05-18 follow-up: host consumed Greater Components `greater-v0.8.14` /
+commit `74ce64890bab7c85b83847a1ff72dc882b66ebc5` for primitive CSS, which
+removes the plain-CSS `:global(...)` selectors from the vendored stylesheet.
+
 ### The concern (under host's constraints)
 
 Host builds a static Svelte 5 SPA with Vite and strict CSP. Some vendored
@@ -263,10 +270,9 @@ third-party stylesheet origins are added.
 
 ### Proposed next step
 
-Greater / FaceTheory stewards should scope a CSS packaging cleanup that removes
-Svelte-only `:global(...)` selector syntax from plain distributed CSS while
-preserving component semantics and strict-CSP compatibility. Host should adopt it
-through a pinned Greater refresh, not by patching Greater locally.
+Completed for host on 2026-05-18 through a pinned Greater `greater-v0.8.14`
+primitive CSS refresh, not a local framework patch. Future Greater refreshes must
+continue preserving component semantics and strict-CSP compatibility.
 
 ## Outbound coordination record
 

--- a/docs/roadmap-theory-cloud-framework-adoption-2026-05-16.md
+++ b/docs/roadmap-theory-cloud-framework-adoption-2026-05-16.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Deliberately adopt AppTheory `v1.6.0`, TableTheory `v1.8.3`, and Greater Components `greater-v0.8.11` in `lesser-host`, close the current Dependabot security alerts, and then consume only the framework capabilities that improve host's reliability, trust/auth audit posture, worker behavior, and maintenance discipline without weakening multi-tenant isolation, on-chain integrity, consumer release verification, trust API instance-auth, or strict CSP.
+Deliberately adopt AppTheory `v1.7.0`, TableTheory `v1.8.3`, and Greater Components `greater-v0.8.14` in `lesser-host`, close the current Dependabot security alerts, and then consume only the framework capabilities that improve host's reliability, trust/auth audit posture, worker behavior, and maintenance discipline without weakening multi-tenant isolation, on-chain integrity, consumer release verification, trust API instance-auth, or strict CSP.
 
 ## Classification
 
@@ -33,7 +33,7 @@ Dependency maintenance, security, operational reliability, trust-API/auth audit 
 
 - **AppTheory**: required for feedback on native SES event-source support; host will locally adopt source provenance, event workload helpers, and typed binding pilots where idiomatic.
 - **TableTheory**: required only if Lambda timeout propagation exposes an interface/ergonomic gap. Initial work is local host consumption.
-- **FaceTheory / Greater**: required for markdown sanitizer/CSP feedback and LightningCSS `:global(...)` warnings.
+- **FaceTheory / Greater**: required for markdown sanitizer/CSP feedback; the LightningCSS `:global(...)` warning feedback was consumed through the Greater `greater-v0.8.14` primitive CSS refresh.
 
 ## External-vendor coordination
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ trust/safety planning.
 - Moderation provider notes: `docs/moderation-provider.md`
 - Tip registry notes: `docs/tip-registry.md`
 - Pinned frameworks (from `app-theory/app.json`):
-  - AppTheory: `github.com/theory-cloud/apptheory@v1.6.0`
+  - AppTheory: `github.com/theory-cloud/apptheory@v1.7.0`
   - TableTheory: `github.com/theory-cloud/tabletheory@v1.8.3`
 
 ## Scope (v1)

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v79 v79.12.0
-	github.com/theory-cloud/apptheory v1.6.0
+	github.com/theory-cloud/apptheory v1.7.0
 	github.com/theory-cloud/tabletheory v1.8.3
 	golang.org/x/net v0.52.0
 )

--- a/go.sum
+++ b/go.sum
@@ -275,8 +275,8 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theory-cloud/apptheory v1.6.0 h1:SgVMnqiO+XJBG0m8U44LFG/la5qTwHu6/3XgtPqbDzo=
-github.com/theory-cloud/apptheory v1.6.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
+github.com/theory-cloud/apptheory v1.7.0 h1:CC0fmSi8GlCwu1jKMlamyr3R97+AZ/WquU7XgtkfQ14=
+github.com/theory-cloud/apptheory v1.7.0/go.mod h1:IWDWb5NChOgaChceWniCEQF0PQ+ddMSca7hpv18ljFY=
 github.com/theory-cloud/tabletheory v1.8.3 h1:LJeON7t8YTjKr8BXWV3GEe7qk69F6ElE4R2XBS1y9IY=
 github.com/theory-cloud/tabletheory v1.8.3/go.mod h1:YV1toSvmQE6J1YhIvQcEkbz5PKygDfrLrCgG+wRTZ3U=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/web/README.md
+++ b/web/README.md
@@ -5,8 +5,9 @@ This is the frontend for `lesser.host` (repo: `lesser-host`).
 ## Stack
 
 - Vite + Svelte 5 + TypeScript
-- `greater-components` (vendored via `greater` CLI, pinned to `greater-v0.8.11` / commit `0abcb00d4466b425473476dd1b38ba628118091c`)
-  - Host keeps a local safety hardening on `MarkdownRenderer`: sanitization is mandatory before `{@html}` output.
+- `greater-components` (vendored via `greater` CLI, config target `greater-v0.8.14` / commit `74ce64890bab7c85b83847a1ff72dc882b66ebc5`; primitives refreshed to that tag)
+  - Host keeps local safety hardening on `MarkdownRenderer`: sanitization is mandatory before `{@html}` output.
+  - Host marks `content` and `adapters` as locally modified in `components.json`; do not overwrite them during Greater refreshes without preserving strict-CSP markdown sanitization and current host soul/x402 adapter contracts.
 
 ## Local dev
 

--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://greater.components.dev/schema.json",
   "version": "1.0.0",
-  "ref": "0abcb00d4466b425473476dd1b38ba628118091c",
+  "ref": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
   "installMode": "vendored",
   "style": "default",
   "rsc": false,
@@ -24,36 +24,36 @@
   "installed": [
     {
       "name": "button",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:15.233Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "icons",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:15.348Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "utils",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:15.356Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "tokens",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:15.361Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     },
     {
       "name": "primitives",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:15.417Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     },
@@ -68,13 +68,13 @@
       "name": "adapters",
       "version": "0abcb00d4466b425473476dd1b38ba628118091c",
       "installedAt": "2026-05-16T12:08:20.819Z",
-      "modified": false,
+      "modified": true,
       "checksums": []
     },
     {
       "name": "headless",
-      "version": "0abcb00d4466b425473476dd1b38ba628118091c",
-      "installedAt": "2026-05-16T12:08:20.837Z",
+      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+      "installedAt": "2026-05-18T15:45:00.000Z",
       "modified": false,
       "checksums": []
     }

--- a/web/src/lib/greater/primitives/theme.css
+++ b/web/src/lib/greater/primitives/theme.css
@@ -753,7 +753,7 @@ body.gr-scroll-locked {
 	height: 0.75rem;
 }
 
-.gr-badge--sm .gr-badge__icon :global(svg) {
+.gr-badge--sm .gr-badge__icon svg {
 	width: 0.75rem;
 	height: 0.75rem;
 }
@@ -763,7 +763,7 @@ body.gr-scroll-locked {
 	height: 0.875rem;
 }
 
-.gr-badge--md .gr-badge__icon :global(svg) {
+.gr-badge--md .gr-badge__icon svg {
 	width: 0.875rem;
 	height: 0.875rem;
 }
@@ -773,7 +773,7 @@ body.gr-scroll-locked {
 	height: 1rem;
 }
 
-.gr-badge--lg .gr-badge__icon :global(svg) {
+.gr-badge--lg .gr-badge__icon svg {
 	width: 1rem;
 	height: 1rem;
 }
@@ -2192,7 +2192,7 @@ body.gr-scroll-locked {
 	gap: 1.5rem;
 }
 
-.gr-list > :global(li) {
+.gr-list > li {
 	display: flex;
 	align-items: flex-start;
 	gap: 0.75rem;
@@ -3429,8 +3429,8 @@ body.gr-scroll-locked {
 }
 
 /* High contrast explicit overrides */
-[data-theme='high-contrast'] .gr-action-bar :global(.gr-action-bar__button:hover:not(:disabled)),
-[data-theme='high-contrast'] .gr-action-bar :global(.gr-action-bar__button--active) {
+[data-theme='high-contrast'] .gr-action-bar .gr-action-bar__button:hover:not(:disabled),
+[data-theme='high-contrast'] .gr-action-bar .gr-action-bar__button--active {
 	color: var(--gr-color-base-black);
 }
 


### PR DESCRIPTION
## Milestone
Dependency maintenance — update host's AppTheory and FaceTheory-adjacent Greater pins, preserving host governance/CSP/provisioning constraints.

## Classification
Dependency-maintenance, framework-consumption, CSP, managed-update/provisioning bug-fix, operational-reliability, docs.

## Surfaces affected
- `go.mod`, `go.sum`, `app-theory/app.json`, `app-theory/init.md`: AppTheory `v1.7.0`.
- `web/components.json`, `web/src/lib/greater/primitives/theme.css`, `web/README.md`: Greater target `greater-v0.8.14` / commit `74ce64890bab7c85b83847a1ff72dc882b66ebc5`, with host-local `content` and `adapters` explicitly marked modified.
- `docs/framework-feedback-signals-2026-05-16.md`, `docs/roadmap-theory-cloud-framework-adoption-2026-05-16.md`, `docs/roadmap.md`: refreshed framework pin/adoption notes.
- `cdk/lib/provision-runner-buildspec.ts`, `cdk/test/provision-runner-buildspec.test.ts`: prior managed-update runner fix retained on this branch.

## Specialist walks referenced
- Provisioning / managed-update / release verification: runner buildspec fix preserves shell literals and adds a rendered `bash -n` regression; no consumer release-verification bypass.
- Trust API / CSP / instance-auth: strict CSP posture preserved; no trust API auth change; Greater CSS refresh removes the plain-CSS `:global(...)` warning source without inline styles or third-party origins.
- Framework: AppTheory pin updated idiomatically; host has no direct FaceTheory package pin, so the appropriate host-side action is the Greater `greater-v0.8.14` refresh. Remaining fail-closed markdown feedback stays recorded; no local framework patching.
- Governance rubric: no verifier weakening or rubric policy change.

## Multi-tenant isolation impact
None. No tenant data paths, credentials, or cross-tenant access changed.

## On-chain impact
None. No Solidity, signer, governance payload, or on-chain-reaching behavior changed.

## Consumer impact
- Managed-update reliability improves through the provision-runner shell-literal fix.
- Host web build consumes the Greater primitive CSS cleanup while retaining strict-CSP markdown hardening and host soul/x402 adapter contracts.

## Tasks
- [x] Preserve provision-runner shell literals in rendered CodeBuild scripts.
- [x] Bump AppTheory to `v1.7.0`.
- [x] Refresh the Greater/FaceTheory-adjacent web pin to `greater-v0.8.14` where safe.
- [x] Record the framework-feedback follow-up for the consumed LightningCSS selector cleanup.

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go')` (empty)
- `git diff --check`
- `cd web && npm ci && npm run lint && npm run typecheck && npm test && npm run build`
- `cd cdk && npm ci && npm test`
- `cd cdk && npm ci && npm run synth -- -c stage=lab`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` (PASS 29 / 0 / 0)

Notes: existing Vite large-chunk and CDK deprecation warnings remain; the prior LightningCSS `:global(...)` selector warnings are gone from the web build.

## Stage rollout plan (handoff after merge)
- [ ] Merged to `main` after review and CI/gov-infra checks.
- [ ] Deploy to `lab` via the canonical AppTheory/CDK path.
- [ ] Lab soak, including a managed Lesser update rerun/canary to confirm the provision-runner script fix.
- [ ] Deploy to `live` only with explicit operator authorization.
- [ ] Post-deploy monitoring: control-plane/trust API errors, provision-worker SQS depth, CodeBuild runner failures, and web CSP/build health.

## Cross-repo coordination
No sibling repo edits. Greater/FaceTheory CSS feedback is consumed via the published Greater release; fail-closed markdown feedback remains routed through the existing framework-feedback record.

## Advisor-brief authorization
Not applicable.