### PR TITLE
fix(comm): annotate recipient soul id and record M3 evidence

### DIFF
--- a/docs/instance-scoped-soul-email-m3-canary.md
+++ b/docs/instance-scoped-soul-email-m3-canary.md
@@ -171,3 +171,66 @@ evidence.
   cross-repo canaries are complete.
 - The validation report belongs in `gov-infra/evidence/project37/` with the
   canary evidence. Commit only redacted evidence.
+
+## Lab evidence pass — 2026-05-22
+
+Release `v0.4.3` was deployed to `lab` before this evidence pass. Host
+recorded the redacted evidence under `gov-infra/evidence/project37/`:
+
+- `m3-email-canary-lab.json` — Host-controlled routing canary evidence for
+  Agent-0 and Arch. It covers primary instance-scoped inbound, outbound,
+  mailbox list/get/content/search, canonical email resolve, contactability,
+  legacy bare inbound canonicalization, legacy resolve fail-closed behavior,
+  and unknown bare alias fail-closed behavior. Steward channel/index state is
+  included in the alias mapping and signed-registration blocker evidence, but
+  not in the two-agent host canary set because this pass did not capture a
+  fresh Steward outbound canary.
+- `m3-email-canary-lab-host-validation.json` — passing host-only verifier
+  output using `--require-legacy-alias --require-unknown-alias`.
+- `m3-email-canary-lab-full-validation-blocked.json` — full release-gate
+  verifier output showing the remaining `--require-body-mcp` dependency.
+- `m3-email-alias-mapping-lab.json` — redacted old-bare to current
+  instance-scoped mapping for the 12 migrated lab advisor agents.
+- `m3-email-canary-lab-blockers.json` — explicit blockers/dependencies for
+  the remaining full-M3 gate.
+
+The host-only validation command for this pass was:
+
+```bash
+go run ./scripts/soul-email-m3-canary \
+  --stage lab \
+  --evidence gov-infra/evidence/project37/m3-email-canary-lab.json \
+  --require-legacy-alias \
+  --require-unknown-alias \
+  --out gov-infra/evidence/project37/m3-email-canary-lab-host-validation.json
+```
+
+Full release-gate validation still requires cross-repo Body MCP evidence:
+
+```bash
+go run ./scripts/soul-email-m3-canary \
+  --stage lab \
+  --evidence gov-infra/evidence/project37/m3-email-canary-lab.json \
+  --require-legacy-alias \
+  --require-body-mcp \
+  --require-unknown-alias \
+  --out gov-infra/evidence/project37/m3-email-canary-lab-validation.json
+```
+
+The 2026-05-22 host pass intentionally does not claim that full gate as green:
+`lesser-body#275` is still the body-facing dependency for
+`identity_whoami`, `identity_lookup`, and mailbox MCP compatibility evidence.
+
+### Signed-registration caveat
+
+Host-controlled `SoulAgentChannel`, `SoulEmailAgentIndex`, and
+`SoulEmailLegacyAliasIndex` state now treats `<agent>.<instance>@lessersoul.ai`
+as the current address and each legacy bare `<agent>@lessersoul.ai` as an
+inbound-only alias. However, the lab signed registration documents served from
+`/api/v1/soul/agents/{agentId}/registration` still returned legacy bare email
+addresses for the checked agents during this pass.
+
+That caveat is recorded as a blocker, not hidden in the passing host-only
+validation. The full M3/M4 release gate needs either self-attested registration
+republish evidence or an explicitly approved host audit path before signed
+public registration surfaces can be treated as fully current.

--- a/gov-infra/evidence/project37/m3-email-alias-mapping-lab.json
+++ b/gov-infra/evidence/project37/m3-email-alias-mapping-lab.json
@@ -1,0 +1,129 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-22T18:45:00Z",
+  "stage": "lab",
+  "table_name": "lesser-host-lab-state",
+  "mode": "redacted-alias-mapping",
+  "contract": {
+    "canonical_address_format": "<agent-local-id>.<instance-slug>@lessersoul.ai",
+    "legacy_alias_policy": "legacy bare addresses are inbound-only aliases for migrated agents and are not assignable current public channels"
+  },
+  "summary": {
+    "migrated_agents": 12,
+    "active_aliases": 12,
+    "instances": [
+      "simulacrum",
+      "theory"
+    ]
+  },
+  "mappings": [
+    {
+      "local_id": "advocate",
+      "agent_id": "0x0d0ff6430055bf84964386c340cd9fa7875771972187d54f70a61b564469c772",
+      "legacy_alias": "advocate@lessersoul.ai",
+      "canonical_address": "advocate.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:55.744041485Z"
+    },
+    {
+      "local_id": "agent-0",
+      "agent_id": "0xaf87d423717e3aecbb2fc829d6224ea2acb66e7475f88c920d1a53e0789f313d",
+      "legacy_alias": "agent-0@lessersoul.ai",
+      "canonical_address": "agent-0.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-agent-0",
+      "updated_at": "2026-05-22T14:04:51.878838493Z"
+    },
+    {
+      "local_id": "arch",
+      "agent_id": "0xfd0a5fa6fe9674866f4a8b87cafc1ce2fe03786392ff9f7e4d93bc0b3ff1db8c",
+      "legacy_alias": "arch@lessersoul.ai",
+      "canonical_address": "arch.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:55.903101525Z"
+    },
+    {
+      "local_id": "counsel",
+      "agent_id": "0xcbafba9c2bd415ca4dd8c58150ba288e3e9022e794a981e0d9620b58156108fb",
+      "legacy_alias": "counsel@lessersoul.ai",
+      "canonical_address": "counsel.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.010825533Z"
+    },
+    {
+      "local_id": "herald",
+      "agent_id": "0x5c523ba7a7152357039b776432daa861b69ea40c1c37086cc433743238cc9ebf",
+      "legacy_alias": "herald@lessersoul.ai",
+      "canonical_address": "herald.theory@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.543732255Z"
+    },
+    {
+      "local_id": "ledger",
+      "agent_id": "0x08e5983b64f2de98355326be34da3f538ae81d6d2a9d29d0f418826990d8c2b7",
+      "legacy_alias": "ledger@lessersoul.ai",
+      "canonical_address": "ledger.theory@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.956873997Z"
+    },
+    {
+      "local_id": "medic",
+      "agent_id": "0xbd70ce31d811b0bed13f70b9ad7fd829399260c6aa16fa58b15754e3b72e5bc7",
+      "legacy_alias": "medic@lessersoul.ai",
+      "canonical_address": "medic.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.127319102Z"
+    },
+    {
+      "local_id": "ops",
+      "agent_id": "0xc328d6c24e5174cac7f4972e9b94ea11026a07a4baeecb6f2ddd69788e18c5b4",
+      "legacy_alias": "ops@lessersoul.ai",
+      "canonical_address": "ops.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.249624476Z"
+    },
+    {
+      "local_id": "pilot",
+      "agent_id": "0xeccb58e7b8df042987cd7ff609c9d3773e625aadccb7a05412dd747d6911b8b1",
+      "legacy_alias": "pilot@lessersoul.ai",
+      "canonical_address": "pilot.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.350497135Z"
+    },
+    {
+      "local_id": "scout",
+      "agent_id": "0x44a3898846ebd204ff4e84630356a652e95569276780c0434279c4f669ebec99",
+      "legacy_alias": "scout@lessersoul.ai",
+      "canonical_address": "scout.simulacrum@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:56.438841055Z"
+    },
+    {
+      "local_id": "scribe",
+      "agent_id": "0x79f6108420796083689c84e2df06790ea1e7aec5d30004da38192e062c75ddac",
+      "legacy_alias": "scribe@lessersoul.ai",
+      "canonical_address": "scribe.theory@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:57.060387651Z"
+    },
+    {
+      "local_id": "steward",
+      "agent_id": "0x85d3a95f9220e3bd257e33ddbdffa1985c7bd4cab509388f1aa7a0c5d750ef77",
+      "legacy_alias": "steward@lessersoul.ai",
+      "canonical_address": "steward.theory@lessersoul.ai",
+      "status": "active",
+      "source": "project37-m2-dev-host-audit-batch",
+      "updated_at": "2026-05-22T14:30:57.155332976Z"
+    }
+  ]
+}

--- a/gov-infra/evidence/project37/m3-email-canary-lab-blockers.json
+++ b/gov-infra/evidence/project37/m3-email-canary-lab-blockers.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-22T18:45:00Z",
+  "stage": "lab",
+  "mode": "m3-evidence-closeout-blockers",
+  "release": {
+    "tag": "v0.4.3",
+    "commit": "40197a31c20ea1ab963c5996dfc3a1830a1c3d56",
+    "url": "https://github.com/equaltoai/lesser-host/releases/tag/v0.4.3"
+  },
+  "host_routing_status": "passed_host_only_validation",
+  "blockers": [
+    {
+      "id": "signed-registration-public-channel",
+      "status": "blocked",
+      "summary": "Host-controlled channel/index state is instance-scoped, but signed public registration documents in lab still advertise legacy bare email addresses.",
+      "evidence": [
+        {
+          "agent_id": "0xaf87d423717e3aecbb2fc829d6224ea2acb66e7475f88c920d1a53e0789f313d",
+          "local_id": "agent-0",
+          "canonical_address": "agent-0.simulacrum@lessersoul.ai",
+          "signed_registration_email": "agent-0@lessersoul.ai"
+        },
+        {
+          "agent_id": "0xfd0a5fa6fe9674866f4a8b87cafc1ce2fe03786392ff9f7e4d93bc0b3ff1db8c",
+          "local_id": "arch",
+          "canonical_address": "arch.simulacrum@lessersoul.ai",
+          "signed_registration_email": "arch@lessersoul.ai"
+        },
+        {
+          "agent_id": "0x85d3a95f9220e3bd257e33ddbdffa1985c7bd4cab509388f1aa7a0c5d750ef77",
+          "local_id": "steward",
+          "canonical_address": "steward.theory@lessersoul.ai",
+          "signed_registration_email": "steward@lessersoul.ai"
+        }
+      ],
+      "next_step": "Use the approved signing/update-registration path, or keep the disclosed dev-host-audit caveat until self-attested registration versions are republished."
+    },
+    {
+      "id": "lesser-body-mcp-compatibility",
+      "status": "pending_cross_repo_evidence",
+      "summary": "Host did not have Body steward MCP evidence at PR creation time; lesser-body issue #275 remains In Progress.",
+      "issue": "https://github.com/equaltoai/lesser-body/issues/275",
+      "next_step": "Attach Body MCP identity/mailbox evidence, then rerun scripts/soul-email-m3-canary with --require-body-mcp."
+    },
+    {
+      "id": "agent0-mcp-credential-unavailable-to-host",
+      "status": "blocked_local_probe",
+      "summary": "Agent-0 MCP delegated credentials were unavailable in the Host steward environment, so Host did not perform new Agent-0 MCP reads from this repo session.",
+      "next_step": "Use the Body steward canary or fresh delegated credentials if Agent-0 MCP evidence is required from Host."
+    }
+  ]
+}

--- a/gov-infra/evidence/project37/m3-email-canary-lab-full-validation-blocked.json
+++ b/gov-infra/evidence/project37/m3-email-canary-lab-full-validation-blocked.json
@@ -1,0 +1,17 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-22T18:45:21Z",
+  "mode": "validate-redacted-canary-evidence",
+  "stage": "lab",
+  "evidence_path": "gov-infra/evidence/project37/m3-email-canary-lab.json",
+  "agents_checked": 2,
+  "primary_checked": 2,
+  "legacy_checked": 2,
+  "body_mcp_checked": 0,
+  "unknown_alias_checked": true,
+  "issues": [
+    "agents[0:0xaf87d423717e3aecbb2fc829d6224ea2acb66e7475f88c920d1a53e0789f313d].body_mcp is required",
+    "agents[1:0xfd0a5fa6fe9674866f4a8b87cafc1ce2fe03786392ff9f7e4d93bc0b3ff1db8c].body_mcp is required",
+    "no body MCP canary evidence checked"
+  ]
+}

--- a/gov-infra/evidence/project37/m3-email-canary-lab-host-validation.json
+++ b/gov-infra/evidence/project37/m3-email-canary-lab-host-validation.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-22T18:45:21Z",
+  "mode": "validate-redacted-canary-evidence",
+  "stage": "lab",
+  "evidence_path": "gov-infra/evidence/project37/m3-email-canary-lab.json",
+  "agents_checked": 2,
+  "primary_checked": 2,
+  "legacy_checked": 2,
+  "body_mcp_checked": 0,
+  "unknown_alias_checked": true
+}

--- a/gov-infra/evidence/project37/m3-email-canary-lab.json
+++ b/gov-infra/evidence/project37/m3-email-canary-lab.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": 1,
+  "generated_at": "2026-05-22T18:45:00Z",
+  "stage": "lab",
+  "table_name": "lesser-host-lab-state",
+  "mode": "redacted-canary",
+  "contract": {
+    "canonical_address_format": "<agent-local-id>.<instance-slug>@lessersoul.ai",
+    "legacy_alias_policy": "host-internal aliases canonicalize before comm-worker channel matching",
+    "redaction_policy": "message bodies, provider payloads, and credentials omitted"
+  },
+  "agents": [
+    {
+      "agent_id": "0xaf87d423717e3aecbb2fc829d6224ea2acb66e7475f88c920d1a53e0789f313d",
+      "local_id": "agent-0",
+      "instance_slug": "simulacrum",
+      "canonical_address": "agent-0.simulacrum@lessersoul.ai",
+      "legacy_alias": "agent-0@lessersoul.ai",
+      "primary": {
+        "inbound": {
+          "passed": true,
+          "recipient": "agent-0.simulacrum@lessersoul.ai",
+          "mailbox_to_address": "agent-0.simulacrum@lessersoul.ai",
+          "status": "accepted",
+          "message_ref": "comm-msg-c7ecaa6a5790701110a7def3@lessersoul.ai",
+          "delivery_id": "comm-delivery-28a7fbe7928e25e14b1b7817"
+        },
+        "outbound": {
+          "passed": true,
+          "sender": "agent-0.simulacrum@lessersoul.ai",
+          "status": "sent",
+          "message_ref": "comm-msg-dfbf303824ad38838b2f81b3",
+          "delivery_id": "comm-delivery-8e44eb7abb4d1a8a08457ff0"
+        },
+        "mailbox": {
+          "list": true,
+          "get": true,
+          "content": true,
+          "search": true,
+          "content_redacted": true,
+          "to_address": "agent-0.simulacrum@lessersoul.ai"
+        },
+        "resolve": {
+          "status": "ok",
+          "agent_id": "0xaf87d423717e3aecbb2fc829d6224ea2acb66e7475f88c920d1a53e0789f313d",
+          "address": "agent-0.simulacrum@lessersoul.ai"
+        },
+        "contactability": {
+          "passed": true,
+          "address": "agent-0.simulacrum@lessersoul.ai",
+          "status": "ok"
+        }
+      },
+      "legacy": {
+        "inbound": {
+          "passed": true,
+          "recipient": "agent-0@lessersoul.ai",
+          "mailbox_to_address": "agent-0.simulacrum@lessersoul.ai",
+          "canonicalized_to": "agent-0.simulacrum@lessersoul.ai",
+          "status": "accepted",
+          "message_ref": "comm-msg-28a83f600b1e36927a57f467@lessersoul.ai",
+          "delivery_id": "comm-delivery-54237cac60c9760d0be13163"
+        },
+        "canonical_mailbox": {
+          "passed": true,
+          "mailbox_to_address": "agent-0.simulacrum@lessersoul.ai",
+          "canonicalized_to": "agent-0.simulacrum@lessersoul.ai"
+        },
+        "non_advertisement": {
+          "passed": true,
+          "public_email_address": "agent-0.simulacrum@lessersoul.ai",
+          "public_email_addresses": [
+            "agent-0.simulacrum@lessersoul.ai"
+          ],
+          "legacy_address_advertised": false
+        },
+        "resolve": {
+          "status": "not_found"
+        }
+      },
+      "notes": [
+        "Host-controlled SoulAgentChannel and SoulEmailAgentIndex advertise only the instance-scoped address; signed registration public endpoints are tracked separately in m3-email-canary-lab-blockers.json.",
+        "Mailbox evidence is redacted to delivery/message references, status, and address fields; message content and provider payloads are omitted.",
+        "Public signed registration endpoint still returned agent-0@lessersoul.ai during the lab evidence pass."
+      ]
+    },
+    {
+      "agent_id": "0xfd0a5fa6fe9674866f4a8b87cafc1ce2fe03786392ff9f7e4d93bc0b3ff1db8c",
+      "local_id": "arch",
+      "instance_slug": "simulacrum",
+      "canonical_address": "arch.simulacrum@lessersoul.ai",
+      "legacy_alias": "arch@lessersoul.ai",
+      "primary": {
+        "inbound": {
+          "passed": true,
+          "recipient": "arch.simulacrum@lessersoul.ai",
+          "mailbox_to_address": "arch.simulacrum@lessersoul.ai",
+          "status": "accepted",
+          "message_ref": "comm-msg-dfbf303824ad38838b2f81b3@lessersoul.ai",
+          "delivery_id": "comm-delivery-8b6c4fc2119378d305dfad50"
+        },
+        "outbound": {
+          "passed": true,
+          "sender": "arch.simulacrum@lessersoul.ai",
+          "status": "sent",
+          "message_ref": "comm-msg-c7ecaa6a5790701110a7def3",
+          "delivery_id": "comm-delivery-23ef1f42b3d4158a2dafc596"
+        },
+        "mailbox": {
+          "list": true,
+          "get": true,
+          "content": true,
+          "search": true,
+          "content_redacted": true,
+          "to_address": "arch.simulacrum@lessersoul.ai"
+        },
+        "resolve": {
+          "status": "ok",
+          "agent_id": "0xfd0a5fa6fe9674866f4a8b87cafc1ce2fe03786392ff9f7e4d93bc0b3ff1db8c",
+          "address": "arch.simulacrum@lessersoul.ai"
+        },
+        "contactability": {
+          "passed": true,
+          "address": "arch.simulacrum@lessersoul.ai",
+          "status": "ok"
+        }
+      },
+      "legacy": {
+        "inbound": {
+          "passed": true,
+          "recipient": "arch@lessersoul.ai",
+          "mailbox_to_address": "arch.simulacrum@lessersoul.ai",
+          "canonicalized_to": "arch.simulacrum@lessersoul.ai",
+          "status": "accepted",
+          "message_ref": "comm-msg-eeac98c77b79a2645397b6c5@lessersoul.ai",
+          "delivery_id": "comm-delivery-a2121a0c4927a77bfedc062c"
+        },
+        "canonical_mailbox": {
+          "passed": true,
+          "mailbox_to_address": "arch.simulacrum@lessersoul.ai",
+          "canonicalized_to": "arch.simulacrum@lessersoul.ai"
+        },
+        "non_advertisement": {
+          "passed": true,
+          "public_email_address": "arch.simulacrum@lessersoul.ai",
+          "public_email_addresses": [
+            "arch.simulacrum@lessersoul.ai"
+          ],
+          "legacy_address_advertised": false
+        },
+        "resolve": {
+          "status": "not_found"
+        }
+      },
+      "notes": [
+        "Host-controlled SoulAgentChannel and SoulEmailAgentIndex advertise only the instance-scoped address; signed registration public endpoints are tracked separately in m3-email-canary-lab-blockers.json.",
+        "Mailbox evidence is redacted to delivery/message references, status, and address fields; message content and provider payloads are omitted.",
+        "Public signed registration endpoint still returned arch@lessersoul.ai during the lab evidence pass."
+      ]
+    }
+  ],
+  "unknown_alias": {
+    "address": "unknown@lessersoul.ai",
+    "resolve_status": "not_found"
+  },
+  "notes": [
+    "Host-controlled canary records include Agent-0 and Arch; Steward channel/index state and signed-registration caveat are recorded separately in blockers/mapping evidence."
+  ]
+}

--- a/internal/commworker/helpers_internal_test.go
+++ b/internal/commworker/helpers_internal_test.go
@@ -21,10 +21,12 @@ import (
 )
 
 const (
-	commTestAgentEmail   = "agent@example.com"
-	commTestSMTPPassword = "smtp-pass"
-	commTestSenderSoulID = "0xsender"
-	commTestSecretValue  = "child"
+	commTestAgentEmail           = "agent@example.com"
+	commTestPilotSimulacrumEmail = "pilot.simulacrum@lessersoul.ai"
+	commTestPilotLegacyEmail     = "pilot@lessersoul.ai"
+	commTestSMTPPassword         = "smtp-pass"
+	commTestSenderSoulID         = "0xsender"
+	commTestSecretValue          = "child"
 )
 
 type stubSecretsManager struct {
@@ -255,13 +257,13 @@ func newCommWorkerStoreHelperStore(now time.Time) *fakeStore {
 		emailIndex: map[string]string{
 			"alice@example.com":                       "0xabc",
 			"agent.with.dot.simulacrum@lessersoul.ai": "0xcompound",
-			"pilot.simulacrum@lessersoul.ai":          "0xpilot-sim",
+			commTestPilotSimulacrumEmail:              "0xpilot-sim",
 			"pilot.other-instance@lessersoul.ai":      "0xpilot-other",
 		},
 		emailAlias: map[string]*models.SoulEmailLegacyAliasIndex{
-			"pilot@lessersoul.ai": {
-				AliasEmail:     "pilot@lessersoul.ai",
-				CanonicalEmail: "pilot.simulacrum@lessersoul.ai",
+			commTestPilotLegacyEmail: {
+				AliasEmail:     commTestPilotLegacyEmail,
+				CanonicalEmail: commTestPilotSimulacrumEmail,
 				AgentID:        "0xpilot-sim",
 				Status:         models.SoulEmailLegacyAliasStatusActive,
 			},
@@ -321,7 +323,7 @@ func testResolveInstanceScopedEmailRecipients(t *testing.T, s *Server) {
 	if err != nil || !ok || agentID != "0xcompound" {
 		t.Fatalf("unexpected compound local-part lookup: %q %v %v", agentID, ok, err)
 	}
-	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "pilot.simulacrum@lessersoul.ai"})
+	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: commTestPilotSimulacrumEmail})
 	if err != nil || !ok || agentID != "0xpilot-sim" {
 		t.Fatalf("unexpected same-local-id first instance lookup: %q %v %v", agentID, ok, err)
 	}
@@ -335,12 +337,12 @@ func testResolveInstanceScopedEmailRecipients(t *testing.T, s *Server) {
 func testResolveLegacyEmailAliasRecipients(t *testing.T, s *Server) {
 	t.Helper()
 
-	legacy := &InboundParty{Address: "pilot@lessersoul.ai"}
+	legacy := &InboundParty{Address: commTestPilotLegacyEmail}
 	agentID, ok, err := s.resolveRecipient(context.Background(), "email", legacy)
 	if err != nil || !ok || agentID != "0xpilot-sim" {
 		t.Fatalf("unexpected legacy alias lookup: %q %v %v", agentID, ok, err)
 	}
-	if legacy.Address != "pilot.simulacrum@lessersoul.ai" {
+	if legacy.Address != commTestPilotSimulacrumEmail {
 		t.Fatalf("expected legacy alias to canonicalize before channel matching, got %q", legacy.Address)
 	}
 	agentID, ok, err = s.resolveRecipient(context.Background(), "email", &InboundParty{Address: "unknown@lessersoul.ai"})

--- a/internal/commworker/server.go
+++ b/internal/commworker/server.go
@@ -338,6 +338,7 @@ func (s *Server) handleRateLimitedInbound(ctx context.Context, agentID string, c
 func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, channel string, notif InboundNotification, identity *models.SoulAgentIdentity, inst *models.Instance, provider string) error {
 	// Best-effort: annotate soul-to-soul sender identity.
 	s.maybeAnnotateSenderSoul(ctx, &notif)
+	annotateRecipientSoulAgentID(agentID, notif.To)
 	s.maybeAnnotateRecipientAddress(ctx, agentID, channel, notif.To)
 
 	if inst == nil {
@@ -379,6 +380,17 @@ func (s *Server) deliverResolvedInbound(ctx context.Context, agentID string, cha
 
 	_ = s.recordInboundActivity(ctx, agentID, channel, notif, "receive", true)
 	return nil
+}
+
+func annotateRecipientSoulAgentID(agentID string, to *InboundParty) {
+	if to == nil {
+		return
+	}
+	agentID = strings.ToLower(strings.TrimSpace(agentID))
+	if agentID == "" {
+		return
+	}
+	to.SoulAgentID = &agentID
 }
 
 func (s *Server) maybeAnnotateRecipientAddress(ctx context.Context, agentID string, channel string, to *InboundParty) {

--- a/internal/commworker/server_more_internal_test.go
+++ b/internal/commworker/server_more_internal_test.go
@@ -661,6 +661,56 @@ func TestProcessInbound_SMSAnnotatesSenderBeforeDelivery(t *testing.T) {
 	}
 }
 
+func TestProcessInbound_AnnotatesResolvedRecipientBeforeDelivery(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 5, 12, 0, 0, 0, time.UTC)
+	agentID := commStoreTestAgentID
+	canonicalTo := commTestPilotSimulacrumEmail
+	legacyTo := commTestPilotLegacyEmail
+	staleToSoulAgentID := "0xstale-recipient"
+
+	fs := newActiveInboundStore(now, agentID, inboundChannelEmail, canonicalTo)
+	fs.emailAlias = map[string]*models.SoulEmailLegacyAliasIndex{
+		legacyTo: {
+			AliasEmail:     legacyTo,
+			CanonicalEmail: canonicalTo,
+			AgentID:        agentID,
+			Status:         models.SoulEmailLegacyAliasStatusActive,
+		},
+	}
+
+	var delivered InboundNotification
+	s := NewServer(config.Config{Stage: "lab"}, fs, nil, nil)
+	s.now = func() time.Time { return now }
+	s.fetchInstanceKeyPlaintext = func(context.Context, *models.Instance) (string, error) { return testInstanceAPIKey, nil }
+	s.deliverNotification = func(_ context.Context, _ string, apiKey string, notif InboundNotification) error {
+		if apiKey != testInstanceAPIKey {
+			t.Fatalf("unexpected api key: %q", apiKey)
+		}
+		delivered = notif
+		return nil
+	}
+
+	msg := newInboundEmailMessage(now, legacyTo)
+	msg.Notification.To.SoulAgentID = &staleToSoulAgentID
+	if err := s.processInbound(context.Background(), "req-recipient-soul", msg); err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if delivered.To == nil {
+		t.Fatal("expected delivered recipient payload")
+	}
+	if delivered.To.Address != canonicalTo {
+		t.Fatalf("expected delivered recipient address to be canonicalized, got %#v", delivered.To)
+	}
+	if delivered.To.SoulAgentID == nil || *delivered.To.SoulAgentID != agentID {
+		t.Fatalf("expected delivered recipient soul agent id %q, got %#v", agentID, delivered.To.SoulAgentID)
+	}
+	if *delivered.To.SoulAgentID == staleToSoulAgentID {
+		t.Fatalf("expected stale inbound recipient soul agent id to be overwritten, got %#v", delivered.To.SoulAgentID)
+	}
+}
+
 func TestProcessInbound_PhoneDeliveryIncludesCanonicalRecipientAddress(t *testing.T) {
 	t.Parallel()
 

--- a/internal/commworker/store_internal_test.go
+++ b/internal/commworker/store_internal_test.go
@@ -161,7 +161,7 @@ func runLookupLegacyEmailAliasTest(t *testing.T, ctx context.Context) {
 
 		st := &dynamoStore{db: tdb.db}
 		alias, ok, err := st.LookupLegacyEmailAlias(ctx, " Pilot@LesserSoul.ai ")
-		if err != nil || !ok || alias == nil || alias.AgentID != commStoreTestAgentID || alias.CanonicalEmail != "pilot.simulacrum@lessersoul.ai" {
+		if err != nil || !ok || alias == nil || alias.AgentID != commStoreTestAgentID || alias.CanonicalEmail != commTestPilotSimulacrumEmail {
 			t.Fatalf("unexpected alias result: alias=%#v ok=%v err=%v", alias, ok, err)
 		}
 	})


### PR DESCRIPTION
## Summary

Records the Project 37 M3 lab evidence closeout after the `v0.4.3` lab deploy and fixes the comm-worker recipient projection gap found during review.

- sets the resolved recipient agent ID on `notif.To.SoulAgentID` before `deliverNotification`
- adds a comm-worker regression proving a delivered legacy-alias payload is canonicalized and carries the resolved recipient agent ID, overwriting any stale inbound `to.soulAgentId`
- adds redacted host-controlled canary evidence for Agent-0 and Arch primary instance-scoped email paths
- adds the 12-agent lab legacy-alias to canonical-address mapping evidence
- records broader M3 release-gate dependencies for Body MCP evidence and signed-registration republish/audit without treating them as blockers for this host PR
- updates the M3 canary doc with the evidence files, validation commands, and signed-registration caveat

Refs #340, #341, #342, #343.

## Stewardship / surface review

- Multi-tenant isolation: read-only lab evidence recording plus in-process comm-worker annotation only; no tenant content, raw MIME, provider payloads, auth headers, SSM values, or credentials are committed.
- On-chain / soul registry: no contract or on-chain mutation; signed public registration republish/audit remains a broader M3 release-gate item.
- Trust API / CSP: no endpoint, instance-auth, attestation, or CSP change.
- Provisioning / release verification: no provisioning worker or managed-release verification path change.
- Governance: evidence is committed under `gov-infra/evidence/project37/` and the gov-infra rubric passes.

## Validation

- `go test ./internal/commworker` — PASS
- `go run ./scripts/soul-email-m3-canary --stage lab --evidence gov-infra/evidence/project37/m3-email-canary-lab.json --require-legacy-alias --require-unknown-alias --out gov-infra/evidence/project37/m3-email-canary-lab-host-validation.json` — PASS
- `go run ./scripts/soul-email-m3-canary --stage lab --evidence gov-infra/evidence/project37/m3-email-canary-lab.json --require-legacy-alias --require-body-mcp --require-unknown-alias --out gov-infra/evidence/project37/m3-email-canary-lab-full-validation-blocked.json` — expected nonzero for the broader M3 release gate until Body MCP evidence lands; blocked report committed as evidence
- `git diff --check` — PASS
- `go test ./...` — PASS
- `go vet ./...` — PASS
- `gofmt -l $(git ls-files '*.go')` — clean
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (29 pass / 0 fail / 0 blocked)
- GitHub checks — PASS (12/12)

## Broader M3 release-gate dependencies, not PR blockers

- `lesser-body#275` remains the Body MCP compatibility evidence dependency for `identity_whoami`, `identity_lookup`, and mailbox MCP paths.
- Lab signed registration endpoints still returned legacy bare emails for checked agents while Host-controlled channel/index state is canonical instance-scoped; this is recorded in `m3-email-canary-lab-blockers.json` and should be closed through signed-registration republish/audit.
- Host did not have fresh Agent-0 delegated MCP credentials in this session, so no new Agent-0 MCP read evidence is claimed from Host.