### PR TITLE
docs(soul): define Project 37 M0 email contract

### DIFF
--- a/docs/instance-scoped-soul-email-m0.md
+++ b/docs/instance-scoped-soul-email-m0.md
@@ -1,0 +1,306 @@
+# Instance-scoped Lesser Soul email — M0 decisions
+
+Project 37: <https://github.com/orgs/equaltoai/projects/37>
+
+Parent blocker: <https://github.com/equaltoai/lesser-host/issues/324>
+
+Arch review carried forward: <https://github.com/equaltoai/lesser-host/issues/329#issuecomment-4509202671>
+
+## Status
+
+This document is the M0 contract for implementing instance-scoped managed Lesser Soul email. It is intentionally limited to decisions, invariants, and dry-run inventory shape. It does **not** implement M1 provisioning, M2 migration apply, provider mutation, live migration, custom handles, alias UI, vanity email domains, multiple public email channels, public alias discovery, cross-instance search, or mailbox redesign.
+
+## Canonical address contract
+
+The canonical managed email address for a Lesser Soul agent is:
+
+```text
+<agent-local-id>.<instance-slug>@lessersoul.ai
+```
+
+The provider local-part is:
+
+```text
+<agent-local-id>.<instance-slug>
+```
+
+Examples:
+
+```text
+pilot.simulacrum@lessersoul.ai
+scout.simulacrum@lessersoul.ai
+```
+
+Contract requirements for M1/M2:
+
+- `agent-local-id` uses the existing soul local ID normalization (`soul.NormalizeLocalAgentID`).
+- `instance-slug` uses the managed instance slug validation already used by host (`^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$`).
+- `instanceSlug` is resolved from the managed `Domain` record's `Domain.InstanceSlug`; code must not parse hostnames to infer instance identity.
+- Exact primary domains, stage-aware managed primary aliases, and exact vanity domains must load a `Domain` record and use `Domain.InstanceSlug`.
+- Stage-aware vanity aliases are not part of this release blocker. If no exact `Domain` record exists for a vanity domain, resolver paths fail closed unless a later explicit design adds that access pattern.
+- The provider/SMTP local-part limit is 64 octets. Because the normalized local ID and slug are ASCII, host enforces `len(<agent-local-id>.<instance-slug>) <= 64` before provider calls.
+- Local-part overflow fails closed with a clear conflict. There is no hash fallback in Project 37.
+- Agent local IDs may contain dots. Code must never split the email local-part to recover `agentLocalID` or `instanceSlug`; resolver/index state is authoritative.
+- New agents only receive the instance-scoped address. New provisioning must not issue bare `<agent>@lessersoul.ai` addresses.
+- After migration, public/current channel surfaces advertise only the instance-scoped address.
+- Legacy bare addresses are inbound-only aliases for existing agents. They are not public/current channels and are not issued to new agents.
+
+## Domain resolution policy
+
+M1 resolver code must mirror the existing managed-domain access posture:
+
+1. Normalize the agent domain.
+2. Attempt exact `Domain` lookup.
+3. If exact lookup misses and the control-plane stage is non-live, permit the managed primary stage alias path (`dev.<base-domain>` / `staging.<base-domain>`) only when:
+   - the base-domain `Domain` record exists;
+   - `Domain.Type == primary`;
+   - `Domain.VerificationMethod == managed`;
+   - `Domain.Status` is `verified` or `active`;
+   - the owning `Instance.HostedBaseDomain` equals the base domain; and
+   - `Domain.InstanceSlug` is present and valid.
+4. For exact vanity domains, use that vanity `Domain.InstanceSlug` directly.
+5. For stage-aware vanity aliases, fail closed unless that support is intentionally added in a later scope.
+
+This preserves Aron's correction in Arch review: vanity domains still require an instance slug at creation, and `Domain.InstanceSlug` remains the source of truth.
+
+## Dry-run inventory command
+
+M0 adds a dry-run inventory command:
+
+```bash
+go run ./scripts/soul-email-m0-inventory \
+  --stage lab \
+  --table-name lesser-host-lab-state \
+  --provider-state path/to/redacted-migadu-provider-state.json \
+  --registration-state path/to/redacted-registration-signing-state.json \
+  --out gov-infra/evidence/project37/m0-email-inventory-lab.json
+```
+
+The command is read-only. It scans soul identities and loads only the host records needed to decide whether migration can proceed:
+
+- `SoulAgentIdentity` (`agentId`, `domain`, `localId`, lifecycle, self-description version);
+- `Domain` (`Domain.InstanceSlug`, type, status, verification method);
+- `Instance` for managed stage-primary alias validation;
+- `SoulAgentChannel` for the current email channel;
+- `SoulEmailAgentIndex` for the current full-address mapping; and
+- `SoulAgentVersion` for registration URI/hash and self-attestation presence.
+
+It computes the proposed `<agent-local-id>.<instance-slug>@lessersoul.ai` address, detects duplicate proposed addresses, and detects local-part overflow before any provider or database mutation. If duplicates, overflow, missing/invalid instance slug state, missing/mismatched current email indexes, or other report-level issues are present, the command exits non-zero (`2`).
+
+The optional provider-state file is a redacted operator snapshot, not a secret export. Shape:
+
+```json
+{
+  "generated_at": "2026-05-21T00:00:00Z",
+  "source": "operator-redacted-migadu-export",
+  "addresses": [
+    {
+      "local_part": "pilot",
+      "mailbox_exists": true,
+      "forwardings": ["pilot@inbound.lessersoul.ai"],
+      "aliases": ["pilot"]
+    },
+    {
+      "local_part": "pilot.simulacrum",
+      "mailbox_exists": false,
+      "forwardings": [],
+      "aliases": []
+    }
+  ]
+}
+```
+
+Never include Migadu credentials, mailbox passwords, raw SSM values, message content, or provider payloads containing secrets in this file. The inventory report stores only mailbox existence, forwarding destinations, alias local-parts, and operator notes.
+
+The optional registration-state file records the current registration email channel and signing posture without embedding full registration JSON or private key material. Shape:
+
+```json
+{
+  "generated_at": "2026-05-21T00:00:00Z",
+  "source": "redacted-registration-export",
+  "agents": [
+    {
+      "agent_id": "0xabc...",
+      "email_channel": "pilot@lessersoul.ai",
+      "can_self_attest": "yes"
+    }
+  ]
+}
+```
+
+`can_self_attest` is `yes`, `no`, or `unknown`. M2 apply remains blocked for `unknown` until the agent signing path or a separately approved host migration/audit path is known.
+
+
+### Known seed addresses
+
+The current local references that motivated M0 inventory are seeds only; the inventory command must verify live host/provider state rather than trust this list as authoritative:
+
+- `agent-0@lessersoul.ai`
+- `pilot@lessersoul.ai`
+- `scout@lessersoul.ai`
+- `counsel@lessersoul.ai`
+- `medic@lessersoul.ai`
+- `ops@lessersoul.ai`
+- `advocate@lessersoul.ai`
+
+### Inventory output fields
+
+For each active managed soul email agent, the report records:
+
+- `agent_id`, `domain`, `local_id`, status, lifecycle, and self-description version;
+- domain resolution result and `Domain.InstanceSlug`;
+- current email channel identifier/provider/status and whether an SSM secret reference is present;
+- current email index owner and whether it matches the channel and agent;
+- registration version URI/hash/change summary, whether a self-attestation is present, and the current registration email channel when a redacted registration-state snapshot is supplied;
+- proposed provider local-part, proposed public address, local-part length, duplicate flag, and overflow flag;
+- redacted provider state for current and proposed local-parts when supplied; and
+- migration-readiness flags.
+
+M0 inventory signoff requires:
+
+- zero duplicate proposed addresses;
+- zero local-part overflows;
+- every live managed email agent has a verified/active `Domain` record with a valid `Domain.InstanceSlug`;
+- every current managed email channel has a matching `SoulEmailAgentIndex`;
+- provider state is known for every current bare address before M2 apply; and
+- each agent's self-attestation/signing path is known before its public channel changes.
+
+Fail-closed overflow is acceptable for new provisioning only if this inventory proves no existing live agent would overflow. If any existing live agent overflows, M1/M2 remain blocked until Aron explicitly chooses defer-vs-deterministic-fallback in a new scoped decision.
+
+## Self-description integrity decision
+
+Changing a public email channel from `agent@lessersoul.ai` to `agent.<instance>@lessersoul.ai` changes the agent's declared contact identity. It must not be a silent unsigned rewrite.
+
+Decision:
+
+- The preferred migration path is a new registration/self-description version signed by the agent using the existing self-attestation flow.
+- M2 inventory must classify every existing agent as `can_self_attest=yes`, `can_self_attest=no`, or `can_self_attest=unknown` before apply.
+- If an agent cannot sign, host does not silently rewrite that agent's public registration. The agent's public channel update is deferred until it can sign, unless Aron approves a separate host migration/audit path with explicit disclosure before implementation.
+- A host migration/audit path, if later approved, must record why self-attestation was unavailable, what authority allowed the host-side change, old and new address, affected registration version(s), and rollback/notification evidence.
+- The M2 live release gate blocks on any `unknown` signing state.
+
+This preserves soul declaration integrity while still allowing Project 37 to proceed for agents that can re-attest.
+
+## Legacy bare-address alias decision
+
+Arch found that provider-only aliases are insufficient: inbound normalization produces `local@lessersoul.ai`, recipient resolution looks up `SoulEmailAgentIndex` by full normalized address, and channel matching requires the notification recipient to equal `SoulAgentChannel.Identifier`.
+
+Decision: **M2 must add a host-internal legacy alias/canonicalization model, not rely on Migadu/provider aliases alone.**
+
+Required contract:
+
+- `SoulAgentChannel.Identifier` remains the current advertised address: `agent.<instance>@lessersoul.ai`.
+- `SoulEmailAgentIndex` remains the current-address lookup for canonical public channels.
+- Legacy bare aliases are represented by a separate host-internal alias/index record, scoped to existing migrated agents only.
+- Canonicalization occurs in comm-worker recipient resolution after exact current `SoulEmailAgentIndex` lookup misses and before channel matching/mailbox capture.
+- A known legacy alias maps `agent@lessersoul.ai` to the canonical `agent.<instance>@lessersoul.ai` and the owning `agentId`.
+- Unknown bare addresses fail closed.
+- Alias records are never returned as public/current channels and never issued for new agents.
+- M1 new provisioning creates no legacy alias records.
+- M2 migration creates legacy alias records only for the existing bare addresses discovered and approved in inventory.
+
+M2.2 provider work must still keep old bare addresses inbound-reachable at Migadu, but provider state alone does not satisfy host delivery. M2.3 must add the host alias/index and comm-worker canonicalization required above.
+
+### Required legacy alias tests/canaries
+
+M2/M3 must prove:
+
+- sending to `agent.<instance>@lessersoul.ai` resolves through `SoulEmailAgentIndex`, matches `SoulAgentChannel.Identifier`, and stores/delivers normally;
+- sending to a known migrated `agent@lessersoul.ai` canonicalizes to `agent.<instance>@lessersoul.ai` before channel matching;
+- unknown bare `unknown@lessersoul.ai` fails closed;
+- public channel discovery returns only the instance-scoped address;
+- an agent local ID containing a dot is not misparsed from the local-part; and
+- two instances can host the same local ID without email collision.
+
+## Migration state machine and invariants
+
+M2 apply must be idempotent, dry-run-first, auditable, and safe to resume. The state machine below defines the required ordering; implementation details may use a script-local state file, operation records, or DynamoDB operation rows, but the observable states and invariants must hold.
+
+### States
+
+1. `inventory_dry_run`
+   - Load host state and redacted provider state.
+   - Compute proposed addresses.
+   - Refuse to proceed on duplicate proposed addresses, local-part overflow, missing/invalid `Domain.InstanceSlug`, missing current channel/index, or unknown signing state.
+
+2. `provider_prepare_pending`
+   - No public host state changes yet.
+   - Create or verify the new provider mailbox/forwarding for `<agent-local-id>.<instance-slug>`.
+   - Preserve the old bare provider mailbox/alias/forwarding.
+   - Do not delete unrelated legacy aliases.
+
+3. `provider_prepared`
+   - New provider local-part accepts inbound delivery to the same canonical host inbound bridge.
+   - Old bare address still accepts inbound delivery.
+   - No public channel switch has occurred yet.
+
+4. `self_attestation_collected`
+   - A new registration document advertising only the instance-scoped email channel has been prepared and signed by the agent, or a separately approved host migration/audit path exists.
+   - The operation records the expected previous self-description version.
+
+5. `host_switch_pending`
+   - Preconditions revalidated: provider still prepared, current DB channel/index still match inventory expectations, expected registration version still current, and alias decision still applies.
+
+6. `host_switched`
+   - Host writes the canonical email channel/index and the legacy alias/index in an idempotent operation.
+   - `SoulAgentChannel.Identifier` becomes the instance-scoped address.
+   - `SoulEmailAgentIndex` resolves the instance-scoped address.
+   - Legacy alias/index resolves only the known bare address to the canonical address/agent.
+   - Public DB-backed surfaces may now show only the instance-scoped address.
+
+7. `registration_published`
+   - The signed registration/self-description version is published with the instance-scoped email channel.
+   - The registration version/hash/self-attestation evidence is recorded.
+
+8. `verified`
+   - Canaries confirm new primary inbound delivery, legacy bare alias delivery, public non-advertisement of the bare alias, mailbox visibility, and body/Lesser/Greater/Sim compatibility evidence where applicable.
+
+9. `needs_repair`
+   - Any partial failure enters this state with redacted evidence and a stop condition. Live release remains blocked until repaired or explicitly rolled back.
+
+10. `rolled_back`
+    - Rollback preserves inbound reachability. If the host switch already occurred but registration publish failed, rollback restores the previous public channel/index and removes or disables the new host alias/index while leaving provider state intact until safe cleanup.
+
+### Ordering invariants
+
+- Provider new mailbox/forwarding exists before any public/current channel advertises the new address.
+- Old bare provider delivery remains in place until M3 verifies legacy alias behavior.
+- Self-attestation or an approved host migration/audit path exists before host switches public channel state.
+- Host canonical channel/index and legacy alias/index switch before the release gate treats the new address as usable.
+- Registration publish follows the host switch immediately in the same migration operation. If publish fails, the operation enters `needs_repair` and either resumes publish or rolls host public state back.
+- Public surfaces advertise only the instance-scoped address after `host_switched`; legacy alias records remain internal.
+- Unknown bare addresses fail closed before and after migration.
+- Re-running apply at any state is safe: it verifies the state already reached, completes the next missing step, or stops with `needs_repair` without deleting unrelated provider state.
+
+## M1/M2 implementation checklist carry-forward
+
+M1 must:
+
+- add the canonical address builder and `Domain.InstanceSlug` resolver;
+- enforce the 64-octet provider local-part limit before provider calls;
+- fail closed on missing, unverified, or cross-instance domain state;
+- update begin/confirm preview parity so stale/bare local-part requests are rejected;
+- use `<agent-local-id>.<instance-slug>` for Migadu mailbox and inbound forwarding local-parts;
+- keep full email addresses opaque through inbound and comm-worker paths; and
+- update UI/API examples so the address is shown as derived, not user-selected.
+
+M2 must:
+
+- use the inventory command before apply;
+- add the host-internal legacy alias/index and comm-worker canonicalization boundary;
+- require self-attestation or an explicitly approved host migration/audit path per agent;
+- implement the state machine above with dry-run, idempotent retry, partial-failure resume, and rollback notes;
+- preserve old bare provider delivery as inbound-only for migrated agents; and
+- produce redacted evidence for the release gate.
+
+## Scope cut
+
+The following remain explicitly out of Project 37:
+
+- custom handles;
+- alias UI;
+- vanity email domains;
+- multiple public email channels per soul;
+- public alias discovery;
+- cross-instance email search; and
+- general mailbox redesign.

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -185,11 +185,13 @@ All write endpoints require `Authorization: Bearer <session>`. Sessions are shar
 Inbound soul email delivery uses a bridge domain instead of direct HTTP forwarding from Migadu:
 
 ```text
-Sender -> Migadu mailbox -> agent@inbound.lessersoul.ai -> SES receipt rule -> email-ingress Lambda -> comm-worker
+Sender -> Migadu mailbox -> <agent-local-id>.<instance-slug>@inbound.lessersoul.ai -> SES receipt rule -> email-ingress Lambda -> comm-worker
 ```
 
 - Migadu remains the mailbox and outbound SMTP provider for `@lessersoul.ai`.
-- New provisioning and operational backfills set Migadu forwarding targets to `<localPart>@inbound.lessersoul.ai`.
+- Project 37 defines the instance-scoped managed address contract in `docs/instance-scoped-soul-email-m0.md`: new managed soul email channels use `<agent-local-id>.<instance-slug>@lessersoul.ai`, with `instanceSlug` resolved from `Domain.InstanceSlug`.
+- New provisioning and operational backfills set Migadu forwarding targets to `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`.
+- Existing bare `<agent-local-id>@lessersoul.ai` addresses are legacy inbound aliases for migrated agents only; they are not current public channels after migration.
 - Amazon SES receives mail for `inbound.lessersoul.ai`, stores the raw message in S3, and invokes `cmd/email-ingress`.
 - `cmd/email-ingress` parses the raw RFC 5322 message and enqueues the existing `communication:inbound` payload shape for `comm-worker`.
 - `comm-worker` continues to resolve the final recipient against the canonical `@lessersoul.ai` address, so downstream routing and delivery semantics stay unchanged.

--- a/scripts/soul-email-m0-inventory/main.go
+++ b/scripts/soul-email-m0-inventory/main.go
@@ -1,0 +1,939 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+
+	"github.com/equaltoai/lesser-host/internal/manageddomain"
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const (
+	inventorySchemaVersion = 1
+	canonicalEmailDomain   = "lessersoul.ai"
+	smtpLocalPartLimit     = 64
+	defaultInventoryStage  = "lab"
+	signingStateYes        = "yes"
+	signingStateNo         = "no"
+	signingStateUnknown    = "unknown"
+)
+
+var managedInstanceSlugRE = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$`)
+
+type dynamoClient interface {
+	Scan(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	GetItem(context.Context, *dynamodb.GetItemInput, ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error)
+}
+
+type inventoryConfig struct {
+	Stage                 string
+	TableName             string
+	ProviderStatePath     string
+	RegistrationStatePath string
+	OutputPath            string
+	PageSize              int32
+	MaxAgents             int
+	IncludeInactive       bool
+}
+
+type inventoryReport struct {
+	SchemaVersion int                     `json:"schema_version"`
+	GeneratedAt   string                  `json:"generated_at"`
+	Mode          string                  `json:"mode"`
+	Stage         string                  `json:"stage"`
+	TableName     string                  `json:"table_name"`
+	Contract      inventoryContract       `json:"contract"`
+	Summary       inventorySummary        `json:"summary"`
+	Agents        []managedEmailInventory `json:"agents"`
+	Issues        []string                `json:"issues,omitempty"`
+}
+
+type inventoryContract struct {
+	CanonicalAddressFormat string `json:"canonical_address_format"`
+	ProviderLocalPart      string `json:"provider_local_part"`
+	SMTPLocalPartLimit     int    `json:"smtp_local_part_limit"`
+	InstanceSlugSource     string `json:"instance_slug_source"`
+	LegacyAliasPolicy      string `json:"legacy_alias_policy"`
+}
+
+type inventorySummary struct {
+	ScannedIdentities         int `json:"scanned_identities"`
+	EligibleManagedEmail      int `json:"eligible_managed_email"`
+	SkippedInactive           int `json:"skipped_inactive"`
+	MissingEmailChannel       int `json:"missing_email_channel"`
+	MissingDomainRecord       int `json:"missing_domain_record"`
+	InactiveDomainRecord      int `json:"inactive_domain_record"`
+	MissingInstanceSlug       int `json:"missing_instance_slug"`
+	InvalidInstanceSlug       int `json:"invalid_instance_slug"`
+	ProposedDuplicateCount    int `json:"proposed_duplicate_count"`
+	ProposedOverflowCount     int `json:"proposed_overflow_count"`
+	MissingCurrentEmailIndex  int `json:"missing_current_email_index"`
+	CurrentEmailIndexMismatch int `json:"current_email_index_mismatch"`
+	ProviderStateEntries      int `json:"provider_state_entries"`
+}
+
+type managedEmailInventory struct {
+	AgentID             string                     `json:"agent_id"`
+	Domain              string                     `json:"domain"`
+	LocalID             string                     `json:"local_id"`
+	Status              string                     `json:"status"`
+	LifecycleStatus     string                     `json:"lifecycle_status,omitempty"`
+	SelfDescription     selfDescriptionInventory   `json:"self_description"`
+	DomainRecord        *domainInventory           `json:"domain_record,omitempty"`
+	CurrentEmailChannel *emailChannelInventory     `json:"current_email_channel,omitempty"`
+	CurrentEmailIndex   *emailIndexInventory       `json:"current_email_index,omitempty"`
+	RegistrationVersion *registrationVersionRecord `json:"registration_version,omitempty"`
+	Proposed            proposedEmailInventory     `json:"proposed"`
+	ProviderState       providerInventory          `json:"provider_state"`
+	MigrationReadiness  migrationReadiness         `json:"migration_readiness"`
+	Issues              []string                   `json:"issues,omitempty"`
+}
+
+type selfDescriptionInventory struct {
+	Version int  `json:"version"`
+	Active  bool `json:"active"`
+}
+
+type domainInventory struct {
+	Domain             string `json:"domain"`
+	InstanceSlug       string `json:"instance_slug"`
+	Type               string `json:"type,omitempty"`
+	Status             string `json:"status,omitempty"`
+	VerificationMethod string `json:"verification_method,omitempty"`
+	Resolution         string `json:"resolution"`
+}
+
+type emailChannelInventory struct {
+	Identifier string `json:"identifier"`
+	Provider   string `json:"provider,omitempty"`
+	Status     string `json:"status,omitempty"`
+	Verified   bool   `json:"verified"`
+	SecretRef  string `json:"secret_ref_present,omitempty"`
+}
+
+type emailIndexInventory struct {
+	Email          string `json:"email"`
+	AgentID        string `json:"agent_id"`
+	MatchesAgent   bool   `json:"matches_agent"`
+	MatchesChannel bool   `json:"matches_channel"`
+}
+
+type registrationVersionRecord struct {
+	VersionNumber          int    `json:"version_number"`
+	RegistrationURI        string `json:"registration_uri,omitempty"`
+	RegistrationSHA256     string `json:"registration_sha256,omitempty"`
+	ChangeSummary          string `json:"change_summary,omitempty"`
+	SelfAttestationPresent bool   `json:"self_attestation_present"`
+	EmailChannel           string `json:"email_channel,omitempty"`
+	Source                 string `json:"source,omitempty"`
+}
+
+type proposedEmailInventory struct {
+	LocalPart       string `json:"local_part,omitempty"`
+	Address         string `json:"address,omitempty"`
+	LocalPartLength int    `json:"local_part_length"`
+	Overflow        bool   `json:"overflow"`
+	Duplicate       bool   `json:"duplicate"`
+}
+
+type providerInventory struct {
+	Current  *providerAddressState `json:"current,omitempty"`
+	Proposed *providerAddressState `json:"proposed,omitempty"`
+	Source   string                `json:"source"`
+}
+
+type migrationReadiness struct {
+	RequiresSelfAttestation bool   `json:"requires_self_attestation"`
+	CanSelfAttest           string `json:"can_self_attest"`
+	HostMigrationPathNeeded bool   `json:"host_migration_path_needed"`
+}
+
+type providerSnapshot struct {
+	GeneratedAt string                 `json:"generated_at,omitempty"`
+	Source      string                 `json:"source,omitempty"`
+	Addresses   []providerAddressState `json:"addresses"`
+}
+
+type registrationSnapshot struct {
+	GeneratedAt string                      `json:"generated_at,omitempty"`
+	Source      string                      `json:"source,omitempty"`
+	Agents      []registrationSnapshotAgent `json:"agents"`
+}
+
+type registrationSnapshotAgent struct {
+	AgentID       string `json:"agent_id"`
+	EmailChannel  string `json:"email_channel,omitempty"`
+	CanSelfAttest string `json:"can_self_attest,omitempty"`
+	Source        string `json:"source,omitempty"`
+}
+
+type providerAddressState struct {
+	LocalPart     string   `json:"local_part"`
+	Address       string   `json:"address,omitempty"`
+	MailboxExists *bool    `json:"mailbox_exists,omitempty"`
+	Forwardings   []string `json:"forwardings,omitempty"`
+	Aliases       []string `json:"aliases,omitempty"`
+	Notes         []string `json:"notes,omitempty"`
+}
+
+type identityRow struct {
+	AgentID                string
+	Domain                 string
+	LocalID                string
+	Status                 string
+	LifecycleStatus        string
+	SelfDescriptionVersion int
+}
+
+func main() {
+	cfg, err := parseConfig(os.Args[1:], os.Getenv)
+	if err != nil {
+		die("%v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		die("load aws config: %v", err)
+	}
+
+	report, err := buildInventoryReport(ctx, dynamodb.NewFromConfig(awsCfg), cfg, time.Now().UTC())
+	if err != nil {
+		die("inventory failed: %v", err)
+	}
+	if err := writeReport(report, cfg.OutputPath, os.Stdout); err != nil {
+		die("write report: %v", err)
+	}
+	if report.Summary.ProposedDuplicateCount > 0 || report.Summary.ProposedOverflowCount > 0 || len(report.Issues) > 0 {
+		os.Exit(2)
+	}
+}
+
+func parseConfig(args []string, getenv func(string) string) (inventoryConfig, error) {
+	stageDefault := strings.ToLower(strings.TrimSpace(getenv("STAGE")))
+	if stageDefault == "" {
+		stageDefault = defaultInventoryStage
+	}
+	tableDefault := strings.TrimSpace(getenv("STATE_TABLE_NAME"))
+	if tableDefault == "" {
+		tableDefault = fmt.Sprintf("lesser-host-%s-state", stageDefault)
+	}
+	cfg := inventoryConfig{Stage: stageDefault, TableName: tableDefault, PageSize: 100}
+	fs := flag.NewFlagSet("soul-email-m0-inventory", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.Stage, "stage", cfg.Stage, "Control-plane stage used for managed stage-domain alias resolution")
+	fs.StringVar(&cfg.TableName, "table-name", cfg.TableName, "DynamoDB state table name")
+	fs.StringVar(&cfg.ProviderStatePath, "provider-state", "", "Optional redacted provider-state JSON snapshot")
+	fs.StringVar(&cfg.RegistrationStatePath, "registration-state", "", "Optional redacted registration/signing-state JSON snapshot")
+	fs.StringVar(&cfg.OutputPath, "out", "", "Output JSON path (default stdout)")
+	fs.IntVar(&cfg.MaxAgents, "max-agents", 0, "Maximum eligible agents to include (0 = unlimited)")
+	fs.BoolVar(&cfg.IncludeInactive, "include-inactive", false, "Include inactive/suspended/archived identities in the report")
+	pageSize := int(cfg.PageSize)
+	fs.IntVar(&pageSize, "page-size", pageSize, "DynamoDB scan page size")
+	if err := fs.Parse(args); err != nil {
+		return inventoryConfig{}, err
+	}
+	cfg.Stage = strings.ToLower(strings.TrimSpace(cfg.Stage))
+	if cfg.Stage == "" {
+		cfg.Stage = defaultInventoryStage
+	}
+	cfg.TableName = strings.TrimSpace(cfg.TableName)
+	if cfg.TableName == "" {
+		return inventoryConfig{}, errors.New("table name is required")
+	}
+	if pageSize <= 0 || pageSize > 1000 {
+		return inventoryConfig{}, errors.New("page-size must be between 1 and 1000")
+	}
+	cfg.PageSize = int32(pageSize)
+	if cfg.MaxAgents < 0 {
+		return inventoryConfig{}, errors.New("max-agents must be non-negative")
+	}
+	return cfg, nil
+}
+
+func buildInventoryReport(ctx context.Context, client dynamoClient, cfg inventoryConfig, now time.Time) (inventoryReport, error) {
+	inputs, err := loadInventoryInputs(cfg)
+	if err != nil {
+		return inventoryReport{}, err
+	}
+	idents, err := scanIdentityRows(ctx, client, cfg)
+	if err != nil {
+		return inventoryReport{}, err
+	}
+
+	report := newInventoryReport(cfg, now, inputs.providerStateCount)
+	for _, ident := range idents {
+		report.Summary.ScannedIdentities++
+		if !identityIsActive(ident) && !cfg.IncludeInactive {
+			report.Summary.SkippedInactive++
+			continue
+		}
+
+		result, err := buildInventoryRecord(ctx, client, cfg, ident, inputs)
+		if err != nil {
+			return inventoryReport{}, err
+		}
+		report.Summary = mergeInventorySummary(report.Summary, result.Summary)
+		if result.Include {
+			report.Agents = append(report.Agents, result.Record)
+		}
+		if cfg.MaxAgents > 0 && report.Summary.EligibleManagedEmail >= cfg.MaxAgents {
+			break
+		}
+	}
+	finalizeInventoryReport(&report)
+	return report, nil
+}
+
+type loadedInventoryInputs struct {
+	providerStates     map[string]providerAddressState
+	providerSource     string
+	providerStateCount int
+	registrationStates map[string]registrationSnapshotAgent
+}
+
+type inventoryRecordResult struct {
+	Record  managedEmailInventory
+	Summary inventorySummary
+	Include bool
+}
+
+func loadInventoryInputs(cfg inventoryConfig) (loadedInventoryInputs, error) {
+	providerStates, providerSource, err := loadProviderSnapshot(cfg.ProviderStatePath)
+	if err != nil {
+		return loadedInventoryInputs{}, err
+	}
+	registrationStates, err := loadRegistrationSnapshot(cfg.RegistrationStatePath)
+	if err != nil {
+		return loadedInventoryInputs{}, err
+	}
+	return loadedInventoryInputs{
+		providerStates:     providerStates,
+		providerSource:     providerSource,
+		providerStateCount: len(providerStates),
+		registrationStates: registrationStates,
+	}, nil
+}
+
+func newInventoryReport(cfg inventoryConfig, now time.Time, providerStateCount int) inventoryReport {
+	return inventoryReport{
+		SchemaVersion: inventorySchemaVersion,
+		GeneratedAt:   now.UTC().Format(time.RFC3339),
+		Mode:          "dry-run",
+		Stage:         cfg.Stage,
+		TableName:     cfg.TableName,
+		Contract: inventoryContract{
+			CanonicalAddressFormat: "<agent-local-id>.<instance-slug>@lessersoul.ai",
+			ProviderLocalPart:      "<agent-local-id>.<instance-slug>",
+			SMTPLocalPartLimit:     smtpLocalPartLimit,
+			InstanceSlugSource:     "Domain.InstanceSlug",
+			LegacyAliasPolicy:      "host-internal legacy alias index canonicalizes existing bare recipients to the current instance-scoped address before comm-worker channel matching",
+		},
+		Summary: inventorySummary{ProviderStateEntries: providerStateCount},
+	}
+}
+
+func buildInventoryRecord(ctx context.Context, client dynamoClient, cfg inventoryConfig, ident identityRow, inputs loadedInventoryInputs) (inventoryRecordResult, error) {
+	result := inventoryRecordResult{Record: baseInventoryRecord(ident, inputs.providerSource), Include: true}
+	_, managed, err := applyEmailChannelInventory(ctx, client, cfg, &result, ident, inputs.providerStates)
+	if err != nil || !managed {
+		return result, err
+	}
+	if err := applyDomainInventory(ctx, client, cfg, &result, ident); err != nil {
+		return inventoryRecordResult{}, err
+	}
+	if err := applyRegistrationInventory(ctx, client, cfg, &result, ident, inputs.registrationStates); err != nil {
+		return inventoryRecordResult{}, err
+	}
+	applyProposedInventory(&result, ident, inputs.providerStates)
+	result.Summary.EligibleManagedEmail++
+	return result, nil
+}
+
+func baseInventoryRecord(ident identityRow, providerSource string) managedEmailInventory {
+	active := identityIsActive(ident)
+	return managedEmailInventory{
+		AgentID:         ident.AgentID,
+		Domain:          ident.Domain,
+		LocalID:         ident.LocalID,
+		Status:          ident.Status,
+		LifecycleStatus: ident.LifecycleStatus,
+		SelfDescription: selfDescriptionInventory{Version: ident.SelfDescriptionVersion, Active: active},
+		ProviderState:   providerInventory{Source: providerSource},
+		MigrationReadiness: migrationReadiness{
+			RequiresSelfAttestation: true,
+			CanSelfAttest:           signingStateUnknown,
+			HostMigrationPathNeeded: true,
+		},
+	}
+}
+
+func applyEmailChannelInventory(ctx context.Context, client dynamoClient, cfg inventoryConfig, result *inventoryRecordResult, ident identityRow, providerStates map[string]providerAddressState) (*emailChannelInventory, bool, error) {
+	channel, found, err := loadEmailChannel(ctx, client, cfg.TableName, ident.AgentID)
+	if err != nil || !found {
+		if !found {
+			result.Summary.MissingEmailChannel++
+			result.Record.Issues = append(result.Record.Issues, "missing_email_channel")
+		}
+		return nil, false, err
+	}
+	result.Record.CurrentEmailChannel = channel
+	if !strings.EqualFold(channel.Provider, "migadu") {
+		result.Record.Issues = append(result.Record.Issues, "email_channel_provider_not_migadu")
+		return channel, false, nil
+	}
+	result.Record.ProviderState.Current = providerStateForEmail(providerStates, channel.Identifier)
+	if err := applyEmailIndexInventory(ctx, client, cfg.TableName, result, ident, channel.Identifier); err != nil {
+		return nil, false, err
+	}
+	return channel, true, nil
+}
+
+func applyEmailIndexInventory(ctx context.Context, client dynamoClient, tableName string, result *inventoryRecordResult, ident identityRow, address string) error {
+	idx, found, err := loadEmailIndex(ctx, client, tableName, address)
+	if err != nil {
+		return err
+	}
+	if !found {
+		result.Summary.MissingCurrentEmailIndex++
+		result.Record.Issues = append(result.Record.Issues, "missing_current_email_index")
+		return nil
+	}
+	idx.MatchesAgent = strings.EqualFold(idx.AgentID, ident.AgentID)
+	idx.MatchesChannel = strings.EqualFold(idx.Email, address)
+	result.Record.CurrentEmailIndex = idx
+	if !idx.MatchesAgent || !idx.MatchesChannel {
+		result.Summary.CurrentEmailIndexMismatch++
+		result.Record.Issues = append(result.Record.Issues, "current_email_index_mismatch")
+	}
+	return nil
+}
+
+func applyDomainInventory(ctx context.Context, client dynamoClient, cfg inventoryConfig, result *inventoryRecordResult, ident identityRow) error {
+	domain, found, err := loadDomainForIdentity(ctx, client, cfg.TableName, cfg.Stage, ident.Domain)
+	if err != nil {
+		return err
+	}
+	if !found {
+		result.Summary.MissingDomainRecord++
+		result.Record.Issues = append(result.Record.Issues, "missing_domain_record")
+		return nil
+	}
+	result.Record.DomainRecord = domain
+	if !domainStatusActive(domain.Status) {
+		result.Summary.InactiveDomainRecord++
+		result.Record.Issues = append(result.Record.Issues, "inactive_domain_record")
+	}
+	if strings.TrimSpace(domain.InstanceSlug) == "" {
+		result.Summary.MissingInstanceSlug++
+		result.Record.Issues = append(result.Record.Issues, "missing_instance_slug")
+	} else if !managedInstanceSlugRE.MatchString(domain.InstanceSlug) {
+		result.Summary.InvalidInstanceSlug++
+		result.Record.Issues = append(result.Record.Issues, "invalid_instance_slug")
+	}
+	return nil
+}
+
+func applyRegistrationInventory(ctx context.Context, client dynamoClient, cfg inventoryConfig, result *inventoryRecordResult, ident identityRow, states map[string]registrationSnapshotAgent) error {
+	version, found, err := loadRegistrationVersion(ctx, client, cfg.TableName, ident.AgentID, ident.SelfDescriptionVersion)
+	if err != nil || !found {
+		return err
+	}
+	if regState, ok := states[ident.AgentID]; ok {
+		version.EmailChannel = normalizeEmail(regState.EmailChannel)
+		version.Source = strings.TrimSpace(regState.Source)
+		result.Record.MigrationReadiness.CanSelfAttest = normalizeSigningState(regState.CanSelfAttest)
+		result.Record.MigrationReadiness.HostMigrationPathNeeded = result.Record.MigrationReadiness.CanSelfAttest != signingStateYes
+	}
+	result.Record.RegistrationVersion = version
+	return nil
+}
+
+func applyProposedInventory(result *inventoryRecordResult, ident identityRow, providerStates map[string]providerAddressState) {
+	if result.Record.DomainRecord == nil {
+		return
+	}
+	proposed, err := buildProposedManagedAddress(ident.LocalID, result.Record.DomainRecord.InstanceSlug)
+	result.Record.Proposed = proposed
+	if err != nil {
+		result.Record.Issues = append(result.Record.Issues, err.Error())
+	}
+	if proposed.Overflow {
+		result.Summary.ProposedOverflowCount++
+	}
+	result.Record.ProviderState.Proposed = providerStateForEmail(providerStates, proposed.Address)
+}
+
+func mergeInventorySummary(dst, src inventorySummary) inventorySummary {
+	dst.EligibleManagedEmail += src.EligibleManagedEmail
+	dst.MissingEmailChannel += src.MissingEmailChannel
+	dst.MissingDomainRecord += src.MissingDomainRecord
+	dst.InactiveDomainRecord += src.InactiveDomainRecord
+	dst.MissingInstanceSlug += src.MissingInstanceSlug
+	dst.InvalidInstanceSlug += src.InvalidInstanceSlug
+	dst.ProposedOverflowCount += src.ProposedOverflowCount
+	dst.MissingCurrentEmailIndex += src.MissingCurrentEmailIndex
+	dst.CurrentEmailIndexMismatch += src.CurrentEmailIndexMismatch
+	return dst
+}
+
+func finalizeInventoryReport(report *inventoryReport) {
+	annotateProposedDuplicates(report.Agents)
+	for _, rec := range report.Agents {
+		if rec.Proposed.Duplicate {
+			report.Summary.ProposedDuplicateCount++
+		}
+	}
+	report.Issues = appendReportIssues(report.Issues, report.Summary)
+	sort.Slice(report.Agents, func(i, j int) bool {
+		if report.Agents[i].Domain == report.Agents[j].Domain {
+			return report.Agents[i].LocalID < report.Agents[j].LocalID
+		}
+		return report.Agents[i].Domain < report.Agents[j].Domain
+	})
+}
+
+func appendReportIssues(issues []string, summary inventorySummary) []string {
+	if summary.MissingDomainRecord > 0 {
+		issues = appendUnique(issues, "missing_domain_record")
+	}
+	if summary.InactiveDomainRecord > 0 {
+		issues = appendUnique(issues, "inactive_domain_record")
+	}
+	if summary.MissingInstanceSlug > 0 {
+		issues = appendUnique(issues, "missing_instance_slug")
+	}
+	if summary.InvalidInstanceSlug > 0 {
+		issues = appendUnique(issues, "invalid_instance_slug")
+	}
+	if summary.MissingCurrentEmailIndex > 0 {
+		issues = appendUnique(issues, "missing_current_email_index")
+	}
+	if summary.CurrentEmailIndexMismatch > 0 {
+		issues = appendUnique(issues, "current_email_index_mismatch")
+	}
+	return issues
+}
+
+func scanIdentityRows(ctx context.Context, client dynamoClient, cfg inventoryConfig) ([]identityRow, error) {
+	if client == nil {
+		return nil, errors.New("dynamodb client is required")
+	}
+	var rows []identityRow
+	input := &dynamodb.ScanInput{
+		TableName:                aws.String(cfg.TableName),
+		Limit:                    aws.Int32(cfg.PageSize),
+		FilterExpression:         aws.String("#sk = :sk"),
+		ExpressionAttributeNames: map[string]string{"#sk": "SK"},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":sk": &types.AttributeValueMemberS{Value: "IDENTITY"},
+		},
+	}
+	for {
+		out, err := client.Scan(ctx, input)
+		if err != nil {
+			return nil, err
+		}
+		for _, item := range out.Items {
+			row := identityRow{
+				AgentID:                strings.ToLower(strings.TrimSpace(itemString(item, "agentId"))),
+				Domain:                 normalizeDomain(itemString(item, "domain")),
+				LocalID:                strings.TrimSpace(itemString(item, "localId")),
+				Status:                 strings.ToLower(strings.TrimSpace(itemString(item, "status"))),
+				LifecycleStatus:        strings.ToLower(strings.TrimSpace(itemString(item, "lifecycleStatus"))),
+				SelfDescriptionVersion: itemInt(item, "selfDescriptionVersion"),
+			}
+			if row.AgentID == "" {
+				continue
+			}
+			rows = append(rows, row)
+		}
+		if len(out.LastEvaluatedKey) == 0 {
+			break
+		}
+		input.ExclusiveStartKey = out.LastEvaluatedKey
+	}
+	return rows, nil
+}
+
+func loadEmailChannel(ctx context.Context, client dynamoClient, tableName, agentID string) (*emailChannelInventory, bool, error) {
+	item, found, err := getItem(ctx, client, tableName, "SOUL#AGENT#"+strings.ToLower(strings.TrimSpace(agentID)), "CHANNEL#email")
+	if err != nil || !found {
+		return nil, found, err
+	}
+	secretRef := ""
+	if strings.TrimSpace(itemString(item, "secretRef")) != "" {
+		secretRef = "present"
+	}
+	return &emailChannelInventory{
+		Identifier: normalizeEmail(itemString(item, "identifier")),
+		Provider:   strings.ToLower(strings.TrimSpace(itemString(item, "provider"))),
+		Status:     strings.ToLower(strings.TrimSpace(itemString(item, "status"))),
+		Verified:   itemBool(item, "verified"),
+		SecretRef:  secretRef,
+	}, true, nil
+}
+
+func loadEmailIndex(ctx context.Context, client dynamoClient, tableName, email string) (*emailIndexInventory, bool, error) {
+	email = normalizeEmail(email)
+	item, found, err := getItem(ctx, client, tableName, "SOUL#EMAIL#"+email, "AGENT")
+	if err != nil || !found {
+		return nil, found, err
+	}
+	return &emailIndexInventory{Email: normalizeEmail(itemString(item, "email")), AgentID: strings.ToLower(strings.TrimSpace(itemString(item, "agentId")))}, true, nil
+}
+
+func loadRegistrationVersion(ctx context.Context, client dynamoClient, tableName, agentID string, version int) (*registrationVersionRecord, bool, error) {
+	if version <= 0 {
+		return nil, false, nil
+	}
+	item, found, err := getItem(ctx, client, tableName, "SOUL#AGENT#"+strings.ToLower(strings.TrimSpace(agentID)), fmt.Sprintf("VERSION#%d", version))
+	if err != nil || !found {
+		return nil, found, err
+	}
+	return &registrationVersionRecord{
+		VersionNumber:          version,
+		RegistrationURI:        strings.TrimSpace(itemString(item, "registrationUri")),
+		RegistrationSHA256:     strings.TrimSpace(itemString(item, "registrationSha256")),
+		ChangeSummary:          strings.TrimSpace(itemString(item, "changeSummary")),
+		SelfAttestationPresent: strings.TrimSpace(itemString(item, "selfAttestation")) != "",
+	}, true, nil
+}
+
+func loadDomainForIdentity(ctx context.Context, client dynamoClient, tableName, stage, rawDomain string) (*domainInventory, bool, error) {
+	domain := normalizeDomain(rawDomain)
+	if domain == "" {
+		return nil, false, nil
+	}
+	if rec, found, err := loadDomainRecord(ctx, client, tableName, domain, "exact"); err != nil || found {
+		return rec, found, err
+	}
+	baseDomain, ok := manageddomain.BaseDomainFromStageDomain(stage, domain)
+	if !ok {
+		return nil, false, nil
+	}
+	rec, found, err := loadDomainRecord(ctx, client, tableName, baseDomain, "managed_stage_primary_alias")
+	if err != nil || !found {
+		return rec, found, err
+	}
+	if rec.Type != models.DomainTypePrimary || rec.VerificationMethod != "managed" || !domainStatusActive(rec.Status) {
+		return nil, false, nil
+	}
+	inst, instFound, err := loadInstance(ctx, client, tableName, rec.InstanceSlug)
+	if err != nil || !instFound {
+		return nil, false, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(inst.HostedBaseDomain), rec.Domain) {
+		return nil, false, nil
+	}
+	return rec, true, nil
+}
+
+type instanceInventory struct {
+	Slug             string
+	HostedBaseDomain string
+}
+
+func loadInstance(ctx context.Context, client dynamoClient, tableName, slug string) (instanceInventory, bool, error) {
+	item, found, err := getItem(ctx, client, tableName, "INSTANCE#"+strings.TrimSpace(slug), models.SKMetadata)
+	if err != nil || !found {
+		return instanceInventory{}, found, err
+	}
+	return instanceInventory{Slug: strings.TrimSpace(itemString(item, "slug")), HostedBaseDomain: normalizeDomain(itemString(item, "hostedBaseDomain"))}, true, nil
+}
+
+func loadDomainRecord(ctx context.Context, client dynamoClient, tableName, domain, resolution string) (*domainInventory, bool, error) {
+	item, found, err := getItem(ctx, client, tableName, "DOMAIN#"+normalizeDomain(domain), models.SKMetadata)
+	if err != nil || !found {
+		return nil, found, err
+	}
+	return &domainInventory{
+		Domain:             normalizeDomain(itemString(item, "domain")),
+		InstanceSlug:       strings.TrimSpace(itemString(item, "instanceSlug")),
+		Type:               strings.ToLower(strings.TrimSpace(itemString(item, "type"))),
+		Status:             strings.ToLower(strings.TrimSpace(itemString(item, "status"))),
+		VerificationMethod: strings.ToLower(strings.TrimSpace(itemString(item, "verificationMethod"))),
+		Resolution:         resolution,
+	}, true, nil
+}
+
+func getItem(ctx context.Context, client dynamoClient, tableName, pk, sk string) (map[string]types.AttributeValue, bool, error) {
+	out, err := client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      aws.String(tableName),
+		ConsistentRead: aws.Bool(true),
+		Key: map[string]types.AttributeValue{
+			"PK": &types.AttributeValueMemberS{Value: pk},
+			"SK": &types.AttributeValueMemberS{Value: sk},
+		},
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if len(out.Item) == 0 {
+		return nil, false, nil
+	}
+	return out.Item, true, nil
+}
+
+func buildProposedManagedAddress(agentLocalID, instanceSlug string) (proposedEmailInventory, error) {
+	localID, err := soul.NormalizeLocalAgentID(agentLocalID)
+	if err != nil || localID == "" {
+		return proposedEmailInventory{}, errors.New("invalid_agent_local_id")
+	}
+	instanceSlug = strings.ToLower(strings.TrimSpace(instanceSlug))
+	if !managedInstanceSlugRE.MatchString(instanceSlug) {
+		return proposedEmailInventory{}, errors.New("invalid_instance_slug")
+	}
+	localPart := localID + "." + instanceSlug
+	proposed := proposedEmailInventory{
+		LocalPart:       localPart,
+		Address:         localPart + "@" + canonicalEmailDomain,
+		LocalPartLength: len(localPart),
+		Overflow:        len(localPart) > smtpLocalPartLimit,
+	}
+	if proposed.Overflow {
+		return proposed, errors.New("proposed_local_part_overflow")
+	}
+	return proposed, nil
+}
+
+func annotateProposedDuplicates(records []managedEmailInventory) {
+	counts := map[string]int{}
+	for _, rec := range records {
+		addr := normalizeEmail(rec.Proposed.Address)
+		if addr == "" {
+			continue
+		}
+		counts[addr]++
+	}
+	for i := range records {
+		addr := normalizeEmail(records[i].Proposed.Address)
+		if addr != "" && counts[addr] > 1 {
+			records[i].Proposed.Duplicate = true
+			records[i].Issues = appendUnique(records[i].Issues, "duplicate_proposed_address")
+		}
+	}
+}
+
+func loadProviderSnapshot(path string) (map[string]providerAddressState, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return map[string]providerAddressState{}, "not_collected", nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // Operator-provided local snapshot path for dry-run inventory only.
+	if err != nil {
+		return nil, "", err
+	}
+	var snap providerSnapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, "", err
+	}
+	out := make(map[string]providerAddressState, len(snap.Addresses)*2)
+	for _, state := range snap.Addresses {
+		state.LocalPart = strings.ToLower(strings.TrimSpace(state.LocalPart))
+		state.Address = normalizeEmail(state.Address)
+		if state.Address == "" && state.LocalPart != "" {
+			state.Address = state.LocalPart + "@" + canonicalEmailDomain
+		}
+		state.Forwardings = normalizeEmailList(state.Forwardings)
+		state.Aliases = normalizeStringList(state.Aliases)
+		if state.LocalPart != "" {
+			out[state.LocalPart] = state
+		}
+		if state.Address != "" {
+			out[state.Address] = state
+		}
+	}
+	source := strings.TrimSpace(snap.Source)
+	if source == "" {
+		source = path
+	}
+	return out, source, nil
+}
+
+func loadRegistrationSnapshot(path string) (map[string]registrationSnapshotAgent, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return map[string]registrationSnapshotAgent{}, nil
+	}
+	raw, err := os.ReadFile(path) //nolint:gosec // Operator-provided local snapshot path for dry-run inventory only.
+	if err != nil {
+		return nil, err
+	}
+	var snap registrationSnapshot
+	if err := json.Unmarshal(raw, &snap); err != nil {
+		return nil, err
+	}
+	out := make(map[string]registrationSnapshotAgent, len(snap.Agents))
+	for _, agent := range snap.Agents {
+		agent.AgentID = strings.ToLower(strings.TrimSpace(agent.AgentID))
+		agent.EmailChannel = normalizeEmail(agent.EmailChannel)
+		agent.CanSelfAttest = normalizeSigningState(agent.CanSelfAttest)
+		if strings.TrimSpace(agent.Source) == "" {
+			agent.Source = strings.TrimSpace(snap.Source)
+		}
+		if agent.AgentID != "" {
+			out[agent.AgentID] = agent
+		}
+	}
+	return out, nil
+}
+
+func normalizeSigningState(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "yes", "true", "can_self_attest":
+		return signingStateYes
+	case "no", "false", "cannot_self_attest":
+		return signingStateNo
+	default:
+		return signingStateUnknown
+	}
+}
+
+func providerStateForEmail(states map[string]providerAddressState, email string) *providerAddressState {
+	if len(states) == 0 {
+		return nil
+	}
+	email = normalizeEmail(email)
+	localPart, _, ok := strings.Cut(email, "@")
+	if state, found := states[email]; found {
+		return &state
+	}
+	if ok {
+		if state, found := states[localPart]; found {
+			return &state
+		}
+	}
+	return nil
+}
+
+func identityIsActive(row identityRow) bool {
+	status := strings.ToLower(strings.TrimSpace(row.Status))
+	lifecycle := strings.ToLower(strings.TrimSpace(row.LifecycleStatus))
+	return status == models.SoulAgentStatusActive && (lifecycle == "" || lifecycle == models.SoulAgentStatusActive)
+}
+
+func domainStatusActive(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case models.DomainStatusVerified, models.DomainStatusActive:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeReport(report inventoryReport, outputPath string, stdout io.Writer) error {
+	raw, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" || outputPath == "-" {
+		_, err = stdout.Write(raw)
+		return err
+	}
+	return os.WriteFile(outputPath, raw, 0o600) //nolint:gosec // Inventory evidence is written only to the operator-selected local output path.
+}
+
+func itemString(item map[string]types.AttributeValue, name string) string {
+	if item == nil {
+		return ""
+	}
+	switch v := item[name].(type) {
+	case *types.AttributeValueMemberS:
+		return strings.TrimSpace(v.Value)
+	case *types.AttributeValueMemberN:
+		return strings.TrimSpace(v.Value)
+	default:
+		return ""
+	}
+}
+
+func itemInt(item map[string]types.AttributeValue, name string) int {
+	raw := itemString(item, name)
+	if raw == "" {
+		return 0
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+func itemBool(item map[string]types.AttributeValue, name string) bool {
+	if item == nil {
+		return false
+	}
+	switch v := item[name].(type) {
+	case *types.AttributeValueMemberBOOL:
+		return v.Value
+	case *types.AttributeValueMemberS:
+		return strings.EqualFold(strings.TrimSpace(v.Value), "true")
+	default:
+		return false
+	}
+}
+
+func normalizeDomain(raw string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(raw)), ".")
+}
+
+func normalizeEmail(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func normalizeEmailList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if v := normalizeEmail(value); v != "" {
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeStringList(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if v := strings.ToLower(strings.TrimSpace(value)); v != "" {
+			out = append(out, v)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}
+
+func die(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/scripts/soul-email-m0-inventory/main_test.go
+++ b/scripts/soul-email-m0-inventory/main_test.go
@@ -1,0 +1,338 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+const (
+	testPilotEmail        = "pilot@lessersoul.ai"
+	testPilotInboundEmail = "pilot@inbound.lessersoul.ai"
+	testPilotScopedEmail  = "pilot.simulacrum@lessersoul.ai"
+	testScoutScopedEmail  = "scout.simulacrum@lessersoul.ai"
+	testAttrAgentID       = "agentId"
+	testAttrStatus        = "status"
+)
+
+func TestBuildProposedManagedAddress(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildProposedManagedAddress(" Agent.With.Dot ", "Simulacrum")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if got.LocalPart != "agent.with.dot.simulacrum" || got.Address != "agent.with.dot.simulacrum@lessersoul.ai" {
+		t.Fatalf("unexpected proposed address: %#v", got)
+	}
+	if got.LocalPartLength != len("agent.with.dot.simulacrum") || got.Overflow {
+		t.Fatalf("unexpected proposed length/overflow: %#v", got)
+	}
+}
+
+func TestBuildProposedManagedAddressRejectsInvalidSlugAndOverflow(t *testing.T) {
+	t.Parallel()
+
+	if _, err := buildProposedManagedAddress("agent", "bad_slug"); err == nil || err.Error() != "invalid_instance_slug" {
+		t.Fatalf("expected invalid_instance_slug, got %v", err)
+	}
+
+	got, err := buildProposedManagedAddress("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug")
+	if err == nil || err.Error() != "proposed_local_part_overflow" {
+		t.Fatalf("expected overflow, got proposed=%#v err=%v", got, err)
+	}
+	if !got.Overflow || got.LocalPartLength <= smtpLocalPartLimit {
+		t.Fatalf("expected overflow metadata, got %#v", got)
+	}
+}
+
+func TestAnnotateProposedDuplicates(t *testing.T) {
+	t.Parallel()
+
+	records := []managedEmailInventory{
+		{AgentID: "a", Proposed: proposedEmailInventory{Address: "Pilot.Simulacrum@lessersoul.ai"}},
+		{AgentID: "b", Proposed: proposedEmailInventory{Address: "pilot.simulacrum@lessersoul.ai"}},
+		{AgentID: "c", Proposed: proposedEmailInventory{Address: testScoutScopedEmail}},
+	}
+	annotateProposedDuplicates(records)
+	if !records[0].Proposed.Duplicate || !records[1].Proposed.Duplicate || records[2].Proposed.Duplicate {
+		t.Fatalf("unexpected duplicate annotations: %#v", records)
+	}
+	if len(records[0].Issues) != 1 || records[0].Issues[0] != "duplicate_proposed_address" {
+		t.Fatalf("expected duplicate issue, got %#v", records[0].Issues)
+	}
+}
+
+func TestLoadProviderSnapshotNormalizesRedactedState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "provider.json")
+	if err := os.WriteFile(path, []byte(`{
+  "source":"operator-redacted-migadu-export",
+  "addresses":[
+    {"local_part":" Pilot ","mailbox_exists":true,"forwardings":["Pilot@Inbound.LesserSoul.ai"],"aliases":[" PILOT "]},
+    {"address":"`+testScoutScopedEmail+`","mailbox_exists":false}
+  ]
+}`), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	states, source, err := loadProviderSnapshot(path)
+	if err != nil {
+		t.Fatalf("load snapshot: %v", err)
+	}
+	if source != "operator-redacted-migadu-export" {
+		t.Fatalf("unexpected source %q", source)
+	}
+	pilot := states["pilot"]
+	if pilot.Address != testPilotEmail || len(pilot.Forwardings) != 1 || pilot.Forwardings[0] != testPilotInboundEmail || len(pilot.Aliases) != 1 || pilot.Aliases[0] != "pilot" {
+		t.Fatalf("unexpected normalized pilot state: %#v", pilot)
+	}
+	if got := providerStateForEmail(states, "Scout.Simulacrum@LesserSoul.ai"); got == nil || got.Address != testScoutScopedEmail {
+		t.Fatalf("expected scout provider state, got %#v", got)
+	}
+}
+
+func TestParseConfigDefaults(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseConfig(nil, func(key string) string {
+		switch key {
+		case "STAGE":
+			return "live"
+		case "STATE_TABLE_NAME":
+			return ""
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if cfg.Stage != "live" || cfg.TableName != "lesser-host-live-state" || cfg.PageSize != 100 {
+		t.Fatalf("unexpected defaults: %#v", cfg)
+	}
+}
+
+func TestLoadRegistrationSnapshotNormalizesSigningState(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registration.json")
+	if err := os.WriteFile(path, []byte(`{
+  "source":"redacted-registration-export",
+  "agents":[
+    {"agent_id":" 0xABC ","email_channel":" Pilot@LesserSoul.ai ","can_self_attest":"true"},
+    {"agent_id":"0xdef","email_channel":"`+testScoutScopedEmail+`","can_self_attest":"no","source":"agent-note"}
+  ]
+}`), 0o600); err != nil {
+		t.Fatalf("write snapshot: %v", err)
+	}
+
+	states, err := loadRegistrationSnapshot(path)
+	if err != nil {
+		t.Fatalf("load registration snapshot: %v", err)
+	}
+	if got := states["0xabc"]; got.EmailChannel != "pilot@lessersoul.ai" || got.CanSelfAttest != signingStateYes || got.Source != "redacted-registration-export" {
+		t.Fatalf("unexpected first state: %#v", got)
+	}
+	if got := states["0xdef"]; got.EmailChannel != testScoutScopedEmail || got.CanSelfAttest != signingStateNo || got.Source != "agent-note" {
+		t.Fatalf("unexpected second state: %#v", got)
+	}
+}
+
+type fakeDynamoClient struct {
+	items map[string]map[string]types.AttributeValue
+}
+
+func (f fakeDynamoClient) Scan(ctx context.Context, in *dynamodb.ScanInput, opts ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+	_ = ctx
+	_ = in
+	_ = opts
+	out := &dynamodb.ScanOutput{}
+	for _, item := range f.items {
+		if itemString(item, "SK") == "IDENTITY" {
+			out.Items = append(out.Items, item)
+		}
+	}
+	return out, nil
+}
+
+func (f fakeDynamoClient) GetItem(ctx context.Context, in *dynamodb.GetItemInput, opts ...func(*dynamodb.Options)) (*dynamodb.GetItemOutput, error) {
+	_ = ctx
+	_ = opts
+	pk := itemString(in.Key, "PK")
+	sk := itemString(in.Key, "SK")
+	item := f.items[pk+"|"+sk]
+	return &dynamodb.GetItemOutput{Item: item}, nil
+}
+
+func TestBuildInventoryReportHappyPath(t *testing.T) {
+	t.Parallel()
+
+	report, err := buildHappyInventoryReport(t)
+	if err != nil {
+		t.Fatalf("build report: %v", err)
+	}
+	assertHappyInventoryReport(t, report)
+}
+
+func buildHappyInventoryReport(t *testing.T) (inventoryReport, error) {
+	t.Helper()
+	dir := t.TempDir()
+	providerPath := filepath.Join(dir, "provider.json")
+	registrationPath := filepath.Join(dir, "registration.json")
+	writeHappyInventorySnapshots(t, providerPath, registrationPath)
+	client := fakeDynamoClient{items: map[string]map[string]types.AttributeValue{}}
+	seedHappyInventoryDynamo(client.items)
+	cfg := inventoryConfig{Stage: defaultInventoryStage, TableName: "table", ProviderStatePath: providerPath, RegistrationStatePath: registrationPath, PageSize: 100}
+	return buildInventoryReport(context.Background(), client, cfg, time.Unix(0, 0).UTC())
+}
+
+func writeHappyInventorySnapshots(t *testing.T, providerPath string, registrationPath string) {
+	t.Helper()
+	mustWriteTestFile(t, providerPath, `{
+  "source":"provider-redacted",
+  "addresses":[
+    {"local_part":"pilot","mailbox_exists":true,"forwardings":["pilot@inbound.lessersoul.ai"]},
+    {"local_part":"pilot.simulacrum","mailbox_exists":false}
+  ]
+}`)
+	mustWriteTestFile(t, registrationPath, `{
+  "source":"registration-redacted",
+  "agents":[
+    {"agent_id":"0xagent","email_channel":"pilot@lessersoul.ai","can_self_attest":"yes"}
+  ]
+}`)
+}
+
+func seedHappyInventoryDynamo(items map[string]map[string]types.AttributeValue) {
+	putFakeItem(items, "SOUL#AGENT#0xagent", "IDENTITY", map[string]types.AttributeValue{
+		testAttrAgentID:          avs("0xagent"),
+		"domain":                 avs("dev.simulacrum.greater.website"),
+		"localId":                avs("pilot"),
+		testAttrStatus:           avs("active"),
+		"lifecycleStatus":        avs("active"),
+		"selfDescriptionVersion": avn("3"),
+	})
+	putFakeItem(items, "SOUL#AGENT#0xagent", "CHANNEL#email", map[string]types.AttributeValue{
+		testAttrAgentID: avs("0xagent"),
+		"identifier":    avs(testPilotEmail),
+		"provider":      avs("migadu"),
+		testAttrStatus:  avs("active"),
+		"verified":      avb(true),
+		"secretRef":     avs("/redacted"),
+	})
+	putFakeItem(items, "SOUL#EMAIL#pilot@lessersoul.ai", "AGENT", map[string]types.AttributeValue{
+		"email":         avs(testPilotEmail),
+		testAttrAgentID: avs("0xagent"),
+	})
+	putFakeItem(items, "DOMAIN#simulacrum.greater.website", "METADATA", map[string]types.AttributeValue{
+		"domain":             avs("simulacrum.greater.website"),
+		"instanceSlug":       avs("simulacrum"),
+		"type":               avs("primary"),
+		testAttrStatus:       avs("verified"),
+		"verificationMethod": avs("managed"),
+	})
+	putFakeItem(items, "INSTANCE#simulacrum", "METADATA", map[string]types.AttributeValue{
+		"slug":             avs("simulacrum"),
+		"hostedBaseDomain": avs("simulacrum.greater.website"),
+	})
+	putFakeItem(items, "SOUL#AGENT#0xagent", "VERSION#3", map[string]types.AttributeValue{
+		"versionNumber":      avn("3"),
+		"registrationUri":    avs("s3://bucket/registry/v1/agents/0xagent/registration.json"),
+		"registrationSha256": avs("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		"changeSummary":      avs("seed"),
+		"selfAttestation":    avs("0xsig"),
+	})
+}
+
+func assertHappyInventoryReport(t *testing.T, report inventoryReport) {
+	t.Helper()
+	if report.Summary.EligibleManagedEmail != 1 || len(report.Issues) != 0 || len(report.Agents) != 1 {
+		t.Fatalf("unexpected report summary/issues: summary=%#v issues=%#v agents=%d", report.Summary, report.Issues, len(report.Agents))
+	}
+	agent := report.Agents[0]
+	assertHappyInventoryDomain(t, agent)
+	assertHappyInventoryRegistration(t, agent)
+	if agent.Proposed.Address != testPilotScopedEmail || agent.Proposed.Overflow || agent.Proposed.Duplicate {
+		t.Fatalf("unexpected proposed address: %#v", agent.Proposed)
+	}
+	if agent.MigrationReadiness.CanSelfAttest != signingStateYes || agent.MigrationReadiness.HostMigrationPathNeeded {
+		t.Fatalf("unexpected readiness: %#v", agent.MigrationReadiness)
+	}
+	if agent.ProviderState.Current == nil || agent.ProviderState.Proposed == nil {
+		t.Fatalf("expected provider state on current and proposed: %#v", agent.ProviderState)
+	}
+}
+
+func assertHappyInventoryDomain(t *testing.T, agent managedEmailInventory) {
+	t.Helper()
+	if agent.DomainRecord == nil || agent.DomainRecord.Resolution != "managed_stage_primary_alias" || agent.DomainRecord.InstanceSlug != "simulacrum" {
+		t.Fatalf("unexpected domain record: %#v", agent.DomainRecord)
+	}
+}
+
+func assertHappyInventoryRegistration(t *testing.T, agent managedEmailInventory) {
+	t.Helper()
+	if agent.RegistrationVersion == nil || agent.RegistrationVersion.EmailChannel != testPilotEmail || !agent.RegistrationVersion.SelfAttestationPresent {
+		t.Fatalf("unexpected registration version: %#v", agent.RegistrationVersion)
+	}
+}
+
+func TestAppendReportIssuesAndAttributeHelpers(t *testing.T) {
+	t.Parallel()
+
+	issues := appendReportIssues(nil, inventorySummary{MissingDomainRecord: 1, InactiveDomainRecord: 1, MissingInstanceSlug: 1, InvalidInstanceSlug: 1, MissingCurrentEmailIndex: 1, CurrentEmailIndexMismatch: 1})
+	if len(issues) != 6 {
+		t.Fatalf("expected 6 report issues, got %#v", issues)
+	}
+	item := map[string]types.AttributeValue{"s": avs(" value "), "n": avn("42"), "b": avb(true)}
+	if itemString(item, "s") != "value" || itemInt(item, "n") != 42 || !itemBool(item, "b") {
+		t.Fatalf("unexpected helper output")
+	}
+}
+
+func mustWriteTestFile(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func putFakeItem(items map[string]map[string]types.AttributeValue, pk string, sk string, attrs map[string]types.AttributeValue) {
+	attrs["PK"] = avs(pk)
+	attrs["SK"] = avs(sk)
+	items[pk+"|"+sk] = attrs
+}
+
+func avs(v string) types.AttributeValue { return &types.AttributeValueMemberS{Value: v} }
+func avn(v string) types.AttributeValue { return &types.AttributeValueMemberN{Value: v} }
+func avb(v bool) types.AttributeValue   { return &types.AttributeValueMemberBOOL{Value: v} }
+
+func TestWriteReportStdoutAndFile(t *testing.T) {
+	t.Parallel()
+
+	report := newInventoryReport(inventoryConfig{Stage: defaultInventoryStage, TableName: "table"}, time.Unix(0, 0).UTC(), 0)
+	var stdout bytes.Buffer
+	if err := writeReport(report, "-", &stdout); err != nil {
+		t.Fatalf("write stdout: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte(`"schema_version": 1`)) {
+		t.Fatalf("stdout report missing schema version: %s", stdout.String())
+	}
+	path := filepath.Join(t.TempDir(), "report.json")
+	if err := writeReport(report, path, &bytes.Buffer{}); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if info, err := os.Stat(path); err != nil || info.Size() == 0 {
+		t.Fatalf("expected report file, info=%#v err=%v", info, err)
+	}
+}


### PR DESCRIPTION
## Milestone
Project 37 M0 — Contract, inventory, and architecture review for instance-scoped Lesser Soul email

## Classification
soul-registry / host-comm / docs / operational-reliability / migration-planning

## Surfaces affected
- `docs/instance-scoped-soul-email-m0.md`
- `docs/soul-surface.md`
- `scripts/soul-email-m0-inventory/*`

## Specialist walks referenced
- Governance rubric: no verifier/rubric changes; gov-rubric run locally and passed.
- Provisioning / managed-update / release verification: M1/M2 are constrained, but this PR does not change provisioning, provider mutation, managed-update, or consumer release verification code.
- Soul registry: M0 defines registration/self-description integrity, `SoulAgentChannel`, `SoulEmailAgentIndex`, and future legacy alias/index invariants; no Solidity/on-chain-reaching code changed.
- Trust API / CSP / instance-auth: not affected.
- Framework: not affected.

## Multi-tenant isolation impact
No tenant data is read into host. The inventory command is read-only against host metadata and supports redacted provider/registration snapshots only.

## On-chain impact
None. No contracts, Safe-ready payloads, mint-signer handling, or on-chain state changed.

## Consumer impact
- Managed Lesser Soul agents get a documented future address contract: `<agent-local-id>.<instance-slug>@lessersoul.ai`.
- M1/M2 implementation is blocked on the documented M0 invariants and dry-run inventory signoff.
- Body/Lesser/Greater/Sim compatibility remains tracked in Project 37 M3 issues.

## Tasks
- [x] Refs #326 — canonical address contract and length policy.
- [x] Refs #327 — repeatable dry-run inventory command/output shape for current host/provider/registration state.
- [x] Refs #328 — self-description integrity path for migrated email channels.
- [x] Refs #348 — legacy bare-address alias/canonicalization contract.
- [x] Refs #349 — migration state machine and invariants.
- [x] Links Arch review outcome from #329.

## Validation
- `go test ./...`
- `go vet ./...`
- `gofmt -l $(git ls-files '*.go'; find scripts/soul-email-m0-inventory -name '*.go')` (empty)
- `git diff --check`
- `golangci-lint run ./scripts/soul-email-m0-inventory`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
No deploy required for M0 docs/tooling. M1/M2 implementation and any live inventory/migration evidence remain separate Project 37 milestones.

## Cross-repo coordination
Required later for M3 compatibility issues in Lesser, Body, Greater, and Simulacrum. No cross-repo code changes in this PR.

## Advisor-brief authorization
Aron authorized Arch's Project 37 M0 assignment in-session on 2026-05-21. Assignment source: `agents/arch/project37-m0-host-assignment-20260521.md`; Arch review outcome: https://github.com/equaltoai/lesser-host/issues/329#issuecomment-4509202671.

## M1 assignment gate
M1 should remain blocked until this PR is reviewed and the M0 issue bodies/checklists carry forward the documented alias/index and migration-state constraints.
