### PR TITLE
[codex] Project 37 M2 existing-agent email migration aliases

### DIFF
--- a/docs/instance-scoped-soul-email-m2-migration.md
+++ b/docs/instance-scoped-soul-email-m2-migration.md
@@ -17,7 +17,7 @@ provider state, and registration authority are reviewed.
   capture. Unknown bare recipients fail closed.
 - v3 registration sync now permits the narrow Project 37 migration:
   a trusted managed Migadu email channel may move from an existing
-  `@lessersoul.ai` address to the derived
+  old bare `<normalized-agent-local-id>@lessersoul.ai` address to the derived
   `<agent-local-id>.<instance-slug>@lessersoul.ai` address. The sync preserves
   managed-channel metadata, writes the new current `SoulEmailAgentIndex`, and
   creates the internal legacy alias record. Other managed identifier changes
@@ -25,7 +25,8 @@ provider state, and registration authority are reviewed.
 - `go run ./scripts/soul-email-m2-migration` reads M0 inventory evidence,
   plans provider/registration/host-sync actions, and can apply provider-prepare
   forwarding idempotently. It does not execute the live migration gate by
-  itself.
+  itself. The command refuses inventory whose `schema_version`, `stage`, or
+  `table_name` does not match the requested run config.
 
 ## Required sequence
 
@@ -51,6 +52,9 @@ provider state, and registration authority are reviewed.
    per-agent mailbox password from
    `/lesser-host/soul/<stage>/agents/<agentId>/channels/email/migadu_password`
    and ensures the new Migadu mailbox plus inbound forwarding:
+   `provider_prepared` requires the exact expected forwarding target
+   `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`; an unrelated
+   forwarding or alias is not sufficient.
 
    ```bash
    SOUL_EMAIL_INBOUND_DOMAIN=inbound.lessersoul.ai \

--- a/docs/instance-scoped-soul-email-m2-migration.md
+++ b/docs/instance-scoped-soul-email-m2-migration.md
@@ -1,0 +1,98 @@
+# Instance-scoped Lesser Soul email — M2 migration runbook
+
+Project 37 M2 implements the safe migration path from legacy bare managed
+addresses (`agent@lessersoul.ai`) to canonical instance-scoped addresses
+(`agent.<instance>@lessersoul.ai`).
+
+Live execution remains held under
+<https://github.com/equaltoai/lesser-host/issues/339> until dry-run evidence,
+provider state, and registration authority are reviewed.
+
+## What M2 added
+
+- `SoulEmailLegacyAliasIndex` is a host-internal alias model. It maps a known
+  legacy recipient to the canonical current address and owning `agentId`.
+- `comm-worker` canonicalizes a legacy alias only after the current
+  `SoulEmailAgentIndex` lookup misses, and before channel matching/mailbox
+  capture. Unknown bare recipients fail closed.
+- v3 registration sync now permits the narrow Project 37 migration:
+  a trusted managed Migadu email channel may move from an existing
+  `@lessersoul.ai` address to the derived
+  `<agent-local-id>.<instance-slug>@lessersoul.ai` address. The sync preserves
+  managed-channel metadata, writes the new current `SoulEmailAgentIndex`, and
+  creates the internal legacy alias record. Other managed identifier changes
+  still require deprovisioning first.
+- `go run ./scripts/soul-email-m2-migration` reads M0 inventory evidence,
+  plans provider/registration/host-sync actions, and can apply provider-prepare
+  forwarding idempotently. It does not execute the live migration gate by
+  itself.
+
+## Required sequence
+
+1. Run M0 inventory with redacted provider and registration/signing snapshots.
+2. Review the inventory for:
+   - zero duplicate proposed addresses;
+   - zero 64-octet local-part overflows;
+   - valid `Domain.InstanceSlug` for every selected agent;
+   - current email channel/index parity;
+   - known provider state for old and proposed local-parts; and
+   - `can_self_attest=yes`, or an explicitly approved host audit path.
+3. Run M2 dry-run evidence:
+
+   ```bash
+   go run ./scripts/soul-email-m2-migration \
+     --stage live \
+     --table-name lesser-host-live-state \
+     --inventory gov-infra/evidence/project37/m0-email-inventory-live.json \
+     --out gov-infra/evidence/project37/m2-email-migration-live-dry-run.json
+   ```
+
+4. After review, prepare provider state only. The command reuses the existing
+   per-agent mailbox password from
+   `/lesser-host/soul/<stage>/agents/<agentId>/channels/email/migadu_password`
+   and ensures the new Migadu mailbox plus inbound forwarding:
+
+   ```bash
+   SOUL_EMAIL_INBOUND_DOMAIN=inbound.lessersoul.ai \
+   go run ./scripts/soul-email-m2-migration \
+     --stage live \
+     --table-name lesser-host-live-state \
+     --inventory gov-infra/evidence/project37/m0-email-inventory-live.json \
+     --apply \
+     --out gov-infra/evidence/project37/m2-email-provider-prepare-live.json
+   ```
+
+5. Each selected agent publishes a self-attested registration update advertising
+   only the new instance-scoped email address, or Aron approves a disclosed host
+   audit path before any host-side rewrite.
+6. Registration sync performs the host switch:
+   - `SoulAgentChannel.Identifier` becomes the instance-scoped address;
+   - `SoulEmailAgentIndex` resolves the instance-scoped address;
+   - `SoulEmailLegacyAliasIndex` maps the old known address to the new address;
+   - public channel surfaces advertise only the instance-scoped address.
+7. M3 canaries verify new-address inbound, legacy-alias inbound,
+   non-advertisement of the legacy address, and body/lesser compatibility.
+
+## Rollback and repair
+
+Any partial failure enters `needs_repair` evidence. Rollback preserves inbound
+reachability:
+
+- Do not delete the old bare provider delivery during M2/M3.
+- If provider prepare succeeded but registration was not published, leave the
+  provider state in place and retry/self-attest when ready.
+- If host switch occurred but registration publish failed, restore the previous
+  `SoulAgentChannel` and `SoulEmailAgentIndex`, then disable/remove the internal
+  legacy alias. Provider state remains until canaries prove safe cleanup.
+- Never expose legacy aliases through public channel discovery or portal alias
+  management.
+
+## Credential envelope for reviewed apply
+
+The M2 command reads Migadu API credentials through the existing runtime SSM
+loader (`/lesser-host/migadu`) and reads the existing per-agent mailbox password
+only when `--apply` is present. Evidence and logs must not include Migadu
+credentials, mailbox passwords, raw SSM values, message content, or provider
+payloads containing secrets.
+
+No live apply under issue #339 is part of this milestone.

--- a/internal/commworker/helpers_internal_test.go
+++ b/internal/commworker/helpers_internal_test.go
@@ -258,6 +258,14 @@ func newCommWorkerStoreHelperStore(now time.Time) *fakeStore {
 			"pilot.simulacrum@lessersoul.ai":          "0xpilot-sim",
 			"pilot.other-instance@lessersoul.ai":      "0xpilot-other",
 		},
+		emailAlias: map[string]*models.SoulEmailLegacyAliasIndex{
+			"pilot@lessersoul.ai": {
+				AliasEmail:     "pilot@lessersoul.ai",
+				CanonicalEmail: "pilot.simulacrum@lessersoul.ai",
+				AgentID:        "0xpilot-sim",
+				Status:         models.SoulEmailLegacyAliasStatusActive,
+			},
+		},
 		phoneIndex: map[string]string{"+15551234567": "0xdef"},
 		domains:    map[string]*models.Domain{"example.com": {Domain: "example.com", InstanceSlug: "inst-1"}},
 		instances:  map[string]*models.Instance{"inst-1": {Slug: "inst-1", HostedBaseDomain: "demo.example.com"}},
@@ -320,6 +328,24 @@ func testResolveInstanceScopedEmailRecipients(t *testing.T, s *Server) {
 	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "pilot.other-instance@lessersoul.ai"})
 	if err != nil || !ok || agentID != "0xpilot-other" {
 		t.Fatalf("unexpected same-local-id second instance lookup: %q %v %v", agentID, ok, err)
+	}
+	testResolveLegacyEmailAliasRecipients(t, s)
+}
+
+func testResolveLegacyEmailAliasRecipients(t *testing.T, s *Server) {
+	t.Helper()
+
+	legacy := &InboundParty{Address: "pilot@lessersoul.ai"}
+	agentID, ok, err := s.resolveRecipient(context.Background(), "email", legacy)
+	if err != nil || !ok || agentID != "0xpilot-sim" {
+		t.Fatalf("unexpected legacy alias lookup: %q %v %v", agentID, ok, err)
+	}
+	if legacy.Address != "pilot.simulacrum@lessersoul.ai" {
+		t.Fatalf("expected legacy alias to canonicalize before channel matching, got %q", legacy.Address)
+	}
+	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "unknown@lessersoul.ai"})
+	if err != nil || ok || agentID != "" {
+		t.Fatalf("expected unknown bare alias to fail closed, got %q %v %v", agentID, ok, err)
 	}
 }
 

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -433,7 +433,11 @@ func (s *Server) resolveRecipient(ctx context.Context, channel string, to *Inbou
 		if addr == "" {
 			return "", false, nil
 		}
-		return s.store.LookupAgentByEmail(ctx, addr)
+		agentID, ok, err := s.store.LookupAgentByEmail(ctx, addr)
+		if err != nil || ok {
+			return agentID, ok, err
+		}
+		return s.resolveLegacyEmailAlias(ctx, addr, to)
 	case inboundChannelSMS, inboundChannelVoice:
 		num := normalizePhone(to.Number)
 		if num == "" {
@@ -443,6 +447,32 @@ func (s *Server) resolveRecipient(ctx context.Context, channel string, to *Inbou
 	default:
 		return "", false, nil
 	}
+}
+
+func (s *Server) resolveLegacyEmailAlias(ctx context.Context, addr string, to *InboundParty) (string, bool, error) {
+	alias, ok, err := s.store.LookupLegacyEmailAlias(ctx, addr)
+	if err != nil || !ok || alias == nil {
+		return "", false, err
+	}
+	if alias.Status != models.SoulEmailLegacyAliasStatusActive {
+		return "", false, nil
+	}
+	canonical := strings.ToLower(strings.TrimSpace(alias.CanonicalEmail))
+	agentID := strings.ToLower(strings.TrimSpace(alias.AgentID))
+	if canonical == "" || agentID == "" || strings.EqualFold(canonical, addr) {
+		return "", false, nil
+	}
+
+	canonicalAgentID, canonicalOK, err := s.store.LookupAgentByEmail(ctx, canonical)
+	if err != nil || !canonicalOK {
+		return "", false, err
+	}
+	if !strings.EqualFold(strings.TrimSpace(canonicalAgentID), agentID) {
+		return "", false, nil
+	}
+
+	to.Address = canonical
+	return agentID, true, nil
 }
 
 func channelRecordType(channel string) string {

--- a/internal/commworker/server_internal_test.go
+++ b/internal/commworker/server_internal_test.go
@@ -2,6 +2,7 @@ package commworker
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ func (f *fakeMailboxContentStore) GetContent(_ context.Context, _ commmailbox.Co
 
 type fakeStore struct {
 	emailIndex map[string]string
+	emailAlias map[string]*models.SoulEmailLegacyAliasIndex
 	phoneIndex map[string]string
 
 	identities map[string]*models.SoulAgentIdentity
@@ -63,6 +65,14 @@ func (f *fakeStore) LookupAgentByEmail(_ context.Context, email string) (string,
 	}
 	id, ok := f.emailIndex[email]
 	return id, ok, nil
+}
+
+func (f *fakeStore) LookupLegacyEmailAlias(_ context.Context, email string) (*models.SoulEmailLegacyAliasIndex, bool, error) {
+	if f == nil || f.emailAlias == nil {
+		return nil, false, nil
+	}
+	alias, ok := f.emailAlias[strings.ToLower(strings.TrimSpace(email))]
+	return alias, ok, nil
 }
 
 func (f *fakeStore) LookupAgentByPhone(_ context.Context, phone string) (string, bool, error) {

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -26,6 +26,7 @@ type hookedStore struct {
 	*fakeStore
 
 	lookupAgentByEmailFn       func(context.Context, string) (string, bool, error)
+	lookupLegacyEmailAliasFn   func(context.Context, string) (*models.SoulEmailLegacyAliasIndex, bool, error)
 	lookupAgentByPhoneFn       func(context.Context, string) (string, bool, error)
 	getSoulAgentIdentityFn     func(context.Context, string) (*models.SoulAgentIdentity, bool, error)
 	getSoulAgentChannelFn      func(context.Context, string, string) (*models.SoulAgentChannel, bool, error)
@@ -43,6 +44,16 @@ func (h *hookedStore) LookupAgentByEmail(ctx context.Context, email string) (str
 		return h.fakeStore.LookupAgentByEmail(ctx, email)
 	}
 	return "", false, nil
+}
+
+func (h *hookedStore) LookupLegacyEmailAlias(ctx context.Context, email string) (*models.SoulEmailLegacyAliasIndex, bool, error) {
+	if h.lookupLegacyEmailAliasFn != nil {
+		return h.lookupLegacyEmailAliasFn(ctx, email)
+	}
+	if h.fakeStore != nil {
+		return h.fakeStore.LookupLegacyEmailAlias(ctx, email)
+	}
+	return nil, false, nil
 }
 
 func (h *hookedStore) LookupAgentByPhone(ctx context.Context, phone string) (string, bool, error) {

--- a/internal/commworker/store.go
+++ b/internal/commworker/store.go
@@ -13,6 +13,7 @@ import (
 
 type commStore interface {
 	LookupAgentByEmail(ctx context.Context, email string) (string, bool, error)
+	LookupLegacyEmailAlias(ctx context.Context, email string) (*models.SoulEmailLegacyAliasIndex, bool, error)
 	LookupAgentByPhone(ctx context.Context, phone string) (string, bool, error)
 
 	GetSoulAgentIdentity(ctx context.Context, agentID string) (*models.SoulAgentIdentity, bool, error)
@@ -53,6 +54,32 @@ func (s *dynamoStore) LookupAgentByEmail(ctx context.Context, email string) (str
 	return s.lookupAgentIndex(ctx, &models.SoulEmailAgentIndex{}, idx.GetPK(), idx.GetSK(), &item, func() string {
 		return item.AgentID
 	})
+}
+
+func (s *dynamoStore) LookupLegacyEmailAlias(ctx context.Context, email string) (*models.SoulEmailLegacyAliasIndex, bool, error) {
+	if s == nil || s.db == nil {
+		return nil, false, fmt.Errorf("store not initialized")
+	}
+	idx := &models.SoulEmailLegacyAliasIndex{AliasEmail: strings.TrimSpace(email)}
+	_ = idx.UpdateKeys()
+
+	var item models.SoulEmailLegacyAliasIndex
+	err := s.db.WithContext(ctx).
+		Model(&models.SoulEmailLegacyAliasIndex{}).
+		Where("PK", "=", idx.GetPK()).
+		Where("SK", "=", idx.GetSK()).
+		First(&item)
+	if theoryErrors.IsNotFound(err) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	_ = item.UpdateKeys()
+	if item.Status != models.SoulEmailLegacyAliasStatusActive || strings.TrimSpace(item.AgentID) == "" || strings.TrimSpace(item.CanonicalEmail) == "" {
+		return nil, false, nil
+	}
+	return &item, true, nil
 }
 
 func (s *dynamoStore) LookupAgentByPhone(ctx context.Context, phone string) (string, bool, error) {

--- a/internal/commworker/store_internal_test.go
+++ b/internal/commworker/store_internal_test.go
@@ -23,6 +23,7 @@ const (
 type commStoreTestDB struct {
 	db       *ttmocks.MockExtendedDB
 	qEmail   *ttmocks.MockQuery
+	qAlias   *ttmocks.MockQuery
 	qPhone   *ttmocks.MockQuery
 	qIdent   *ttmocks.MockQuery
 	qChannel *ttmocks.MockQuery
@@ -38,6 +39,7 @@ type commStoreTestDB struct {
 func newCommStoreTestDB() commStoreTestDB {
 	db := ttmocks.NewMockExtendedDB()
 	qEmail := new(ttmocks.MockQuery)
+	qAlias := new(ttmocks.MockQuery)
 	qPhone := new(ttmocks.MockQuery)
 	qIdent := new(ttmocks.MockQuery)
 	qChannel := new(ttmocks.MockQuery)
@@ -51,6 +53,7 @@ func newCommStoreTestDB() commStoreTestDB {
 
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(qEmail).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulEmailLegacyAliasIndex")).Return(qAlias).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(qPhone).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(qIdent).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
@@ -62,7 +65,7 @@ func newCommStoreTestDB() commStoreTestDB {
 	db.On("Model", mock.AnythingOfType("*models.Domain")).Return(qDomain).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
 
-	for _, q := range []*ttmocks.MockQuery{qEmail, qPhone, qIdent, qChannel, qPrefs, qAct, qQueue, qMailbox, qEvent, qDomain, qInst} {
+	for _, q := range []*ttmocks.MockQuery{qEmail, qAlias, qPhone, qIdent, qChannel, qPrefs, qAct, qQueue, qMailbox, qEvent, qDomain, qInst} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
@@ -77,6 +80,7 @@ func newCommStoreTestDB() commStoreTestDB {
 	return commStoreTestDB{
 		db:       db,
 		qEmail:   qEmail,
+		qAlias:   qAlias,
 		qPhone:   qPhone,
 		qIdent:   qIdent,
 		qChannel: qChannel,
@@ -109,8 +113,12 @@ func TestDynamoStoreLookupsAndGets(t *testing.T) {
 	if _, _, err := nilStore.LookupAgentByEmail(ctx, "user@example.com"); err == nil {
 		t.Fatalf("expected store not initialized error")
 	}
+	if _, _, err := nilStore.LookupLegacyEmailAlias(ctx, "user@example.com"); err == nil {
+		t.Fatalf("expected store not initialized error")
+	}
 
 	runLookupAgentByEmailTest(t, ctx)
+	runLookupLegacyEmailAliasTest(t, ctx)
 	runLookupAgentByPhoneTest(t, ctx)
 	runGetSoulAgentIdentityTest(t, ctx)
 	runGetSoulAgentChannelTest(t, ctx)
@@ -132,6 +140,40 @@ func runLookupAgentByEmailTest(t *testing.T, ctx context.Context) {
 		agentID, ok, err := st.LookupAgentByEmail(ctx, " User@example.com ")
 		if err != nil || !ok || agentID != "0xabcd" {
 			t.Fatalf("unexpected lookup result: agentID=%q ok=%v err=%v", agentID, ok, err)
+		}
+	})
+}
+
+func runLookupLegacyEmailAliasTest(t *testing.T, ctx context.Context) {
+	t.Helper()
+
+	t.Run("lookup legacy email alias success normalizes and filters disabled", func(t *testing.T) {
+		tdb := newCommStoreTestDB()
+		tdb.qAlias.On("First", mock.AnythingOfType("*models.SoulEmailLegacyAliasIndex")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.SoulEmailLegacyAliasIndex](t, args, 0)
+			*dest = models.SoulEmailLegacyAliasIndex{
+				AliasEmail:     " Pilot@LesserSoul.ai ",
+				CanonicalEmail: " Pilot.Simulacrum@LesserSoul.ai ",
+				AgentID:        " 0xAGENT ",
+				Status:         models.SoulEmailLegacyAliasStatusActive,
+			}
+		}).Once()
+
+		st := &dynamoStore{db: tdb.db}
+		alias, ok, err := st.LookupLegacyEmailAlias(ctx, " Pilot@LesserSoul.ai ")
+		if err != nil || !ok || alias == nil || alias.AgentID != commStoreTestAgentID || alias.CanonicalEmail != "pilot.simulacrum@lessersoul.ai" {
+			t.Fatalf("unexpected alias result: alias=%#v ok=%v err=%v", alias, ok, err)
+		}
+	})
+
+	t.Run("lookup legacy email alias not found", func(t *testing.T) {
+		tdb := newCommStoreTestDB()
+		tdb.qAlias.On("First", mock.AnythingOfType("*models.SoulEmailLegacyAliasIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+
+		st := &dynamoStore{db: tdb.db}
+		alias, ok, err := st.LookupLegacyEmailAlias(ctx, "unknown@lessersoul.ai")
+		if err != nil || ok || alias != nil {
+			t.Fatalf("unexpected alias result: alias=%#v ok=%v err=%v", alias, ok, err)
 		}
 	})
 }

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -25,14 +25,15 @@ import (
 )
 
 const (
-	provisionTestAgentLocalID    = "agent-alice"
-	provisionTestInstanceSlug    = "inst1"
-	provisionTestEmailLocalPart  = provisionTestAgentLocalID + "." + provisionTestInstanceSlug
-	provisionTestEmailAddress    = provisionTestEmailLocalPart + "@lessersoul.ai"
-	provisionTestEmailENSName    = provisionTestAgentLocalID + ".lessersoul.eth"
-	provisionTestAgentDomain     = "example.com"
-	provisionTestStageAlias      = "dev.simulacrum.greater.website"
-	provisionTestStageBaseDomain = "simulacrum.greater.website"
+	provisionTestAgentLocalID     = "agent-alice"
+	provisionTestInstanceSlug     = "inst1"
+	provisionTestEmailLocalPart   = provisionTestAgentLocalID + "." + provisionTestInstanceSlug
+	provisionTestEmailAddress     = provisionTestEmailLocalPart + "@lessersoul.ai"
+	provisionTestEmailENSName     = provisionTestAgentLocalID + ".lessersoul.eth"
+	provisionTestAgentDomain      = "example.com"
+	provisionTestStageAlias       = "dev.simulacrum.greater.website"
+	provisionTestStageBaseDomain  = "simulacrum.greater.website"
+	provisionTestPilotScopedEmail = "pilot.simulacrum@lessersoul.ai"
 )
 
 func mustMarshalJSON(t testing.TB, v any) []byte {
@@ -189,7 +190,7 @@ func TestBuildSoulProvisionManagedEmailAddress_AllowsDotsAndSameLocalIDAcrossIns
 	if appErr != nil {
 		t.Fatalf("expected second instance success, got %v", appErr)
 	}
-	if a.Address == b.Address || a.Address != "pilot.simulacrum@lessersoul.ai" || b.Address != "pilot.sim-lab@lessersoul.ai" {
+	if a.Address == b.Address || a.Address != provisionTestPilotScopedEmail || b.Address != "pilot.sim-lab@lessersoul.ai" {
 		t.Fatalf("expected same local id to derive distinct instance addresses: a=%#v b=%#v", a, b)
 	}
 }

--- a/internal/controlplane/handlers_soul_lifecycle_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_internal_test.go
@@ -122,6 +122,7 @@ type soulLifecycleTestDB struct {
 	qChannel    *ttmocks.MockQuery
 	qPrefs      *ttmocks.MockQuery
 	qEmailIdx   *ttmocks.MockQuery
+	qEmailAlias *ttmocks.MockQuery
 	qPhoneIdx   *ttmocks.MockQuery
 	qChannelIdx *ttmocks.MockQuery
 	qENS        *ttmocks.MockQuery
@@ -146,6 +147,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 	qChannel := new(ttmocks.MockQuery)
 	qContactPrefs := new(ttmocks.MockQuery)
 	qEmailIdx := new(ttmocks.MockQuery)
+	qEmailAlias := new(ttmocks.MockQuery)
 	qPhoneIdx := new(ttmocks.MockQuery)
 	qChannelTypeIdx := new(ttmocks.MockQuery)
 	qENSResolution := new(ttmocks.MockQuery)
@@ -168,6 +170,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentChannel")).Return(qChannel).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentContactPreferences")).Return(qContactPrefs).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(qEmailIdx).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulEmailLegacyAliasIndex")).Return(qEmailAlias).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(qPhoneIdx).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulChannelAgentIndex")).Return(qChannelTypeIdx).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(qENSResolution).Maybe()
@@ -190,6 +193,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 		qChannel,
 		qContactPrefs,
 		qEmailIdx,
+		qEmailAlias,
 		qPhoneIdx,
 		qChannelTypeIdx,
 		qENSResolution,
@@ -228,6 +232,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 		qChannel:    qChannel,
 		qPrefs:      qContactPrefs,
 		qEmailIdx:   qEmailIdx,
+		qEmailAlias: qEmailAlias,
 		qPhoneIdx:   qPhoneIdx,
 		qChannelIdx: qChannelTypeIdx,
 		qENS:        qENSResolution,

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -642,7 +642,7 @@ func (s *Server) buildLegacyEmailAliasForManagedMigration(
 	if existingCopy.Provider != commDeliveryProviderMigadu || desiredCopy.ChannelType != models.SoulChannelTypeEmail {
 		return nil, nil
 	}
-	if !isLegacyBareSoulEmailAlias(existingCopy.Identifier) {
+	if !isExpectedLegacyBareSoulEmailAlias(existingCopy.Identifier, identity) {
 		return nil, nil
 	}
 	expected, appErr := s.resolveSoulProvisionEmailAddress(ctx, identity, "")
@@ -661,10 +661,23 @@ func (s *Server) buildLegacyEmailAliasForManagedMigration(
 	}, nil
 }
 
-func isLegacyBareSoulEmailAlias(address string) bool {
-	address = strings.ToLower(strings.TrimSpace(address))
-	local, domain, ok := strings.Cut(address, "@")
-	return ok && strings.TrimSpace(local) != "" && domain == soulManagedEmailDomain
+func isExpectedLegacyBareSoulEmailAlias(address string, identity *models.SoulAgentIdentity) bool {
+	expected, ok := expectedLegacyBareSoulEmailAlias(identity)
+	if !ok {
+		return false
+	}
+	return strings.EqualFold(strings.ToLower(strings.TrimSpace(address)), expected)
+}
+
+func expectedLegacyBareSoulEmailAlias(identity *models.SoulAgentIdentity) (string, bool) {
+	if identity == nil {
+		return "", false
+	}
+	localID, err := soul.NormalizeLocalAgentID(identity.LocalID)
+	if err != nil || strings.TrimSpace(localID) == "" {
+		return "", false
+	}
+	return localID + "@" + soulManagedEmailDomain, true
 }
 
 func (s *Server) loadExistingSoulChannel(ctx context.Context, agentIDHex string, channelType string) (*models.SoulAgentChannel, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -593,17 +593,78 @@ func (s *Server) syncSoulV3Channel(
 	if err != nil {
 		return err
 	}
-	if trustedManagedSoulChannelForIndex(existing) && !soulChannelsSameIdentifier(existing, desired) {
+	legacyEmailAlias, appErr := s.buildLegacyEmailAliasForManagedMigration(ctx, identity, existing, desired, channelType)
+	if appErr != nil {
+		return appErr
+	}
+	if trustedManagedSoulChannelForIndex(existing) && !soulChannelsSameIdentifier(existing, desired) && legacyEmailAlias == nil {
 		return &apptheory.AppError{Code: "app.conflict", Message: "managed channel must be deprovisioned before changing identifier"}
 	}
-	preserveManagedSoulChannelMetadata(desired, existing)
+	if legacyEmailAlias != nil {
+		preserveManagedSoulChannelProvisioningMetadata(desired, existing)
+	} else {
+		preserveManagedSoulChannelMetadata(desired, existing)
+	}
+	if legacyEmailAlias != nil {
+		if appErr := s.ensureSoulEmailLegacyAliasIndex(ctx, legacyEmailAlias); appErr != nil {
+			return appErr
+		}
+	}
 	if appErr := s.cleanupSoulV3ChannelIndexes(ctx, agentIDHex, channelType, identity, existing, desired); appErr != nil {
 		return appErr
 	}
 	if desired == nil {
 		return s.deleteSoulV3Channel(ctx, identity, channelType, existing)
 	}
-	return s.upsertSoulV3Channel(ctx, identity, channelType, desired, desiredEmailIndex, desiredPhoneIndex, desiredENS)
+	if appErr := s.upsertSoulV3Channel(ctx, identity, channelType, desired, desiredEmailIndex, desiredPhoneIndex, desiredENS); appErr != nil {
+		return appErr
+	}
+	return nil
+}
+
+func (s *Server) buildLegacyEmailAliasForManagedMigration(
+	ctx context.Context,
+	identity *models.SoulAgentIdentity,
+	existing *models.SoulAgentChannel,
+	desired *models.SoulAgentChannel,
+	channelType string,
+) (*models.SoulEmailLegacyAliasIndex, *apptheory.AppError) {
+	if channelType != models.SoulChannelTypeEmail || existing == nil || desired == nil {
+		return nil, nil
+	}
+	if !trustedManagedSoulChannelForIndex(existing) || soulChannelsSameIdentifier(existing, desired) {
+		return nil, nil
+	}
+	existingCopy := *existing
+	desiredCopy := *desired
+	_ = existingCopy.UpdateKeys()
+	_ = desiredCopy.UpdateKeys()
+	if existingCopy.Provider != commDeliveryProviderMigadu || desiredCopy.ChannelType != models.SoulChannelTypeEmail {
+		return nil, nil
+	}
+	if !isLegacyBareSoulEmailAlias(existingCopy.Identifier) {
+		return nil, nil
+	}
+	expected, appErr := s.resolveSoulProvisionEmailAddress(ctx, identity, "")
+	if appErr != nil {
+		return nil, appErr
+	}
+	if !strings.EqualFold(strings.TrimSpace(desiredCopy.Identifier), expected.Address) {
+		return nil, nil
+	}
+	return &models.SoulEmailLegacyAliasIndex{
+		AliasEmail:     existingCopy.Identifier,
+		CanonicalEmail: desiredCopy.Identifier,
+		AgentID:        strings.TrimSpace(desiredCopy.AgentID),
+		Status:         models.SoulEmailLegacyAliasStatusActive,
+		Source:         "project37-m2-registration-sync",
+	}, nil
+}
+
+func isLegacyBareSoulEmailAlias(address string) bool {
+	address = strings.ToLower(strings.TrimSpace(address))
+	local, domain, ok := strings.Cut(address, "@")
+	return ok && strings.TrimSpace(local) != "" && domain == soulManagedEmailDomain
 }
 
 func (s *Server) loadExistingSoulChannel(ctx context.Context, agentIDHex string, channelType string) (*models.SoulAgentChannel, *apptheory.AppError) {
@@ -620,6 +681,13 @@ func preserveManagedSoulChannelMetadata(desired *models.SoulAgentChannel, existi
 		return
 	}
 	if !soulChannelsSameIdentifier(existing, desired) {
+		return
+	}
+	preserveManagedSoulChannelProvisioningMetadata(desired, existing)
+}
+
+func preserveManagedSoulChannelProvisioningMetadata(desired *models.SoulAgentChannel, existing *models.SoulAgentChannel) {
+	if desired == nil || existing == nil {
 		return
 	}
 	if strings.TrimSpace(desired.Provider) == "" {
@@ -842,6 +910,42 @@ func (s *Server) ensureSoulPhoneAgentIndex(ctx context.Context, idx *models.Soul
 		}
 		return ""
 	})
+}
+
+func (s *Server) ensureSoulEmailLegacyAliasIndex(ctx context.Context, idx *models.SoulEmailLegacyAliasIndex) *apptheory.AppError {
+	if idx == nil {
+		return nil
+	}
+	_ = idx.UpdateKeys()
+	if strings.TrimSpace(idx.AliasEmail) == "" || strings.TrimSpace(idx.CanonicalEmail) == "" || strings.TrimSpace(idx.AgentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "legacy email alias is invalid"}
+	}
+	var existing models.SoulEmailLegacyAliasIndex
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulEmailLegacyAliasIndex{}).
+		Where("PK", "=", idx.PK).
+		Where("SK", "=", idx.SK).
+		First(&existing)
+	if err == nil {
+		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(idx.AgentID)) &&
+			strings.EqualFold(strings.TrimSpace(existing.CanonicalEmail), strings.TrimSpace(idx.CanonicalEmail)) {
+			if updateErr := s.store.DB.WithContext(ctx).Model(idx).CreateOrUpdate(); updateErr != nil {
+				return &apptheory.AppError{Code: "app.internal", Message: "failed to update legacy email alias"}
+			}
+			return nil
+		}
+		return &apptheory.AppError{Code: "app.conflict", Message: "legacy email alias is already assigned"}
+	}
+	if !theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate legacy email alias"}
+	}
+	if err := s.store.DB.WithContext(ctx).Model(idx).Create(); err != nil {
+		if theoryErrors.IsConditionFailed(err) {
+			return &apptheory.AppError{Code: "app.conflict", Message: "legacy email alias is already assigned"}
+		}
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to update legacy email alias"}
+	}
+	return nil
 }
 
 func (s *Server) ensureSoulContactAgentIndex(

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -1021,6 +1021,103 @@ func TestSyncSoulV3StateFromRegistration_RejectsManagedChannelIdentifierChange(t
 	}
 }
 
+func TestSyncSoulV3StateFromRegistration_AllowsProject37LegacyEmailMigration(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{cfg: config.Config{Stage: "lab"}, store: store.New(tdb.db)}
+	now := time.Date(2026, time.May, 21, 14, 0, 0, 0, time.UTC)
+	identity := &models.SoulAgentIdentity{
+		AgentID:         soulLifecycleTestAgentIDHex,
+		Domain:          "simulacrum.greater.website",
+		LocalID:         "pilot",
+		LifecycleStatus: models.SoulAgentStatusActive,
+	}
+	oldAddress := "pilot@lessersoul.ai"
+	newAddress := provisionTestPilotScopedEmail
+
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:       identity.AgentID,
+			ChannelType:   models.SoulChannelTypeEmail,
+			Identifier:    oldAddress,
+			Provider:      "migadu",
+			Verified:      true,
+			ProvisionedAt: now.Add(-24 * time.Hour),
+			Status:        models.SoulChannelStatusActive,
+			SecretRef:     "/lesser-host/soul/lab/agents/0xabc/channels/email/migadu_password",
+			Capabilities:  []string{"receive", "send"},
+			Protocols:     []string{"imap", "smtp"},
+		}
+	}).Once()
+	tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
+		*dest = models.Domain{
+			Domain:       identity.Domain,
+			InstanceSlug: "simulacrum",
+			Status:       models.DomainStatusVerified,
+		}
+	}).Once()
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulEmailAgentIndex](t, args, 0)
+		*dest = models.SoulEmailAgentIndex{Email: oldAddress, AgentID: identity.AgentID}
+	}).Once()
+	tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qEmailAlias.On("First", mock.AnythingOfType("*models.SoulEmailLegacyAliasIndex")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	appErr := s.syncSoulV3StateFromRegistration(context.Background(), identity.AgentID, identity, &soul.RegistrationFileV3{
+		Channels: &soul.ChannelsV3{
+			Email: &soul.EmailChannelV3{
+				Address:      newAddress,
+				Capabilities: []string{"receive", "send"},
+				Protocols:    []string{"smtp", "imap"},
+				Verified:     true,
+				VerifiedAt:   now.Format(time.RFC3339Nano),
+			},
+		},
+	}, now)
+	if appErr != nil {
+		t.Fatalf("unexpected appErr: %v", appErr)
+	}
+
+	migratedChannel, aliasIndex := findProject37EmailMigrationModels(tdb.db.Calls, oldAddress, newAddress)
+	if migratedChannel == nil || migratedChannel.Provider != commDeliveryProviderMigadu || migratedChannel.ProvisionedAt.IsZero() || migratedChannel.SecretRef == "" {
+		t.Fatalf("expected migrated managed channel metadata to be preserved, got %#v", migratedChannel)
+	}
+	if aliasIndex == nil || aliasIndex.CanonicalEmail != newAddress || aliasIndex.AgentID != identity.AgentID || aliasIndex.Status != models.SoulEmailLegacyAliasStatusActive {
+		t.Fatalf("expected legacy alias index for old bare address, got %#v", aliasIndex)
+	}
+}
+
+func findProject37EmailMigrationModels(calls []mock.Call, oldAddress string, newAddress string) (*models.SoulAgentChannel, *models.SoulEmailLegacyAliasIndex) {
+	var migratedChannel *models.SoulAgentChannel
+	var aliasIndex *models.SoulEmailLegacyAliasIndex
+	for _, call := range calls {
+		if call.Method != modelCallMethod || len(call.Arguments) == 0 {
+			continue
+		}
+		migratedChannel, aliasIndex = recordProject37EmailMigrationModel(call.Arguments.Get(0), oldAddress, newAddress, migratedChannel, aliasIndex)
+	}
+	return migratedChannel, aliasIndex
+}
+
+func recordProject37EmailMigrationModel(model any, oldAddress string, newAddress string, migratedChannel *models.SoulAgentChannel, aliasIndex *models.SoulEmailLegacyAliasIndex) (*models.SoulAgentChannel, *models.SoulEmailLegacyAliasIndex) {
+	switch v := model.(type) {
+	case *models.SoulAgentChannel:
+		if v.ChannelType == models.SoulChannelTypeEmail && v.Identifier == newAddress {
+			migratedChannel = v
+		}
+	case *models.SoulEmailLegacyAliasIndex:
+		if v.AliasEmail == oldAddress {
+			aliasIndex = v
+		}
+	}
+	return migratedChannel, aliasIndex
+}
+
 func TestEnsureSoulEmailAgentIndex_RejectsForeignOwner(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -1092,6 +1092,47 @@ func TestSyncSoulV3StateFromRegistration_AllowsProject37LegacyEmailMigration(t *
 	}
 }
 
+func TestSyncSoulV3StateFromRegistration_RejectsNonAgentLegacyEmailAlias(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{cfg: config.Config{Stage: "lab"}, store: store.New(tdb.db)}
+	now := time.Date(2026, time.May, 22, 8, 0, 0, 0, time.UTC)
+	identity := &models.SoulAgentIdentity{
+		AgentID:         soulLifecycleTestAgentIDHex,
+		Domain:          "simulacrum.greater.website",
+		LocalID:         "pilot",
+		LifecycleStatus: models.SoulAgentStatusActive,
+	}
+
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:       identity.AgentID,
+			ChannelType:   models.SoulChannelTypeEmail,
+			Identifier:    "other@lessersoul.ai",
+			Provider:      "migadu",
+			Verified:      true,
+			ProvisionedAt: now.Add(-24 * time.Hour),
+			Status:        models.SoulChannelStatusActive,
+			SecretRef:     "/lesser-host/soul/lab/agents/0xabc/channels/email/migadu_password",
+		}
+	}).Once()
+
+	appErr := s.syncSoulV3StateFromRegistration(context.Background(), identity.AgentID, identity, &soul.RegistrationFileV3{
+		Channels: &soul.ChannelsV3{
+			Email: &soul.EmailChannelV3{
+				Address:  provisionTestPilotScopedEmail,
+				Verified: true,
+			},
+		},
+	}, now)
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "managed channel must be deprovisioned before changing identifier" {
+		t.Fatalf("expected managed channel conflict for non-agent legacy alias, got %v", appErr)
+	}
+}
+
 func findProject37EmailMigrationModels(calls []mock.Call, oldAddress string, newAddress string) (*models.SoulAgentChannel, *models.SoulEmailLegacyAliasIndex) {
 	var migratedChannel *models.SoulAgentChannel
 	var aliasIndex *models.SoulEmailLegacyAliasIndex

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -81,6 +81,7 @@ func LambdaInit() (DB, error) {
 		&models.SoulCommMailboxEvent{},
 		&models.SoulOperation{},
 		&models.SoulEmailAgentIndex{},
+		&models.SoulEmailLegacyAliasIndex{},
 		&models.SoulPhoneAgentIndex{},
 		&models.SoulChannelAgentIndex{},
 		&models.SoulRelationshipFromIndex{},

--- a/internal/store/models/soul_agent_channel_index_items.go
+++ b/internal/store/models/soul_agent_channel_index_items.go
@@ -3,6 +3,14 @@ package models
 import (
 	"fmt"
 	"strings"
+	"time"
+)
+
+// SoulEmailLegacyAliasStatus* constants describe host-internal legacy email
+// aliases used only for migrated bare Lesser Soul addresses.
+const (
+	SoulEmailLegacyAliasStatusActive   = "active"
+	SoulEmailLegacyAliasStatusDisabled = "disabled"
 )
 
 // SoulEmailAgentIndex is a materialized index for looking up an agent by email address.
@@ -53,6 +61,104 @@ func (i *SoulEmailAgentIndex) GetPK() string { return i.PK }
 
 // GetSK returns the sort key for SoulEmailAgentIndex.
 func (i *SoulEmailAgentIndex) GetSK() string { return i.SK }
+
+// SoulEmailLegacyAliasIndex is a host-internal deprecated alias lookup used
+// only for migrated managed Lesser Soul email channels. It is deliberately
+// separate from SoulEmailAgentIndex so public/current channel lookup remains
+// the canonical instance-scoped address only.
+//
+// Keys:
+//
+//	PK: SOUL#EMAIL_ALIAS#{normalizedLegacyAliasEmail}
+//	SK: CANONICAL
+type SoulEmailLegacyAliasIndex struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK string `theorydb:"pk,attr:PK" json:"-"`
+	SK string `theorydb:"sk,attr:SK" json:"-"`
+
+	AliasEmail     string    `theorydb:"attr:aliasEmail" json:"alias_email"`
+	CanonicalEmail string    `theorydb:"attr:canonicalEmail" json:"canonical_email"`
+	AgentID        string    `theorydb:"attr:agentId" json:"agent_id"`
+	Status         string    `theorydb:"attr:status" json:"status"`
+	Source         string    `theorydb:"attr:source" json:"source,omitempty"`
+	CreatedAt      time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt      time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+}
+
+// TableName returns the database table name for SoulEmailLegacyAliasIndex.
+func (SoulEmailLegacyAliasIndex) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating SoulEmailLegacyAliasIndex.
+func (i *SoulEmailLegacyAliasIndex) BeforeCreate() error {
+	now := time.Now().UTC()
+	if i.CreatedAt.IsZero() {
+		i.CreatedAt = now
+	}
+	i.UpdatedAt = now
+	if strings.TrimSpace(i.Status) == "" {
+		i.Status = SoulEmailLegacyAliasStatusActive
+	}
+	if err := i.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("aliasEmail", i.AliasEmail); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("canonicalEmail", i.CanonicalEmail); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", i.AgentID); err != nil {
+		return err
+	}
+	if err := requireOneOf("status", i.Status, SoulEmailLegacyAliasStatusActive, SoulEmailLegacyAliasStatusDisabled); err != nil {
+		return err
+	}
+	return nil
+}
+
+// BeforeUpdate updates timestamps before updating SoulEmailLegacyAliasIndex.
+func (i *SoulEmailLegacyAliasIndex) BeforeUpdate() error {
+	i.UpdatedAt = time.Now().UTC()
+	if strings.TrimSpace(i.Status) == "" {
+		i.Status = SoulEmailLegacyAliasStatusActive
+	}
+	if err := i.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("aliasEmail", i.AliasEmail); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("canonicalEmail", i.CanonicalEmail); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", i.AgentID); err != nil {
+		return err
+	}
+	if err := requireOneOf("status", i.Status, SoulEmailLegacyAliasStatusActive, SoulEmailLegacyAliasStatusDisabled); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateKeys updates the database keys for SoulEmailLegacyAliasIndex.
+func (i *SoulEmailLegacyAliasIndex) UpdateKeys() error {
+	i.AliasEmail = normalizeSoulEmail(i.AliasEmail)
+	i.CanonicalEmail = normalizeSoulEmail(i.CanonicalEmail)
+	i.AgentID = strings.ToLower(strings.TrimSpace(i.AgentID))
+	i.Status = strings.ToLower(strings.TrimSpace(i.Status))
+	i.Source = strings.TrimSpace(i.Source)
+
+	i.PK = fmt.Sprintf("SOUL#EMAIL_ALIAS#%s", i.AliasEmail)
+	i.SK = "CANONICAL"
+	return nil
+}
+
+// GetPK returns the partition key for SoulEmailLegacyAliasIndex.
+func (i *SoulEmailLegacyAliasIndex) GetPK() string { return i.PK }
+
+// GetSK returns the sort key for SoulEmailLegacyAliasIndex.
+func (i *SoulEmailLegacyAliasIndex) GetSK() string { return i.SK }
 
 // SoulPhoneAgentIndex is a materialized index for looking up an agent by phone number (E.164).
 //

--- a/internal/store/models/soul_models_v3_test.go
+++ b/internal/store/models/soul_models_v3_test.go
@@ -43,6 +43,27 @@ func TestSoulEmailAgentIndex_Keys(t *testing.T) {
 	require.Equal(t, "0xabc", i.AgentID)
 }
 
+func TestSoulEmailLegacyAliasIndex_Keys(t *testing.T) {
+	t.Parallel()
+
+	i := &SoulEmailLegacyAliasIndex{
+		AliasEmail:     " Agent-Bob@Lessersoul.ai ",
+		CanonicalEmail: " Agent-Bob.Simulacrum@LesserSoul.ai ",
+		AgentID:        " 0xABC ",
+		Source:         " project37-m2 ",
+	}
+	require.NoError(t, i.BeforeCreate())
+	require.Equal(t, "SOUL#EMAIL_ALIAS#agent-bob@lessersoul.ai", i.PK)
+	require.Equal(t, "CANONICAL", i.SK)
+	require.Equal(t, "agent-bob@lessersoul.ai", i.AliasEmail)
+	require.Equal(t, "agent-bob.simulacrum@lessersoul.ai", i.CanonicalEmail)
+	require.Equal(t, "0xabc", i.AgentID)
+	require.Equal(t, SoulEmailLegacyAliasStatusActive, i.Status)
+	require.Equal(t, "project37-m2", i.Source)
+	require.False(t, i.CreatedAt.IsZero())
+	require.False(t, i.UpdatedAt.IsZero())
+}
+
 func TestSoulPhoneAgentIndex_Keys(t *testing.T) {
 	t.Parallel()
 
@@ -59,6 +80,9 @@ func TestSoulContactAgentIndexes_RequireNonEmptyIdentity(t *testing.T) {
 
 	require.Error(t, (&SoulEmailAgentIndex{AgentID: "0xabc"}).BeforeCreate())
 	require.Error(t, (&SoulEmailAgentIndex{Email: "agent@example.com"}).BeforeCreate())
+	require.Error(t, (&SoulEmailLegacyAliasIndex{CanonicalEmail: "agent.example@lessersoul.ai", AgentID: "0xabc"}).BeforeCreate())
+	require.Error(t, (&SoulEmailLegacyAliasIndex{AliasEmail: "agent@lessersoul.ai", AgentID: "0xabc"}).BeforeCreate())
+	require.Error(t, (&SoulEmailLegacyAliasIndex{AliasEmail: "agent@lessersoul.ai", CanonicalEmail: "agent.example@lessersoul.ai"}).BeforeCreate())
 	require.Error(t, (&SoulPhoneAgentIndex{AgentID: "0xabc"}).BeforeCreate())
 	require.Error(t, (&SoulPhoneAgentIndex{Phone: "+15550123456"}).BeforeCreate())
 }

--- a/scripts/soul-email-m2-migration/main.go
+++ b/scripts/soul-email-m2-migration/main.go
@@ -247,6 +247,9 @@ func runMigration(ctx context.Context, provider providerClient, cfg migrationCon
 	if err != nil {
 		return migrationReport{}, err
 	}
+	if err := validateInventoryMetadata(inventory, cfg); err != nil {
+		return migrationReport{}, err
+	}
 	report := newMigrationReport(cfg, inventory, now)
 	report.Issues = append(report.Issues, inventoryBlockingIssues(inventory)...)
 	selected := selectInventoryAgents(inventory.Agents, cfg.AgentID, cfg.MaxAgents)
@@ -282,6 +285,25 @@ func runMigration(ctx context.Context, provider providerClient, cfg migrationCon
 		return report.Agents[i].Domain < report.Agents[j].Domain
 	})
 	return report, nil
+}
+
+func validateInventoryMetadata(inventory inventoryReport, cfg migrationConfig) error {
+	var mismatches []string
+	if inventory.SchemaVersion != migrationSchemaVersion {
+		mismatches = append(mismatches, fmt.Sprintf("schema_version=%d expected=%d", inventory.SchemaVersion, migrationSchemaVersion))
+	}
+	inventoryStage := strings.ToLower(strings.TrimSpace(inventory.Stage))
+	if inventoryStage != cfg.Stage {
+		mismatches = append(mismatches, fmt.Sprintf("stage=%q expected=%q", inventoryStage, cfg.Stage))
+	}
+	inventoryTable := strings.TrimSpace(inventory.TableName)
+	if inventoryTable != cfg.TableName {
+		mismatches = append(mismatches, fmt.Sprintf("table_name=%q expected=%q", inventoryTable, cfg.TableName))
+	}
+	if len(mismatches) > 0 {
+		return fmt.Errorf("inventory metadata mismatch: %s", strings.Join(mismatches, "; "))
+	}
+	return nil
 }
 
 func newMigrationReport(cfg migrationConfig, inventory inventoryReport, now time.Time) migrationReport {
@@ -352,7 +374,7 @@ func selectInventoryAgents(records []managedEmailInventory, agentID string, maxA
 }
 
 func planAgentMigration(rec managedEmailInventory, emailInboundDomain string) migrationAgentReport {
-	agent := baseMigrationAgentReport(rec)
+	agent := baseMigrationAgentReport(rec, emailInboundDomain)
 	if rec.DomainRecord != nil {
 		agent.InstanceSlug = strings.ToLower(strings.TrimSpace(rec.DomainRecord.InstanceSlug))
 	}
@@ -368,7 +390,7 @@ func planAgentMigration(rec managedEmailInventory, emailInboundDomain string) mi
 	return planPendingAgentMigration(agent, rec, emailInboundDomain)
 }
 
-func baseMigrationAgentReport(rec managedEmailInventory) migrationAgentReport {
+func baseMigrationAgentReport(rec managedEmailInventory, emailInboundDomain string) migrationAgentReport {
 	return migrationAgentReport{
 		AgentID:             strings.ToLower(strings.TrimSpace(rec.AgentID)),
 		Domain:              strings.ToLower(strings.TrimSpace(rec.Domain)),
@@ -378,7 +400,7 @@ func baseMigrationAgentReport(rec managedEmailInventory) migrationAgentReport {
 		ProviderLocalPart:   strings.ToLower(strings.TrimSpace(rec.Proposed.LocalPart)),
 		CanSelfAttest:       normalizeSigningState(rec.MigrationReadiness.CanSelfAttest),
 		State:               migrationStateInventoryDryRun,
-		ProviderState:       providerMigrationStateFor(rec),
+		ProviderState:       providerMigrationStateFor(rec, emailInboundDomain),
 		RegistrationVersion: rec.RegistrationVersion,
 		Rollback: []string{
 			"preserve old bare provider delivery during rollback",
@@ -495,14 +517,14 @@ func registrationAndHostSyncActions(agent migrationAgentReport) []migrationActio
 	}
 }
 
-func providerMigrationStateFor(rec managedEmailInventory) providerMigrationState {
+func providerMigrationStateFor(rec managedEmailInventory, emailInboundDomain string) providerMigrationState {
 	current := rec.ProviderState.Current
 	proposed := rec.ProviderState.Proposed
 	return providerMigrationState{
 		CurrentKnown:      current != nil,
 		CurrentReachable:  providerReachable(current),
 		ProposedKnown:     proposed != nil,
-		ProposedReachable: providerReachable(proposed),
+		ProposedReachable: providerForwardsTo(proposed, expectedProviderForwardingTarget(rec.Proposed.LocalPart, emailInboundDomain)),
 	}
 }
 
@@ -514,6 +536,31 @@ func providerReachable(state *providerAddressState) bool {
 		return true
 	}
 	return len(state.Forwardings) > 0 || len(state.Aliases) > 0
+}
+
+func providerForwardsTo(state *providerAddressState, target string) bool {
+	if state == nil {
+		return false
+	}
+	target = normalizeEmail(target)
+	if target == "" {
+		return false
+	}
+	for _, forwarding := range state.Forwardings {
+		if normalizeEmail(forwarding) == target {
+			return true
+		}
+	}
+	return false
+}
+
+func expectedProviderForwardingTarget(localPart string, emailInboundDomain string) string {
+	localPart = strings.ToLower(strings.TrimSpace(localPart))
+	emailInboundDomain = strings.ToLower(strings.TrimSpace(emailInboundDomain))
+	if localPart == "" || emailInboundDomain == "" {
+		return ""
+	}
+	return localPart + "@" + emailInboundDomain
 }
 
 func mergeMigrationSummary(summary *migrationSummary, agent migrationAgentReport) {

--- a/scripts/soul-email-m2-migration/main.go
+++ b/scripts/soul-email-m2-migration/main.go
@@ -1,0 +1,844 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/secrets"
+)
+
+const (
+	migrationSchemaVersion = 1
+	defaultStage           = "lab"
+	canonicalEmailDomain   = "lessersoul.ai"
+	defaultInboundDomain   = "inbound.lessersoul.ai"
+	migaduBaseURL          = "https://api.migadu.com/v1"
+
+	migrationStateInventoryDryRun        = "inventory_dry_run"
+	migrationStateProviderPreparePending = "provider_prepare_pending"
+	migrationStateProviderPrepared       = "provider_prepared"
+	migrationStateHostSwitched           = "host_switched"
+	migrationStateNeedsRepair            = "needs_repair"
+
+	actionEnsureProviderForwarding = "ensure_provider_mailbox_forwarding"
+	actionPreserveLegacyProvider   = "preserve_legacy_provider_delivery"
+	actionCollectSelfAttestation   = "collect_self_attestation_or_host_audit_receipt"
+	actionPublishRegistration      = "publish_registration_with_instance_scoped_email"
+	actionHostSync                 = "host_channel_index_legacy_alias_sync"
+	actionVerifyLegacyAlias        = "verify_legacy_alias_canonicalization"
+
+	signingStateYes     = "yes"
+	signingStateNo      = "no"
+	signingStateUnknown = "unknown"
+)
+
+var (
+	migaduCredsLoader    = secrets.MigaduCreds
+	migaduPasswordLoader = func(ctx context.Context, stage string, agentID string) (string, error) {
+		return secrets.GetSSMParameter(ctx, nil, soulEmailPasswordSSMParam(stage, agentID))
+	}
+	migaduAPIBaseURL = migaduBaseURL
+	newHTTPClient    = func() *http.Client { return &http.Client{Timeout: 10 * time.Second} }
+)
+
+type migrationConfig struct {
+	Stage              string
+	TableName          string
+	InventoryPath      string
+	OutputPath         string
+	AgentID            string
+	EmailInboundDomain string
+	Apply              bool
+	MaxAgents          int
+}
+
+type migrationReport struct {
+	SchemaVersion int                    `json:"schema_version"`
+	GeneratedAt   string                 `json:"generated_at"`
+	Mode          string                 `json:"mode"`
+	Stage         string                 `json:"stage"`
+	TableName     string                 `json:"table_name"`
+	Inventory     migrationInventoryRef  `json:"inventory"`
+	Contract      migrationContract      `json:"contract"`
+	Summary       migrationSummary       `json:"summary"`
+	Agents        []migrationAgentReport `json:"agents"`
+	Issues        []string               `json:"issues,omitempty"`
+}
+
+type migrationInventoryRef struct {
+	Path          string `json:"path"`
+	GeneratedAt   string `json:"generated_at,omitempty"`
+	SchemaVersion int    `json:"schema_version,omitempty"`
+}
+
+type migrationContract struct {
+	CanonicalAddressFormat string `json:"canonical_address_format"`
+	LegacyAliasPolicy      string `json:"legacy_alias_policy"`
+	RegistrationAuthority  string `json:"registration_authority"`
+	ProviderPolicy         string `json:"provider_policy"`
+	LiveExecutionIssue     string `json:"live_execution_issue"`
+}
+
+type migrationSummary struct {
+	SelectedAgents         int `json:"selected_agents"`
+	AlreadyHostSwitched    int `json:"already_host_switched"`
+	ProviderPrepared       int `json:"provider_prepared"`
+	ProviderActionsPlanned int `json:"provider_actions_planned"`
+	ProviderActionsApplied int `json:"provider_actions_applied"`
+	RegistrationActions    int `json:"registration_actions"`
+	HostSyncActions        int `json:"host_sync_actions"`
+	NeedsRepair            int `json:"needs_repair"`
+	Skipped                int `json:"skipped"`
+	Errors                 int `json:"errors"`
+}
+
+type migrationAgentReport struct {
+	AgentID             string                   `json:"agent_id"`
+	Domain              string                   `json:"domain"`
+	InstanceSlug        string                   `json:"instance_slug,omitempty"`
+	LocalID             string                   `json:"local_id"`
+	OldAddress          string                   `json:"old_address,omitempty"`
+	NewAddress          string                   `json:"new_address,omitempty"`
+	ProviderLocalPart   string                   `json:"provider_local_part,omitempty"`
+	CanSelfAttest       string                   `json:"can_self_attest"`
+	State               string                   `json:"state"`
+	Actions             []migrationAction        `json:"actions,omitempty"`
+	Rollback            []string                 `json:"rollback,omitempty"`
+	ProviderState       providerMigrationState   `json:"provider_state"`
+	RegistrationVersion *registrationVersionInfo `json:"registration_version,omitempty"`
+	Issues              []string                 `json:"issues,omitempty"`
+}
+
+type migrationAction struct {
+	Kind        string `json:"kind"`
+	Status      string `json:"status"`
+	Description string `json:"description"`
+}
+
+type providerMigrationState struct {
+	CurrentKnown      bool `json:"current_known"`
+	CurrentReachable  bool `json:"current_reachable"`
+	ProposedKnown     bool `json:"proposed_known"`
+	ProposedReachable bool `json:"proposed_reachable"`
+}
+
+type migaduCreateForwardingRequest struct {
+	Address string `json:"address"`
+}
+
+type migaduCreateMailboxRequest struct {
+	Name      string `json:"name"`
+	LocalPart string `json:"local_part"`
+	//nolint:gosec // Required by Migadu's mailbox-create API payload; loaded at runtime from SSM.
+	Credential            string `json:"password"`
+	PasswordRecoveryEmail any    `json:"password_recovery_email"`
+}
+
+type providerPrepareRequest struct {
+	Stage             string
+	AgentID           string
+	DisplayName       string
+	LocalPart         string
+	ForwardingAddress string
+}
+
+type providerClient interface {
+	EnsureMailboxAndForwarding(ctx context.Context, req providerPrepareRequest) error
+}
+
+type defaultMigaduClient struct{}
+
+func main() {
+	os.Exit(runCLI(os.Args[1:], os.Getenv, os.Stdout, os.Stderr, defaultMigaduClient{}, time.Now().UTC()))
+}
+
+func runCLI(args []string, getenv func(string) string, stdout io.Writer, stderr io.Writer, provider providerClient, now time.Time) int {
+	cfg, err := parseConfig(args, getenv)
+	if err != nil {
+		fmt.Fprintf(stderr, "%v\n", err)
+		return 1
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+
+	report, err := runMigration(ctx, provider, cfg, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "migration planning failed: %v\n", err)
+		return 1
+	}
+	if err := writeMigrationReport(report, cfg.OutputPath, stdout); err != nil {
+		fmt.Fprintf(stderr, "write report: %v\n", err)
+		return 1
+	}
+	if report.Summary.Errors > 0 {
+		return 1
+	}
+	if len(report.Issues) > 0 || report.Summary.NeedsRepair > 0 {
+		return 2
+	}
+	return 0
+}
+
+func parseConfig(args []string, getenv func(string) string) (migrationConfig, error) {
+	stageDefault := strings.ToLower(strings.TrimSpace(getenv("STAGE")))
+	if stageDefault == "" {
+		stageDefault = defaultStage
+	}
+	tableDefault := strings.TrimSpace(getenv("STATE_TABLE_NAME"))
+	if tableDefault == "" {
+		tableDefault = fmt.Sprintf("lesser-host-%s-state", stageDefault)
+	}
+	inboundDefault := strings.ToLower(strings.TrimSpace(getenv("SOUL_EMAIL_INBOUND_DOMAIN")))
+	if inboundDefault == "" {
+		inboundDefault = defaultInboundDomain
+	}
+
+	cfg := migrationConfig{Stage: stageDefault, TableName: tableDefault, EmailInboundDomain: inboundDefault}
+	fs := flag.NewFlagSet("soul-email-m2-migration", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	fs.StringVar(&cfg.Stage, "stage", cfg.Stage, "Control-plane stage")
+	fs.StringVar(&cfg.TableName, "table-name", cfg.TableName, "DynamoDB state table name recorded in evidence")
+	fs.StringVar(&cfg.InventoryPath, "inventory", "", "M0 inventory report JSON path")
+	fs.StringVar(&cfg.OutputPath, "out", "", "Output migration evidence JSON path (default stdout)")
+	fs.StringVar(&cfg.AgentID, "agent-id", "", "Optional target agent id")
+	fs.StringVar(&cfg.EmailInboundDomain, "email-inbound-domain", cfg.EmailInboundDomain, "Inbound bridge email domain")
+	fs.BoolVar(&cfg.Apply, "apply", false, "Apply provider-prepare mutations only; registration/channel switch still requires self-attested publish path")
+	fs.IntVar(&cfg.MaxAgents, "max-agents", 0, "Maximum selected agents to plan/apply (0 = unlimited)")
+	if err := fs.Parse(args); err != nil {
+		return migrationConfig{}, err
+	}
+	cfg.Stage = strings.ToLower(strings.TrimSpace(cfg.Stage))
+	if cfg.Stage == "" {
+		cfg.Stage = defaultStage
+	}
+	cfg.TableName = strings.TrimSpace(cfg.TableName)
+	cfg.InventoryPath = strings.TrimSpace(cfg.InventoryPath)
+	cfg.OutputPath = strings.TrimSpace(cfg.OutputPath)
+	cfg.AgentID = strings.ToLower(strings.TrimSpace(cfg.AgentID))
+	cfg.EmailInboundDomain = strings.ToLower(strings.TrimSpace(cfg.EmailInboundDomain))
+	if cfg.InventoryPath == "" {
+		return migrationConfig{}, errors.New("--inventory is required")
+	}
+	if cfg.TableName == "" {
+		return migrationConfig{}, errors.New("--table-name or STATE_TABLE_NAME is required")
+	}
+	if cfg.EmailInboundDomain == "" {
+		return migrationConfig{}, errors.New("--email-inbound-domain or SOUL_EMAIL_INBOUND_DOMAIN is required")
+	}
+	if cfg.MaxAgents < 0 {
+		return migrationConfig{}, errors.New("--max-agents must be non-negative")
+	}
+	return cfg, nil
+}
+
+func runMigration(ctx context.Context, provider providerClient, cfg migrationConfig, now time.Time) (migrationReport, error) {
+	inventory, err := loadInventoryReport(cfg.InventoryPath)
+	if err != nil {
+		return migrationReport{}, err
+	}
+	report := newMigrationReport(cfg, inventory, now)
+	report.Issues = append(report.Issues, inventoryBlockingIssues(inventory)...)
+	selected := selectInventoryAgents(inventory.Agents, cfg.AgentID, cfg.MaxAgents)
+	if len(selected) == 0 && cfg.AgentID != "" {
+		report.Issues = appendUnique(report.Issues, "target_agent_not_found")
+	}
+
+	for _, rec := range selected {
+		agent := planAgentMigration(rec, cfg.EmailInboundDomain)
+		report.Agents = append(report.Agents, agent)
+		mergeMigrationSummary(&report.Summary, agent)
+	}
+	if len(report.Issues) > 0 {
+		for i := range report.Agents {
+			report.Agents[i].State = migrationStateNeedsRepair
+			report.Agents[i].Issues = appendUnique(report.Agents[i].Issues, "report_blocking_issue")
+		}
+		report.Summary.NeedsRepair = len(report.Agents)
+		return report, nil
+	}
+	if cfg.Apply {
+		applyProviderPreparedActions(ctx, provider, cfg, &report)
+		applied := report.Summary.ProviderActionsApplied
+		errorsCount := report.Summary.Errors
+		report.Summary = summarizeMigrationAgents(report.Agents)
+		report.Summary.ProviderActionsApplied = applied
+		report.Summary.Errors = errorsCount
+	}
+	sort.SliceStable(report.Agents, func(i, j int) bool {
+		if report.Agents[i].Domain == report.Agents[j].Domain {
+			return report.Agents[i].LocalID < report.Agents[j].LocalID
+		}
+		return report.Agents[i].Domain < report.Agents[j].Domain
+	})
+	return report, nil
+}
+
+func newMigrationReport(cfg migrationConfig, inventory inventoryReport, now time.Time) migrationReport {
+	mode := "dry-run"
+	if cfg.Apply {
+		mode = "apply-provider-prepare"
+	}
+	return migrationReport{
+		SchemaVersion: migrationSchemaVersion,
+		GeneratedAt:   now.UTC().Format(time.RFC3339),
+		Mode:          mode,
+		Stage:         cfg.Stage,
+		TableName:     cfg.TableName,
+		Inventory: migrationInventoryRef{
+			Path:          cfg.InventoryPath,
+			GeneratedAt:   strings.TrimSpace(inventory.GeneratedAt),
+			SchemaVersion: inventory.SchemaVersion,
+		},
+		Contract: migrationContract{
+			CanonicalAddressFormat: "<agent-local-id>.<instance-slug>@lessersoul.ai",
+			LegacyAliasPolicy:      "host-internal SoulEmailLegacyAliasIndex canonicalizes known legacy recipients before comm-worker channel matching; aliases are never public channels",
+			RegistrationAuthority:  "self-attested registration publish preferred; host audit path must be separately approved and disclosed",
+			ProviderPolicy:         "prepare new Migadu mailbox/forwarding before any public channel switch; preserve old bare inbound delivery",
+			LiveExecutionIssue:     "https://github.com/equaltoai/lesser-host/issues/339",
+		},
+	}
+}
+
+func inventoryBlockingIssues(report inventoryReport) []string {
+	var issues []string
+	issues = append(issues, report.Issues...)
+	if report.Summary.ProposedDuplicateCount > 0 {
+		issues = appendUnique(issues, "duplicate_proposed_address")
+	}
+	if report.Summary.ProposedOverflowCount > 0 {
+		issues = appendUnique(issues, "proposed_local_part_overflow")
+	}
+	if report.Summary.MissingCurrentEmailIndex > 0 {
+		issues = appendUnique(issues, "missing_current_email_index")
+	}
+	if report.Summary.CurrentEmailIndexMismatch > 0 {
+		issues = appendUnique(issues, "current_email_index_mismatch")
+	}
+	if report.Summary.MissingDomainRecord > 0 {
+		issues = appendUnique(issues, "missing_domain_record")
+	}
+	if report.Summary.MissingInstanceSlug > 0 {
+		issues = appendUnique(issues, "missing_instance_slug")
+	}
+	if report.Summary.InvalidInstanceSlug > 0 {
+		issues = appendUnique(issues, "invalid_instance_slug")
+	}
+	return issues
+}
+
+func selectInventoryAgents(records []managedEmailInventory, agentID string, maxAgents int) []managedEmailInventory {
+	selected := make([]managedEmailInventory, 0, len(records))
+	for _, rec := range records {
+		if agentID != "" && !strings.EqualFold(strings.TrimSpace(rec.AgentID), agentID) {
+			continue
+		}
+		selected = append(selected, rec)
+		if maxAgents > 0 && len(selected) >= maxAgents {
+			break
+		}
+	}
+	return selected
+}
+
+func planAgentMigration(rec managedEmailInventory, emailInboundDomain string) migrationAgentReport {
+	agent := baseMigrationAgentReport(rec)
+	if rec.DomainRecord != nil {
+		agent.InstanceSlug = strings.ToLower(strings.TrimSpace(rec.DomainRecord.InstanceSlug))
+	}
+	agent.Issues = appendBaseMigrationIssues(agent.Issues, rec, agent.NewAddress, agent.CanSelfAttest)
+
+	if agent.OldAddress == "" || agent.NewAddress == "" || len(agent.Issues) > 0 {
+		agent.State = migrationStateNeedsRepair
+		return agent
+	}
+	if strings.EqualFold(agent.OldAddress, agent.NewAddress) {
+		return planAlreadyHostSwitchedAgent(agent, rec)
+	}
+	return planPendingAgentMigration(agent, rec, emailInboundDomain)
+}
+
+func baseMigrationAgentReport(rec managedEmailInventory) migrationAgentReport {
+	return migrationAgentReport{
+		AgentID:             strings.ToLower(strings.TrimSpace(rec.AgentID)),
+		Domain:              strings.ToLower(strings.TrimSpace(rec.Domain)),
+		LocalID:             strings.TrimSpace(rec.LocalID),
+		OldAddress:          currentEmailAddress(rec.CurrentEmailChannel),
+		NewAddress:          normalizeEmail(rec.Proposed.Address),
+		ProviderLocalPart:   strings.ToLower(strings.TrimSpace(rec.Proposed.LocalPart)),
+		CanSelfAttest:       normalizeSigningState(rec.MigrationReadiness.CanSelfAttest),
+		State:               migrationStateInventoryDryRun,
+		ProviderState:       providerMigrationStateFor(rec),
+		RegistrationVersion: rec.RegistrationVersion,
+		Rollback: []string{
+			"preserve old bare provider delivery during rollback",
+			"if host switch has occurred but registration publish fails, restore previous SoulAgentChannel/SoulEmailAgentIndex and disable the legacy alias index",
+			"leave newly prepared provider forwarding intact until canaries confirm safe cleanup",
+		},
+	}
+}
+
+func currentEmailAddress(ch *emailChannelInventory) string {
+	if ch == nil {
+		return ""
+	}
+	return normalizeEmail(ch.Identifier)
+}
+
+func appendBaseMigrationIssues(issues []string, rec managedEmailInventory, newAddress string, canSelfAttest string) []string {
+	issues = append(issues, rec.Issues...)
+	if rec.CurrentEmailChannel == nil {
+		issues = appendUnique(issues, "missing_old_email_channel")
+	}
+	if newAddress == "" {
+		issues = appendUnique(issues, "missing_proposed_address")
+	}
+	if rec.Proposed.Overflow {
+		issues = appendUnique(issues, "proposed_local_part_overflow")
+	}
+	if rec.Proposed.Duplicate {
+		issues = appendUnique(issues, "duplicate_proposed_address")
+	}
+	if canSelfAttest == signingStateUnknown {
+		issues = appendUnique(issues, "unknown_registration_signing_state")
+	}
+	return issues
+}
+
+func planAlreadyHostSwitchedAgent(agent migrationAgentReport, rec managedEmailInventory) migrationAgentReport {
+	agent.State = migrationStateHostSwitched
+	if rec.CurrentEmailIndex == nil || !rec.CurrentEmailIndex.MatchesAgent || !rec.CurrentEmailIndex.MatchesChannel {
+		agent.Issues = appendUnique(agent.Issues, "current_email_index_not_canonical")
+		agent.State = migrationStateNeedsRepair
+	}
+	if rec.RegistrationVersion == nil || !strings.EqualFold(strings.TrimSpace(rec.RegistrationVersion.EmailChannel), agent.NewAddress) {
+		agent.Issues = appendUnique(agent.Issues, "registration_email_not_instance_scoped")
+		agent.State = migrationStateNeedsRepair
+	}
+	agent.Actions = append(agent.Actions, migrationAction{
+		Kind:        actionVerifyLegacyAlias,
+		Status:      "pending_canary",
+		Description: "verify public channels advertise only the instance-scoped address and any known legacy alias canonicalizes internally",
+	})
+	return agent
+}
+
+func planPendingAgentMigration(agent migrationAgentReport, rec managedEmailInventory, emailInboundDomain string) migrationAgentReport {
+	agent.Actions = append(agent.Actions, migrationAction{
+		Kind:        actionPreserveLegacyProvider,
+		Status:      actionStatus(agent.ProviderState.CurrentReachable),
+		Description: "preserve existing bare provider mailbox/alias/forwarding for inbound-only legacy delivery",
+	})
+	if !agent.ProviderState.CurrentKnown {
+		agent.Issues = appendUnique(agent.Issues, "current_provider_state_unknown")
+	}
+	if !agent.ProviderState.CurrentReachable {
+		agent.Issues = appendUnique(agent.Issues, "current_provider_delivery_not_confirmed")
+	}
+	if rec.CurrentEmailChannel != nil && strings.TrimSpace(rec.CurrentEmailChannel.SecretRef) != "present" {
+		agent.Issues = appendUnique(agent.Issues, "current_email_secret_ref_missing")
+	}
+	if agent.ProviderState.ProposedReachable {
+		agent.State = migrationStateProviderPrepared
+	} else {
+		agent.State = migrationStateProviderPreparePending
+		agent.Actions = append(agent.Actions, ensureProviderForwardingAction(agent, emailInboundDomain))
+	}
+	agent.Actions = append(agent.Actions, registrationAndHostSyncActions(agent)...)
+	if agent.CanSelfAttest == signingStateNo {
+		agent.Issues = appendUnique(agent.Issues, "host_audit_path_required")
+	}
+	if agent.CanSelfAttest == signingStateUnknown {
+		agent.Issues = appendUnique(agent.Issues, "unknown_registration_signing_state")
+	}
+	if len(agent.Issues) > 0 {
+		agent.State = migrationStateNeedsRepair
+	}
+	return agent
+}
+
+func ensureProviderForwardingAction(agent migrationAgentReport, emailInboundDomain string) migrationAction {
+	return migrationAction{
+		Kind:        actionEnsureProviderForwarding,
+		Status:      "pending",
+		Description: "ensure new Migadu mailbox/forwarding delivers to " + agent.ProviderLocalPart + "@" + strings.ToLower(strings.TrimSpace(emailInboundDomain)) + " before public channel switch",
+	}
+}
+
+func registrationAndHostSyncActions(agent migrationAgentReport) []migrationAction {
+	return []migrationAction{
+		{
+			Kind:        actionCollectSelfAttestation,
+			Status:      registrationActionStatus(agent.CanSelfAttest),
+			Description: "collect agent self-attestation for registration document that advertises only the instance-scoped email address, or attach approved host audit receipt",
+		},
+		{
+			Kind:        actionPublishRegistration,
+			Status:      "pending_after_provider_prepared",
+			Description: "publish signed self-description version with " + agent.NewAddress + " as the only public email channel",
+		},
+		{
+			Kind:        actionHostSync,
+			Status:      "implemented_in_control_plane",
+			Description: "registration sync writes SoulAgentChannel/SoulEmailAgentIndex for the new address and SoulEmailLegacyAliasIndex for the old address",
+		},
+	}
+}
+
+func providerMigrationStateFor(rec managedEmailInventory) providerMigrationState {
+	current := rec.ProviderState.Current
+	proposed := rec.ProviderState.Proposed
+	return providerMigrationState{
+		CurrentKnown:      current != nil,
+		CurrentReachable:  providerReachable(current),
+		ProposedKnown:     proposed != nil,
+		ProposedReachable: providerReachable(proposed),
+	}
+}
+
+func providerReachable(state *providerAddressState) bool {
+	if state == nil {
+		return false
+	}
+	if state.MailboxExists != nil && *state.MailboxExists {
+		return true
+	}
+	return len(state.Forwardings) > 0 || len(state.Aliases) > 0
+}
+
+func mergeMigrationSummary(summary *migrationSummary, agent migrationAgentReport) {
+	summary.SelectedAgents++
+	switch agent.State {
+	case migrationStateHostSwitched:
+		summary.AlreadyHostSwitched++
+	case migrationStateProviderPrepared:
+		summary.ProviderPrepared++
+	case migrationStateNeedsRepair:
+		summary.NeedsRepair++
+	}
+	for _, action := range agent.Actions {
+		switch action.Kind {
+		case actionEnsureProviderForwarding:
+			summary.ProviderActionsPlanned++
+		case actionCollectSelfAttestation, actionPublishRegistration:
+			summary.RegistrationActions++
+		case actionHostSync:
+			summary.HostSyncActions++
+		}
+	}
+}
+
+func summarizeMigrationAgents(agents []migrationAgentReport) migrationSummary {
+	var summary migrationSummary
+	for _, agent := range agents {
+		mergeMigrationSummary(&summary, agent)
+	}
+	return summary
+}
+
+func applyProviderPreparedActions(ctx context.Context, provider providerClient, cfg migrationConfig, report *migrationReport) {
+	if provider == nil {
+		report.Issues = appendUnique(report.Issues, "provider_client_not_configured")
+		report.Summary.Errors++
+		return
+	}
+	for i := range report.Agents {
+		if report.Agents[i].State != migrationStateProviderPreparePending {
+			continue
+		}
+		if len(report.Agents[i].Issues) > 0 {
+			report.Agents[i].State = migrationStateNeedsRepair
+			continue
+		}
+		localPart := strings.TrimSpace(report.Agents[i].ProviderLocalPart)
+		forwardingAddress := localPart + "@" + strings.TrimSpace(cfg.EmailInboundDomain)
+		if err := provider.EnsureMailboxAndForwarding(ctx, providerPrepareRequest{
+			Stage:             cfg.Stage,
+			AgentID:           report.Agents[i].AgentID,
+			DisplayName:       report.Agents[i].LocalID,
+			LocalPart:         localPart,
+			ForwardingAddress: forwardingAddress,
+		}); err != nil {
+			report.Agents[i].Issues = appendUnique(report.Agents[i].Issues, "provider_prepare_failed")
+			report.Agents[i].State = migrationStateNeedsRepair
+			report.Summary.Errors++
+			continue
+		}
+		markActionApplied(report.Agents[i].Actions, actionEnsureProviderForwarding)
+		report.Agents[i].State = migrationStateProviderPrepared
+		report.Agents[i].ProviderState.ProposedKnown = true
+		report.Agents[i].ProviderState.ProposedReachable = true
+		report.Summary.ProviderActionsApplied++
+	}
+}
+
+func markActionApplied(actions []migrationAction, kind string) {
+	for i := range actions {
+		if actions[i].Kind == kind {
+			actions[i].Status = "applied"
+		}
+	}
+}
+
+func actionStatus(ok bool) string {
+	if ok {
+		return "verified"
+	}
+	return "needs_repair"
+}
+
+func registrationActionStatus(canSelfAttest string) string {
+	switch canSelfAttest {
+	case signingStateYes:
+		return "ready"
+	case signingStateNo:
+		return "requires_approved_host_audit_path"
+	default:
+		return "blocked_unknown"
+	}
+}
+
+func (defaultMigaduClient) EnsureMailboxAndForwarding(ctx context.Context, input providerPrepareRequest) error {
+	input.Stage = strings.ToLower(strings.TrimSpace(input.Stage))
+	input.AgentID = strings.ToLower(strings.TrimSpace(input.AgentID))
+	input.LocalPart = strings.ToLower(strings.TrimSpace(input.LocalPart))
+	input.ForwardingAddress = strings.ToLower(strings.TrimSpace(input.ForwardingAddress))
+	input.DisplayName = strings.TrimSpace(input.DisplayName)
+	if input.LocalPart == "" || input.ForwardingAddress == "" || input.AgentID == "" {
+		return errors.New("migadu provider prepare requires agentID, localPart, and forwarding address")
+	}
+	password, err := migaduPasswordLoader(ctx, input.Stage, input.AgentID)
+	if err != nil {
+		return err
+	}
+	password = strings.TrimSpace(password)
+	if password == "" {
+		return errors.New("migadu mailbox password is empty")
+	}
+	creds, err := migaduCredsLoader(ctx, nil)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(creds.Username) == "" || strings.TrimSpace(creds.APIToken) == "" {
+		return errors.New("migadu credentials are incomplete")
+	}
+	if input.DisplayName == "" {
+		input.DisplayName = input.LocalPart
+	}
+	if err := defaultMigaduCreateMailbox(ctx, creds, input.LocalPart, input.DisplayName, password); err != nil {
+		return err
+	}
+	return defaultMigaduCreateForwarding(ctx, creds, input.LocalPart, input.ForwardingAddress)
+}
+
+func defaultMigaduCreateMailbox(ctx context.Context, creds secrets.MigaduCredentials, localPart string, displayName string, password string) error {
+	body, err := json.Marshal(migaduCreateMailboxRequest{
+		Name:                  strings.TrimSpace(displayName),
+		LocalPart:             strings.TrimSpace(localPart),
+		Credential:            strings.TrimSpace(password),
+		PasswordRecoveryEmail: nil,
+	})
+	if err != nil {
+		return fmt.Errorf("migadu mailbox encode: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, migaduAPIBaseURL+"/domains/"+canonicalEmailDomain+"/mailboxes", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("migadu mailbox build: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.SetBasicAuth(strings.TrimSpace(creds.Username), strings.TrimSpace(creds.APIToken))
+	client := newHTTPClient()
+	//nolint:gosec // Request target is the fixed Migadu HTTPS API host by default; tests override migaduAPIBaseURL.
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("migadu mailbox: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusConflict:
+		return nil
+	}
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("migadu mailbox: status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(msg)))
+}
+
+func defaultMigaduCreateForwarding(ctx context.Context, creds secrets.MigaduCredentials, localPart string, forwardingAddress string) error {
+	body, err := json.Marshal(migaduCreateForwardingRequest{Address: strings.TrimSpace(forwardingAddress)})
+	if err != nil {
+		return fmt.Errorf("migadu forwarding encode: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, migaduAPIBaseURL+"/domains/"+canonicalEmailDomain+"/mailboxes/"+strings.TrimSpace(localPart)+"/forwardings", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("migadu forwarding build: %w", err)
+	}
+	req.Header.Set("content-type", "application/json")
+	req.SetBasicAuth(strings.TrimSpace(creds.Username), strings.TrimSpace(creds.APIToken))
+	client := newHTTPClient()
+	//nolint:gosec // Request target is the fixed Migadu HTTPS API host by default; tests override migaduAPIBaseURL.
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("migadu forwarding: %w", err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusConflict:
+		return nil
+	}
+	msg, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	return fmt.Errorf("migadu forwarding: status=%d body=%q", resp.StatusCode, strings.TrimSpace(string(msg)))
+}
+
+func soulEmailPasswordSSMParam(stage string, agentID string) string {
+	stage = strings.ToLower(strings.TrimSpace(stage))
+	if stage == "" {
+		stage = defaultStage
+	}
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	// #nosec G101 -- SSM parameter path, not a hardcoded credential.
+	return fmt.Sprintf("/lesser-host/soul/%s/agents/%s/channels/email/migadu_password", stage, agentID)
+}
+
+func loadInventoryReport(path string) (inventoryReport, error) {
+	raw, err := os.ReadFile(path) //nolint:gosec // Operator-provided local M0 evidence path.
+	if err != nil {
+		return inventoryReport{}, err
+	}
+	var report inventoryReport
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return inventoryReport{}, err
+	}
+	return report, nil
+}
+
+func writeMigrationReport(report migrationReport, outputPath string, stdout io.Writer) error {
+	raw, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	outputPath = strings.TrimSpace(outputPath)
+	if outputPath == "" || outputPath == "-" {
+		_, err = stdout.Write(raw)
+		return err
+	}
+	return os.WriteFile(outputPath, raw, 0o600) //nolint:gosec // Evidence is written only to the operator-selected local output path.
+}
+
+type inventoryReport struct {
+	SchemaVersion int                     `json:"schema_version"`
+	GeneratedAt   string                  `json:"generated_at"`
+	Stage         string                  `json:"stage"`
+	TableName     string                  `json:"table_name"`
+	Summary       inventorySummary        `json:"summary"`
+	Agents        []managedEmailInventory `json:"agents"`
+	Issues        []string                `json:"issues,omitempty"`
+}
+
+type inventorySummary struct {
+	MissingDomainRecord       int `json:"missing_domain_record"`
+	MissingInstanceSlug       int `json:"missing_instance_slug"`
+	InvalidInstanceSlug       int `json:"invalid_instance_slug"`
+	ProposedDuplicateCount    int `json:"proposed_duplicate_count"`
+	ProposedOverflowCount     int `json:"proposed_overflow_count"`
+	MissingCurrentEmailIndex  int `json:"missing_current_email_index"`
+	CurrentEmailIndexMismatch int `json:"current_email_index_mismatch"`
+}
+
+type managedEmailInventory struct {
+	AgentID             string                   `json:"agent_id"`
+	Domain              string                   `json:"domain"`
+	LocalID             string                   `json:"local_id"`
+	DomainRecord        *domainInventory         `json:"domain_record,omitempty"`
+	CurrentEmailChannel *emailChannelInventory   `json:"current_email_channel,omitempty"`
+	CurrentEmailIndex   *emailIndexInventory     `json:"current_email_index,omitempty"`
+	RegistrationVersion *registrationVersionInfo `json:"registration_version,omitempty"`
+	Proposed            proposedEmailInventory   `json:"proposed"`
+	ProviderState       providerInventory        `json:"provider_state"`
+	MigrationReadiness  migrationReadiness       `json:"migration_readiness"`
+	Issues              []string                 `json:"issues,omitempty"`
+}
+
+type domainInventory struct {
+	InstanceSlug string `json:"instance_slug"`
+}
+
+type emailChannelInventory struct {
+	Identifier string `json:"identifier"`
+	SecretRef  string `json:"secret_ref_present,omitempty"`
+}
+
+type emailIndexInventory struct {
+	MatchesAgent   bool `json:"matches_agent"`
+	MatchesChannel bool `json:"matches_channel"`
+}
+
+type registrationVersionInfo struct {
+	VersionNumber          int    `json:"version_number"`
+	RegistrationURI        string `json:"registration_uri,omitempty"`
+	RegistrationSHA256     string `json:"registration_sha256,omitempty"`
+	ChangeSummary          string `json:"change_summary,omitempty"`
+	SelfAttestationPresent bool   `json:"self_attestation_present"`
+	EmailChannel           string `json:"email_channel,omitempty"`
+	Source                 string `json:"source,omitempty"`
+}
+
+type proposedEmailInventory struct {
+	LocalPart string `json:"local_part,omitempty"`
+	Address   string `json:"address,omitempty"`
+	Overflow  bool   `json:"overflow"`
+	Duplicate bool   `json:"duplicate"`
+}
+
+type providerInventory struct {
+	Current  *providerAddressState `json:"current,omitempty"`
+	Proposed *providerAddressState `json:"proposed,omitempty"`
+}
+
+type migrationReadiness struct {
+	CanSelfAttest string `json:"can_self_attest"`
+}
+
+type providerAddressState struct {
+	LocalPart     string   `json:"local_part"`
+	MailboxExists *bool    `json:"mailbox_exists,omitempty"`
+	Forwardings   []string `json:"forwardings,omitempty"`
+	Aliases       []string `json:"aliases,omitempty"`
+}
+
+func normalizeSigningState(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "yes", "true", "can_self_attest":
+		return signingStateYes
+	case "no", "false", "cannot_self_attest":
+		return signingStateNo
+	default:
+		return signingStateUnknown
+	}
+}
+
+func normalizeEmail(raw string) string {
+	return strings.ToLower(strings.TrimSpace(raw))
+}
+
+func appendUnique(values []string, value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return values
+	}
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/scripts/soul-email-m2-migration/main_test.go
+++ b/scripts/soul-email-m2-migration/main_test.go
@@ -24,6 +24,7 @@ const (
 	testForwardingAddr  = "pilot.simulacrum@inbound.lessersoul.ai"
 	testDisplayName     = "pilot"
 	testMailboxPassword = "mailbox-password"
+	testLiveStage       = "live"
 )
 
 type fakeProvider struct {
@@ -114,6 +115,84 @@ func TestRunMigration_RefusesInventoryDuplicatesAndOverflow(t *testing.T) {
 	}
 	if !contains(report.Issues, "duplicate_proposed_address") || !contains(report.Issues, "proposed_local_part_overflow") {
 		t.Fatalf("expected duplicate/overflow issues, got %#v", report.Issues)
+	}
+}
+
+func TestRunMigration_RejectsInventoryMetadataMismatch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		mut  func(*inventoryReport)
+		want string
+	}{
+		{
+			name: "schema",
+			mut:  func(inv *inventoryReport) { inv.SchemaVersion = migrationSchemaVersion + 1 },
+			want: "schema_version",
+		},
+		{
+			name: "stage",
+			mut:  func(inv *inventoryReport) { inv.Stage = testLiveStage },
+			want: "stage",
+		},
+		{
+			name: "table",
+			mut:  func(inv *inventoryReport) { inv.TableName = "lesser-host-live-state" },
+			want: "table_name",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			inv := happyInventoryReport(nil)
+			tc.mut(&inv)
+			dir := t.TempDir()
+			path := filepath.Join(dir, "inventory.json")
+			raw, err := jsonMarshalIndent(inv)
+			if err != nil {
+				t.Fatalf("marshal inventory: %v", err)
+			}
+			writeErr := os.WriteFile(path, raw, 0o600)
+			if writeErr != nil {
+				t.Fatalf("write inventory: %v", writeErr)
+			}
+			provider := &fakeProvider{}
+			_, err = runMigration(context.Background(), provider, migrationConfig{
+				Stage:              defaultStage,
+				TableName:          "state",
+				InventoryPath:      path,
+				EmailInboundDomain: defaultInboundDomain,
+				Apply:              true,
+			}, time.Unix(0, 0).UTC())
+			if err == nil || !strings.Contains(err.Error(), "inventory metadata mismatch") || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected metadata mismatch containing %q, got %v", tc.want, err)
+			}
+			if len(provider.calls) != 0 {
+				t.Fatalf("provider should not be called on metadata mismatch, got %#v", provider.calls)
+			}
+		})
+	}
+}
+
+func TestPlanAgentMigration_ProposedProviderRequiresExactInboundForwarding(t *testing.T) {
+	t.Parallel()
+
+	report := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		trueValue := true
+		rec.ProviderState.Proposed = &providerAddressState{
+			LocalPart:     testNewLocalPart,
+			MailboxExists: &trueValue,
+			Forwardings:   []string{"pilot.simulacrum@wrong.example"},
+			Aliases:       []string{testNewEmail},
+		}
+	}))
+	if report.Summary.ProviderPrepared != 0 || report.Summary.ProviderActionsPlanned != 1 {
+		t.Fatalf("expected exact forwarding to be required, summary=%#v agent=%#v", report.Summary, report.Agents[0])
+	}
+	if report.Agents[0].State != migrationStateProviderPreparePending || report.Agents[0].ProviderState.ProposedReachable {
+		t.Fatalf("expected provider_prepare_pending with unreachable proposed state, got %#v", report.Agents[0])
 	}
 }
 
@@ -245,7 +324,7 @@ func TestParseConfigAndWriteReport(t *testing.T) {
 	cfg, err := parseConfig([]string{"--inventory", "inventory.json", "--agent-id", " 0xAGENT ", "--apply", "--max-agents", "2"}, func(key string) string {
 		switch key {
 		case "STAGE":
-			return "live"
+			return testLiveStage
 		case "SOUL_EMAIL_INBOUND_DOMAIN":
 			return "Inbound.LesserSoul.ai"
 		default:
@@ -255,7 +334,7 @@ func TestParseConfigAndWriteReport(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse config: %v", err)
 	}
-	if !cfg.Apply || cfg.Stage != "live" || cfg.TableName != "lesser-host-live-state" || cfg.AgentID != testAgentID || cfg.EmailInboundDomain != defaultInboundDomain || cfg.MaxAgents != 2 {
+	if !cfg.Apply || cfg.Stage != testLiveStage || cfg.TableName != "lesser-host-live-state" || cfg.AgentID != testAgentID || cfg.EmailInboundDomain != defaultInboundDomain || cfg.MaxAgents != 2 {
 		t.Fatalf("unexpected config: %#v", cfg)
 	}
 
@@ -282,7 +361,12 @@ func TestRunCLI(t *testing.T) {
 		t.Fatalf("write inventory: %v", writeErr)
 	}
 	var stdout, stderr bytes.Buffer
-	code := runCLI([]string{"--inventory", inventoryPath}, func(string) string { return "" }, &stdout, &stderr, &fakeProvider{}, time.Unix(0, 0).UTC())
+	code := runCLI([]string{"--inventory", inventoryPath}, func(key string) string {
+		if key == "STATE_TABLE_NAME" {
+			return "state"
+		}
+		return ""
+	}, &stdout, &stderr, &fakeProvider{}, time.Unix(0, 0).UTC())
 	if code != 0 || stderr.Len() != 0 || !bytes.Contains(stdout.Bytes(), []byte(`"mode": "dry-run"`)) {
 		t.Fatalf("unexpected CLI result code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}

--- a/scripts/soul-email-m2-migration/main_test.go
+++ b/scripts/soul-email-m2-migration/main_test.go
@@ -1,0 +1,528 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/secrets"
+)
+
+const (
+	testAgentID         = "0xagent"
+	testOldEmail        = "pilot@lessersoul.ai"
+	testNewEmail        = "pilot.simulacrum@lessersoul.ai"
+	testNewLocalPart    = "pilot.simulacrum"
+	testForwardingAddr  = "pilot.simulacrum@inbound.lessersoul.ai"
+	testDisplayName     = "pilot"
+	testMailboxPassword = "mailbox-password"
+)
+
+type fakeProvider struct {
+	calls []string
+	err   error
+}
+
+func (f *fakeProvider) EnsureMailboxAndForwarding(_ context.Context, input providerPrepareRequest) error {
+	f.calls = append(f.calls, input.AgentID+":"+input.LocalPart+"->"+input.ForwardingAddress)
+	return f.err
+}
+
+func TestPlanAgentMigration_DryRunListsRequiredActions(t *testing.T) {
+	t.Parallel()
+
+	report := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		falseValue := false
+		rec.ProviderState.Proposed = &providerAddressState{LocalPart: testNewLocalPart, MailboxExists: &falseValue}
+	}))
+	if len(report.Issues) != 0 || report.Summary.NeedsRepair != 0 {
+		t.Fatalf("unexpected issues: summary=%#v issues=%#v", report.Summary, report.Issues)
+	}
+	if report.Summary.ProviderActionsPlanned != 1 || report.Summary.RegistrationActions != 2 || report.Summary.HostSyncActions != 1 {
+		t.Fatalf("unexpected action summary: %#v", report.Summary)
+	}
+	agent := report.Agents[0]
+	if agent.OldAddress != testOldEmail || agent.NewAddress != testNewEmail || agent.InstanceSlug != "simulacrum" || agent.State != migrationStateProviderPreparePending {
+		t.Fatalf("unexpected agent plan: %#v", agent)
+	}
+}
+
+func TestRunMigration_ApplyProviderPrepareIsIdempotent(t *testing.T) {
+	t.Parallel()
+
+	provider := &fakeProvider{}
+	report := runMigrationForTestWithProvider(t, provider, true, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.ProviderState.Proposed = nil
+	}))
+	if report.Summary.ProviderActionsApplied != 1 || len(provider.calls) != 1 || provider.calls[0] != testAgentID+":"+testNewLocalPart+"->"+testForwardingAddr {
+		t.Fatalf("expected provider apply once, summary=%#v calls=%#v", report.Summary, provider.calls)
+	}
+	if report.Agents[0].State != migrationStateProviderPrepared {
+		t.Fatalf("expected provider_prepared after apply, got %#v", report.Agents[0])
+	}
+
+	ready := runMigrationForTestWithProvider(t, &fakeProvider{}, true, happyInventoryReport(nil))
+	if ready.Summary.ProviderActionsApplied != 0 || ready.Summary.ProviderActionsPlanned != 0 || ready.Agents[0].State != migrationStateProviderPrepared {
+		t.Fatalf("expected existing provider state to be a no-op, summary=%#v agent=%#v", ready.Summary, ready.Agents[0])
+	}
+}
+
+func TestPlanAgentMigration_ExistingNewChannelRequiresRegistrationParity(t *testing.T) {
+	t.Parallel()
+
+	report := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.CurrentEmailChannel.Identifier = testNewEmail
+		rec.CurrentEmailIndex = &emailIndexInventory{MatchesAgent: true, MatchesChannel: true}
+		rec.RegistrationVersion.EmailChannel = testNewEmail
+	}))
+	if report.Summary.AlreadyHostSwitched != 1 || report.Summary.NeedsRepair != 0 || report.Agents[0].State != migrationStateHostSwitched {
+		t.Fatalf("expected host_switched no-op, summary=%#v agent=%#v", report.Summary, report.Agents[0])
+	}
+}
+
+func TestPlanAgentMigration_MissingOldChannelNeedsRepair(t *testing.T) {
+	t.Parallel()
+
+	report := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.CurrentEmailChannel = nil
+	}))
+	if report.Summary.NeedsRepair != 1 || report.Agents[0].State != migrationStateNeedsRepair {
+		t.Fatalf("expected needs_repair, summary=%#v agent=%#v", report.Summary, report.Agents[0])
+	}
+	if !contains(report.Agents[0].Issues, "missing_old_email_channel") {
+		t.Fatalf("expected missing_old_email_channel issue, got %#v", report.Agents[0].Issues)
+	}
+}
+
+func TestRunMigration_RefusesInventoryDuplicatesAndOverflow(t *testing.T) {
+	t.Parallel()
+
+	inv := happyInventoryReport(nil)
+	inv.Summary.ProposedDuplicateCount = 1
+	inv.Summary.ProposedOverflowCount = 1
+	report := runMigrationForTest(t, false, inv)
+	if len(report.Issues) == 0 || report.Summary.NeedsRepair != 1 || report.Agents[0].State != migrationStateNeedsRepair {
+		t.Fatalf("expected report-level refusal, summary=%#v issues=%#v agent=%#v", report.Summary, report.Issues, report.Agents[0])
+	}
+	if !contains(report.Issues, "duplicate_proposed_address") || !contains(report.Issues, "proposed_local_part_overflow") {
+		t.Fatalf("expected duplicate/overflow issues, got %#v", report.Issues)
+	}
+}
+
+func TestRunMigration_TargetAndProviderFailureIssues(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inventory.json")
+	raw, err := jsonMarshalIndent(happyInventoryReport(nil))
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	writeErr := os.WriteFile(path, raw, 0o600)
+	if writeErr != nil {
+		t.Fatalf("write inventory: %v", writeErr)
+	}
+
+	targetReport, err := runMigration(context.Background(), &fakeProvider{}, migrationConfig{
+		Stage:              defaultStage,
+		TableName:          "state",
+		InventoryPath:      path,
+		AgentID:            "0xmissing",
+		EmailInboundDomain: defaultInboundDomain,
+	}, time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("run target migration: %v", err)
+	}
+	if !contains(targetReport.Issues, "target_agent_not_found") {
+		t.Fatalf("expected target_agent_not_found, got %#v", targetReport.Issues)
+	}
+
+	providerReport := runMigrationForTestWithProvider(t, &fakeProvider{err: errors.New("provider down")}, true, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.ProviderState.Proposed = nil
+	}))
+	if providerReport.Summary.Errors != 1 || providerReport.Agents[0].State != migrationStateNeedsRepair || !contains(providerReport.Agents[0].Issues, "provider_prepare_failed") {
+		t.Fatalf("expected provider failure repair, summary=%#v agent=%#v", providerReport.Summary, providerReport.Agents[0])
+	}
+}
+
+func TestPlanAgentMigration_SigningAndAlreadySwitchedRepairBranches(t *testing.T) {
+	t.Parallel()
+
+	needsAudit := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.MigrationReadiness.CanSelfAttest = signingStateNo
+	}))
+	if needsAudit.Agents[0].State != migrationStateNeedsRepair || !contains(needsAudit.Agents[0].Issues, "host_audit_path_required") {
+		t.Fatalf("expected host audit repair, got %#v", needsAudit.Agents[0])
+	}
+
+	mismatch := runMigrationForTest(t, false, happyInventoryReport(func(rec *managedEmailInventory) {
+		rec.CurrentEmailChannel.Identifier = testNewEmail
+		rec.CurrentEmailIndex = &emailIndexInventory{MatchesAgent: false, MatchesChannel: true}
+		rec.RegistrationVersion.EmailChannel = testOldEmail
+	}))
+	if mismatch.Agents[0].State != migrationStateNeedsRepair ||
+		!contains(mismatch.Agents[0].Issues, "current_email_index_not_canonical") ||
+		!contains(mismatch.Agents[0].Issues, "registration_email_not_instance_scoped") {
+		t.Fatalf("expected already-switched repair issues, got %#v", mismatch.Agents[0])
+	}
+}
+
+func TestInventoryAndHelperErrorBranches(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	badPath := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badPath, []byte(`{"agents":`), 0o600); err != nil {
+		t.Fatalf("write bad inventory: %v", err)
+	}
+	if _, err := loadInventoryReport(badPath); err == nil {
+		t.Fatalf("expected invalid inventory error")
+	}
+	if got := appendUnique([]string{"x"}, "x"); len(got) != 1 {
+		t.Fatalf("expected duplicate append to be ignored, got %#v", got)
+	}
+	if got := appendUnique(nil, " "); len(got) != 0 {
+		t.Fatalf("expected blank append to be ignored, got %#v", got)
+	}
+	if normalizeSigningState("cannot_self_attest") != signingStateNo || normalizeSigningState("can_self_attest") != signingStateYes {
+		t.Fatalf("unexpected signing normalization")
+	}
+
+	reportPath := filepath.Join(dir, "report.json")
+	if err := writeMigrationReport(newMigrationReport(migrationConfig{Stage: defaultStage, TableName: "state", InventoryPath: "inventory.json"}, inventoryReport{}, time.Unix(0, 0).UTC()), reportPath, &bytes.Buffer{}); err != nil {
+		t.Fatalf("write report file: %v", err)
+	}
+	if info, err := os.Stat(reportPath); err != nil || info.Size() == 0 {
+		t.Fatalf("expected report file, info=%#v err=%v", info, err)
+	}
+
+	issues := inventoryBlockingIssues(inventoryReport{Summary: inventorySummary{
+		MissingDomainRecord:       1,
+		MissingInstanceSlug:       1,
+		InvalidInstanceSlug:       1,
+		MissingCurrentEmailIndex:  1,
+		CurrentEmailIndexMismatch: 1,
+	}})
+	for _, issue := range []string{"missing_domain_record", "missing_instance_slug", "invalid_instance_slug", "missing_current_email_index", "current_email_index_mismatch"} {
+		if !contains(issues, issue) {
+			t.Fatalf("expected inventory issue %q in %#v", issue, issues)
+		}
+	}
+}
+
+func TestApplyProviderPreparedActionsNilProviderAndSelection(t *testing.T) {
+	t.Parallel()
+
+	records := []managedEmailInventory{
+		{AgentID: "0x1"},
+		{AgentID: "0x2"},
+	}
+	if got := selectInventoryAgents(records, "", 1); len(got) != 1 || got[0].AgentID != "0x1" {
+		t.Fatalf("unexpected max selection: %#v", got)
+	}
+	if got := selectInventoryAgents(records, "0x2", 0); len(got) != 1 || got[0].AgentID != "0x2" {
+		t.Fatalf("unexpected target selection: %#v", got)
+	}
+
+	report := migrationReport{Agents: []migrationAgentReport{{State: migrationStateProviderPreparePending}}}
+	applyProviderPreparedActions(context.Background(), nil, migrationConfig{}, &report)
+	if report.Summary.Errors != 1 || !contains(report.Issues, "provider_client_not_configured") {
+		t.Fatalf("expected provider client error, summary=%#v issues=%#v", report.Summary, report.Issues)
+	}
+}
+
+func TestParseConfigAndWriteReport(t *testing.T) {
+	t.Parallel()
+
+	cfg, err := parseConfig([]string{"--inventory", "inventory.json", "--agent-id", " 0xAGENT ", "--apply", "--max-agents", "2"}, func(key string) string {
+		switch key {
+		case "STAGE":
+			return "live"
+		case "SOUL_EMAIL_INBOUND_DOMAIN":
+			return "Inbound.LesserSoul.ai"
+		default:
+			return ""
+		}
+	})
+	if err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	if !cfg.Apply || cfg.Stage != "live" || cfg.TableName != "lesser-host-live-state" || cfg.AgentID != testAgentID || cfg.EmailInboundDomain != defaultInboundDomain || cfg.MaxAgents != 2 {
+		t.Fatalf("unexpected config: %#v", cfg)
+	}
+
+	var stdout bytes.Buffer
+	if err := writeMigrationReport(newMigrationReport(cfg, inventoryReport{}, time.Unix(0, 0).UTC()), "-", &stdout); err != nil {
+		t.Fatalf("write stdout: %v", err)
+	}
+	if !bytes.Contains(stdout.Bytes(), []byte(`"schema_version": 1`)) {
+		t.Fatalf("stdout missing schema version: %s", stdout.String())
+	}
+}
+
+func TestRunCLI(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	inventoryPath := filepath.Join(dir, "inventory.json")
+	raw, err := jsonMarshalIndent(happyInventoryReport(nil))
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	writeErr := os.WriteFile(inventoryPath, raw, 0o600)
+	if writeErr != nil {
+		t.Fatalf("write inventory: %v", writeErr)
+	}
+	var stdout, stderr bytes.Buffer
+	code := runCLI([]string{"--inventory", inventoryPath}, func(string) string { return "" }, &stdout, &stderr, &fakeProvider{}, time.Unix(0, 0).UTC())
+	if code != 0 || stderr.Len() != 0 || !bytes.Contains(stdout.Bytes(), []byte(`"mode": "dry-run"`)) {
+		t.Fatalf("unexpected CLI result code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runCLI(nil, func(string) string { return "" }, &stdout, &stderr, &fakeProvider{}, time.Unix(0, 0).UTC())
+	if code != 1 || !strings.Contains(stderr.String(), "--inventory is required") {
+		t.Fatalf("expected config failure, code=%d stderr=%s", code, stderr.String())
+	}
+}
+
+func TestDefaultMigaduClientEnsuresMailboxAndForwarding(t *testing.T) {
+	var paths []string
+	server := newMigaduProviderTestServer(t, &paths)
+	defer server.Close()
+
+	oldCredsLoader := migaduCredsLoader
+	oldPasswordLoader := migaduPasswordLoader
+	oldBaseURL := migaduAPIBaseURL
+	migaduCredsLoader = func(context.Context, secrets.SSMAPI) (secrets.MigaduCredentials, error) {
+		return secrets.MigaduCredentials{Username: "migadu-user", APIToken: "migadu-token"}, nil
+	}
+	migaduPasswordLoader = func(_ context.Context, stage string, agentID string) (string, error) {
+		if stage != defaultStage || agentID != testAgentID {
+			t.Fatalf("unexpected password lookup stage=%q agent=%q", stage, agentID)
+		}
+		return testMailboxPassword, nil
+	}
+	migaduAPIBaseURL = server.URL
+	t.Cleanup(func() {
+		migaduCredsLoader = oldCredsLoader
+		migaduPasswordLoader = oldPasswordLoader
+		migaduAPIBaseURL = oldBaseURL
+	})
+
+	err := defaultMigaduClient{}.EnsureMailboxAndForwarding(context.Background(), providerPrepareRequest{
+		Stage:             defaultStage,
+		AgentID:           testAgentID,
+		DisplayName:       testDisplayName,
+		LocalPart:         testNewLocalPart,
+		ForwardingAddress: testForwardingAddr,
+	})
+	if err != nil {
+		t.Fatalf("EnsureMailboxAndForwarding: %v", err)
+	}
+	got := strings.Join(paths, ",")
+	if got != "POST /domains/lessersoul.ai/mailboxes,POST /domains/lessersoul.ai/mailboxes/"+testNewLocalPart+"/forwardings" {
+		t.Fatalf("unexpected request order: %s", got)
+	}
+}
+
+func newMigaduProviderTestServer(t *testing.T, paths *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*paths = append(*paths, r.Method+" "+r.URL.Path)
+		assertMigaduTestAuth(t, r)
+		switch r.URL.Path {
+		case "/domains/lessersoul.ai/mailboxes":
+			assertMigaduMailboxRequest(t, r)
+			w.WriteHeader(http.StatusCreated)
+		case "/domains/lessersoul.ai/mailboxes/" + testNewLocalPart + "/forwardings":
+			assertMigaduForwardingRequest(t, r)
+			w.WriteHeader(http.StatusConflict)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+}
+
+func assertMigaduTestAuth(t *testing.T, r *http.Request) {
+	t.Helper()
+	user, pass, ok := r.BasicAuth()
+	if !ok || user != "migadu-user" || pass != "migadu-token" {
+		t.Fatalf("unexpected auth user=%q pass=%q ok=%v", user, pass, ok)
+	}
+}
+
+func assertMigaduMailboxRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	var req migaduCreateMailboxRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode mailbox: %v", err)
+	}
+	if req.LocalPart != testNewLocalPart || req.Credential != testMailboxPassword || req.Name != testDisplayName {
+		t.Fatalf("unexpected mailbox request: %#v", req)
+	}
+}
+
+func assertMigaduForwardingRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	var req migaduCreateForwardingRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Fatalf("decode forwarding: %v", err)
+	}
+	if req.Address != testForwardingAddr {
+		t.Fatalf("unexpected forwarding request: %#v", req)
+	}
+}
+
+func TestDefaultMigaduClientRejectsMissingInputs(t *testing.T) {
+	t.Parallel()
+
+	if err := (defaultMigaduClient{}).EnsureMailboxAndForwarding(context.Background(), providerPrepareRequest{}); err == nil {
+		t.Fatalf("expected missing input error")
+	}
+	if got := soulEmailPasswordSSMParam(" LIVE ", " 0xABC "); got != "/lesser-host/soul/live/agents/0xabc/channels/email/migadu_password" {
+		t.Fatalf("unexpected password param %q", got)
+	}
+}
+
+func TestDefaultMigaduClientProviderFailures(t *testing.T) {
+	oldCredsLoader := migaduCredsLoader
+	oldPasswordLoader := migaduPasswordLoader
+	oldBaseURL := migaduAPIBaseURL
+	migaduPasswordLoader = func(context.Context, string, string) (string, error) { return testMailboxPassword, nil }
+	t.Cleanup(func() {
+		migaduCredsLoader = oldCredsLoader
+		migaduPasswordLoader = oldPasswordLoader
+		migaduAPIBaseURL = oldBaseURL
+	})
+
+	migaduCredsLoader = func(context.Context, secrets.SSMAPI) (secrets.MigaduCredentials, error) {
+		return secrets.MigaduCredentials{}, nil
+	}
+	if err := validDefaultMigaduPrepare().EnsureMailboxAndForwarding(context.Background(), validProviderPrepareRequest()); err == nil {
+		t.Fatalf("expected incomplete credentials error")
+	}
+
+	migaduCredsLoader = func(context.Context, secrets.SSMAPI) (secrets.MigaduCredentials, error) {
+		return secrets.MigaduCredentials{Username: "migadu-user", APIToken: "migadu-token"}, nil
+	}
+	migaduAPIBaseURL = newFailingMigaduTestServer(t, http.StatusInternalServerError, http.StatusCreated).URL
+	if err := validDefaultMigaduPrepare().EnsureMailboxAndForwarding(context.Background(), validProviderPrepareRequest()); err == nil || !strings.Contains(err.Error(), "migadu mailbox") {
+		t.Fatalf("expected mailbox provider error, got %v", err)
+	}
+
+	migaduAPIBaseURL = newFailingMigaduTestServer(t, http.StatusCreated, http.StatusBadGateway).URL
+	if err := validDefaultMigaduPrepare().EnsureMailboxAndForwarding(context.Background(), validProviderPrepareRequest()); err == nil || !strings.Contains(err.Error(), "migadu forwarding") {
+		t.Fatalf("expected forwarding provider error, got %v", err)
+	}
+}
+
+func validDefaultMigaduPrepare() defaultMigaduClient {
+	return defaultMigaduClient{}
+}
+
+func validProviderPrepareRequest() providerPrepareRequest {
+	return providerPrepareRequest{
+		Stage:             defaultStage,
+		AgentID:           testAgentID,
+		DisplayName:       testDisplayName,
+		LocalPart:         testNewLocalPart,
+		ForwardingAddress: testForwardingAddr,
+	}
+}
+
+func newFailingMigaduTestServer(t *testing.T, mailboxStatus int, forwardingStatus int) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/domains/lessersoul.ai/mailboxes":
+			http.Error(w, "mailbox failed", mailboxStatus)
+		case "/domains/lessersoul.ai/mailboxes/" + testNewLocalPart + "/forwardings":
+			http.Error(w, "forwarding failed", forwardingStatus)
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func runMigrationForTest(t *testing.T, apply bool, inv inventoryReport) migrationReport {
+	t.Helper()
+	return runMigrationForTestWithProvider(t, &fakeProvider{}, apply, inv)
+}
+
+func runMigrationForTestWithProvider(t *testing.T, provider providerClient, apply bool, inv inventoryReport) migrationReport {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "inventory.json")
+	raw, err := jsonMarshalIndent(inv)
+	if err != nil {
+		t.Fatalf("marshal inventory: %v", err)
+	}
+	writeErr := os.WriteFile(path, raw, 0o600)
+	if writeErr != nil {
+		t.Fatalf("write inventory: %v", writeErr)
+	}
+	report, err := runMigration(context.Background(), provider, migrationConfig{
+		Stage:              defaultStage,
+		TableName:          "state",
+		InventoryPath:      path,
+		EmailInboundDomain: defaultInboundDomain,
+		Apply:              apply,
+	}, time.Unix(0, 0).UTC())
+	if err != nil {
+		t.Fatalf("run migration: %v", err)
+	}
+	if len(report.Agents) != 1 {
+		t.Fatalf("expected one agent, got %#v", report.Agents)
+	}
+	return report
+}
+
+func happyInventoryReport(mut func(*managedEmailInventory)) inventoryReport {
+	trueValue := true
+	rec := managedEmailInventory{
+		AgentID: testAgentID,
+		Domain:  "dev.simulacrum.greater.website",
+		LocalID: "pilot",
+		DomainRecord: &domainInventory{
+			InstanceSlug: "simulacrum",
+		},
+		CurrentEmailChannel: &emailChannelInventory{Identifier: testOldEmail, SecretRef: "present"},
+		CurrentEmailIndex:   &emailIndexInventory{MatchesAgent: true, MatchesChannel: true},
+		RegistrationVersion: &registrationVersionInfo{VersionNumber: 3, EmailChannel: testOldEmail, SelfAttestationPresent: true},
+		Proposed:            proposedEmailInventory{LocalPart: testNewLocalPart, Address: testNewEmail},
+		ProviderState: providerInventory{
+			Current:  &providerAddressState{LocalPart: "pilot", MailboxExists: &trueValue},
+			Proposed: &providerAddressState{LocalPart: testNewLocalPart, Forwardings: []string{testForwardingAddr}},
+		},
+		MigrationReadiness: migrationReadiness{CanSelfAttest: signingStateYes},
+	}
+	if mut != nil {
+		mut(&rec)
+	}
+	return inventoryReport{SchemaVersion: 1, GeneratedAt: time.Unix(0, 0).UTC().Format(time.RFC3339), Stage: defaultStage, TableName: "state", Agents: []managedEmailInventory{rec}}
+}
+
+func jsonMarshalIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
+}
+
+func contains(values []string, value string) bool {
+	for _, existing := range values {
+		if existing == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Implements Project 37 M2 (#335, #336, #337, #338) without executing the live migration gate (#339 remains held):

- adds a host-internal `SoulEmailLegacyAliasIndex` model and comm-worker canonicalization path for known legacy bare addresses;
- allows the narrow self-attested Project 37 managed-email migration from `agent@lessersoul.ai` to the derived `agent.<instance>@lessersoul.ai`, preserving managed channel metadata and writing the canonical current index plus internal legacy alias;
- adds `go run ./scripts/soul-email-m2-migration` for M0-inventory-driven dry-run evidence and idempotent provider prepare (Migadu mailbox + forwarding, with secrets loaded only from SSM at apply time);
- documents the M2 runbook, rollback/repair rules, and credential envelope.

## Guardrails

- No live migration was executed.
- No secrets or provider payloads are included.
- Legacy aliases are host-internal only and are not returned as public/current channels.
- Unknown bare recipients still fail closed.
- Issue #339 remains blocked pending reviewed dry-run evidence, provider state, registration authority, and M3 canaries.

## Validation

- `go test ./...`
- `go vet ./...`
- tracked Go `gofmt` check
- `git diff --check`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0
