### PR TITLE
feat(soul): implement instance-scoped email provisioning

### DIFF
--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -139,6 +139,11 @@ components:
                 address:
                   type: string
                   format: email
+                  description: >
+                    Current managed lessersoul.ai channels are derived as
+                    <agent-local-id>.<instance-slug>@lessersoul.ai. Legacy bare
+                    <agent-local-id>@lessersoul.ai addresses are inbound aliases
+                    for migrated agents only and are not current public channels.
                 capabilities:
                   type: array
                   minItems: 1

--- a/docs/soul-surface.md
+++ b/docs/soul-surface.md
@@ -190,7 +190,7 @@ Sender -> Migadu mailbox -> <agent-local-id>.<instance-slug>@inbound.lessersoul.
 
 - Migadu remains the mailbox and outbound SMTP provider for `@lessersoul.ai`.
 - Project 37 defines the instance-scoped managed address contract in `docs/instance-scoped-soul-email-m0.md`: new managed soul email channels use `<agent-local-id>.<instance-slug>@lessersoul.ai`, with `instanceSlug` resolved from `Domain.InstanceSlug`.
-- New provisioning and operational backfills set Migadu forwarding targets to `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`.
+- New provisioning derives the provider local-part from `Domain.InstanceSlug` and sets Migadu forwarding targets to `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`.
 - Existing bare `<agent-local-id>@lessersoul.ai` addresses are legacy inbound aliases for migrated agents only; they are not current public channels after migration.
 - Amazon SES receives mail for `inbound.lessersoul.ai`, stores the raw message in S3, and invokes `cmd/email-ingress`.
 - `cmd/email-ingress` parses the raw RFC 5322 message and enqueues the existing `communication:inbound` payload shape for `comm-worker`.

--- a/docs/spec/v3/README.md
+++ b/docs/spec/v3/README.md
@@ -6,6 +6,10 @@ surfaces implemented by `lesser-host`.
 - `schemas/` — JSON Schema (draft 2020-12)
 - `fixtures/` — example payloads intended for cross-repo consumption (`lesser`, `lesser-body`)
 
+Managed `@lessersoul.ai` email examples use the Project 37 current-channel form
+`<agent-local-id>.<instance-slug>@lessersoul.ai`. Bare `<agent-local-id>@lessersoul.ai`
+addresses are legacy inbound aliases only after migration and should not appear as
+current public managed channels in new fixtures.
+
 These files are intended to be stable. If you need to change a schema, treat it as a protocol change (reviewed
 alongside the spec).
-

--- a/docs/spec/v3/fixtures/communication-inbound-notification.email.example.json
+++ b/docs/spec/v3/fixtures/communication-inbound-notification.email.example.json
@@ -7,7 +7,7 @@
     "displayName": "Alice"
   },
   "to": {
-    "address": "agent-bob@lessersoul.ai"
+    "address": "agent-bob.simulacrum@lessersoul.ai"
   },
   "subject": "Re: Project collaboration",
   "body": "Hello Bob,\\n\\nAre you available to collaborate on the project?\\n",

--- a/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
+++ b/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
@@ -7,7 +7,7 @@
     "displayName": "agent-alice.lessersoul.eth"
   },
   "to": {
-    "address": "agent-bob@lessersoul.ai",
+    "address": "agent-bob.simulacrum@lessersoul.ai",
     "number": "+15551234"
   },
   "body": "Hey — can you review the draft by tonight?",

--- a/docs/spec/v3/fixtures/soul-agent-channels.response.example.json
+++ b/docs/spec/v3/fixtures/soul-agent-channels.response.example.json
@@ -7,7 +7,7 @@
       "chain": "mainnet"
     },
     "email": {
-      "address": "agent-bob@lessersoul.ai",
+      "address": "agent-bob.simulacrum@lessersoul.ai",
       "capabilities": ["receive", "send"],
       "protocols": ["smtp"],
       "verified": true,

--- a/internal/commworker/helpers_internal_test.go
+++ b/internal/commworker/helpers_internal_test.go
@@ -252,7 +252,12 @@ func TestCommWorkerStoreAndNotificationHelpers(t *testing.T) {
 
 func newCommWorkerStoreHelperStore(now time.Time) *fakeStore {
 	return &fakeStore{
-		emailIndex: map[string]string{"alice@example.com": "0xabc"},
+		emailIndex: map[string]string{
+			"alice@example.com":                       "0xabc",
+			"agent.with.dot.simulacrum@lessersoul.ai": "0xcompound",
+			"pilot.simulacrum@lessersoul.ai":          "0xpilot-sim",
+			"pilot.other-instance@lessersoul.ai":      "0xpilot-other",
+		},
 		phoneIndex: map[string]string{"+15551234567": "0xdef"},
 		domains:    map[string]*models.Domain{"example.com": {Domain: "example.com", InstanceSlug: "inst-1"}},
 		instances:  map[string]*models.Instance{"inst-1": {Slug: "inst-1", HostedBaseDomain: "demo.example.com"}},
@@ -266,7 +271,8 @@ func newCommWorkerStoreHelperStore(now time.Time) *fakeStore {
 			},
 		},
 		channels: map[string]*models.SoulAgentChannel{
-			"0xabc#email": {AgentID: "0xabc", ChannelType: "email", Identifier: commTestAgentEmail, SecretRef: "/pw"},
+			"0xabc#email":      {AgentID: "0xabc", ChannelType: "email", Identifier: commTestAgentEmail, SecretRef: "/pw"},
+			"0xcompound#email": {AgentID: "0xcompound", ChannelType: "email", Identifier: "agent.with.dot.simulacrum@lessersoul.ai", SecretRef: "/pw"},
 		},
 	}
 }
@@ -294,6 +300,34 @@ func testResolveRecipientAndChannelMatching(t *testing.T, s *Server) {
 	}
 	if s.channelMatchesNotification(nil, "sms", &InboundParty{Number: "1"}) {
 		t.Fatalf("expected nil channel to miss")
+	}
+
+	testResolveInstanceScopedEmailRecipients(t, s)
+	testChannelMatchesInstanceScopedEmail(t, s)
+}
+
+func testResolveInstanceScopedEmailRecipients(t *testing.T, s *Server) {
+	t.Helper()
+
+	agentID, ok, err := s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "Agent.With.Dot.Simulacrum@LesserSoul.ai"})
+	if err != nil || !ok || agentID != "0xcompound" {
+		t.Fatalf("unexpected compound local-part lookup: %q %v %v", agentID, ok, err)
+	}
+	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "pilot.simulacrum@lessersoul.ai"})
+	if err != nil || !ok || agentID != "0xpilot-sim" {
+		t.Fatalf("unexpected same-local-id first instance lookup: %q %v %v", agentID, ok, err)
+	}
+	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "pilot.other-instance@lessersoul.ai"})
+	if err != nil || !ok || agentID != "0xpilot-other" {
+		t.Fatalf("unexpected same-local-id second instance lookup: %q %v %v", agentID, ok, err)
+	}
+}
+
+func testChannelMatchesInstanceScopedEmail(t *testing.T, s *Server) {
+	t.Helper()
+
+	if !s.channelMatchesNotification(&models.SoulAgentChannel{Identifier: "agent.with.dot.simulacrum@lessersoul.ai"}, "email", &InboundParty{Address: "Agent.With.Dot.Simulacrum@LesserSoul.ai"}) {
+		t.Fatalf("expected compound email match")
 	}
 }
 

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -15,13 +15,25 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
+	"github.com/equaltoai/lesser-host/internal/domains"
 	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/secrets"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
+const (
+	soulManagedEmailDomain    = "lessersoul.ai"
+	soulEmailSMTPLocalPartMax = 64
+
+	soulEmailProvisionErrAddressTaken        = "email address is already provisioned"
+	soulEmailProvisionErrDerivedLocalPartReq = "local_part must match derived provider local part"
+)
+
 type soulProvisionEmailBeginRequest struct {
+	// LocalPart is retained for wire compatibility only. New managed soul email
+	// provisioning derives the provider local part from agent local ID +
+	// Domain.InstanceSlug, and callers may not choose a bare/custom handle.
 	LocalPart string `json:"local_part,omitempty"`
 }
 
@@ -37,6 +49,9 @@ type soulProvisionEmailBeginResponse struct {
 }
 
 type soulProvisionEmailConfirmRequest struct {
+	// LocalPart is retained for wire compatibility only. When present it must
+	// match the derived provider local part exactly; stale bare local-parts are
+	// rejected before provider calls.
 	LocalPart string `json:"local_part,omitempty"`
 
 	IssuedAt        string `json:"issued_at"`
@@ -63,11 +78,11 @@ func (s *Server) handleSoulBeginProvisionEmailChannel(ctx *apptheory.Context) (*
 		}
 	}
 
-	localNorm, address, ensName, appErr := resolveSoulProvisionEmailAddress(identity, req.LocalPart)
+	emailAddress, appErr := s.resolveSoulProvisionEmailAddress(ctx.Context(), identity, req.LocalPart)
 	if appErr != nil {
 		return nil, appErr
 	}
-	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); availabilityErr != nil {
+	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, emailAddress.Address); availabilityErr != nil {
 		return nil, availabilityErr
 	}
 
@@ -82,9 +97,9 @@ func (s *Server) handleSoulBeginProvisionEmailChannel(ctx *apptheory.Context) (*
 	nextVersion := expectedVersion + 1
 
 	regMap, regV3, digest, appErr := s.buildSoulProvisionEmailRegistration(ctx.Context(), baseReg, baseVersion, agentIDHex, identity, soulProvisionEmailBuildInput{
-		LocalPart:          localNorm,
-		EmailAddress:       address,
-		ENSName:            ensName,
+		LocalPart:          emailAddress.ProviderLocalPart,
+		EmailAddress:       emailAddress.Address,
+		ENSName:            emailAddress.ENSName,
 		IssuedAt:           now,
 		ExpectedPrev:       expectedVersion,
 		NextVersion:        nextVersion,
@@ -97,8 +112,8 @@ func (s *Server) handleSoulBeginProvisionEmailChannel(ctx *apptheory.Context) (*
 
 	return apptheory.JSON(http.StatusOK, soulProvisionEmailBeginResponse{
 		Version:         "1",
-		Address:         address,
-		ENSName:         ensName,
+		Address:         emailAddress.Address,
+		ENSName:         emailAddress.ENSName,
 		DigestHex:       "0x" + hex.EncodeToString(digest),
 		IssuedAt:        now.Format(time.RFC3339Nano),
 		ExpectedVersion: expectedVersion,
@@ -130,11 +145,11 @@ func (s *Server) handleSoulProvisionEmailChannel(ctx *apptheory.Context) (*appth
 		return nil, &apptheory.AppError{Code: "app.conflict", Message: "version conflict; reload and try again"}
 	}
 
-	localNorm, address, ensName, appErr := resolveSoulProvisionEmailAddress(identity, req.LocalPart)
+	emailAddress, appErr := s.resolveSoulProvisionEmailAddress(ctx.Context(), identity, req.LocalPart)
 	if appErr != nil {
 		return nil, appErr
 	}
-	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, address); availabilityErr != nil {
+	if availabilityErr := s.validateSoulProvisionEmailAddressAvailability(ctx.Context(), agentIDHex, emailAddress.Address); availabilityErr != nil {
 		return nil, availabilityErr
 	}
 
@@ -147,9 +162,9 @@ func (s *Server) handleSoulProvisionEmailChannel(ctx *apptheory.Context) (*appth
 	nextVersion := expectedVersion + 1
 
 	regMap, regV3, digest, appErr := s.buildSoulProvisionEmailRegistration(ctx.Context(), baseReg, baseVersion, agentIDHex, identity, soulProvisionEmailBuildInput{
-		LocalPart:          localNorm,
-		EmailAddress:       address,
-		ENSName:            ensName,
+		LocalPart:          emailAddress.ProviderLocalPart,
+		EmailAddress:       emailAddress.Address,
+		ENSName:            emailAddress.ENSName,
 		IssuedAt:           issuedAt.UTC(),
 		ExpectedPrev:       expectedVersion,
 		NextVersion:        nextVersion,
@@ -162,7 +177,7 @@ func (s *Server) handleSoulProvisionEmailChannel(ctx *apptheory.Context) (*appth
 	if verifyErr := verifyEthereumSignatureBytes(identity.Wallet, digest, selfSig); verifyErr != nil {
 		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid registration signature"}
 	}
-	return s.finalizeSoulProvisionEmailChannel(ctx, agentIDHex, identity, expectedVersion, localNorm, address, regMap, regV3, selfSig)
+	return s.finalizeSoulProvisionEmailChannel(ctx, agentIDHex, identity, expectedVersion, emailAddress.ProviderLocalPart, emailAddress.Address, regMap, regV3, selfSig)
 }
 
 func parseSoulProvisionConfirm(expectedVersion *int, issuedAtRaw string, selfAttestation string) (int, time.Time, string, *apptheory.AppError) {
@@ -484,33 +499,94 @@ func (s *Server) requireSoulProvisionIdentity(ctx *apptheory.Context) (string, *
 	return agentIDHex, identity, nil
 }
 
-func resolveSoulProvisionEmailAddress(identity *models.SoulAgentIdentity, requestedLocalPart string) (string, string, string, *apptheory.AppError) {
+type soulProvisionManagedEmailAddress struct {
+	AgentLocalID      string
+	InstanceSlug      string
+	ProviderLocalPart string
+	Address           string
+	ENSName           string
+}
+
+func (s *Server) resolveSoulProvisionEmailAddress(ctx context.Context, identity *models.SoulAgentIdentity, requestedLocalPart string) (soulProvisionManagedEmailAddress, *apptheory.AppError) {
 	if identity == nil {
-		return "", "", "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	canonicalLocal, err := soul.NormalizeLocalAgentID(identity.LocalID)
 	if err != nil || canonicalLocal == "" {
-		return "", "", "", &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
 	}
-	localPart := strings.TrimSpace(requestedLocalPart)
-	if localPart == "" {
-		localPart = canonicalLocal
+	instanceSlug, appErr := s.resolveSoulProvisionEmailInstanceSlug(ctx, identity)
+	if appErr != nil {
+		return soulProvisionManagedEmailAddress{}, appErr
 	}
-	localNorm, err := soul.NormalizeLocalAgentID(localPart)
+	return buildSoulProvisionManagedEmailAddress(canonicalLocal, instanceSlug, requestedLocalPart)
+}
+
+func (s *Server) resolveSoulProvisionEmailInstanceSlug(ctx context.Context, identity *models.SoulAgentIdentity) (string, *apptheory.AppError) {
+	if s == nil || identity == nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	normalizedDomain, err := domains.NormalizeDomain(identity.Domain)
 	if err != nil {
-		return "", "", "", &apptheory.AppError{Code: "app.bad_request", Message: "localPart is invalid"}
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is invalid"}
 	}
-	if localNorm != canonicalLocal {
-		return "", "", "", &apptheory.AppError{Code: "app.conflict", Message: "localPart must match agent local id"}
+
+	domain, loadErr := s.loadManagedStageAwareDomain(ctx, normalizedDomain)
+	if theoryErrors.IsNotFound(loadErr) {
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not registered for managed email"}
 	}
-	ensName := soulCanonicalENSName(canonicalLocal)
-	return localNorm, localNorm + "@lessersoul.ai", ensName, nil
+	if loadErr != nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "failed to load agent domain"}
+	}
+	if domain == nil || !domainIsVerifiedOrActive(domain.Status) {
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not verified for managed email"}
+	}
+
+	instanceSlug := strings.ToLower(strings.TrimSpace(domain.InstanceSlug))
+	if !instanceSlugRE.MatchString(instanceSlug) {
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain instance slug is invalid"}
+	}
+	return instanceSlug, nil
+}
+
+func buildSoulProvisionManagedEmailAddress(agentLocalID string, instanceSlug string, requestedLocalPart string) (soulProvisionManagedEmailAddress, *apptheory.AppError) {
+	canonicalLocal, err := soul.NormalizeLocalAgentID(agentLocalID)
+	if err != nil || canonicalLocal == "" {
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
+	}
+	slug := strings.ToLower(strings.TrimSpace(instanceSlug))
+	if !instanceSlugRE.MatchString(slug) {
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent domain instance slug is invalid"}
+	}
+
+	providerLocalPart := canonicalLocal + "." + slug
+	if len(providerLocalPart) > soulEmailSMTPLocalPartMax {
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "email local_part exceeds 64-octet SMTP limit"}
+	}
+
+	if requested := strings.TrimSpace(requestedLocalPart); requested != "" {
+		requestedNorm, err := soul.NormalizeLocalAgentID(requested)
+		if err != nil {
+			return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.bad_request", Message: "local_part is invalid"}
+		}
+		if requestedNorm != providerLocalPart {
+			return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: soulEmailProvisionErrDerivedLocalPartReq}
+		}
+	}
+
+	return soulProvisionManagedEmailAddress{
+		AgentLocalID:      canonicalLocal,
+		InstanceSlug:      slug,
+		ProviderLocalPart: providerLocalPart,
+		Address:           providerLocalPart + "@" + soulManagedEmailDomain,
+		ENSName:           soulCanonicalENSName(canonicalLocal),
+	}, nil
 }
 
 func (s *Server) validateSoulProvisionEmailAddressAvailability(ctx context.Context, agentIDHex string, address string) *apptheory.AppError {
 	emailIdx := &models.SoulEmailAgentIndex{Email: address}
 	_ = emailIdx.UpdateKeys()
-	return s.validateSoulProvisionIndexAvailability(ctx, &models.SoulEmailAgentIndex{}, emailIdx.PK, emailIdx.SK, agentIDHex, "email address is already provisioned", "failed to validate email mapping", func() any {
+	return s.validateSoulProvisionIndexAvailability(ctx, &models.SoulEmailAgentIndex{}, emailIdx.PK, emailIdx.SK, agentIDHex, soulEmailProvisionErrAddressTaken, "failed to validate email mapping", func() any {
 		return &models.SoulEmailAgentIndex{}
 	}, func(existing any) string {
 		if idx, ok := existing.(*models.SoulEmailAgentIndex); ok && idx != nil {

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -25,9 +25,14 @@ import (
 )
 
 const (
-	provisionTestEmailLocalPart = "agent-alice"
-	provisionTestEmailAddress   = provisionTestEmailLocalPart + "@lessersoul.ai"
-	provisionTestEmailENSName   = provisionTestEmailLocalPart + ".lessersoul.eth"
+	provisionTestAgentLocalID    = "agent-alice"
+	provisionTestInstanceSlug    = "inst1"
+	provisionTestEmailLocalPart  = provisionTestAgentLocalID + "." + provisionTestInstanceSlug
+	provisionTestEmailAddress    = provisionTestEmailLocalPart + "@lessersoul.ai"
+	provisionTestEmailENSName    = provisionTestAgentLocalID + ".lessersoul.eth"
+	provisionTestAgentDomain     = "example.com"
+	provisionTestStageAlias      = "dev.simulacrum.greater.website"
+	provisionTestStageBaseDomain = "simulacrum.greater.website"
 )
 
 func mustMarshalJSON(t testing.TB, v any) []byte {
@@ -53,8 +58,8 @@ func testProvisionManagedChannelBaseRegistration(agentIDHex string, wallet strin
 	return map[string]any{
 		"version": "2",
 		"agentId": agentIDHex,
-		"domain":  "example.com",
-		"localId": provisionTestEmailLocalPart,
+		"domain":  provisionTestAgentDomain,
+		"localId": provisionTestAgentLocalID,
 		"wallet":  wallet,
 		"principal": map[string]any{
 			"type":        "individual",
@@ -144,22 +149,200 @@ func TestHandleSoulProvisionEmail_BeginThenConfirm_PublishesV3WithChannelAndIsId
 	assertProvisionEmailIdempotent(t, fixture, confirmBody)
 }
 
-func TestResolveSoulProvisionEmailAddress_RequiresAgentLocalID(t *testing.T) {
+func TestBuildSoulProvisionManagedEmailAddress_DerivesInstanceScopedAddress(t *testing.T) {
 	t.Parallel()
 
-	identity := &models.SoulAgentIdentity{LocalID: "agent-alice"}
-	_, _, _, appErr := resolveSoulProvisionEmailAddress(identity, "victim")
-	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "localPart must match agent local id" {
-		t.Fatalf("expected local id conflict, got %v", appErr)
+	_, appErr := buildSoulProvisionManagedEmailAddress(provisionTestAgentLocalID, provisionTestInstanceSlug, "victim")
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrDerivedLocalPartReq {
+		t.Fatalf("expected stale local_part conflict, got %v", appErr)
 	}
 
-	local, address, ens, appErr := resolveSoulProvisionEmailAddress(identity, "")
+	got, appErr := buildSoulProvisionManagedEmailAddress(provisionTestAgentLocalID, provisionTestInstanceSlug, "")
 	if appErr != nil {
-		t.Fatalf("expected canonical local id success, got %v", appErr)
+		t.Fatalf("expected derived address success, got %v", appErr)
 	}
-	if local != "agent-alice" || address != provisionTestEmailAddress || ens != provisionTestEmailENSName {
-		t.Fatalf("unexpected resolved address: local=%q address=%q ens=%q", local, address, ens)
+	if got.AgentLocalID != provisionTestAgentLocalID ||
+		got.InstanceSlug != provisionTestInstanceSlug ||
+		got.ProviderLocalPart != provisionTestEmailLocalPart ||
+		got.Address != provisionTestEmailAddress ||
+		got.ENSName != provisionTestEmailENSName {
+		t.Fatalf("unexpected resolved address: %#v", got)
 	}
+}
+
+func TestBuildSoulProvisionManagedEmailAddress_AllowsDotsAndSameLocalIDAcrossInstances(t *testing.T) {
+	t.Parallel()
+
+	got, appErr := buildSoulProvisionManagedEmailAddress("Agent.With.Dot", "simulacrum", "agent.with.dot.simulacrum")
+	if appErr != nil {
+		t.Fatalf("expected dotted local id success, got %v", appErr)
+	}
+	if got.ProviderLocalPart != "agent.with.dot.simulacrum" || got.Address != "agent.with.dot.simulacrum@lessersoul.ai" {
+		t.Fatalf("unexpected dotted address: %#v", got)
+	}
+
+	a, appErr := buildSoulProvisionManagedEmailAddress("pilot", "simulacrum", "")
+	if appErr != nil {
+		t.Fatalf("expected first instance success, got %v", appErr)
+	}
+	b, appErr := buildSoulProvisionManagedEmailAddress("pilot", "sim-lab", "")
+	if appErr != nil {
+		t.Fatalf("expected second instance success, got %v", appErr)
+	}
+	if a.Address == b.Address || a.Address != "pilot.simulacrum@lessersoul.ai" || b.Address != "pilot.sim-lab@lessersoul.ai" {
+		t.Fatalf("expected same local id to derive distinct instance addresses: a=%#v b=%#v", a, b)
+	}
+}
+
+func TestBuildSoulProvisionManagedEmailAddress_RejectsOverflowAndInvalidSlug(t *testing.T) {
+	t.Parallel()
+
+	_, appErr := buildSoulProvisionManagedEmailAddress(strings.Repeat("a", 56), "simulacrum", "")
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "email local_part exceeds 64-octet SMTP limit" {
+		t.Fatalf("expected SMTP local_part overflow conflict, got %v", appErr)
+	}
+
+	_, appErr = buildSoulProvisionManagedEmailAddress("pilot", "bad_slug", "")
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "agent domain instance slug is invalid" {
+		t.Fatalf("expected invalid slug conflict, got %v", appErr)
+	}
+}
+
+func TestValidateSoulProvisionEmailAddressAvailability_PreventsDuplicateFullAddress(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.SoulEmailAgentIndex")
+	qEmail := queries[0]
+	qEmail.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{
+			Email:   "pilot.simulacrum@lessersoul.ai",
+			AgentID: "0xother",
+		}
+	}).Once()
+
+	s := &Server{store: store.New(db)}
+	appErr := s.validateSoulProvisionEmailAddressAvailability(context.Background(), "0xagent", "pilot.simulacrum@lessersoul.ai")
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrAddressTaken {
+		t.Fatalf("expected duplicate full-address conflict, got %v", appErr)
+	}
+}
+
+func TestResolveSoulProvisionEmailAddress_ExactVanityDomain(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain")
+	qDomain := queries[0]
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:       "agents.example.com",
+			InstanceSlug: "vanity-inst",
+			Type:         models.DomainTypeVanity,
+			Status:       models.DomainStatusVerified,
+		}
+	}).Once()
+
+	s := &Server{store: store.New(db)}
+	got, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{
+		Domain:  "agents.example.com",
+		LocalID: "Pilot",
+	}, "")
+	if appErr != nil {
+		t.Fatalf("expected exact vanity resolution, got %v", appErr)
+	}
+	if got.ProviderLocalPart != "pilot.vanity-inst" || got.Address != "pilot.vanity-inst@lessersoul.ai" {
+		t.Fatalf("unexpected exact vanity address: %#v", got)
+	}
+}
+
+func TestResolveSoulProvisionEmailAddress_ManagedStagePrimaryAlias(t *testing.T) {
+	t.Parallel()
+
+	db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+	qDomain := queries[0]
+	qInstance := queries[1]
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+	qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:             provisionTestStageBaseDomain,
+			InstanceSlug:       "simulacrum",
+			Type:               models.DomainTypePrimary,
+			Status:             models.DomainStatusActive,
+			VerificationMethod: "managed",
+		}
+	}).Once()
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "simulacrum", HostedBaseDomain: provisionTestStageBaseDomain}
+	}).Once()
+
+	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+	got, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{
+		Domain:  provisionTestStageAlias,
+		LocalID: "Pilot",
+	}, "")
+	if appErr != nil {
+		t.Fatalf("expected managed stage alias resolution, got %v", appErr)
+	}
+	if got.ProviderLocalPart != "pilot.simulacrum" || got.Address != "pilot.simulacrum@lessersoul.ai" {
+		t.Fatalf("unexpected stage alias address: %#v", got)
+	}
+}
+
+func TestResolveSoulProvisionEmailAddress_FailsClosedForDomainState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing domain", func(t *testing.T) {
+		t.Parallel()
+
+		db, queries := newTestDBWithModelQueries("*models.Domain")
+		queries[0].On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+		s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+		_, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{Domain: "example.com", LocalID: "pilot"}, "")
+		if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "agent domain is not registered for managed email" {
+			t.Fatalf("expected missing-domain conflict, got %v", appErr)
+		}
+	})
+
+	t.Run("unverified exact domain", func(t *testing.T) {
+		t.Parallel()
+
+		db, queries := newTestDBWithModelQueries("*models.Domain")
+		queries[0].On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+			*dest = models.Domain{Domain: "example.com", InstanceSlug: "simulacrum", Status: models.DomainStatusPending}
+		}).Once()
+		s := &Server{store: store.New(db)}
+		_, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{Domain: "example.com", LocalID: "pilot"}, "")
+		if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "agent domain is not verified for managed email" {
+			t.Fatalf("expected unverified-domain conflict, got %v", appErr)
+		}
+	})
+
+	t.Run("stage vanity alias", func(t *testing.T) {
+		t.Parallel()
+
+		db, queries := newTestDBWithModelQueries("*models.Domain", "*models.Instance")
+		qDomain := queries[0]
+		qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(theoryErrors.ErrItemNotFound).Once()
+		qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+			*dest = models.Domain{
+				Domain:             "vanity.example.com",
+				InstanceSlug:       "simulacrum",
+				Type:               models.DomainTypeVanity,
+				Status:             models.DomainStatusVerified,
+				VerificationMethod: "dns_txt",
+			}
+		}).Once()
+		s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
+		_, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{Domain: "dev.vanity.example.com", LocalID: "pilot"}, "")
+		if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "agent domain is not registered for managed email" {
+			t.Fatalf("expected stage vanity alias conflict, got %v", appErr)
+		}
+	})
 }
 
 func newProvisionEmailE2EFixture(t *testing.T) *provisionEmailE2EFixture {
@@ -240,11 +423,11 @@ func seedProvisionEmailE2EAccess(t *testing.T, fixture *provisionEmailE2EFixture
 
 	fixture.tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
-		*dest = models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}
-	}).Times(3)
+		*dest = models.Domain{Domain: provisionTestAgentDomain, InstanceSlug: provisionTestInstanceSlug, Status: models.DomainStatusVerified}
+	}).Times(5)
 	fixture.tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
-		*dest = models.Instance{Slug: "inst1", Owner: "admin"}
+		*dest = models.Instance{Slug: provisionTestInstanceSlug, Owner: "admin"}
 	}).Times(3)
 
 	identityCalls := 0
@@ -257,8 +440,8 @@ func seedProvisionEmailE2EAccess(t *testing.T, fixture *provisionEmailE2EFixture
 		}
 		*dest = models.SoulAgentIdentity{
 			AgentID:                fixture.agentIDHex,
-			Domain:                 "example.com",
-			LocalID:                provisionTestEmailLocalPart,
+			Domain:                 provisionTestAgentDomain,
+			LocalID:                provisionTestAgentLocalID,
 			Wallet:                 fixture.wallet,
 			Status:                 models.SoulAgentStatusActive,
 			LifecycleStatus:        models.SoulAgentStatusActive,
@@ -350,6 +533,10 @@ func assertProvisionEmailConfirmCreated(t *testing.T, fixture *provisionEmailE2E
 	if confirmResp.Status != http.StatusCreated {
 		t.Fatalf("confirm expected 201, got %d (body=%q)", confirmResp.Status, string(confirmResp.Body))
 	}
+	confirmOut := mustUnmarshalJSON[soulProvisionEmailConfirmResponse](t, confirmResp.Body)
+	if confirmOut.Address != provisionTestEmailAddress || confirmOut.RegistrationVersion != 4 {
+		t.Fatalf("unexpected confirm response: %#v", confirmOut)
+	}
 	if len(fixture.migaduCalls) != 1 {
 		t.Fatalf("expected 1 migadu call, got %d", len(fixture.migaduCalls))
 	}
@@ -362,7 +549,7 @@ func assertProvisionEmailConfirmCreated(t *testing.T, fixture *provisionEmailE2E
 	if fixture.forwardingCalls[0].localPart != provisionTestEmailLocalPart {
 		t.Fatalf("expected forwarding localPart %s, got %q", provisionTestEmailLocalPart, fixture.forwardingCalls[0].localPart)
 	}
-	if fixture.forwardingCalls[0].address != "agent-alice@inbound.lessersoul.ai" {
+	if fixture.forwardingCalls[0].address != "agent-alice.inst1@inbound.lessersoul.ai" {
 		t.Fatalf("unexpected forwarding address: %q", fixture.forwardingCalls[0].address)
 	}
 }
@@ -408,6 +595,10 @@ func assertProvisionEmailIdempotent(t *testing.T, fixture *provisionEmailE2EFixt
 	}
 	if confirmResp.Status != http.StatusOK {
 		t.Fatalf("confirm2 expected 200, got %d (body=%q)", confirmResp.Status, string(confirmResp.Body))
+	}
+	confirmOut := mustUnmarshalJSON[soulProvisionEmailConfirmResponse](t, confirmResp.Body)
+	if confirmOut.Address != provisionTestEmailAddress || confirmOut.RegistrationVersion != 4 {
+		t.Fatalf("unexpected idempotent confirm response: %#v", confirmOut)
 	}
 	if len(fixture.migaduCalls) != 1 {
 		t.Fatalf("expected migadu not called again; got %d calls", len(fixture.migaduCalls))
@@ -457,6 +648,57 @@ func TestHandleSoulProvisionEmail_ForwardingFailureRollsBackMailboxAndStopsPubli
 	published := mustUnmarshalJSON[map[string]any](t, fixture.packs.objects[fixture.s3Key].body)
 	if got := strings.TrimSpace(extractStringField(published, "version")); got != "2" {
 		t.Fatalf("expected registration version to remain 2 after rollback, got %q", got)
+	}
+}
+
+func TestHandleSoulProvisionEmail_RejectsStaleBareLocalPartOnConfirm(t *testing.T) {
+	t.Parallel()
+
+	fixture := newProvisionEmailE2EFixture(t)
+	beginOut := runProvisionEmailBegin(t, fixture)
+	var confirmBody map[string]any
+	if err := json.Unmarshal(buildProvisionEmailConfirmBody(t, fixture, beginOut), &confirmBody); err != nil {
+		t.Fatalf("unmarshal confirm body: %v", err)
+	}
+	confirmBody["local_part"] = provisionTestAgentLocalID
+
+	confirmCtx := &apptheory.Context{
+		RequestID:    "r-email-confirm-stale-local-1",
+		AuthIdentity: "admin",
+		Params:       map[string]string{"agentId": fixture.agentIDHex},
+		Request:      apptheory.Request{Body: mustMarshalJSON(t, confirmBody)},
+	}
+	confirmCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+
+	_, err := fixture.server.handleSoulProvisionEmailChannel(confirmCtx)
+	appErr := requireProvisionEmailAppErr(t, err)
+	if appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrDerivedLocalPartReq {
+		t.Fatalf("unexpected app error: %#v", appErr)
+	}
+	if len(fixture.migaduCalls) != 0 || len(fixture.forwardingCalls) != 0 || len(fixture.deleteMailboxCalls) != 0 {
+		t.Fatalf("expected stale local_part to stop before provider calls: creates=%#v forwardings=%#v deletes=%#v", fixture.migaduCalls, fixture.forwardingCalls, fixture.deleteMailboxCalls)
+	}
+}
+
+func TestHandleSoulBeginProvisionEmail_RejectsStaleBareLocalPart(t *testing.T) {
+	t.Parallel()
+
+	fixture := newProvisionEmailE2EFixture(t)
+	beginCtx := &apptheory.Context{
+		RequestID:    "r-email-begin-stale-local-1",
+		AuthIdentity: "admin",
+		Params:       map[string]string{"agentId": fixture.agentIDHex},
+		Request:      apptheory.Request{Body: []byte(`{"local_part":"agent-alice"}`)},
+	}
+	beginCtx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+
+	_, err := fixture.server.handleSoulBeginProvisionEmailChannel(beginCtx)
+	appErr := requireProvisionEmailAppErr(t, err)
+	if appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrDerivedLocalPartReq {
+		t.Fatalf("unexpected app error: %#v", appErr)
+	}
+	if len(fixture.migaduCalls) != 0 || len(fixture.forwardingCalls) != 0 || len(fixture.deleteMailboxCalls) != 0 {
+		t.Fatalf("expected stale local_part to stop before provider calls: creates=%#v forwardings=%#v deletes=%#v", fixture.migaduCalls, fixture.forwardingCalls, fixture.deleteMailboxCalls)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -819,7 +819,7 @@ func (s *Server) ensureSoulEmailAgentIndex(ctx context.Context, idx *models.Soul
 		return nil
 	}
 	_ = idx.UpdateKeys()
-	return s.ensureSoulContactAgentIndex(ctx, idx, idx.PK, idx.SK, idx.Email, idx.AgentID, "email index is invalid", "email address is already provisioned", "failed to validate email mapping", "failed to update email index", func() any {
+	return s.ensureSoulContactAgentIndex(ctx, idx, idx.PK, idx.SK, idx.Email, idx.AgentID, "email index is invalid", soulEmailProvisionErrAddressTaken, "failed to validate email mapping", "failed to update email index", func() any {
 		return &models.SoulEmailAgentIndex{}
 	}, func(existing any) string {
 		if idx, ok := existing.(*models.SoulEmailAgentIndex); ok && idx != nil {

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -1035,7 +1035,7 @@ func TestEnsureSoulEmailAgentIndex_RejectsForeignOwner(t *testing.T) {
 		Email:   "agent@example.com",
 		AgentID: soulLifecycleTestAgentIDHex,
 	})
-	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "email address is already provisioned" {
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrAddressTaken {
 		t.Fatalf("expected foreign owner conflict, got %v", appErr)
 	}
 }
@@ -1086,7 +1086,7 @@ func TestEnsureSoulContactIndexes_FailClosedOnInvalidAndRaces(t *testing.T) {
 		Email:   "agent@example.com",
 		AgentID: soulLifecycleTestAgentIDHex,
 	})
-	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "email address is already provisioned" {
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != soulEmailProvisionErrAddressTaken {
 		t.Fatalf("expected create race conflict, got %v", appErr)
 	}
 }

--- a/internal/emailingress/server_internal_test.go
+++ b/internal/emailingress/server_internal_test.go
@@ -75,6 +75,9 @@ func TestNormalizeInboundRecipient(t *testing.T) {
 	if got, ok := normalizeInboundRecipient("Agent@Inbound.LesserSoul.ai", "inbound.lessersoul.ai"); !ok || got != "agent@lessersoul.ai" {
 		t.Fatalf("unexpected recipient mapping: got=%q ok=%v", got, ok)
 	}
+	if got, ok := normalizeInboundRecipient("Agent.With.Dot.Simulacrum@Inbound.LesserSoul.ai", "inbound.lessersoul.ai"); !ok || got != "agent.with.dot.simulacrum@lessersoul.ai" {
+		t.Fatalf("unexpected compound recipient mapping: got=%q ok=%v", got, ok)
+	}
 	if _, ok := normalizeInboundRecipient("agent@example.com", "inbound.lessersoul.ai"); ok {
 		t.Fatal("expected non-bridge recipient to be rejected")
 	}

--- a/web/src/lib/api/soul.ts
+++ b/web/src/lib/api/soul.ts
@@ -105,7 +105,9 @@ export interface SoulProvisionEmailConfirmResponse {
 	registration_version: number;
 }
 
-export function soulProvisionEmailBegin(token: string, agentId: string, input: { local_part?: string }): Promise<SoulProvisionEmailBeginResponse> {
+// local_part is retained by the backend for internal compatibility only.
+// Managed email addresses are derived as <agent-local-id>.<instance-slug>@lessersoul.ai.
+export function soulProvisionEmailBegin(token: string, agentId: string, input: { local_part?: string } = {}): Promise<SoulProvisionEmailBeginResponse> {
 	const req = jsonRequest(input);
 	return fetchJson<SoulProvisionEmailBeginResponse>(`/api/v1/soul/agents/${encodeURIComponent(agentId)}/channels/email/provision/begin`, {
 		method: 'POST',

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -877,7 +877,10 @@ export interface components {
                     chain: string;
                 } | null;
                 email: {
-                    /** Format: email */
+                    /**
+                     * Format: email
+                     * @description Current managed lessersoul.ai channels are derived as <agent-local-id>.<instance-slug>@lessersoul.ai. Legacy bare <agent-local-id>@lessersoul.ai addresses are inbound aliases for migrated agents only and are not current public channels.
+                     */
                     address: string;
                     capabilities: ("receive" | "send")[];
                     protocols?: ("smtp" | "imap")[];

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -127,7 +127,6 @@
 	let mintDirectTxHash = $state('');
 
 	// Channel provisioning state
-	let emailLocalPart = $state('');
 	let emailProvisionBegin = $state<SoulProvisionEmailBeginResponse | null>(null);
 	let emailProvisionSignature = $state('');
 	let emailProvisionError = $state<string | null>(null);
@@ -869,9 +868,7 @@
 
 		emailProvisionBeginLoading = true;
 		try {
-			emailProvisionBegin = await soulProvisionEmailBegin(token, agentId, {
-				local_part: emailLocalPart.trim() || undefined,
-			});
+			emailProvisionBegin = await soulProvisionEmailBegin(token, agentId, {});
 		} catch (err) {
 			if (await handleAuthError(err)) return;
 			emailProvisionError = formatError(err);
@@ -934,12 +931,10 @@
 		emailProvisionConfirmLoading = true;
 		try {
 			emailProvisionResult = await soulProvisionEmailConfirm(token, agentId, {
-				local_part: emailLocalPart.trim() || undefined,
 				issued_at: emailProvisionBegin.issued_at,
 				expected_version: emailProvisionBegin.expected_version,
 				self_attestation: emailProvisionSignature.trim(),
 			});
-			emailLocalPart = '';
 			emailProvisionSignature = '';
 			emailProvisionBegin = null;
 			await load();
@@ -2090,7 +2085,9 @@
 				<div class="soul-agent__divider"></div>
 
 				<Heading level={4} size="base">Provision email</Heading>
-				<Text size="sm" color="secondary">Creates a managed mailbox on <span class="soul-agent__mono">lessersoul.ai</span>.</Text>
+				<Text size="sm" color="secondary">
+					Creates a derived managed mailbox on <span class="soul-agent__mono">&lt;agent-local-id&gt;.&lt;instance-slug&gt;@lessersoul.ai</span>.
+				</Text>
 
 				{#if emailProvisionError}
 					<Alert variant="error" title="Email provisioning">{emailProvisionError}</Alert>
@@ -2102,7 +2099,6 @@
 				{/if}
 
 				<div class="soul-agent__form">
-					<TextField label="Local part (optional)" bind:value={emailLocalPart} placeholder="local-id" />
 					<div class="soul-agent__row">
 						<Button
 							variant="outline"


### PR DESCRIPTION
## Milestone
Project 37 M1 — Host provisioning, resolver, and UI contract

Part of #330. Builds on M0 PR #350 and uses `docs/instance-scoped-soul-email-m0.md` as the carry-forward checklist.

Closes #331.
Closes #332.
Closes #333.
Closes #334.

## Classification
soul-registry, host-comm, host-web, docs, test-coverage

## Surfaces affected
- Control-plane soul email provisioning begin/confirm path.
- Migadu mailbox local-part and inbound forwarding target derivation.
- `SoulEmailAgentIndex` full-address availability/upsert behavior.
- Email ingress and comm-worker opaque full-address regressions.
- Portal soul agent detail UI and REST/OpenAPI/spec examples.

## Specialist walks referenced
- Governance rubric: no verifier/rubric change; gov-rubric PASS 29/0/0.
- Provisioning / managed-update / release verification: not touched; no managed-instance provisioning runner or consumer release verification behavior changed.
- Soul registry: `evolve-soul-registry` walk applied. Off-chain channel/index state only; no Solidity, no on-chain transaction path, no Safe-ready payload, no mint-signer handling.
- Trust API / CSP / instance-auth: not touched. Portal remains first-party/static with no inline or third-party script changes.
- Framework: no framework patch or feedback item.

## Multi-tenant isolation impact
Elevated scrutiny but preserved. The resolver loads the managed `Domain` record and derives the email slug from `Domain.InstanceSlug`; it does not parse hostnames or email local-parts. Missing/unverified/invalid domain state fails closed, exact vanity domains use their own Domain record, stage-aware managed primary aliases stay behind the existing managed primary alias validation posture, and stage-aware vanity aliases fail closed.

## On-chain impact
None. This updates the self-description signing payload for future email-channel provisioning, but does not change Solidity, minting, Safe governance, or Ethereum transaction code.

## Consumer impact
- New managed soul email provisioning now issues `<agent-local-id>.<instance-slug>@lessersoul.ai`.
- Migadu mailbox and forwarding setup use `<agent-local-id>.<instance-slug>` and `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`.
- Comm consumers continue to resolve by full normalized email address; local-parts are opaque and may contain dots.
- Portal/docs/examples no longer present managed email as a custom or bare handle picker.

## Tasks
- [x] #331 — Add managed email address builder and instance slug resolver.
- [x] #332 — Update provision begin/confirm and Migadu mailbox forwarding.
- [x] #333 — Update inbound bridge, comm-worker resolution, and email indexes.
- [x] #334 — Update portal UI, OpenAPI examples, and provisioning docs.

## Validation
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `gofmt -l $(git ls-files '*.go')` empty
- [x] `git diff --check origin/main...HEAD`
- [x] `cd web && npm run verify:lesser-host-contracts`
- [x] `cd web && npm run lint`
- [x] `cd web && npm run typecheck`
- [x] `cd web && npm test`
- [x] `cd web && npm run build`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0

## Stage rollout plan (handoff after merge)
- [ ] Merged to main
- [ ] Deployed to lab
- [ ] Lab soak complete
- [ ] M2 migration tooling assigned only after M1 review/merge
- [ ] M3 canaries validate new primary + legacy alias behavior before M4 live gate
- [ ] Deployed to live only after M0–M4 evidence is complete and operator-authorized

## Cross-repo coordination
No sibling-repo code changes in this PR. Project 37 M3 still owns lesser-body, Lesser, Greater, and Simulacrum compatibility canaries/fixture verification.

## M2 dependency / release blocker note
M2 remains required after this merge. This PR intentionally does not migrate existing agents, create legacy bare alias records, or implement the M0.5 legacy alias/index canonicalization path. Existing bare `<agent>@lessersoul.ai` behavior remains a migration concern and must block M2 assignment/live rollout until implemented and verified.
