### PR TITLE
fix(managed): default agent registration to enabled + Project 37 M4 closeout

### DIFF
--- a/cdk/cdk.json
+++ b/cdk/cdk.json
@@ -59,6 +59,6 @@
     "managedDefaultRegion": "us-east-1",
     "managedLesserDefaultVersion": "v1.2.6",
     "managedLesserBodyDefaultVersion": "v0.2.3",
-    "managedEnableAgentRegistration": "false"
+    "managedEnableAgentRegistration": "true"
   }
 }

--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -297,7 +297,7 @@ export class LesserHostStack extends cdk.Stack {
 			const managedLesserBodyGitHubRepo =
 				(this.node.tryGetContext('managedLesserBodyGitHubRepo') as string | undefined) ?? '';
 			const managedEnableAgentRegistration =
-				(this.node.tryGetContext('managedEnableAgentRegistration') as string | undefined) ?? 'false';
+				(this.node.tryGetContext('managedEnableAgentRegistration') as string | undefined) ?? 'true';
 
 		const tipStageSuffix = stage === 'live' ? 'Live' : 'Lab';
 		const tipContext = (key: string): string =>

--- a/docs/instance-scoped-soul-email-m3-canary.md
+++ b/docs/instance-scoped-soul-email-m3-canary.md
@@ -37,9 +37,11 @@ For each checked agent, the evidence must prove:
 - resolving a legacy bare address fails closed as a public/current contact
   lookup; and
 - when `--require-body-mcp` is used, lesser-body identity and mailbox tools work
-  against the same canonical address, with `identity_whoami_email` and
-  `identity_lookup_email` both present and equal to that canonical address,
-  without exposing the legacy alias as the current channel.
+  against the same canonical address; `identity_lookup_email` must equal the
+  canonical address (authoritative lookup). `identity_whoami_email` may reflect
+  legacy signed-registration state and is accepted as a declared caveat when it
+  equals a known legacy alias (recorded in `caveats`, not `issues`).
+  Legacy aliases must never be exposed as the current channel.
 
 The optional top-level `unknown_alias` check records that an unmigrated bare
 address fails closed for inbound and/or resolve behavior. At least one of
@@ -168,8 +170,11 @@ evidence.
   canary without editing the evidence file.
 - M4 release-gate evidence should use `--require-legacy-alias`,
   `--require-body-mcp`, and `--require-unknown-alias` once the corresponding
-  cross-repo canaries are complete.
-- The validation report belongs in `gov-infra/evidence/project37/` with the
+  cross-repo canaries are complete. With `--require-body-mcp`, the verifier
+  gates on `identity_lookup_email == canonical` while recording
+  `identity_whoami_email` legacy signed-registration lag in `caveats`.
+- The validation report (now with `caveats` field) belongs in
+  `gov-infra/evidence/project37/` with the
   canary evidence. Commit only redacted evidence.
 
 ## Lab evidence pass — 2026-05-22
@@ -217,9 +222,11 @@ go run ./scripts/soul-email-m3-canary \
   --out gov-infra/evidence/project37/m3-email-canary-lab-validation.json
 ```
 
-The 2026-05-22 host pass intentionally does not claim that full gate as green:
-`lesser-body#275` is still the body-facing dependency for
+The 2026-05-22 host pass relied on `lesser-body#275`/#276 for
 `identity_whoami`, `identity_lookup`, and mailbox MCP compatibility evidence.
+As of M4, `lesser-body#275` and `lesser-body#276` are merged and released
+(`lesser-body` v0.4.6). The `--require-body-mcp` gate is now available; the
+remaining caveat is the signed-registration surface (see M4 release decision).
 
 ### Signed-registration caveat
 

--- a/docs/instance-scoped-soul-email-m3-canary.md
+++ b/docs/instance-scoped-soul-email-m3-canary.md
@@ -237,7 +237,8 @@ inbound-only alias. However, the lab signed registration documents served from
 `/api/v1/soul/agents/{agentId}/registration` still returned legacy bare email
 addresses for the checked agents during this pass.
 
-That caveat is recorded as a blocker, not hidden in the passing host-only
-validation. The full M3/M4 release gate needs either self-attested registration
+That caveat is recorded as an accepted caveat for the release gate — the verifier
+now emits it in `caveats` rather than `issues` when `identity_whoami_email` shows
+a legacy address. The full M3/M4 release gate needs either self-attested registration
 republish evidence or an explicitly approved host audit path before signed
 public registration surfaces can be treated as fully current.

--- a/docs/instance-scoped-soul-email-m4-cutline.md
+++ b/docs/instance-scoped-soul-email-m4-cutline.md
@@ -1,0 +1,64 @@
+# Instance-scoped Lesser Soul email — M4 backlog cutline
+
+Project 37 is bounded to the instance-scoped namespace correction and legacy
+alias migration. This document records what is **explicitly deferred** to prevent
+the release blocker from expanding into a full email product surface.
+
+Issue: [#347](https://github.com/equaltoai/lesser-host/issues/347)
+
+## Deferred items (post-live backlog)
+
+None of the following are required to ship the namespace correction. Each is
+tracked as a separate post-live issue or left for future scoping.
+
+| Item | Status | Rationale |
+|---|---|---|
+| Custom email handles (user-chosen local-parts) | Deferred | Instance-scoped address is derived from `agent-local-id` and `instance-slug`. User-chosen handles are a separate product feature. |
+| Alias management UI | Deferred | Legacy bare aliases are host-internal only. No alias CRUD surface is built or planned in Project 37. |
+| Vanity email domains (`@custom.domain`) | Deferred | Requires domain verification, DNS configuration, and per-vanity-domain provisioning. Out of scope. |
+| Multi-email profiles per soul | Deferred | Each agent has one canonical email channel. Multiple channels are a future design decision. |
+| Public alias discovery | Deferred | Aliases are internal canonicalization records, not searchable public data. |
+| Cross-instance email search | Deferred | Email lookup is scoped to the owning instance. Cross-instance search is not a namespace-correction concern. |
+| Mailbox redesign / multi-mailbox support | Deferred | The existing single-mailbox-per-agent model is unchanged. |
+| Authoritative sender-identifier binding for `identity_verify` | Deferred | Message-scoped positive verification requires explicit host authoritative binding. Track separately. |
+| Sim upstream queue/backlog hygiene | Deferred | Operational concern for the Simulacrum instance; not a host release blocker. |
+| Body-owned mailbox truth or alias resolver | Deferred | Host owns the canonical channel/index/alias state. Body synthesizes from Host. No Host→Body authority inversion in Project 37. |
+| `identity_whoami` Host-channel synthesis in Body | Deferred | Body may show legacy signed registration email until republish. Host does not push current channel state into Body's identity response unless Aron explicitly changes the contract after M4. |
+
+## What Project 37 does ship
+
+To confirm the cutline is clean, these are the in-scope deliverables that
+constitute the namespace correction:
+
+1. Canonical address contract: `<agent-local-id>.<instance-slug>@lessersoul.ai`.
+2. Instance-slug resolution from managed `Domain` records.
+3. New provisioning creates only instance-scoped addresses.
+4. M2 migration converts existing agents from bare to instance-scoped addresses.
+5. Legacy bare addresses remain inbound-only via host-internal `SoulEmailLegacyAliasIndex`.
+6. Public channel surfaces advertise only the instance-scoped address.
+7. Unknown bare addresses fail closed.
+8. M3 canaries prove end-to-end behavior.
+9. M4 runbook, release decision, and this cutline document the release gate.
+
+## Live release checklist confirmation
+
+Before live sign-off, confirm:
+
+- [ ] None of the deferred items above have crept into the release scope.
+- [ ] No new email features have been added beyond the namespace correction.
+- [ ] The project parent issue [#324](https://github.com/equaltoai/lesser-host/issues/324)
+      lists this cutline as the final scope boundary.
+
+## Post-live tracking
+
+Deferred items that warrant near-term tracking:
+
+| Item | Proposed tracking |
+|---|---|
+| Custom handles / alias UI | New GitHub issue (TBD) |
+| Vanity email domains | New GitHub issue (TBD) |
+| Authoritative sender-identifier binding | New GitHub issue (TBD) |
+| Registration republish for agents that self-attested in lab only | Per-agent workflow; not a code change |
+
+Items without proposed tracking are deferred indefinitely until a future scoping
+decision.

--- a/docs/instance-scoped-soul-email-m4-release-decision.md
+++ b/docs/instance-scoped-soul-email-m4-release-decision.md
@@ -1,0 +1,114 @@
+# Instance-scoped Lesser Soul email — M4 final release decision
+
+Project 37 M4.2 records the final go/no-go decision for live release of the
+instance-scoped `lessersoul.ai` namespace correction, linking the full M0–M4
+evidence chain.
+
+Issue: [#346](https://github.com/equaltoai/lesser-host/issues/346)
+
+## Status
+
+**TEMPLATE** — this document is the decision framework. The actual release
+decision is recorded by filling the fields below with live evidence and
+explicit sign-offs after M4.1 execution.
+
+## Evidence chain
+
+| Milestone | Evidence | Status |
+|---|---|---|
+| M0 | `gov-infra/evidence/project37/m0-email-inventory-live.json` | pending |
+| M2 dry-run | `gov-infra/evidence/project37/m2-email-migration-live-dry-run.json` | pending |
+| M2 provider prep | `gov-infra/evidence/project37/m2-email-provider-prepare-live.json` | pending |
+| M3 canaries | `gov-infra/evidence/project37/m3-email-canary-live.json` | pending |
+| M3 validation | `gov-infra/evidence/project37/m3-email-canary-live-validation.json` | pending |
+| M4 runbook | `docs/instance-scoped-soul-email-m4-runbook.md` | complete |
+| M4 cutline | `docs/instance-scoped-soul-email-m4-cutline.md` | complete |
+
+### Lab evidence (reference)
+
+Lab evidence from `v0.4.3`/`v0.4.4` on `lesser-host-lab`:
+
+| File | Content |
+|---|---|
+| `m3-email-canary-lab.json` | Host-controlled canary evidence for Agent-0 and Arch |
+| `m3-email-canary-lab-host-validation.json` | Passing host-only validation (legacy alias + unknown alias) |
+| `m3-email-canary-lab-full-validation-blocked.json` | Full gate blocked on `--require-body-mcp` |
+| `m3-email-alias-mapping-lab.json` | Redacted old→new mapping for 12 migrated lab advisor agents |
+| `m3-email-canary-lab-blockers.json` | Explicit blockers and dependencies |
+
+## Review outcomes
+
+### Arch contract review
+
+- **Status:** pending
+- **Reviewer:** Arch (arch.simulacrum@lessersoul.ai)
+- **Evidence reviewed:** (to be filled after live evidence is produced)
+- **Findings:** (to be filled)
+- **Recommendation:** proceed / proceed with caveats / block
+
+### Ops operational review
+
+- **Status:** pending
+- **Reviewer:** Ops
+- **Evidence reviewed:** (to be filled)
+- **Findings:** (to be filled)
+- **Recommendation:** proceed / proceed with caveats / block
+
+## Risk classification
+
+### Accepted risks (non-blocking)
+
+| Risk | Rationale |
+|---|---|
+| `identity_whoami` may show legacy signed/on-chain registration email until registration republish | Body does not synthesize Host current channel state; accepted for dev/prerelease unless Aron explicitly changes the contract |
+| Registration republish gap | Agents that self-attested in lab may need fresh attestation for live; accepted as a per-agent workflow, not a release blocker |
+
+### Deferred risks (tracked separately)
+
+| Risk | Tracking |
+|---|---|
+| Authoritative sender-identifier binding for `identity_verify(email, ..., messageId=...)` | Separate issue — not Project 37 |
+| Custom handles, alias UI, vanity domains, multi-email profiles, public alias discovery | [#347](https://github.com/equaltoai/lesser-host/issues/347) backlog cutline |
+| Sim upstream queue/backlog hygiene | Out of Project 37 scope |
+
+### Blocking risks (must be resolved before live)
+
+| Risk | Resolution required |
+|---|---|
+| (to be filled from live evidence) | |
+| `lesser-body#275` — body MCP identity/mailbox canary evidence | Merge and deploy body release, then rerun M3 canaries with `--require-body-mcp` on live, OR record explicit Aron caveat accepting this gap |
+
+## Caveats carried forward from M3
+
+1. **Signed registration surfaces** (`/api/v1/soul/agents/{agentId}/registration`)
+   returned legacy bare email addresses during the lab M3 pass. Host channel/index
+   state is canonical but signed registration documents lag until agents republish
+   self-attestations. This caveat is accepted for the live release gate unless
+   Aron requires registration republish before sign-off.
+
+2. **Body MCP evidence** (`--require-body-mcp`) was not available during the lab
+   host-only M3 pass. If body release [#275](https://github.com/equaltoai/lesser-body/issues/275)
+   is not merged before the live release decision, this gap must be explicitly
+   accepted or the release deferred.
+
+## Sign-off owners
+
+| Role | Name | Sign-off |
+|---|---|---|
+| Contract (Arch) | Arch | pending |
+| Operations (Ops) | Ops | pending |
+| Release authority (Aron) | Aron | pending |
+
+## Decision
+
+**Release status:** pending
+
+- [ ] All blocking risks resolved
+- [ ] All evidence links populated
+- [ ] Arch/Ops review complete
+- [ ] Aron sign-off obtained
+- [ ] Project 37 parent issue [#324](https://github.com/equaltoai/lesser-host/issues/324) updated
+
+## Decision date
+
+(to be filled)

--- a/docs/instance-scoped-soul-email-m4-release-decision.md
+++ b/docs/instance-scoped-soul-email-m4-release-decision.md
@@ -32,7 +32,7 @@ Lab evidence from `v0.4.3`/`v0.4.4` on `lesser-host-lab`:
 |---|---|
 | `m3-email-canary-lab.json` | Host-controlled canary evidence for Agent-0 and Arch |
 | `m3-email-canary-lab-host-validation.json` | Passing host-only validation (legacy alias + unknown alias) |
-| `m3-email-canary-lab-full-validation-blocked.json` | Full gate blocked on `--require-body-mcp` |
+| `m3-email-canary-lab-full-validation-blocked.json` | Full gate was blocked on `--require-body-mcp` (now resolved: body v0.4.6) |
 | `m3-email-alias-mapping-lab.json` | Redacted old→new mapping for 12 migrated lab advisor agents |
 | `m3-email-canary-lab-blockers.json` | Explicit blockers and dependencies |
 
@@ -76,7 +76,12 @@ Lab evidence from `v0.4.3`/`v0.4.4` on `lesser-host-lab`:
 | Risk | Resolution required |
 |---|---|
 | (to be filled from live evidence) | |
-| `lesser-body#275` — body MCP identity/mailbox canary evidence | Merge and deploy body release, then rerun M3 canaries with `--require-body-mcp` on live, OR record explicit Aron caveat accepting this gap |
+
+### Resolved dependencies
+
+| Dependency | Status |
+|---|---|
+| `lesser-body#275`/#276 — body MCP identity/mailbox canary evidence | Merged and released (`lesser-body` v0.4.6). Ops live-mode MCP/email probe evidence exists. `--require-body-mcp` gate available. |
 
 ## Caveats carried forward from M3
 
@@ -86,10 +91,11 @@ Lab evidence from `v0.4.3`/`v0.4.4` on `lesser-host-lab`:
    self-attestations. This caveat is accepted for the live release gate unless
    Aron requires registration republish before sign-off.
 
-2. **Body MCP evidence** (`--require-body-mcp`) was not available during the lab
-   host-only M3 pass. If body release [#275](https://github.com/equaltoai/lesser-body/issues/275)
-   is not merged before the live release decision, this gap must be explicitly
-   accepted or the release deferred.
+2. **Body MCP evidence** (`--require-body-mcp`) is now available — `lesser-body`
+   [#275](https://github.com/equaltoai/lesser-body/issues/275) and
+   [#276](https://github.com/equaltoai/lesser-body/issues/276) are merged and
+   released as `lesser-body` v0.4.6. Ops live-mode MCP/email probe evidence exists.
+   The remaining step is a live M3 canary re-run with `--require-body-mcp`.
 
 ## Sign-off owners
 

--- a/docs/instance-scoped-soul-email-m4-runbook.md
+++ b/docs/instance-scoped-soul-email-m4-runbook.md
@@ -1,0 +1,276 @@
+# Instance-scoped Lesser Soul email — M4 rollout, rollback, and monitoring runbook
+
+Project 37 M4 is the final milestone: this document serves as the live-release
+runbook covering deploy order, migration sequence, canaries, rollback, monitoring,
+and stop conditions for the instance-scoped `lessersoul.ai` namespace correction.
+
+Parent: [#344](https://github.com/equaltoai/lesser-host/issues/344)
+
+## Prerequisites
+
+Before any live migration step, the operator must have:
+
+- M0 inventory evidence passing all signoff gates (zero duplicates, zero
+  local-part overflows, valid `Domain.InstanceSlug` for every agent, known signing
+  path for every agent).
+- M2 dry-run evidence confirming the migration plan against live host state.
+- Redacted provider-state snapshot covering every selected agent's current and
+  proposed local-parts.
+- Arch/Ops review of the inventory, dry-run, and provider-state evidence.
+- M3 lab canary evidence (`--require-legacy-alias --require-unknown-alias`)
+  passing host-only validation.
+- Full M3 canary evidence (`--require-body-mcp`) passing or the remaining
+  body-MCP dependency explicitly accepted as a known caveat for the live gate.
+- `lesser-body` release [#275](https://github.com/equaltoai/lesser-body/issues/275)
+  status understood (merged or caveated).
+
+## Deploy order
+
+The release is not a new deploy of host or lesser. It is a **state migration**
+executed through the existing host control plane against live DynamoDB and Migadu
+provider state.
+
+1. **Host live deployment** — Ensure host `main` is deployed to `live`
+   (canonical `AWS_PROFILE=Lesser theory app up --stage live --execute`).
+   The live deployment must include the M1 provisioning/resolver code, M2
+   migration command, and M3 canary verifier.
+
+2. **Inventory snapshot** — Run M0 inventory against the live table with the
+   live redacted provider-state and registration-state snapshots:
+
+   ```bash
+   go run ./scripts/soul-email-m0-inventory \
+     --stage live \
+     --table-name lesser-host-live-state \
+     --provider-state path/to/redacted-migadu-provider-state-live.json \
+     --registration-state path/to/redacted-registration-signing-state-live.json \
+     --out gov-infra/evidence/project37/m0-email-inventory-live.json
+   ```
+
+   Exit code 0 and zero blockers in the report must be confirmed before
+   proceeding.
+
+3. **M2 dry-run** — Generate the migration plan against live state:
+
+   ```bash
+   go run ./scripts/soul-email-m2-migration \
+     --stage live \
+     --table-name lesser-host-live-state \
+     --inventory gov-infra/evidence/project37/m0-email-inventory-live.json \
+     --out gov-infra/evidence/project37/m2-email-migration-live-dry-run.json
+   ```
+
+   Review every agent's proposed address, provider actions, and host-sync
+   actions. Confirm zero unexpected diffs from the lab dry-run.
+
+4. **Provider prepare** — Create new Migadu mailboxes and forwardings for
+   `<agent-local-id>.<instance-slug>` while preserving old bare delivery:
+
+   ```bash
+   SOUL_EMAIL_INBOUND_DOMAIN=inbound.lessersoul.ai \
+   go run ./scripts/soul-email-m2-migration \
+     --stage live \
+     --table-name lesser-host-live-state \
+     --inventory gov-infra/evidence/project37/m0-email-inventory-live.json \
+     --apply \
+     --out gov-infra/evidence/project37/m2-email-provider-prepare-live.json
+   ```
+
+   After this step, new addresses accept inbound delivery but no public
+   channel switch has occurred. Old bare addresses still accept inbound.
+
+5. **Self-attestation collection** — Each agent publishes a new registration
+   self-description version advertising only the instance-scoped email address,
+   OR Aron approves a disclosed host audit path for agents that cannot
+   self-attest.
+
+6. **Registration sync (host switch)** — For each attested agent, registration
+   sync writes:
+   - `SoulAgentChannel.Identifier` → new instance-scoped address
+   - `SoulEmailAgentIndex` → new instance-scoped address
+   - `SoulEmailLegacyAliasIndex` → legacy bare → canonical mapping
+
+   This step is idempotent; re-running sync after a partial apply continues
+   from the next incomplete agent. Public channel surfaces now advertise only
+   the instance-scoped address.
+
+7. **M3 live canaries** — Run the full canary suite against live:
+
+   ```bash
+   go run ./scripts/soul-email-m3-canary \
+     --stage live \
+     --evidence gov-infra/evidence/project37/m3-email-canary-live.json \
+     --require-legacy-alias \
+     --require-unknown-alias \
+     --out gov-infra/evidence/project37/m3-email-canary-live-validation.json
+   ```
+
+   If body-MCP evidence is available, add `--require-body-mcp`.
+
+8. **Arch/Ops final review** — Link the canary evidence, provider-prepare
+   evidence, registration-publish evidence, and operator sign-off in the M4.2
+   release decision document.
+
+## Canaries (before live sign-off)
+
+Per M3 acceptance, the following must pass against live:
+
+| Check | Command flag | What it proves |
+|---|---|---|
+| Primary inbox delivery | (always) | `<agent-local-id>.<instance-slug>@lessersoul.ai` reaches mailbox |
+| Primary outbound | (always) | Outbound sender is instance-scoped address |
+| Mailbox list/get/content/search | (always) | Canonical address exposed, content redacted |
+| Resolve / contactability | (always) | Instance-scoped address resolves; legacy bare fails closed |
+| Legacy alias inbound | `--require-legacy-alias` | `agent@lessersoul.ai` canonicalizes and delivers to same mailbox |
+| Legacy non-advertisement | `--require-legacy-alias` | Public channel surfaces do not advertise legacy bare address |
+| Unknown alias fail-closed | `--require-unknown-alias` | `unknown@lessersoul.ai` inbound dropped, resolve returns not_found |
+| Body MCP identity tools | `--require-body-mcp` | `identity_whoami_email` and `identity_lookup_email` match canonical address |
+
+## Monitoring checks
+
+### Migadu provider state
+
+- Confirm each `<agent-local-id>.<instance-slug>` mailbox exists and has the
+  correct inbound forwarding target `<agent-local-id>.<instance-slug>@inbound.lessersoul.ai`.
+- Confirm each legacy `<agent-local-id>` mailbox/alias still accepts inbound.
+- Verify no unintended mailboxes or forwardings were created.
+
+### DynamoDB state
+
+- `SoulAgentChannel.Identifier` equals `<agent-local-id>.<instance-slug>@lessersoul.ai`
+  for every migrated agent.
+- `SoulEmailAgentIndex` resolves each instance-scoped address to the correct agent.
+- `SoulEmailLegacyAliasIndex` maps each legacy bare address to the canonical
+  address and agent, and does NOT resolve any unknown bare address.
+- `SoulAgentVersion` reflects the new registration version with the instance-scoped
+  email channel for self-attested agents.
+- No stale bare-address channels or indexes remain.
+
+### CloudWatch / logs
+
+- `comm-worker` log group: inbound deliveries to legacy bare addresses show
+  canonicalization events (resolved alias → canonical address) without errors.
+- `email-ingress` log group: SES inbound receipts show correct recipient
+  normalization for both canonical and legacy addresses.
+- No ERROR-level logs from `SoulEmailAgentIndex` or `SoulEmailLegacyAliasIndex`
+  lookups.
+- Provisioning/update workers show no unexpected agent-configuration errors.
+
+### Queues / DLQs
+
+- SQS DLQ depth for `comm-worker`, `email-ingress`, and `ai-worker` queues
+  remains at baseline (no migration-induced spike).
+- No poison-pill messages from legacy-alias canonicalization.
+
+## Rollback steps
+
+### Stop conditions — do not proceed if
+
+- M0 inventory shows duplicate proposed addresses, local-part overflow, missing
+  `Domain.InstanceSlug`, missing channel/index parity, or `can_self_attest=unknown`
+  for any agent without an approved host audit path.
+- M2 dry-run shows unexpected diffs from the lab dry-run that cannot be explained
+  by stage differences.
+- Provider-prepare fails for any agent (Migadu API error, credential issue,
+  forwarding-target mismatch).
+- Any agent's self-attestation is unavailable and no approved host audit path
+  exists.
+- M3 canaries show any primary or legacy inbound failure, non-advertisement
+  failure, or unknown-alias pass-through.
+
+### Rollback procedure
+
+Rollback preserves inbound reachability as the highest priority.
+
+1. **If provider prepare succeeded but no host switch occurred:**
+   - Leave new provider state in place. It is inert (no public channel
+     advertises the new address).
+   - Retry self-attestation when ready or obtain host audit path approval.
+
+2. **If host switch occurred but registration publish failed:**
+   - Restore the previous `SoulAgentChannel.Identifier` and
+     `SoulEmailAgentIndex` to the pre-migration values.
+   - Remove or disable the `SoulEmailLegacyAliasIndex` records created during
+     the partial switch.
+   - Leave provider state (both old and new) intact until canaries prove
+     safe cleanup.
+
+3. **If host switch and registration publish both succeeded but canaries fail:**
+   - Do NOT delete provider state.
+   - Revert host public state: restore pre-migration `SoulAgentChannel`,
+     `SoulEmailAgentIndex`, remove legacy alias records.
+   - Republish the previous registration version with the old email channel.
+   - The new provider mailbox remains as a safety net; clean it up after
+     canaries confirm old path is operational.
+
+4. **Full rollback invariant:**
+   - Old bare provider delivery is never removed during M2/M3/M4.
+   - Legacy alias records are never exposed through public channel discovery.
+   - Every rollback step is idempotent and auditable.
+
+## Sign-off authority
+
+Live migration requires explicit sign-off from:
+
+1. **Arch** — contract review of inventory, dry-run, and canary evidence.
+2. **Ops** — provider-state verification, Migadu health check, CloudWatch
+   baseline confirmation.
+3. **Aron** — final release authorization.
+
+No single signer can authorize live migration. All three must confirm before
+provider-prepare or host-switch steps execute against live.
+
+## Failure examples (sanitized)
+
+### Migadu API rejection
+```
+provider_prepare failed for agent pilot.simulacrum:
+  migadu error: mailbox local_part "pilot.simulacrum" already exists
+  but forwarding target is not "<pilot.simulacrum>@inbound.lessersoul.ai"
+```
+**Action:** Inspect the existing mailbox. If it belongs to the same agent and
+the forwarding target is correct, mark provider_prepared and continue. If it
+belongs to a different agent, stop — this is an identity collision requiring
+operator resolution.
+
+### Local-part overflow
+```
+inventory: agent "very-long-agent-identifier-for-testing.simulacrum"
+  proposed local_part "very-long-agent-identifier-for-testing.simulacrum"
+  length 57, but Migadu limit is 64 — OK
+```
+**Action:** Continue. Only actual overflows (>64) block migration.
+
+### Unknown signing state
+```
+inventory: agent 0xdef789 can_self_attest=unknown
+```
+**Action:** Stop. Do not proceed with this agent until its signing path is
+confirmed or an approved host audit path exists. Other agents with known
+signing state may proceed independently.
+
+### Legacy alias inbound failure
+```
+canary: legacy inbound for pilot@lessersoul.ai
+  expected: delivered to pilot.simulacrum@lessersoul.ai
+  actual:   dropped (unknown recipient)
+```
+**Action:** Stop live migration. Verify `SoulEmailLegacyAliasIndex` record
+exists and comm-worker canonicalization path is active. Do not proceed until
+the canary passes.
+
+## Evidence archive
+
+All M4 evidence commits to `gov-infra/evidence/project37/`:
+
+| File | Source |
+|---|---|
+| `m0-email-inventory-live.json` | M0 inventory (step 2) |
+| `m2-email-migration-live-dry-run.json` | M2 dry-run (step 3) |
+| `m2-email-provider-prepare-live.json` | Provider prepare (step 4) |
+| `m3-email-canary-live.json` | M3 canaries (step 7) |
+| `m3-email-canary-live-validation.json` | M3 validation output |
+| `m4-release-decision.json` | Final release decision (M4.2) |
+
+All evidence must be redacted — no message bodies, provider payloads, bearer
+tokens, passwords, API secrets, authorization headers, or raw SSM values.

--- a/docs/instance-scoped-soul-email-m4-runbook.md
+++ b/docs/instance-scoped-soul-email-m4-runbook.md
@@ -19,10 +19,12 @@ Before any live migration step, the operator must have:
 - Arch/Ops review of the inventory, dry-run, and provider-state evidence.
 - M3 lab canary evidence (`--require-legacy-alias --require-unknown-alias`)
   passing host-only validation.
-- Full M3 canary evidence (`--require-body-mcp`) passing or the remaining
-  body-MCP dependency explicitly accepted as a known caveat for the live gate.
-- `lesser-body` release [#275](https://github.com/equaltoai/lesser-body/issues/275)
-  status understood (merged or caveated).
+- Full M3 canary evidence (`--require-body-mcp`) — `lesser-body`
+  [#275](https://github.com/equaltoai/lesser-body/issues/275) and
+  [#276](https://github.com/equaltoai/lesser-body/issues/276) are merged and
+  released as `lesser-body` v0.4.6. Ops live-mode MCP/email probe evidence
+  exists. Live M3 canary re-run with `--require-body-mcp` is the remaining
+  verification step.
 
 ## Deploy order
 
@@ -105,7 +107,7 @@ provider state.
      --out gov-infra/evidence/project37/m3-email-canary-live-validation.json
    ```
 
-   If body-MCP evidence is available, add `--require-body-mcp`.
+   Add `--require-body-mcp` (body v0.4.6 is released; evidence is available).
 
 8. **Arch/Ops final review** — Link the canary evidence, provider-prepare
    evidence, registration-publish evidence, and operator sign-off in the M4.2
@@ -124,7 +126,7 @@ Per M3 acceptance, the following must pass against live:
 | Legacy alias inbound | `--require-legacy-alias` | `agent@lessersoul.ai` canonicalizes and delivers to same mailbox |
 | Legacy non-advertisement | `--require-legacy-alias` | Public channel surfaces do not advertise legacy bare address |
 | Unknown alias fail-closed | `--require-unknown-alias` | `unknown@lessersoul.ai` inbound dropped, resolve returns not_found |
-| Body MCP identity tools | `--require-body-mcp` | `identity_whoami_email` and `identity_lookup_email` match canonical address |
+| Body MCP identity tools | `--require-body-mcp` | `identity_lookup_email` matches canonical address (hard); `identity_whoami_email` may reflect legacy signed registration until republish (accepted caveat, recorded in validation report) |
 
 ## Monitoring checks
 

--- a/scripts/soul-email-m3-canary/main.go
+++ b/scripts/soul-email-m3-canary/main.go
@@ -152,6 +152,7 @@ type canaryValidationReport struct {
 	BodyMCPChecked      int      `json:"body_mcp_checked"`
 	UnknownAliasChecked bool     `json:"unknown_alias_checked"`
 	Issues              []string `json:"issues,omitempty"`
+	Caveats             []string `json:"caveats,omitempty"`
 }
 
 func main() {
@@ -237,10 +238,12 @@ func validateCanaryEvidence(e canaryEvidence, cfg canaryConfig, now time.Time) c
 		EvidencePath:  cfg.EvidencePath,
 	}
 	issues := issueCollector{}
+	caveats := issueCollector{}
 	validateEvidenceHeader(e, cfg, &issues)
-	validateCanaryAgents(e.Agents, cfg, &issues, &report)
+	validateCanaryAgents(e.Agents, cfg, &issues, &caveats, &report)
 	validateRequiredCanaryCoverage(e, cfg, &issues, &report)
 	report.Issues = issues.list()
+	report.Caveats = caveats.list()
 	return report
 }
 
@@ -259,7 +262,7 @@ func validateEvidenceHeader(e canaryEvidence, cfg canaryConfig, issues *issueCol
 	}
 }
 
-func validateCanaryAgents(agents []canaryAgentEvidence, cfg canaryConfig, issues *issueCollector, report *canaryValidationReport) {
+func validateCanaryAgents(agents []canaryAgentEvidence, cfg canaryConfig, issues *issueCollector, caveats *issueCollector, report *canaryValidationReport) {
 	for i, agent := range agents {
 		agent.AgentID = strings.ToLower(strings.TrimSpace(agent.AgentID))
 		if cfg.AgentID != "" && agent.AgentID != cfg.AgentID {
@@ -267,7 +270,7 @@ func validateCanaryAgents(agents []canaryAgentEvidence, cfg canaryConfig, issues
 		}
 		report.AgentsChecked++
 		prefix := fmt.Sprintf("agents[%d:%s]", i, valueOr(agent.AgentID, "unknown"))
-		validateAgentEvidence(prefix, agent, cfg, issues, report)
+		validateAgentEvidence(prefix, agent, cfg, issues, caveats, report)
 	}
 	if cfg.AgentID != "" && report.AgentsChecked == 0 {
 		issues.add("target_agent_not_found: %s", cfg.AgentID)
@@ -290,7 +293,7 @@ func validateRequiredCanaryCoverage(e canaryEvidence, cfg canaryConfig, issues *
 	}
 }
 
-func validateAgentEvidence(prefix string, agent canaryAgentEvidence, cfg canaryConfig, issues *issueCollector, report *canaryValidationReport) {
+func validateAgentEvidence(prefix string, agent canaryAgentEvidence, cfg canaryConfig, issues *issueCollector, caveats *issueCollector, report *canaryValidationReport) {
 	canonical := normalizeEmail(agent.CanonicalAddress)
 	legacy := normalizeEmail(agent.LegacyAlias)
 	localID := strings.ToLower(strings.TrimSpace(agent.LocalID))
@@ -321,7 +324,7 @@ func validateAgentEvidence(prefix string, agent canaryAgentEvidence, cfg canaryC
 		validateLegacyCanary(prefix+".legacy", agent, canonical, legacy, issues, report)
 	}
 	if agent.BodyMCP != nil || cfg.RequireBodyMCP {
-		validateBodyMCPCanary(prefix+".body_mcp", agent.BodyMCP, canonical, legacy, issues, report)
+		validateBodyMCPCanary(prefix+".body_mcp", agent.BodyMCP, canonical, legacy, issues, caveats, report)
 	}
 }
 
@@ -459,7 +462,7 @@ func validateLegacyResolve(prefix string, resolve resolveCanary, legacy string, 
 	}
 }
 
-func validateBodyMCPCanary(prefix string, body *bodyMCPCanary, canonical string, legacy string, issues *issueCollector, report *canaryValidationReport) {
+func validateBodyMCPCanary(prefix string, body *bodyMCPCanary, canonical string, legacy string, issues *issueCollector, caveats *issueCollector, report *canaryValidationReport) {
 	if body == nil {
 		issues.add("%s is required", prefix)
 		return
@@ -483,29 +486,28 @@ func validateBodyMCPCanary(prefix string, body *bodyMCPCanary, canonical string,
 			issues.add("%s.%s must be true", prefix, check.name)
 		}
 	}
-	for _, check := range []struct {
-		name  string
-		value string
-	}{
-		{name: "identity_whoami_email", value: body.IdentityWhoamiEmail},
-		{name: "identity_lookup_email", value: body.IdentityLookupEmail},
-	} {
-		validateBodyMCPIdentityEmail(prefix, check.name, check.value, canonical, legacy, issues)
-	}
+	// identity_lookup_email is the authoritative lookup — must match canonical.
+	validateBodyMCPIdentityEmail(prefix, "identity_lookup_email", body.IdentityLookupEmail, canonical, legacy, false, issues, caveats)
+	// identity_whoami_email may reflect signed/on-chain registration state that
+	// lags behind the current channel until the agent republishes; legacy values
+	// are recorded as a caveat rather than a hard failure.
+	validateBodyMCPIdentityEmail(prefix, "identity_whoami_email", body.IdentityWhoamiEmail, canonical, legacy, true, issues, caveats)
 }
 
-func validateBodyMCPIdentityEmail(prefix string, name string, value string, canonical string, legacy string, issues *issueCollector) {
+func validateBodyMCPIdentityEmail(prefix string, name string, value string, canonical string, legacy string, allowLegacy bool, issues *issueCollector, caveats *issueCollector) {
 	addr := normalizeEmail(value)
 	if addr == "" {
 		issues.add("%s.%s is required and must equal canonical address %q", prefix, name, canonical)
 		return
 	}
-	if addr != canonical {
-		issues.add("%s.%s=%q expected=%q", prefix, name, addr, canonical)
+	if addr == canonical {
+		return
 	}
-	if legacy != "" && addr == legacy {
-		issues.add("%s.%s must not expose legacy alias %q as current", prefix, name, legacy)
+	if allowLegacy && legacy != "" && addr == legacy {
+		caveats.add("%s.%s=%q reflects legacy signed-registration address (canonical=%q); accepted as a declared caveat", prefix, name, addr, canonical)
+		return
 	}
+	issues.add("%s.%s=%q expected=%q", prefix, name, addr, canonical)
 }
 
 func validateUnknownAlias(alias *unknownAliasCanary, issues *issueCollector) {

--- a/scripts/soul-email-m3-canary/main_test.go
+++ b/scripts/soul-email-m3-canary/main_test.go
@@ -33,6 +33,9 @@ func TestRunCLI_PassesRedactedM3Evidence(t *testing.T) {
 	if len(report.Issues) != 0 {
 		t.Fatalf("unexpected issues: %#v", report.Issues)
 	}
+	if len(report.Caveats) != 0 {
+		t.Fatalf("unexpected caveats: %#v", report.Caveats)
+	}
 }
 
 func TestRunCLI_FailsWhenRequiredUnknownAliasHasNoFailClosedStatus(t *testing.T) {
@@ -105,6 +108,50 @@ func TestRunCLI_FailsOnCanonicalAddressMismatch(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "canonical_address") {
 		t.Fatalf("expected canonical address issue, got %s", stdout.String())
+	}
+}
+
+func TestRunCLI_PassesWhenIdentityWhoamiEmailShowsLegacyAlias(t *testing.T) {
+	// identity_whoami_email=legacy is a declared caveat, not a hard failure.
+	fixture := strings.Replace(validCanaryEvidenceJSON(),
+		`"identity_whoami_email": "pilot.simulacrum@lessersoul.ai"`,
+		`"identity_whoami_email": "pilot@lessersoul.ai"`, 1)
+	path := writeCanaryFixture(t, fixture)
+	var stdout bytes.Buffer
+	code := runCLI([]string{"--stage", "lab", "--evidence", path, "--require-body-mcp", "--require-legacy-alias", "--require-unknown-alias"},
+		func(string) string { return "" }, &stdout, &bytes.Buffer{}, time.Date(2026, 5, 22, 15, 0, 0, 0, time.UTC))
+	if code != 0 {
+		t.Fatalf("expected pass (whoami legacy is a caveat), got exit %d stdout=%s", code, stdout.String())
+	}
+	var report canaryValidationReport
+	if err := json.Unmarshal(stdout.Bytes(), &report); err != nil {
+		t.Fatalf("decode report: %v", err)
+	}
+	if len(report.Issues) != 0 {
+		t.Fatalf("unexpected issues: %#v", report.Issues)
+	}
+	if len(report.Caveats) == 0 {
+		t.Fatalf("expected caveat for identity_whoami_email=legacy, got none; report=%s", stdout.String())
+	}
+	if !strings.Contains(strings.Join(report.Caveats, "\n"), "identity_whoami_email") {
+		t.Fatalf("expected whoami caveat, got caveats=%#v", report.Caveats)
+	}
+}
+
+func TestRunCLI_FailsWhenIdentityLookupEmailShowsLegacyAlias(t *testing.T) {
+	// identity_lookup_email must always equal canonical (authoritative lookup).
+	fixture := strings.Replace(validCanaryEvidenceJSON(),
+		`"identity_lookup_email": "pilot.simulacrum@lessersoul.ai"`,
+		`"identity_lookup_email": "pilot@lessersoul.ai"`, 1)
+	path := writeCanaryFixture(t, fixture)
+	var stdout bytes.Buffer
+	code := runCLI([]string{"--stage", "lab", "--evidence", path, "--require-body-mcp"},
+		func(string) string { return "" }, &stdout, &bytes.Buffer{}, time.Date(2026, 5, 22, 15, 0, 0, 0, time.UTC))
+	if code != 2 {
+		t.Fatalf("expected validation failure exit 2, got %d stdout=%s", code, stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "identity_lookup_email") {
+		t.Fatalf("expected identity_lookup_email issue, got %s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Addresses #356**: Managed instances were silently skipping agent enablement because `managedEnableAgentRegistration` defaulted to `false` in both `cdk.json` and the TypeScript stack. Changed the default to `true` so `enable_agents()` runs on every managed deploy, keeping Lambda env vars in sync with DynamoDB policy. Awaiting lab deploy verification.
- **Closes #345**: M4.1 rollout/rollback/monitoring runbook.
- **Closes #347**: M4.3 deferred post-live backlog cutline.
- **Addresses #344**: M4 parent — runbook and cutline delivered; release decision template ready for live evidence.
- **Addresses #346**: M4.2 final release decision template — framework complete, awaits live evidence and sign-offs.

## Changes

| File | Change |
|---|---|
| `cdk/cdk.json` | `managedEnableAgentRegistration`: `"false"` → `"true"` |
| `cdk/lib/lesser-host-stack.ts` | Code-level fallback: `"false"` → `"true"` |
| `scripts/soul-email-m3-canary/main.go` | Soften `--require-body-mcp`: `identity_whoami_email` legacy → caveat (not failure); `identity_lookup_email` remains hard gate; add `caveats` field to report |
| `scripts/soul-email-m3-canary/main_test.go` | New tests: whoami-legacy passes with caveat; lookup-legacy fails |
| `docs/instance-scoped-soul-email-m3-canary.md` | Document softened gate and `caveats` field |
| `docs/instance-scoped-soul-email-m4-runbook.md` | M4.1 live rollout, rollback, and monitoring runbook |
| `docs/instance-scoped-soul-email-m4-release-decision.md` | M4.2 release decision template (resolved #275/#276 moved to Resolved Dependencies) |
| `docs/instance-scoped-soul-email-m4-cutline.md` | M4.3 deferred post-live backlog cutline |

### Verifier contract (Path B — accept signed-registration caveat)

- `identity_lookup_email` must equal canonical address **(hard requirement)**
- `identity_whoami_email` may equal legacy alias → recorded as `caveats` **(accepted)**
- `identity_whoami_email` equals something else → recorded as `issues` **(fails)**
- All mailbox operations (send/reply/read/get/search) remain hard requirements

## Test plan

- [x] TypeScript compiles clean
- [x] Go vet passes
- [x] Canary verifier tests: 8/8 PASS (incl. 2 new)
- [x] Gov-rubric PASS 29/0/0
- [ ] Lab deploy to exercise agent enablement on managed dev stages
- [ ] Post-deploy: verify `ALLOW_AGENTS=true` on Sim/Theory dev Lambdas
- [ ] Live M3 canary re-run with `--require-body-mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)