### PR TITLE
Project 39 M0.1-M0.5 (FaceTheory foundation) + Project 40 planning docs baseline

### DIFF
--- a/docs/enumerated-changes-managed-client-deployment-2026-05-24.md
+++ b/docs/enumerated-changes-managed-client-deployment-2026-05-24.md
@@ -1,0 +1,615 @@
+# Enumerated changes: Managed client deployment for `/l/`
+
+Date: 2026-05-24
+Author: host steward
+
+Source roadmap: `docs/roadmap-managed-client-deployment-2026-05-24.md`.
+
+These items are scoped as one logical commit or one sibling-repo issue each. Host issues preserve tenant isolation, do not touch on-chain state, and keep consumer release verification explicit. Sibling items are coordination work for their respective stewards; host does not edit those repos.
+
+## Milestone map
+
+- **M0: Managed Client M0 — Contract blockers and artifact readiness** — Freeze the cross-repo contracts that unblock host runner work and Simulacrum default-client readiness.
+- **M1: Managed Client M1 — Host verification and governance baseline** — Add host-side catalog/release verification and governance evidence before data or runner implementation.
+- **M2: Managed Client M2 — GitHub App and data foundation** — Add tenant-bounded state, GitHub App secret/config loading, and onboarding verification primitives.
+- **M3: Managed Client M3 — Portal APIs and webhook ingress** — Expose customer/operator APIs and authenticated GitHub webhook ingestion without deploying clients yet.
+- **M4: Managed Client M4 — Runner isolation and infrastructure** — Split custom source builds from tenant deploy, add scoped tenant role, and provision queues/runners safely.
+- **M5: Managed Client M5 — Deploy orchestration, default, and reset** — Wire client deploy jobs into provisioning, reset, and install-history/recovery flows.
+- **M6: Managed Client M6 — Portal UX, validation, and rollout** — Ship the portal/operator UX, validation harnesses, docs, evidence, and lab/live rollout gates.
+
+## Change list
+
+### 1. [L1] Support ambient credentials for lesser client install
+
+- **Repository**: `equaltoai/lesser`
+- **Milestone**: M0
+- **Paths**: `cmd/lesser`, Lesser CLI AWS config helpers, client install tests/docs
+- **Surface**: lesser CLI
+- **Classification**: provisioning / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; enables scoped role
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: `lesser client install --skip-build` works noninteractively from ambient CodeBuild role credentials while `--aws-profile` remains an optional override.
+- **Validation**: Lesser CLI tests plus a noninteractive ambient-credential smoke path.
+- **Conventional Commit subject**: `fix(cli): allow ambient credentials for client install`
+
+### 2. [L2] Document Lesser client install receipt and least-privilege IAM contract
+
+- **Repository**: `equaltoai/lesser`
+- **Milestone**: M0
+- **Paths**: Lesser client guide/docs/tests
+- **Surface**: docs/tests
+- **Classification**: docs / provisioning / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; narrows tenant role
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Docs name required receipt outputs, explicit-stage automation use, and the install-only S3/CloudFront IAM shape.
+- **Validation**: Docs review plus CLI help/tests updated.
+- **Conventional Commit subject**: `docs(client): document managed install automation contract`
+
+### 3. [S1] Package immutable Simulacrum managed-client release artifacts
+
+- **Repository**: `equaltoai/simulacrum`
+- **Milestone**: M0
+- **Paths**: `scripts/package-client-release.mjs`, `package.json`, release docs
+- **Surface**: sim release tooling
+- **Classification**: release / docs
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: producer artifact contract
+- **Framework consumption**: FaceTheory idiomatic
+- **Acceptance**: After `pnpm build`, Sim produces an archive containing `build/server`, `build/client`, `facetheory.lesser.json`, release metadata, and checksums.
+- **Validation**: `pnpm check`, `pnpm build`, packaging script.
+- **Conventional Commit subject**: `feat(release): package managed client artifact`
+
+### 4. [S2] Verify Simulacrum managed-client release artifacts
+
+- **Repository**: `equaltoai/simulacrum`
+- **Milestone**: M0
+- **Paths**: `scripts/verify-client-release.mjs`, tests/docs
+- **Surface**: sim release verification
+- **Classification**: release / test-coverage / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: producer artifact verifier
+- **Framework consumption**: FaceTheory idiomatic
+- **Acceptance**: Verifier checks file manifest, checksums, allowed manifest overrides, `/l` metadata, path safety, no symlinks, and required entry files.
+- **Validation**: Verifier passes on generated artifact and fails on tampered/missing entries.
+- **Conventional Commit subject**: `test(release): verify managed client artifact`
+
+### 5. [S3] Remove or guard Simulacrum preview-domain fallback data
+
+- **Repository**: `equaltoai/simulacrum`
+- **Milestone**: M0
+- **Paths**: `src/facetheory/loaders.ts`, focused guard/test
+- **Surface**: sim FaceTheory runtime
+- **Classification**: CSP / docs / test-coverage
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: blocks default catalog promotion
+- **Framework consumption**: FaceTheory idiomatic
+- **Acceptance**: Managed-instance runtime surfaces do not expose `simulacrum.dev` as an origin or customer-visible deployment assumption.
+- **Validation**: Focused grep/test plus `pnpm check` and `pnpm build`.
+- **Conventional Commit subject**: `fix(facetheory): remove managed-default preview domains`
+
+### 6. [S4] Publish candidate/stable Simulacrum client artifacts
+
+- **Repository**: `equaltoai/simulacrum`
+- **Milestone**: M0
+- **Paths**: `.github/workflows/*` or release command docs
+- **Surface**: sim release workflow
+- **Classification**: release / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP evidence preserving
+- **Consumer-release-verification impact**: producer publish path
+- **Framework consumption**: FaceTheory idiomatic
+- **Acceptance**: A semver-tagged candidate artifact can be published with immutable URLs, release metadata, and sha256 digests for host catalog pinning.
+- **Validation**: Release workflow dry run or operator-run release command evidence.
+- **Conventional Commit subject**: `ci(release): publish managed client artifacts`
+
+### 7. [H1] Freeze managed client deployment contracts and ADR
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M0
+- **Paths**: `docs/`, optional `docs/adr/`
+- **Surface**: docs
+- **Classification**: docs / provisioning / governance
+- **Governance-rubric impact**: none; records gates
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: documents catalog vs custom artifact boundary
+- **Framework consumption**: idiomatic
+- **Acceptance**: Roadmap/ADR records host-owned GitHub App, Lesser install boundary, Sim artifact contract, runner split, and open product choices.
+- **Validation**: Markdown review; no runtime validation.
+- **Conventional Commit subject**: `docs(client): freeze managed client deployment contracts`
+
+### 8. [H2] Define managed client catalog schema and fixtures
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M1
+- **Paths**: `internal/...`, `scripts/managed-client-release-certification/testdata`, `docs/`
+- **Surface**: internal/config / scripts / docs
+- **Classification**: consumer-release-verification / docs
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: touches verification pipeline
+- **Framework consumption**: idiomatic
+- **Acceptance**: Host can represent immutable catalog entries with exact artifact URL/tag/sha256, channel pointer, allowed manifest overrides, and validation evidence fields.
+- **Validation**: Go/unit tests or script fixture tests.
+- **Conventional Commit subject**: `feat(client): define managed client catalog schema`
+
+### 9. [H3] Add managed client release certification verifier
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M1
+- **Paths**: `scripts/managed-client-release-certification/`, fixtures
+- **Surface**: scripts
+- **Classification**: consumer-release-verification / security
+- **Governance-rubric impact**: additive evidence target
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: touches verification pipeline
+- **Framework consumption**: idiomatic
+- **Acceptance**: Verifier rejects checksum mismatch, path traversal, symlinks/hardlinks, missing entry files, absolute paths, files outside allowed prefixes, and unauthorized manifest mutations.
+- **Validation**: Verifier fixture suite including positive and negative cases.
+- **Conventional Commit subject**: `feat(client): certify managed client artifacts`
+
+### 10. [H4] Add gov-infra evidence for managed client supply-chain checks
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M1
+- **Paths**: `gov-infra/verifiers`, `gov-infra/planning`, `gov-infra/evidence`
+- **Surface**: gov-infra
+- **Classification**: governance / consumer-release-verification
+- **Governance-rubric impact**: additive verifier/evidence only
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: touches verification pipeline
+- **Framework consumption**: idiomatic
+- **Acceptance**: Gov verifier emits evidence for managed-client artifact verification without weakening existing rubric checks.
+- **Validation**: `bash gov-infra/verifiers/gov-verify-rubric.sh`.
+- **Conventional Commit subject**: `feat(gov): verify managed client release evidence`
+
+### 11. [H5] Document managed client release readiness and recovery
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M1
+- **Paths**: `docs/managed-client-release-certification.md`, `docs/recovery.md`, related docs
+- **Surface**: docs
+- **Classification**: docs / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: documents verification gate
+- **Framework consumption**: idiomatic
+- **Acceptance**: Docs distinguish host-certified catalog artifacts from tenant-owned custom GitHub artifacts and describe reset/recovery.
+- **Validation**: Docs review.
+- **Conventional Commit subject**: `docs(client): describe release readiness and recovery`
+
+### 12. [H6] Add TableTheory models for client deploy state
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M2
+- **Paths**: `internal/store/models`, `internal/store`
+- **Surface**: internal/store
+- **Classification**: tenant-isolation / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: owner/slug bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: TableTheory idiomatic
+- **Acceptance**: Models cover catalog entry reference, instance client state, deploy jobs, GitHub binding, and webhook ledger without storing secrets or raw repo source.
+- **Validation**: `go test ./internal/store/...` plus projection tests.
+- **Conventional Commit subject**: `feat(store): add managed client deploy models`
+
+### 13. [H7] Implement owner-bounded client deploy store accessors
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M2
+- **Paths**: `internal/store`
+- **Surface**: internal/store
+- **Classification**: tenant-isolation / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; no cross-tenant query
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: TableTheory idiomatic
+- **Acceptance**: All client-state/binding/job accessors are slug and owner bounded with tests preventing cross-tenant reads.
+- **Validation**: `go test ./internal/store/...`.
+- **Conventional Commit subject**: `feat(store): bound client deploy access by owner`
+
+### 14. [H8] Load stage-scoped host-owned GitHub App secrets
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M2
+- **Paths**: `internal/config`, `internal/secrets`, `cdk` env refs
+- **Surface**: internal/config / internal/secrets
+- **Classification**: security / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: none
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: AppTheory idiomatic
+- **Acceptance**: Host loads app id, private-key ref, webhook secret ref, and callback settings from stage-scoped SSM/Secrets refs without logging values.
+- **Validation**: `go test ./internal/config/... ./internal/secrets/...` with redaction tests.
+- **Conventional Commit subject**: `feat(github): load client app secret refs`
+
+### 15. [H9] Implement GitHub App installation verification service
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M2
+- **Paths**: `internal/controlplane` or new `internal/githubapp`
+- **Surface**: internal service
+- **Classification**: security / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; repo binding owner-gated
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Service mints short-lived installation tokens, verifies installations server-side, derives repository candidates, and never persists tokens.
+- **Validation**: Unit tests with mocked GitHub responses and redacted logs.
+- **Conventional Commit subject**: `feat(github): verify client app installations`
+
+### 16. [H10] Add managed client audit and redaction helpers
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M2
+- **Paths**: `internal/controlplane`, logging helpers/tests
+- **Surface**: internal/controlplane
+- **Classification**: security / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Audit events record connect/deploy/reset/disable decisions while redacting tokens, webhook signatures, repo secrets, AWS creds, and PII.
+- **Validation**: Unit tests for redaction and audit event shape.
+- **Conventional Commit subject**: `feat(client): audit managed client actions safely`
+
+### 17. [H11] Add portal APIs for catalog, deploy status, history, and reset
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M3
+- **Paths**: `internal/controlplane`, API docs
+- **Surface**: control-plane API
+- **Classification**: provisioning / managed-update / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: owner bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: uses verified catalog entries
+- **Framework consumption**: AppTheory idiomatic
+- **Acceptance**: Portal customers can list catalog options, inspect safe deploy history/status, and enqueue reset for only their instance.
+- **Validation**: `go test ./internal/controlplane/...` with auth/ownership cases.
+- **Conventional Commit subject**: `feat(portal): expose managed client catalog and reset`
+
+### 18. [H12] Add no-paste GitHub App connect and disconnect APIs
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M3
+- **Paths**: `internal/controlplane`, web callback docs
+- **Surface**: control-plane API
+- **Classification**: security / tenant-isolation
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: owner bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: AppTheory idiomatic
+- **Acceptance**: Start/callback/bind/disconnect flow validates state, verifies installation/repo server-side, stores only binding metadata, and supports disabling without deleting audit history.
+- **Validation**: Auth, CSRF/state, ownership, and installation mismatch tests.
+- **Conventional Commit subject**: `feat(portal): connect GitHub App client deploys`
+
+### 19. [H13] Add GitHub webhook HMAC verification and delivery ledger
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M3
+- **Paths**: `internal/controlplane`, `cmd/control-plane-api` routing, store accessors
+- **Surface**: control-plane API / store
+- **Classification**: security / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: binding-scoped
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: custom artifact boundary
+- **Framework consumption**: AppTheory idiomatic
+- **Acceptance**: Webhook accepts only valid `X-Hub-Signature-256` push events matching the bound repo and exact `refs/heads/<branch>`, dedupes deliveries, and ignores non-matching events safely.
+- **Validation**: Fixture tests for HMAC, replay, event/ref mismatch, and redacted logs.
+- **Conventional Commit subject**: `feat(github): queue client deploy webhooks safely`
+
+### 20. [H14] Gate custom GitHub deploy availability by feature flag or allowlist
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M3
+- **Paths**: `internal/controlplane`, config/docs
+- **Surface**: control-plane API
+- **Classification**: security / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Custom GitHub deploys can launch as operator-allowlisted while catalog reset remains available by policy.
+- **Validation**: Unit tests for gated/ungated portal behavior.
+- **Conventional Commit subject**: `feat(client): gate custom GitHub deploy access`
+
+### 21. [H15] Provision managed client queues, DLQs, alarms, and runner settings
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: `cdk/`, `app-theory/app.json` if needed
+- **Surface**: cdk
+- **Classification**: provisioning / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: AppTheory CDK idiomatic
+- **Acceptance**: CDK adds client deploy queue/DLQ/alarm resources and CodeBuild settings without changing live stateful retention policies.
+- **Validation**: `cd cdk && npm run synth`.
+- **Conventional Commit subject**: `feat(cdk): add managed client deploy infrastructure`
+
+### 22. [H16] Add narrow tenant client-deploy IAM role policy
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: `cdk/`, runner role docs
+- **Surface**: cdk / docs
+- **Classification**: tenant-isolation / security / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: tightens tenant boundary
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Tenant deploy role grants only the required S3 PutObject prefixes and CloudFront CreateInvalidation on the target distribution for routine client install.
+- **Validation**: CDK synth plus IAM snapshot/policy assertion tests.
+- **Conventional Commit subject**: `feat(cdk): scope tenant client deploy role`
+
+### 23. [H17] Implement catalog deploy runner path
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: `cdk/lib/provision-runner` or new runner scripts
+- **Surface**: runner scripts
+- **Classification**: consumer-release-verification / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP verification
+- **Consumer-release-verification impact**: touches verification pipeline
+- **Framework consumption**: idiomatic
+- **Acceptance**: Runner downloads exact catalog artifact, verifies schema/checksums/path safety, renders only allowed manifest fields, then calls `lesser client install --skip-build`.
+- **Validation**: Runner script tests with good/bad fixtures.
+- **Conventional Commit subject**: `feat(client): install verified catalog artifacts`
+
+### 24. [H18] Implement custom source build runner without tenant AWS credentials
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: runner scripts/buildspecs, tests
+- **Surface**: runner scripts / CodeBuild
+- **Classification**: security / tenant-isolation / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; source build has no tenant role
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: custom artifact boundary
+- **Framework consumption**: idiomatic
+- **Acceptance**: Custom GitHub source builds run with repository token only, no tenant AWS role, no tenant secrets, and output a bounded deploy artifact inventory.
+- **Validation**: Buildspec/static tests proving tenant role is not assumed before custom build.
+- **Conventional Commit subject**: `feat(client): build custom clients without tenant creds`
+
+### 25. [H19] Implement deploy-only runner validation for custom artifacts
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: runner scripts/buildspecs, tests
+- **Surface**: runner scripts / CodeBuild
+- **Classification**: security / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves; deploy role only after artifact validation
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP verification
+- **Consumer-release-verification impact**: custom artifact verification
+- **Framework consumption**: idiomatic
+- **Acceptance**: Deploy-only runner validates bounded artifact inventory before assuming scoped tenant role and running Lesser install.
+- **Validation**: Runner tests for tampered inventory, path traversal, missing entries, and allowed manifest fields.
+- **Conventional Commit subject**: `feat(client): deploy validated custom client artifacts`
+
+### 26. [H20] Assert runner split and credential redaction in tests
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M4
+- **Paths**: runner tests, `scripts/validate`, gov evidence hooks
+- **Surface**: tests / scripts
+- **Classification**: security / test-coverage / governance
+- **Governance-rubric impact**: additive evidence if wired
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: touches custom verification
+- **Framework consumption**: idiomatic
+- **Acceptance**: Tests fail if custom build assumes tenant role early or logs GitHub tokens/webhook signatures/AWS credentials.
+- **Validation**: Runner tests plus gov verifier if added.
+- **Conventional Commit subject**: `test(client): prove runner credential isolation`
+
+### 27. [H21] Implement ClientDeployJob state machine
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M5
+- **Paths**: `internal/provisionworker`, `internal/store`, worker entrypoint
+- **Surface**: provision-worker
+- **Classification**: provisioning / managed-update / reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: slug bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: uses verified artifacts
+- **Framework consumption**: AppTheory idiomatic
+- **Acceptance**: Jobs cover catalog deploy, reset, and custom GitHub deploy with retryable/nonretryable states and safe receipt ingest.
+- **Validation**: Provision-worker unit/state-machine tests.
+- **Conventional Commit subject**: `feat(worker): orchestrate client deploy jobs`
+
+### 28. [H22] Install default Simulacrum during new managed provisioning
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M5
+- **Paths**: `internal/provisionworker`, provisioning docs/tests
+- **Surface**: provision-worker
+- **Classification**: provisioning / consumer-release-verification
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP validation
+- **Consumer-release-verification impact**: uses verified Sim artifact
+- **Framework consumption**: idiomatic
+- **Acceptance**: New managed provisions install the pinned verified Simulacrum catalog artifact before ready, with recoverable client-deploy failure state.
+- **Validation**: Provisioning tests and lab disposable slug install.
+- **Conventional Commit subject**: `feat(provision): install default managed client`
+
+### 29. [H23] Implement reset semantics for catalog client deployment
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M5
+- **Paths**: `internal/controlplane`, `internal/provisionworker`, docs/tests
+- **Surface**: portal API / provision-worker
+- **Classification**: managed-update / provisioning / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: owner bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP validation
+- **Consumer-release-verification impact**: uses verified catalog
+- **Framework consumption**: idiomatic
+- **Acceptance**: Reset reinstalls selected catalog artifact idempotently and disables custom auto-triggering unless the operator explicitly re-enables it.
+- **Validation**: API/worker tests for idempotency and disabled-binding behavior.
+- **Conventional Commit subject**: `feat(client): reset managed client to catalog`
+
+### 30. [H24] Add install history, retry, and concurrency guards
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M5
+- **Paths**: `internal/store`, `internal/provisionworker`, docs/tests
+- **Surface**: store / provision-worker
+- **Classification**: reliability / managed-update / provisioning
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: slug bounded
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: none
+- **Consumer-release-verification impact**: preserves verified artifact references
+- **Framework consumption**: TableTheory/AppTheory idiomatic
+- **Acceptance**: Client deploys cannot race core provisioning or managed updates; install history supports safe retry/recovery without storing raw artifacts or secrets.
+- **Validation**: Concurrency and retry tests.
+- **Conventional Commit subject**: `feat(client): record install history and deploy guards`
+
+### 31. [H25] Build portal managed clients UI
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M6
+- **Paths**: `web/`
+- **Surface**: web
+- **Classification**: host-web / CSP / portal
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: owner scoped views
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: preserves strict CSP
+- **Consumer-release-verification impact**: displays catalog/custom boundary
+- **Framework consumption**: Svelte/FaceTheory patterns idiomatic
+- **Acceptance**: Portal supports catalog selection, reset, deploy status/history, GitHub connect/disconnect, and branch display with no inline scripts/styles or third-party embeds.
+- **Validation**: `cd web && npm run lint && npm run typecheck && npm test && npm run build` plus CSP scan.
+- **Conventional Commit subject**: `feat(web): add managed client portal`
+
+### 32. [H26] Add operator support views for managed client deployments
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M6
+- **Paths**: `web/`, `internal/controlplane` as needed
+- **Surface**: web / control-plane API
+- **Classification**: operational-reliability / security
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: safe metadata only
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: none
+- **Framework consumption**: idiomatic
+- **Acceptance**: Operator/support surfaces show safe job/delivery metadata only, without raw logs, tokens, repo source, or PII.
+- **Validation**: API/UI tests and redaction checks.
+- **Conventional Commit subject**: `feat(web): show managed client support metadata`
+
+### 33. [H27] Add end-to-end validation harness for catalog, custom, reset, and CSP
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M6
+- **Paths**: `scripts/validate`, `scripts/managed-client-release-certification`, test fixtures
+- **Surface**: scripts / tests
+- **Classification**: test-coverage / security / provisioning
+- **Governance-rubric impact**: additive evidence path
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP verification
+- **Consumer-release-verification impact**: real consumer path validation
+- **Framework consumption**: idiomatic
+- **Acceptance**: Harness covers HMAC handling, no-paste onboarding, catalog checksum mismatch abort, custom disposable repo deploy, reset, and `/l/*` CSP smoke.
+- **Validation**: Harness dry run and lab disposable slug evidence.
+- **Conventional Commit subject**: `test(client): validate managed client deployment paths`
+
+### 34. [H28] Finalize managed client runbooks and rollout docs
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M6
+- **Paths**: `docs/recovery.md`, `docs/managed-instance-provisioning.md`, new managed-client docs
+- **Surface**: docs
+- **Classification**: docs / operational-reliability
+- **Governance-rubric impact**: none
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP preserving
+- **Consumer-release-verification impact**: documents verification and recovery
+- **Framework consumption**: idiomatic
+- **Acceptance**: Runbooks cover disable binding, rotate GitHub App credentials, retry failed deploy, reset to Simulacrum, previous install rollback, lab soak, and live canary gates.
+- **Validation**: Docs review.
+- **Conventional Commit subject**: `docs(client): finalize runbooks and rollout`
+
+### 35. [H29] Collect lab and live-canary rollout evidence
+
+- **Repository**: `equaltoai/lesser-host`
+- **Milestone**: M6
+- **Paths**: `gov-infra/evidence`, `docs/deployments` or release notes
+- **Surface**: evidence / docs
+- **Classification**: governance / operational-reliability
+- **Governance-rubric impact**: evidence emission
+- **Multi-tenant-isolation impact**: preserves
+- **On-chain impact**: none
+- **Trust-API / CSP / instance-auth impact**: CSP evidence
+- **Consumer-release-verification impact**: real artifact verification evidence
+- **Framework consumption**: idiomatic
+- **Acceptance**: Evidence captures exact Sim artifact digest, disposable lab slug deploy/reset/custom cycles, and live internal canary outcome before broader availability.
+- **Validation**: Gov verifier plus recorded lab/live canary checks.
+- **Conventional Commit subject**: `chore(client): record managed client rollout evidence`

--- a/docs/github-project-managed-client-deployment-2026-05-24.md
+++ b/docs/github-project-managed-client-deployment-2026-05-24.md
@@ -1,0 +1,54 @@
+# GitHub Project: Managed `/l/` Client Deployments
+
+Date: 2026-05-24
+
+Project: https://github.com/orgs/equaltoai/projects/40
+Umbrella issue: https://github.com/equaltoai/lesser-host/issues/460
+
+## Phase parent issues
+
+- **M0**: https://github.com/equaltoai/lesser-host/issues/461
+- **M1**: https://github.com/equaltoai/lesser-host/issues/462
+- **M2**: https://github.com/equaltoai/lesser-host/issues/463
+- **M3**: https://github.com/equaltoai/lesser-host/issues/464
+- **M4**: https://github.com/equaltoai/lesser-host/issues/465
+- **M5**: https://github.com/equaltoai/lesser-host/issues/466
+- **M6**: https://github.com/equaltoai/lesser-host/issues/467
+
+## Enumerated child issues
+
+- **L1** (`equaltoai/lesser`): https://github.com/equaltoai/lesser/issues/1095
+- **L2** (`equaltoai/lesser`): https://github.com/equaltoai/lesser/issues/1096
+- **S1** (`equaltoai/simulacrum`): https://github.com/equaltoai/simulacrum/issues/176
+- **S2** (`equaltoai/simulacrum`): https://github.com/equaltoai/simulacrum/issues/177
+- **S3** (`equaltoai/simulacrum`): https://github.com/equaltoai/simulacrum/issues/178
+- **S4** (`equaltoai/simulacrum`): https://github.com/equaltoai/simulacrum/issues/179
+- **H1** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/468
+- **H2** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/469
+- **H3** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/470
+- **H4** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/471
+- **H5** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/472
+- **H6** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/473
+- **H7** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/474
+- **H8** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/475
+- **H9** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/476
+- **H10** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/477
+- **H11** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/478
+- **H12** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/479
+- **H13** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/480
+- **H14** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/481
+- **H15** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/482
+- **H16** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/483
+- **H17** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/484
+- **H18** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/485
+- **H19** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/486
+- **H20** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/487
+- **H21** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/488
+- **H22** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/489
+- **H23** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/490
+- **H24** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/491
+- **H25** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/492
+- **H26** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/493
+- **H27** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/494
+- **H28** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/495
+- **H29** (`equaltoai/lesser-host`): https://github.com/equaltoai/lesser-host/issues/496

--- a/docs/roadmap-managed-client-deployment-2026-05-24.md
+++ b/docs/roadmap-managed-client-deployment-2026-05-24.md
@@ -1,0 +1,254 @@
+# Roadmap: Managed client deployment for `/l/`
+
+Date: 2026-05-24
+Author: host steward
+
+## Goal
+
+Deliver a first-class managed client deployment capability for `lesser-host` managed instances: new managed instances default to a checksum-verified EqualToAI client catalog entry, initially **Simulacrum**, operators can safely reset `/l/` back to a selected catalog client, and operators can optionally connect a **host-owned GitHub App** to one customer repository/branch so branch updates deploy a custom Lesser client to `/l/` without exposing AWS credentials.
+
+The design preserves host's boundaries: host remains the managed-hosting control plane, Lesser remains the `/l/` serving/deploy authority through `lesser client install`, Simulacrum owns its client release artifacts, customer custom client source stays tenant-owned, and host does not weaken core Lesser/body consumer release verification.
+
+## Classification
+
+Provisioning, managed-update, consumer-release-verification, security, tenant-isolation, operational-reliability, CSP, governance, docs.
+
+## Surfaces affected
+
+- `internal/store/models`, `internal/store`: instance client state, client deploy jobs, GitHub App bindings, webhook delivery ledger.
+- `internal/config`, `internal/secrets`: stage-scoped host-owned GitHub App settings and secret refs.
+- `internal/controlplane`: portal APIs for catalog, reset/deploy, GitHub connect/disconnect, webhook ingress, audit visibility.
+- `internal/provisionworker`: client deploy job state machine, catalog preflight, CodeBuild polling/receipt ingest.
+- `cdk/`: client deploy queues, DLQs, CodeBuild runner split, GitHub App secret access, alarms.
+- `cdk/lib/provision-runner` or new runner scripts: trusted catalog deploy and split custom build/deploy paths.
+- `web/`: portal and operator UI for managed clients.
+- `scripts/managed-client-release-certification`, `scripts/validate`: catalog artifact validation and fixture-gated GitHub/App validation.
+- `gov-infra/`: additive verifier/evidence coverage for the new supply-chain and GitHub boundary.
+- `docs/`: architecture, release contract, recovery, rollout, and steward coordination docs.
+
+## Key architectural decisions
+
+1. **Use a host-owned GitHub App for v1.** Operators install the stage-scoped `lesser.host` client-deploy app into their chosen repo. Host stores global app credential refs; per-instance bindings store only installation/repository/branch policy and audit metadata.
+2. **Drive Lesser's existing `/l/` contract.** Host should call `lesser client install --skip-build` rather than copying Lesser's S3/CloudFront/manifest behavior.
+3. **Split custom builds from tenant deploy.** The current provision runner assumes the tenant AWS role in prebuild, so it must not execute customer build commands. Custom GitHub source build runs without tenant AWS credentials; trusted deploy consumes only a bounded build artifact.
+4. **Catalog clients are checksum-verified.** Simulacrum/default/reset deployments use a managed client release contract and checksum verification before install.
+5. **Custom GitHub clients are tenant-owned artifacts.** They are not host-certified Lesser/body releases. The UI and audit trail must make that boundary explicit.
+
+## Sibling-repo coordination
+
+- **lesser: blocker identified before host runner work.** Lesser confirmed that host should call `lesser client install --skip-build` and not duplicate Lesser's S3/CloudFront/manifest behavior. The Lesser-local blocker is ambient AWS credential support: `lesser client install` must work from a scoped CodeBuild role without requiring `--aws-profile`. Host must pass explicit `--stage`, a non-secret Lesser state receipt containing `ClientBucketName`, `ClientArtifactBucketName`, `ClientInstallManifestKey`, and `FrontendDistributionId`, and a narrow tenant-account client-deploy role.
+- **sim: blocker identified before default-client rollout.** Simulacrum confirmed that host should consume immutable built client artifacts plus release metadata/checksums, not a source checkout. Simulacrum must publish a `simulacrum-client-release.json`-style artifact contract, verifier, release packaging path, and clean/guard user-visible `simulacrum.dev` preview fallback data before host uses Simulacrum as the default managed client.
+- **body: not required for v1.** No body comm API or lesser-body deploy contract changes are expected.
+- **soul: not required for v1.** No soul registry/on-chain/namespace changes are expected.
+- **greater: not required for v1.** No greater-components API changes are expected.
+
+## Framework coordination
+
+- **AppTheory: not required initially.** AppTheory routing/SQS/Lambda patterns are sufficient.
+- **TableTheory: not required initially.** Existing single-table/GSI modeling patterns are sufficient.
+- **FaceTheory: not required initially.** Simulacrum's FaceTheory client release must remain `/l` and CSP-safe, but no framework feature request is known yet.
+
+## External-vendor coordination
+
+- **GitHub:** create/configure the host-owned GitHub App per stage with webhook URL, push event subscription, and contents/metadata read permissions. Installation token permissions should be repository-scoped.
+- **AWS:** new SQS/CodeBuild/Secrets Manager/IAM resources; live deploy requires normal operator authorization and no CDK timeouts.
+- **Stripe / billing:** not required.
+- **SES / comm vendors:** not required.
+- **AI providers:** not required.
+- **eth_rpc / Safe signers:** not required; no on-chain changes.
+
+## Steward response incorporation
+
+### Lesser response incorporated
+
+- The supported boundary is Lesser's `lesser client install --skip-build`; host must not reimplement `/l/` object publication or CloudFront invalidation semantics.
+- Host automation must pass an explicit single stage and a non-secret `lesser up` state receipt. Host should treat `ClientBucketName`, `ClientArtifactBucketName`, `ClientInstallManifestKey`, and `FrontendDistributionId` as required receipt fields.
+- Before host depends on CodeBuild automation, Lesser needs ambient AWS credentials/region support for `client install`; `--aws-profile` should remain an optional operator override, not a required automation flag.
+- Routine client install only needs `s3:PutObject` to the client artifact install/history paths, active manifest key, client asset prefix `l/_assets/*`, and `cloudfront:CreateInvalidation` scoped to the target distribution. It must not need DynamoDB, Secrets Manager, SSM writes, Lambda, CloudFormation, Route53, IAM mutation, or bootstrap mnemonic access.
+- Reset/rollback should prefer reinstalling the exact known-good catalog artifact. Hot activation of an older manifest is optional future Lesser work if host needs receipt-synchronized rollback.
+
+### Simulacrum response incorporated
+
+- Host must consume immutable built artifacts with metadata/checksums and must not clone/build Simulacrum source for catalog/default/reset deployment.
+- The expected built shape is `build/server/**`, `build/client/**`, and `facetheory.lesser.json`; host may render only `app_name` and `display_name`, while server/assets paths and handler fields remain checksum-verified invariants.
+- Catalog verification must reject path traversal, absolute paths, symlinks/hardlinks, files outside allowed prefixes, missing required entry files, checksum mismatches, and rendered manifest mutations beyond the allowed per-instance fields.
+- Simulacrum must remove, derive, or quarantine user-visible `simulacrum.dev` fallback preview URLs before default managed-client promotion.
+- Host should accept a `candidate` artifact for lab integration, then promote the same digest to `stable` only after dev/lab install and browser/CSP smoke evidence is green.
+
+### Updated blockers
+
+1. Lesser ambient-credential support for `lesser client install --skip-build` is the runner-work blocker.
+2. Simulacrum immutable client artifact packaging/verifier plus preview-domain cleanup is the default-client blocker.
+3. Host product choices that remain: initial availability of custom GitHub deploys (recommended: operator allowlist first) and reset semantics (recommended: preserve GitHub binding disabled unless explicitly disconnected).
+
+## Phases
+
+### Phase 0: Coordination and contract freeze
+
+- **Items**: L1, L2, S1, S2, S3, S4, H1, steward briefs.
+- **Dependencies**: none.
+- **Risks**:
+  - Lesser's CLI contract may need small changes before host automation.
+  - Simulacrum may not yet publish deploy-ready release artifacts.
+- **Exit criteria**:
+  - Lesser confirms the stable `lesser client install --skip-build` automation surface and rollback/receipt contract.
+  - Simulacrum confirms the managed client artifact contract or returns repo-local change requirements.
+  - The host-owned GitHub App choice is recorded as the v1 product boundary.
+
+### Phase 1: Governance and release-verification baseline
+
+- **Items**: H2, H3, H4, H5.
+- **Dependencies**: Phase 0 contract answers for final schema details.
+- **Risks**:
+  - Silent weakening of supply-chain gates if client artifacts are treated as ordinary downloads.
+  - Confusion between host-certified catalog artifacts and tenant-owned custom artifacts.
+- **Exit criteria**:
+  - Managed client release schema and certification scripts validate known-good fixtures and reject checksum/path/schema mismatches.
+  - Gov verifier additions are additive only and emit evidence.
+
+### Phase 2: Data, config, and GitHub App foundation
+
+- **Items**: H6, H7, H8, H9, H10.
+- **Dependencies**: Phase 1 schema names stable enough to reference.
+- **Risks**:
+  - Storing credential material in DynamoDB instead of refs.
+  - Unbounded binding queries crossing instance ownership.
+- **Exit criteria**:
+  - TableTheory models and accessors are slug/owner bounded.
+  - Host-owned GitHub App credentials load from stage-scoped refs.
+  - Installation tokens are short-lived, repo-scoped, never persisted, and redacted from logs/tests.
+
+### Phase 3: Portal APIs and webhook ingress
+
+- **Items**: H11, H12, H13, H14.
+- **Dependencies**: Phase 2 models/accessors and GitHub auth service.
+- **Risks**:
+  - Treating callback `installation_id` as proof instead of verifying server-side.
+  - Webhook replay or branch/ref confusion causing unintended deploys.
+- **Exit criteria**:
+  - No-paste onboarding flow: start install, callback state validation, server-side installation verification, server-derived repo candidates, exact repo+branch binding.
+  - Webhook requires valid `X-Hub-Signature-256`, exact `push` event, exact `refs/heads/<branch>`, dedupe ledger, and safe ignored outcomes for non-matching events.
+
+### Phase 4: Infrastructure and runner split
+
+- **Items**: H15, H16, H17, H18, H19, H20.
+- **Dependencies**: Phase 1 verification scripts and Phase 2 config.
+- **Risks**:
+  - Custom client build accidentally runs after assuming tenant AWS credentials.
+  - Tenant deploy role is broader than needed.
+  - Build artifacts leak source content or secrets into host logs/artifacts.
+- **Exit criteria**:
+  - CDK adds queues, DLQs, alarms, and separate runner paths.
+  - Catalog runner verifies release artifacts and runs trusted deploy.
+  - Custom build runner has no tenant AWS role; trusted deploy runner installs only validated artifact inventory.
+  - Buildspec tests assert the tenant role is not assumed before custom source build.
+
+### Phase 5: Provision-worker client deploy state machine
+
+- **Items**: H21, H22, H23, H24.
+- **Dependencies**: Phase 4 runner paths.
+- **Risks**:
+  - Client deploy races with core Lesser/body/MCP managed updates.
+  - Default-client failure leaves provisioned tenant infrastructure without clear recovery.
+- **Exit criteria**:
+  - `ClientDeployJob` supports catalog deploy, reset, and custom GitHub deploy.
+  - New provisions install default Simulacrum before marking ready, with recoverable failure state.
+  - Reset is idempotent, disables custom auto-triggering unless explicitly re-enabled, and never touches tenant data/body/soul/instance keys.
+
+### Phase 6: Portal/operator UX
+
+- **Items**: H25, H26.
+- **Dependencies**: Phase 3 APIs and Phase 5 job responses.
+- **Risks**:
+  - UI loosens CSP through GitHub embeds/scripts.
+  - Operator views expose raw logs, tokens, repo source, or PII.
+- **Exit criteria**:
+  - Portal supports catalog selection, reset, deploy history, GitHub connect/disconnect, and branch display.
+  - Operator support views show safe job/delivery metadata only.
+  - Web build remains strict-CSP compatible with no inline script/style additions.
+
+### Phase 7: Validation, docs, and rollout evidence
+
+- **Items**: H27, H28, H29.
+- **Dependencies**: all behavior implemented.
+- **Risks**:
+  - Fixture-only validation could miss the real published artifact path.
+  - GitHub webhook validation could be untested against live delivery headers.
+- **Exit criteria**:
+  - Fixture-gated harness covers HMAC handling, redaction, no-paste onboarding, catalog checksum mismatch abort, custom GitHub build/deploy in a disposable repo, and reset.
+  - Recovery runbooks cover disable binding, rotate GitHub App credentials, retry failed deploy, reset to Simulacrum, and previous client install rollback.
+  - Gov-infra evidence is fresh and committed with the verifier output.
+
+## Stage rollout plan for host
+
+### Lab
+
+- **Command**: `AWS_PROFILE=<lab-profile> theory app up --stage lab --execute`
+- **Timeout discipline**: no timeout on deploy; let CloudFormation finish or roll back.
+- **Soak duration**: at least one full successful disposable test-slug cycle plus a webhook-triggered redeploy cycle.
+- **Soak criteria**:
+  - `go test ./...`, `cd cdk && npm test && npm run synth`, `cd web && npm run lint && npm run typecheck && npm test && npm run build`, and `bash gov-infra/verifiers/gov-verify-rubric.sh` pass.
+  - Known-good Simulacrum catalog artifact installs to `/l/` for a disposable lab slug.
+  - Known-bad/mismatched Simulacrum artifact aborts before deploy.
+  - GitHub App can connect a disposable repo/branch and a push enqueues exactly one client deploy.
+  - Custom build logs and CodeBuild environment do not expose GitHub tokens, webhook signatures, AWS credentials, or repo source content beyond safe build output.
+  - Reset returns the lab slug to Simulacrum and disables custom auto-deploy.
+  - `/l/`, `/l/_assets/*`, `/l/identity` or equivalent client routes, and `/auth/login` remain healthy.
+
+### Live
+
+- **Command**: `AWS_PROFILE=<live-profile> theory app up --stage live --execute`
+- **Authorization**: explicit Aron/operator approval after lab soak.
+- **Post-deploy monitoring**:
+  - control-plane Lambda error rate and latency;
+  - provision-worker queue depth, DLQ count, and active client deploy age;
+  - CodeBuild failure rate by mode: catalog, custom-build, custom-deploy;
+  - CloudFront 4xx/5xx for portal/API;
+  - GitHub webhook rejected/ignored/queued counts;
+  - secret-redaction verifier/evidence freshness;
+  - canary `/l/` response health for selected slug.
+
+## On-chain rollout plan
+
+No on-chain changes. No contracts, Safe-ready payloads, Sepolia/mainnet deploys, mint-signer handling, or TipSplitter changes are expected.
+
+## Managed-instance rollout plan
+
+1. **Lab disposable slug**: exercise catalog install, custom GitHub deploy, reset, disconnect, and previous-install rollback.
+2. **Live internal canary slug**: enable managed client deploy for one operator-owned managed instance; observe at least one catalog reset and one custom GitHub deploy from a disposable repo.
+3. **New-instance default**: enable Simulacrum default on new live provisions after canary success.
+4. **Existing managed instances**: expose reset/deploy UI as opt-in; do not automatically alter existing `/l/` clients without operator/customer action unless Aron explicitly chooses a migration campaign.
+5. **Broader custom GitHub availability**: enable after webhook delivery ledger and credential-rotation runbook are proven in live canary.
+
+## Release artifact plan
+
+- **Host release**: standard host release/PR with gov-infra evidence and release notes.
+- **Simulacrum release**: requires a managed-client release artifact published by `equaltoai/simulacrum` before default/reset can be live-enabled.
+- **Lesser release**: may require a confirmed or updated Lesser CLI release if `lesser client install --skip-build` needs host-specific automation stability or receipt fields.
+- **Managed consumer impact**: host consumes Simulacrum and Lesser artifacts; host must verify exact published artifacts through the real consumer path before declaring readiness.
+
+## Rollback plan
+
+- **Portal/API feature rollback**: disable managed-client feature flags/config, revert code, redeploy host through normal lab/live flow.
+- **Webhook rollback**: disable GitHub App webhook processing or mark all bindings disabled; keep delivery ledger for audit.
+- **Catalog client rollback**: run client reset to previous catalog release or use Lesser's active install rollback procedure if available.
+- **Custom client rollback**: disable the binding/branch trigger, run reset to Simulacrum or previous install, and rotate GitHub App credentials if exposure is suspected.
+- **CDK rollback**: revert commit and redeploy; retain stateful queues/buckets/tables per stage policy.
+- **On-chain rollback**: n/a.
+
+## AGPL posture
+
+- No proprietary blobs in host.
+- Catalog/client artifacts consumed from published GitHub Releases with source available in the producer repos.
+- New Go/TS dependencies, if any, require AGPL-compatible license vetting.
+- Custom customer client source is tenant-owned input processed by the deployment pipeline; host does not import it into host source or certify it as EqualToAI code.
+
+## Steward briefs
+
+Prepared separately in `docs/steward-briefs-managed-client-deployment-2026-05-24.md`.
+
+## Open questions
+
+1. Host product: should custom GitHub builds be enabled for all paid managed instances at launch, or initially only by operator allowlist? Current recommendation: operator allowlist first, then broaden after live canary.
+2. Host product: should reset preserve GitHub binding disabled-by-default, or fully disconnect by default? Current recommendation: preserve disabled unless explicit disconnect.
+3. Host implementation: should host persist the Lesser state receipt from provisioning as the canonical client-install input, or should a later Lesser SSM/install-target resolver become the preferred source? Current recommendation: persist and pass the non-secret receipt for v1.

--- a/docs/steward-briefs-managed-client-deployment-2026-05-24.md
+++ b/docs/steward-briefs-managed-client-deployment-2026-05-24.md
@@ -1,0 +1,106 @@
+# Steward briefs: Managed client deployment for `/l/`
+
+Date: 2026-05-24
+Author: host steward
+
+## Shared context
+
+`lesser-host` is planning a managed client deployment capability for hosted Lesser instances:
+
+- new managed instances default to a checksum-verified EqualToAI client catalog entry, initially **Simulacrum**;
+- operators can reset `/l/` back to a selected catalog client without AWS credentials;
+- operators can optionally install a **host-owned GitHub App** into one customer repo and bind one exact branch so branch updates deploy a custom Lesser client to `/l/`;
+- custom GitHub source builds must not run with tenant AWS credentials;
+- trusted deployment should use Lesser's existing `lesser client install --skip-build` contract rather than duplicating Lesser's S3/CloudFront/manifest behavior in host.
+
+Non-goals:
+
+- host will not read tenant Lesser data or content;
+- host will not weaken Lesser/body release checksum verification;
+- host will not make on-chain or soul-registry changes;
+- host will not build a general website hosting service;
+- host will not ask customers for AWS credentials;
+- per-instance generated GitHub Apps are out of v1; v1 uses one host-owned GitHub App per stage.
+
+## Brief for Lesser steward
+
+Subject: `Input requested: Lesser /l client install contract for lesser-host managed client deploys`
+
+Lesser steward,
+
+I want your input on a host-side managed client deployment plan for Lesser instances provisioned by `lesser-host`.
+
+Business need:
+
+- Managed instance operators should be able to manage their `/l/` client without AWS credentials.
+- New hosted instances should default to a verified EqualToAI client, starting with Simulacrum.
+- Operators should be able to reset `/l/` to a catalog client and optionally deploy a custom client from a GitHub App-bound repo/branch.
+
+Boundary:
+
+- Host should drive Lesser's existing `/l/` serving/deploy authority; host should not duplicate S3/CloudFront/active-manifest logic.
+- Custom GitHub source builds must not receive tenant AWS credentials. A trusted deploy-only step should install a validated artifact.
+
+Your focus:
+
+1. Confirm the stable noninteractive automation contract for `lesser client install --skip-build` from a CodeBuild runner.
+2. Confirm the required local/receipt state for host to run client install after `lesser up`.
+3. Confirm active install receipt shape and previous-install rollback expectations.
+4. Confirm `/l`, `/l/*`, `/l/_assets/*`, `/auth/*`, and CloudFront invalidation invariants host should treat as stable.
+5. Identify the narrowest tenant-account IAM permissions or role shape for client deploy only.
+6. Call out any Lesser changes needed before host implements default Simulacrum/reset/custom GitHub client deployment.
+
+Requested outputs:
+
+1. scope-need, if Lesser changes are needed;
+2. enumerate-changes for Lesser-local work;
+3. plan-roadmap for any Lesser release needed by host;
+4. create-github-project only if the Lesser-side work warrants tracked project state.
+
+Please keep this Lesser-specific, but call out host/simulacrum dependencies explicitly.
+
+## Brief for Simulacrum steward
+
+Subject: `Input requested: Simulacrum managed-client release artifact for lesser-host default /l client`
+
+Simulacrum steward,
+
+I want your input on making Simulacrum the default managed `/l/` client for new `lesser-host` managed instances.
+
+Business need:
+
+- New hosted Lesser instances should have a verified default client deployed at `/l/`, starting with Simulacrum.
+- Host needs to consume Simulacrum as a release artifact, not as a mutable source checkout, for default and reset operations.
+- Operators should also be able to reset custom-client instances back to Simulacrum without AWS credentials.
+
+Boundary:
+
+- Simulacrum owns the client build and release artifact contract.
+- Host consumes exact published artifacts through checksum verification and runs Lesser's `lesser client install --skip-build` path.
+- Host should not patch Simulacrum source, vendor custom builds into host, or loosen host CSP.
+
+Your focus:
+
+1. Define the managed-client release artifact shape Simulacrum can publish from current outputs: `build/server`, `build/client`, and `facetheory.lesser.json`.
+2. Confirm `/l` base-path compatibility and no hard-coded domain assumptions.
+3. Confirm strict CSP compatibility for host-managed instances.
+4. Identify manifest/checksum fields host should verify before deploy.
+5. Identify any Simulacrum repo changes needed to publish a `simulacrum-client-release.json`, checksums, and artifact bundle.
+6. Call out versioning/channel expectations for host's default catalog (`stable`, exact semver tag, etc.).
+
+Requested outputs:
+
+1. scope-need, if Simulacrum changes are needed;
+2. enumerate-changes for Simulacrum-local work;
+3. plan-roadmap for any Simulacrum release needed by host;
+4. create-github-project only if the Simulacrum-side work warrants tracked project state.
+
+Please keep this Simulacrum-specific, but call out host/Lesser dependencies explicitly.
+
+## Brief for Body steward
+
+No v1 brief planned. The managed client deployment path should not change lesser-body release contracts or body comm APIs. Revisit only if the final client contract touches body-provided tools or comm surfaces.
+
+## Brief for Soul steward
+
+No v1 brief planned. The managed client deployment path should not change soul registry contracts, namespace semantics, minting, or on-chain flows. Revisit only if client catalog entries become soul-attested artifacts.

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,6 +14,7 @@
         "@graphql-typed-document-node/core": "^3.2.0",
         "@noble/hashes": "^2.0.1",
         "@safe-global/safe-apps-sdk": "^9.1.0",
+        "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.3.0/theory-cloud-facetheory-3.3.0.tgz",
         "focus-trap": "^8.0.0",
         "graphql": "^16.13.1",
         "graphql-ws": "^6.0.7",
@@ -586,7 +587,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -597,7 +598,7 @@
       "version": "2.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -608,7 +609,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -618,14 +619,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1217,7 +1218,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
       "integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^8.9.0"
@@ -1241,6 +1242,49 @@
       "peerDependencies": {
         "svelte": "^5.46.4",
         "vite": "^8.0.0-beta.7 || ^8.0.0"
+      }
+    },
+    "node_modules/@theory-cloud/facetheory": {
+      "version": "3.3.0",
+      "resolved": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.3.0/theory-cloud-facetheory-3.3.0.tgz",
+      "integrity": "sha512-IrD7oc0h6SAQFZxmuGNqboIN3j1ByLoAITvXnmYe7S/p5J3LlHb4cowZ543uuT0JZokuCp6wKwjt/23E/q8Q1g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=24"
+      },
+      "peerDependencies": {
+        "@emotion/cache": ">=11",
+        "@emotion/react": ">=11",
+        "@emotion/server": ">=11",
+        "@vue/server-renderer": ">=3",
+        "antd": ">=5",
+        "react": ">=18",
+        "react-dom": ">=18",
+        "svelte": ">=4 <5.46.0 || >=5.55.7",
+        "vue": ">=3"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/cache": {
+          "optional": true
+        },
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/server": {
+          "optional": true
+        },
+        "@vue/server-renderer": {
+          "optional": true
+        },
+        "antd": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tsconfig/svelte": {
@@ -1299,7 +1343,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -1366,7 +1410,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -1525,7 +1569,7 @@
       "version": "8.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.57.0.tgz",
       "integrity": "sha512-dTLI8PEXhjUC7B9Kre+u0XznO696BhXcTlOn0/6kf1fHaQW8+VjJAVHJ3eTI14ZapTxdkOmc80HblPQLaEeJdg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1810,7 +1854,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1877,7 +1921,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.1.tgz",
       "integrity": "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1897,7 +1941,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -2023,7 +2067,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
       "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2193,7 +2237,7 @@
       "version": "5.8.1",
       "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.8.1.tgz",
       "integrity": "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -2440,7 +2484,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
       "integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/espree": {
@@ -2478,7 +2522,7 @@
       "version": "2.2.9",
       "resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.9.tgz",
       "integrity": "sha512-4KijP+NxCWthMCUC3qHbE6n4vCjqgJS1uAYKhuT/GWfFTf1Qyive2TgOjep+gzbSzRfnNyaN/UU9YmdOt8Eg0A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3111,7 +3155,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -3550,7 +3594,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -3593,7 +3637,7 @@
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
@@ -5243,7 +5287,7 @@
       "version": "5.55.7",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
       "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.4",
@@ -6126,7 +6170,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
       "integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/zwitch": {

--- a/web/package.json
+++ b/web/package.json
@@ -41,6 +41,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@noble/hashes": "^2.0.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
+    "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.3.0/theory-cloud-facetheory-3.3.0.tgz",
     "focus-trap": "^8.0.0",
     "graphql": "^16.13.1",
     "graphql-ws": "^6.0.7",

--- a/web/src/client/face-client.ts
+++ b/web/src/client/face-client.ts
@@ -4,38 +4,85 @@
  * Bootstrap module loaded by FaceTheory's strict-no-inline-CSP hydration path.
  * The SSR Lambda emits a `<script type="module" src=".../face-client-*.js">`
  * head tag (via `viteAssetsForEntry`) plus a JSON sidecar at
- * `/_facetheory/data/<route>.json` (via `externalHydrationForEntry`); the
+ * `/_facetheory/data/<routeId>.json` (via `externalHydrationForEntry`); the
  * browser fetches the sidecar, then evaluates this module to hydrate the
  * server-rendered DOM.
  *
- * M0.3 — bootstrap only. We read the hydration payload and stash it on
- * `window.__FACETHEORY_PROBE__` so the probe response is visibly hydrated
- * during the M0 lab soak without claiming any real route. M0.4 ports the
- * existing Portal / Operator / Trust / Login / Setup / Account / Home /
- * NotFound / TipRegistry routes onto Svelte FaceModules and replaces this
- * stash with `mount(...)`-style hydration of the real components. M0.5 adds
- * `startAwsOacFormTransport()` here so any marked `<form
- * data-facetheory-oac-form>` rendered in M0.4+ submits with the right
+ * M0.4 — per-route shell hydration. Reads the `ShellHydrationPayload` (route
+ * discriminator + path) the SSR Lambda wrote to the sidecar, exposes it on
+ * `window.__FACETHEORY_SHELL__` for evidence/observability, then mounts the
+ * existing `src/App.svelte` into `<div id="app">` exactly as `src/main.ts`
+ * does today. App.svelte's in-house router at `src/lib/router.ts` keeps
+ * driving the per-page logic, so every existing page is rendered through
+ * its FaceModule without a per-page rewrite. M0.5 adds
+ * `startAwsOacFormTransport()` here so any future marked
+ * `<form data-facetheory-oac-form>` submits with the right
  * `x-amz-content-sha256` signing.
  *
- * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+ * The M0.3 `/_facetheory/probe` route still emits the legacy
+ * `FaceTheoryProbePayload` shape; we keep reading both payload shapes so the
+ * probe + the real routes coexist during lab soak.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.4
  * ========================================================================== */
+
+import { mount } from 'svelte';
 
 import { readFaceHydrationData } from '@theory-cloud/facetheory';
 
+import App from '../App.svelte';
+import 'src/lib/styles/greater/tokens.css';
+import 'src/lib/styles/greater/primitives.css';
+import '../app.css';
+
+import type { ShellHydrationPayload } from '../routes/index';
+
+/** Legacy M0.3 probe payload shape. */
 export interface FaceTheoryProbePayload {
 	route: string;
 	timestamp: string;
 }
 
-// Read the hydration payload the SSR Lambda wrote to the sidecar. Returns
-// `null` if the document has no FaceTheory hydration marker (e.g. when this
-// bundle is loaded by a not-yet-ported legacy page); the probe just no-ops in
-// that case until M0.4 ports real routes.
-const data = readFaceHydrationData<FaceTheoryProbePayload>();
+type FaceTheoryHydrationPayload = ShellHydrationPayload | FaceTheoryProbePayload;
 
-if (typeof window !== 'undefined' && data) {
-	(window as unknown as { __FACETHEORY_PROBE__?: FaceTheoryProbePayload }).__FACETHEORY_PROBE__ = data;
+declare global {
+	interface Window {
+		__FACETHEORY_SHELL__?: ShellHydrationPayload;
+		__FACETHEORY_PROBE__?: FaceTheoryProbePayload;
+	}
+}
+
+function isShellPayload(payload: FaceTheoryHydrationPayload | null): payload is ShellHydrationPayload {
+	return !!payload && typeof (payload as ShellHydrationPayload).routeId === 'string';
+}
+
+function isProbePayload(payload: FaceTheoryHydrationPayload | null): payload is FaceTheoryProbePayload {
+	return (
+		!!payload &&
+		typeof (payload as FaceTheoryProbePayload).timestamp === 'string' &&
+		typeof (payload as { routeId?: string }).routeId !== 'string'
+	);
+}
+
+const data = readFaceHydrationData<FaceTheoryHydrationPayload>();
+
+if (typeof window !== 'undefined') {
+	if (isShellPayload(data)) {
+		window.__FACETHEORY_SHELL__ = data;
+	} else if (isProbePayload(data)) {
+		window.__FACETHEORY_PROBE__ = data;
+	}
+
+	// Mount the existing host app into the SSR-emitted `<div id="app">`. The
+	// shell HTML contains no Svelte SSR'd content (M0.4 is shell-only); the
+	// client mount drives every page exactly as `src/main.ts` does for the
+	// legacy CSR entrypoint, so existing pages and `src/lib/router.ts` keep
+	// working unchanged. M0.6+ replaces this `mount` with `hydrate` when the
+	// shell primitives ship from greater-components.
+	const target = document.getElementById('app');
+	if (target) {
+		mount(App, { target });
+	}
 }
 
 export {};

--- a/web/src/client/face-client.ts
+++ b/web/src/client/face-client.ts
@@ -1,0 +1,41 @@
+/* ============================================================================
+ * FaceTheory client entry (host web/)
+ *
+ * Bootstrap module loaded by FaceTheory's strict-no-inline-CSP hydration path.
+ * The SSR Lambda emits a `<script type="module" src=".../face-client-*.js">`
+ * head tag (via `viteAssetsForEntry`) plus a JSON sidecar at
+ * `/_facetheory/data/<route>.json` (via `externalHydrationForEntry`); the
+ * browser fetches the sidecar, then evaluates this module to hydrate the
+ * server-rendered DOM.
+ *
+ * M0.3 — bootstrap only. We read the hydration payload and stash it on
+ * `window.__FACETHEORY_PROBE__` so the probe response is visibly hydrated
+ * during the M0 lab soak without claiming any real route. M0.4 ports the
+ * existing Portal / Operator / Trust / Login / Setup / Account / Home /
+ * NotFound / TipRegistry routes onto Svelte FaceModules and replaces this
+ * stash with `mount(...)`-style hydration of the real components. M0.5 adds
+ * `startAwsOacFormTransport()` here so any marked `<form
+ * data-facetheory-oac-form>` rendered in M0.4+ submits with the right
+ * `x-amz-content-sha256` signing.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+ * ========================================================================== */
+
+import { readFaceHydrationData } from '@theory-cloud/facetheory';
+
+export interface FaceTheoryProbePayload {
+	route: string;
+	timestamp: string;
+}
+
+// Read the hydration payload the SSR Lambda wrote to the sidecar. Returns
+// `null` if the document has no FaceTheory hydration marker (e.g. when this
+// bundle is loaded by a not-yet-ported legacy page); the probe just no-ops in
+// that case until M0.4 ports real routes.
+const data = readFaceHydrationData<FaceTheoryProbePayload>();
+
+if (typeof window !== 'undefined' && data) {
+	(window as unknown as { __FACETHEORY_PROBE__?: FaceTheoryProbePayload }).__FACETHEORY_PROBE__ = data;
+}
+
+export {};

--- a/web/src/client/face-client.ts
+++ b/web/src/client/face-client.ts
@@ -3,25 +3,30 @@
  *
  * Bootstrap module loaded by FaceTheory's strict-no-inline-CSP hydration path.
  * The SSR Lambda emits a `<script type="module" src=".../face-client-*.js">`
- * head tag (via `viteAssetsForEntry`) plus a JSON sidecar at
- * `/_facetheory/data/<routeId>.json` (via `externalHydrationForEntry`); the
- * browser fetches the sidecar, then evaluates this module to hydrate the
- * server-rendered DOM.
+ * head tag (via `viteAssetsForEntry`) plus a same-origin JSON hydration
+ * sidecar URL pointer (via `externalHydrationForEntry`); FaceTheory's
+ * `readFaceHydrationDataUrl(doc)` reads that URL from the
+ * `#__FACETHEORY_DATA_URL__` link tag, and this module fetches it before
+ * mounting `App.svelte`. `readFaceHydrationData(doc)` is checked first
+ * for inline payloads (today's shells never emit inline, but the dual
+ * read keeps the client compatible with both modes for SSG / ISR /
+ * future inline-hydration routes).
  *
- * M0.4 — per-route shell hydration. Reads the `ShellHydrationPayload` (route
- * discriminator + path) the SSR Lambda wrote to the sidecar, exposes it on
- * `window.__FACETHEORY_SHELL__` for evidence/observability, then mounts the
- * existing `src/App.svelte` into `<div id="app">` exactly as `src/main.ts`
- * does today. App.svelte's in-house router at `src/lib/router.ts` keeps
- * driving the per-page logic, so every existing page is rendered through
- * its FaceModule without a per-page rewrite.
+ * M0.4 — per-route shell hydration. Reads the `ShellHydrationPayload`
+ * (`{ routeId, route }`) the SSR Lambda wrote to the sidecar via the
+ * `/_facetheory/data/<routeId>.json` pre-router in `face-app.ts`, exposes
+ * it on `window.__FACETHEORY_SHELL__` for evidence/observability, then
+ * mounts the existing `src/App.svelte` into `<div id="app">` exactly as
+ * `src/main.ts` does today. App.svelte's in-house router at
+ * `src/lib/router.ts` keeps driving the per-page logic. The mount runs
+ * synchronously alongside the fetch — App.svelte does not depend on the
+ * hydration payload (shell-only architecture), so a slow sidecar fetch
+ * never blocks user-visible rendering.
  *
  * M0.5 — `startAwsOacFormTransport()` is wired via `ensureAwsOacFormTransport`
  * (see `oac-form.ts`) so any future `<form data-facetheory-oac-form>` rendered
  * by an SSR-route is submitted with the `x-amz-content-sha256` digest that
- * CloudFront Lambda URL OAC signing requires. The current shells emit no such
- * forms; the transport stages the listener for later (SEC-7 verifier covers
- * marker hygiene once it lands later in M0).
+ * CloudFront Lambda URL OAC signing requires.
  *
  * The M0.3 `/_facetheory/probe` route still emits the legacy
  * `FaceTheoryProbePayload` shape; we keep reading both payload shapes so the
@@ -32,7 +37,7 @@
 
 import { mount } from 'svelte';
 
-import { readFaceHydrationData } from '@theory-cloud/facetheory';
+import { readFaceHydrationData, readFaceHydrationDataUrl } from '@theory-cloud/facetheory';
 
 import App from '../App.svelte';
 import 'src/lib/styles/greater/tokens.css';
@@ -45,7 +50,7 @@ import type { ShellHydrationPayload } from '../routes/index';
 /** Legacy M0.3 probe payload shape. */
 export interface FaceTheoryProbePayload {
 	route: string;
-	timestamp: string;
+	timestamp?: string;
 }
 
 type FaceTheoryHydrationPayload = ShellHydrationPayload | FaceTheoryProbePayload;
@@ -57,25 +62,74 @@ declare global {
 	}
 }
 
-function isShellPayload(payload: FaceTheoryHydrationPayload | null): payload is ShellHydrationPayload {
-	return !!payload && typeof (payload as ShellHydrationPayload).routeId === 'string';
+function isShellPayload(payload: unknown): payload is ShellHydrationPayload {
+	return !!payload && typeof (payload as { routeId?: unknown }).routeId === 'string';
 }
 
-function isProbePayload(payload: FaceTheoryHydrationPayload | null): payload is FaceTheoryProbePayload {
+function isProbePayload(payload: unknown): payload is FaceTheoryProbePayload {
 	return (
 		!!payload &&
-		typeof (payload as FaceTheoryProbePayload).timestamp === 'string' &&
-		typeof (payload as { routeId?: string }).routeId !== 'string'
+		typeof (payload as { route?: unknown }).route === 'string' &&
+		typeof (payload as { routeId?: unknown }).routeId !== 'string'
 	);
 }
 
-const data = readFaceHydrationData<FaceTheoryHydrationPayload>();
+function stashHydrationPayload(payload: unknown): void {
+	if (isShellPayload(payload)) {
+		window.__FACETHEORY_SHELL__ = payload;
+	} else if (isProbePayload(payload)) {
+		window.__FACETHEORY_PROBE__ = payload;
+	}
+}
 
-if (typeof window !== 'undefined') {
-	if (isShellPayload(data)) {
-		window.__FACETHEORY_SHELL__ = data;
-	} else if (isProbePayload(data)) {
-		window.__FACETHEORY_PROBE__ = data;
+/** Fetch the external hydration sidecar URL. Strict same-origin + `redirect:
+ *  'error'` so a 307/308 open redirect cannot relocate the request to a
+ *  cross-origin endpoint and exfiltrate any future credentials/cookies that
+ *  the sidecar handler might consume. Returns `null` on any non-2xx or
+ *  parse failure — the mount path runs unconditionally so a missing sidecar
+ *  never blocks the user-visible app. */
+async function fetchSidecarPayload(rawUrl: string): Promise<FaceTheoryHydrationPayload | null> {
+	let url: URL;
+	try {
+		url = new URL(rawUrl, document.location.origin);
+	} catch {
+		return null;
+	}
+	if (url.origin !== document.location.origin) {
+		// Cross-origin sidecars are refused regardless of CORS; the SSR
+		// Lambda only ever emits same-origin URLs, so a cross-origin URL
+		// here would be a marker-tampering attempt.
+		return null;
+	}
+	try {
+		const res = await fetch(url, {
+			credentials: 'same-origin',
+			redirect: 'error',
+			headers: { accept: 'application/json' },
+		});
+		if (!res.ok) {
+			return null;
+		}
+		return (await res.json()) as FaceTheoryHydrationPayload;
+	} catch {
+		return null;
+	}
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+	// 1. Try inline hydration first (FaceInlineHydration; not used by today's
+	//    shells but kept for forward compatibility with future SSG/ISR routes).
+	const inlineData = readFaceHydrationData<FaceTheoryHydrationPayload>();
+	if (inlineData) {
+		stashHydrationPayload(inlineData);
+	} else {
+		// 2. Otherwise look for the external sidecar URL the SSR shell wrote
+		//    into `<link id="__FACETHEORY_DATA_URL__" rel="facetheory-hydration">`
+		//    and fetch it. Fire-and-forget — the mount runs independently.
+		const sidecarUrl = readFaceHydrationDataUrl();
+		if (sidecarUrl) {
+			void fetchSidecarPayload(sidecarUrl).then(stashHydrationPayload);
+		}
 	}
 
 	// Stage the OAC-safe form transport once per document. Idempotent; safe

--- a/web/src/client/face-client.ts
+++ b/web/src/client/face-client.ts
@@ -14,10 +14,14 @@
  * existing `src/App.svelte` into `<div id="app">` exactly as `src/main.ts`
  * does today. App.svelte's in-house router at `src/lib/router.ts` keeps
  * driving the per-page logic, so every existing page is rendered through
- * its FaceModule without a per-page rewrite. M0.5 adds
- * `startAwsOacFormTransport()` here so any future marked
- * `<form data-facetheory-oac-form>` submits with the right
- * `x-amz-content-sha256` signing.
+ * its FaceModule without a per-page rewrite.
+ *
+ * M0.5 — `startAwsOacFormTransport()` is wired via `ensureAwsOacFormTransport`
+ * (see `oac-form.ts`) so any future `<form data-facetheory-oac-form>` rendered
+ * by an SSR-route is submitted with the `x-amz-content-sha256` digest that
+ * CloudFront Lambda URL OAC signing requires. The current shells emit no such
+ * forms; the transport stages the listener for later (SEC-7 verifier covers
+ * marker hygiene once it lands later in M0).
  *
  * The M0.3 `/_facetheory/probe` route still emits the legacy
  * `FaceTheoryProbePayload` shape; we keep reading both payload shapes so the
@@ -35,6 +39,7 @@ import 'src/lib/styles/greater/tokens.css';
 import 'src/lib/styles/greater/primitives.css';
 import '../app.css';
 
+import { ensureAwsOacFormTransport } from './oac-form';
 import type { ShellHydrationPayload } from '../routes/index';
 
 /** Legacy M0.3 probe payload shape. */
@@ -72,6 +77,11 @@ if (typeof window !== 'undefined') {
 	} else if (isProbePayload(data)) {
 		window.__FACETHEORY_PROBE__ = data;
 	}
+
+	// Stage the OAC-safe form transport once per document. Idempotent; safe
+	// to call before any marked `<form data-facetheory-oac-form>` exists in
+	// the DOM — the transport listens for `submit` events lazily.
+	ensureAwsOacFormTransport();
 
 	// Mount the existing host app into the SSR-emitted `<div id="app">`. The
 	// shell HTML contains no Svelte SSR'd content (M0.4 is shell-only); the

--- a/web/src/client/oac-form.ts
+++ b/web/src/client/oac-form.ts
@@ -1,0 +1,67 @@
+/* ============================================================================
+ * OAC-safe form transport bootstrap (host web/)
+ *
+ * Idempotent client-side bootstrap that wires
+ * `startAwsOacFormTransport()` from `@theory-cloud/facetheory` once per
+ * document. The transport listens for `submit` events on any
+ * `<form data-facetheory-oac-form>` and rewrites the request so:
+ *   - The URL-encoded body is hashed (SHA-256) and the digest is set as
+ *     `x-amz-content-sha256` — the header CloudFront Lambda URL OAC signing
+ *     requires for body-bearing requests.
+ *   - The mutating fetch runs with `redirect: 'error'` so a 307/308 open
+ *     redirect cannot replay the signed body to another origin.
+ *
+ * M0.5 stages the transport ahead of any consumer:
+ *   - The current FaceModule shells emit no `<form data-facetheory-oac-form>`
+ *     (verified by `grep -r data-facetheory-oac-form web/dist`), so the
+ *     transport hooks the document's `submit` listener but never intercepts
+ *     a real form during M0 lab soak. M0.6+ shell primitives may introduce
+ *     the first marked form.
+ *   - Bootstrap is idempotent: a module-scoped flag prevents double-start if
+ *     `face-client.ts` is somehow loaded twice (e.g. dev HMR replays).
+ *
+ * Posture invariants:
+ *   - `allowedOrigin` defaults to `document.location.origin`, so off-origin
+ *     POSTs are rejected by the transport before any signing happens —
+ *     consistent with host's multi-tenant per-slug origin isolation.
+ *   - `strictCsp: true` matches host's `style-src 'self'; script-src 'self'`
+ *     posture; FaceTheory rejects SPA navigation if response HTML would
+ *     require inline styles/scripts.
+ *   - `markerAttribute` stays at the default `data-facetheory-oac-form`;
+ *     SEC-7 verifier (lands later in M0) asserts the marker is exclusively
+ *     applied to forms whose action is OAC-signed.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.5
+ * ========================================================================== */
+
+import {
+	startAwsOacFormTransport,
+	type AwsOacFormTransportController,
+} from '@theory-cloud/facetheory';
+
+let controller: AwsOacFormTransportController | null = null;
+
+/**
+ * Start the OAC-safe form transport for the current document. Safe to call
+ * multiple times — subsequent calls return the existing controller without
+ * re-registering listeners. Returns `null` outside browser environments
+ * (e.g. during SSR rendering of `face-client.ts` if it ever gets pulled
+ * into a server build, which today it does not).
+ */
+export function ensureAwsOacFormTransport(): AwsOacFormTransportController | null {
+	if (controller) {
+		return controller;
+	}
+	if (typeof window === 'undefined' || typeof document === 'undefined') {
+		return null;
+	}
+	controller = startAwsOacFormTransport({
+		// allowedOrigin defaults to document.location.origin; explicit here for
+		// audit clarity and to make multi-origin misconfigurations obvious.
+		allowedOrigin: document.location.origin,
+		// Host's strict no-inline CSP posture; transport rejects SPA-style
+		// navigation HTML that would require inline scripts/styles.
+		strictCsp: true,
+	});
+	return controller;
+}

--- a/web/src/lib/tokens/ds.css
+++ b/web/src/lib/tokens/ds.css
@@ -1,0 +1,364 @@
+/* ============================================================================
+ * Lesser Design System — Foundations (host)
+ *
+ * Tokens for color, type, spacing, radii, shadows, motion. Mirrors the design
+ * handoff at docs/design/web-ui-rework-2026-05-24/project/assets/tokens.css.
+ *
+ * The system has one canonical theme:
+ *
+ *   AGENT GENESIS  (every product surface)
+ *     Warm parchment background, amber primary, violet secondary,
+ *     glassmorphic panels, Manrope + Noto Serif. Applies at :root.
+ *
+ * The deep #9333ea Lesser purple survives in one role only — the literal
+ * `<` brand-mark glyph (favicon, app icon, auth screen logo). See
+ * --ds-lesser-* below.
+ *
+ * For migration / legacy reference, the original dark-themed auth surface
+ * is preserved as `.theme-lesser` at the bottom of this file. Do not use
+ * it for new work.
+ *
+ * The `--gr-*` bridge to greater-components tokens lives in the sibling
+ * file `gr-bridge.css`. Both files are surfaced through `index.ts`.
+ *
+ * Webfonts: Manrope, Noto Serif, Inter, JetBrains Mono are referenced by
+ * --ds-font-* family stacks. Loading is intentionally deferred to a later
+ * milestone — Google Fonts @import would violate host's strict single-origin
+ * CSP (`style-src 'self'`), so fonts must be self-hosted before consumer
+ * adoption. System fallbacks in each stack keep the scaffold usable until
+ * then. See Project 39 enumerated changes for the self-hosting follow-up.
+ * ========================================================================== */
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * AGENT GENESIS THEME  (default; applies at :root)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+
+  /* ─── Primary scale — warm amber/gold ─────────────────────────────────── */
+  --ds-primary-50:  #fff8ef;
+  --ds-primary-100: #ffe8bf;
+  --ds-primary-200: #ffd596;
+  --ds-primary-300: #f4bf6b;
+  --ds-primary-400: #e6a645;
+  --ds-primary-500: #cd8331;   /* base */
+  --ds-primary-600: #b56b24;
+  --ds-primary-700: #8f5018;
+  --ds-primary-800: #6b3810;
+  --ds-primary-900: #49220a;
+
+  /* ─── Secondary scale — soft violet ───────────────────────────────────── */
+  --ds-secondary-50:  #faf6ff;
+  --ds-secondary-100: #ece2ff;
+  --ds-secondary-200: #dac7ff;
+  --ds-secondary-300: #c3a7ff;
+  --ds-secondary-400: #aa84f2;
+  --ds-secondary-500: #8d64d1;   /* base */
+  --ds-secondary-600: #714ab0;
+  --ds-secondary-700: #57358b;
+  --ds-secondary-800: #402667;
+  --ds-secondary-900: #2b1847;
+
+  /* ─── Lesser purple (for auth surfaces; do not use in Agent contexts) ─── */
+  --ds-lesser-50:  #faf5ff;
+  --ds-lesser-100: #f3e8ff;
+  --ds-lesser-200: #e9d5ff;
+  --ds-lesser-300: #d8b4fe;
+  --ds-lesser-400: #c084fc;
+  --ds-lesser-500: #a855f7;
+  --ds-lesser-600: #9333ea;   /* the badge / wordmark mark color */
+  --ds-lesser-700: #7e22ce;
+  --ds-lesser-800: #6b21a8;
+  --ds-lesser-900: #581c87;
+
+  /* ─── Semantic status colors ──────────────────────────────────────────── */
+  --ds-success-50:  #f0fdf4;
+  --ds-success-100: #dcfce7;
+  --ds-success-300: #86efac;
+  --ds-success-500: #22c55e;
+  --ds-success-700: #15803d;
+  --ds-success-800: #166534;
+
+  --ds-warning-50:  #fffbeb;
+  --ds-warning-100: #fef3c7;
+  --ds-warning-300: #fcd34d;
+  --ds-warning-500: #f59e0b;
+  --ds-warning-700: #b45309;
+  --ds-warning-800: #92400e;
+
+  --ds-error-50:  #fef2f2;
+  --ds-error-100: #fee2e2;
+  --ds-error-300: #fca5a5;
+  --ds-error-500: #ef4444;
+  --ds-error-700: #b91c1c;
+  --ds-error-800: #991b1b;
+
+  --ds-info-500: #3b82f6;
+  --ds-info-700: #1d4ed8;
+
+  /* ─── Foreground (warm dark brown, not black) ─────────────────────────── */
+  --ds-fg-1:        #332116;                 /* primary text */
+  --ds-fg-2:        rgba(51, 33, 22, 0.78);  /* secondary text */
+  --ds-fg-3:        rgba(51, 33, 22, 0.58);  /* tertiary / eyebrow */
+  --ds-fg-disabled: rgba(51, 33, 22, 0.32);
+  --ds-fg-inverse:  #fffaf2;
+
+  /* ─── Background (cream / parchment, translucent panels) ──────────────── */
+  --ds-bg-base:      #f8f1e7;                /* page background */
+  --ds-bg-primary:   rgba(255, 252, 247, 0.92);
+  --ds-bg-secondary: rgba(247, 239, 231, 0.92);
+  --ds-bg-tertiary:  rgba(238, 229, 220, 0.88);
+  --ds-bg-surface:   rgba(255, 251, 245, 0.92);  /* card */
+  --ds-bg-raised:    rgba(255, 255, 255, 0.72);  /* nested chip / metric */
+  --ds-bg-glass:     rgba(255, 251, 245, 0.82);  /* the glassmorphic panel */
+  --ds-bg-overlay:   rgba(45, 25, 10, 0.45);
+
+  /* Ambient page background — the signature radial-glow gradient.
+   * Apply to body: `background: var(--ds-page-gradient);` */
+  --ds-page-gradient:
+    radial-gradient(circle at top right, rgba(141, 100, 209, 0.16), transparent 32rem),
+    radial-gradient(circle at top left,  rgba(230, 166, 69, 0.16),  transparent 28rem),
+    linear-gradient(180deg, #fdf7ef 0%, #f4eadf 100%);
+
+  /* ─── Borders (warm brown, low-opacity) ───────────────────────────────── */
+  --ds-border-subtle:  rgba(107, 56, 16, 0.10);
+  --ds-border-default: rgba(107, 56, 16, 0.16);
+  --ds-border-strong:  rgba(107, 56, 16, 0.28);
+  --ds-border-focus:   var(--ds-secondary-500);
+
+  /* ─── Action / interactive colors ─────────────────────────────────────── */
+  --ds-action-primary:        var(--ds-secondary-500);
+  --ds-action-primary-hover:  var(--ds-secondary-600);
+  --ds-action-primary-active: var(--ds-secondary-700);
+  --ds-action-link:           var(--ds-secondary-700);
+
+  /* The signature gradient button: violet → amber */
+  --ds-action-gradient: linear-gradient(135deg, var(--ds-secondary-500), var(--ds-primary-400));
+
+  /* ─── Typography ──────────────────────────────────────────────────────── *
+   * Self-host fonts before any consumer route adopts these tokens (see file
+   * header). Stacks fall through to system fonts until the self-hosted
+   * sources land.
+   * ────────────────────────────────────────────────────────────────────── */
+  --ds-font-sans:    'Manrope', 'Avenir Next', 'Segoe UI', system-ui, sans-serif;
+  --ds-font-serif:   'Noto Serif', 'Iowan Old Style', 'Palatino Linotype', Georgia, serif;
+  --ds-font-heading: var(--ds-font-serif);    /* headings are serif */
+  --ds-font-mono:    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+
+  /* Type scale (rem; 1rem = 16px) */
+  --ds-text-xs:   0.75rem;     /* 12 */
+  --ds-text-sm:   0.875rem;    /* 14 */
+  --ds-text-base: 1rem;        /* 16 */
+  --ds-text-lg:   1.125rem;    /* 18 */
+  --ds-text-xl:   1.25rem;     /* 20 */
+  --ds-text-2xl:  1.5rem;      /* 24 */
+  --ds-text-3xl:  1.875rem;    /* 30 */
+  --ds-text-4xl:  2.25rem;     /* 36 */
+  --ds-text-5xl:  3rem;        /* 48 */
+  --ds-text-hero: clamp(2.3rem, 4vw, 4rem);   /* responsive page-hero */
+
+  --ds-weight-normal:    400;
+  --ds-weight-medium:    500;
+  --ds-weight-semibold:  600;
+  --ds-weight-bold:      700;
+
+  --ds-leading-tight:    1.1;
+  --ds-leading-snug:     1.3;
+  --ds-leading-normal:   1.5;
+  --ds-leading-relaxed:  1.65;
+
+  /* The eyebrow treatment — used everywhere above panel titles */
+  --ds-eyebrow-size:    0.78rem;
+  --ds-eyebrow-weight:  700;
+  --ds-eyebrow-track:   0.12em;
+
+  /* ─── Spacing scale (8pt grid; matches greater-components scale) ──────── */
+  --ds-space-0:  0;
+  --ds-space-1:  0.25rem;
+  --ds-space-2:  0.5rem;
+  --ds-space-3:  0.75rem;
+  --ds-space-4:  1rem;
+  --ds-space-5:  1.25rem;
+  --ds-space-6:  1.5rem;
+  --ds-space-8:  2rem;
+  --ds-space-10: 2.5rem;
+  --ds-space-12: 3rem;
+  --ds-space-16: 4rem;
+  --ds-space-20: 5rem;
+
+  /* ─── Radii (generous; this is a rounded system) ──────────────────────── */
+  --ds-radius-none:  0;
+  --ds-radius-sm:    0.375rem;     /* fields when compact */
+  --ds-radius-md:    0.75rem;      /* nested chips, sub-cards */
+  --ds-radius-lg:    1rem;         /* fields, items, sub-panels */
+  --ds-radius-xl:    1.25rem;      /* panels */
+  --ds-radius-2xl:   1.5rem;       /* feature panels */
+  --ds-radius-3xl:   1.75rem;      /* hero panels */
+  --ds-radius-pill:  999px;        /* all buttons, badges, chips */
+
+  /* ─── Shadows (warm-tinted, soft) ─────────────────────────────────────── */
+  --ds-shadow-xs:   0 1px 2px 0 rgba(73, 34, 10, 0.04);
+  --ds-shadow-sm:   0 4px 10px rgba(73, 34, 10, 0.05);
+  --ds-shadow-md:   0 10px 24px rgba(73, 34, 10, 0.08);
+  --ds-shadow-lg:   0 18px 40px rgba(73, 34, 10, 0.10);   /* panels */
+  --ds-shadow-xl:   0 24px 50px rgba(73, 34, 10, 0.14);
+  --ds-shadow-button-primary: 0 18px 40px rgba(148, 74, 0, 0.18);
+  --ds-shadow-button-hover:   0 10px 24px rgba(73, 34, 10, 0.10);
+
+  /* ─── Motion ──────────────────────────────────────────────────────────── */
+  --ds-duration-fast:  140ms;
+  --ds-duration-base:  250ms;
+  --ds-duration-slow:  400ms;
+  --ds-ease-standard:  cubic-bezier(0.4, 0, 0.2, 1);
+  --ds-ease-out:       cubic-bezier(0, 0, 0.2, 1);
+  --ds-ease-in:        cubic-bezier(0.4, 0, 1, 1);
+
+  /* ─── Blur (for glass surfaces) ───────────────────────────────────────── */
+  --ds-blur-glass: 20px;
+  --ds-blur-nav:   24px;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * LEGACY: `.theme-lesser`  — the original dark navy + saturated purple
+ * palette the Lesser auth UI shipped with. Kept here for migration
+ * reference; the live auth UI has been moved to Agent Genesis.
+ * Do not use for new work. The `--gr-*` overrides for this theme live in
+ * `gr-bridge.css`.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+.theme-lesser {
+  --ds-font-sans:    'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --ds-font-heading: var(--ds-font-sans);
+  --ds-font-mono:    'JetBrains Mono', 'Fira Code', monospace;
+
+  /* Saturated purple replaces secondary in this theme */
+  --ds-action-primary:        var(--ds-lesser-600);
+  --ds-action-primary-hover:  var(--ds-lesser-700);
+  --ds-action-primary-active: var(--ds-lesser-800);
+  --ds-action-link:           var(--ds-lesser-500);
+
+  /* Dark foreground/background */
+  --ds-bg-base:      #0f0f23;
+  --ds-bg-primary:   #0f0f23;
+  --ds-bg-secondary: #1a1a2e;
+  --ds-bg-surface:   #16213e;   /* the auth card */
+  --ds-bg-raised:    #1d2748;
+  --ds-bg-glass:     rgba(22, 33, 62, 0.88);
+  --ds-bg-overlay:   rgba(0, 0, 0, 0.75);
+
+  --ds-fg-1:         #f7fafc;
+  --ds-fg-2:         #a0aec0;
+  --ds-fg-3:         #718096;
+  --ds-fg-disabled:  #4a5568;
+  --ds-fg-inverse:   #1a1a2e;
+
+  --ds-border-subtle:  rgba(255, 255, 255, 0.06);
+  --ds-border-default: #2d3748;
+  --ds-border-strong:  #4a5568;
+
+  /* Dark-mode shadows are darker; the auth card uses a deep drop. */
+  --ds-shadow-lg: 0 20px 60px rgba(0, 0, 0, 0.30);
+
+  /* Linear gradient backdrop for the auth landing */
+  --ds-page-gradient: linear-gradient(135deg, #0f0f23 0%, #1a1a2e 100%);
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * SEMANTIC TYPE PRIMITIVES — drop-in tags
+ * Reset margins (consumers wrap with their own spacing) and set the system
+ * scale. Apply to a root element with `.ds-prose` or use as `.ds-h1` etc.
+ * Style-bearing classes only; no `:global()` to keep these usable as plain
+ * CSS (closes the 2026-05-16 LightningCSS feedback locally).
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+.ds-prose,
+.ds-prose * {
+  margin: 0;
+}
+
+/* Headings — serif in Agent Genesis, sans in Lesser */
+.ds-h1 {
+  font-family: var(--ds-font-heading);
+  font-size: var(--ds-text-hero);
+  line-height: 0.98;
+  font-weight: var(--ds-weight-bold);
+  color: var(--ds-fg-1);
+  letter-spacing: -0.01em;
+}
+
+.ds-h2 {
+  font-family: var(--ds-font-heading);
+  font-size: var(--ds-text-2xl);
+  line-height: var(--ds-leading-snug);
+  font-weight: var(--ds-weight-bold);
+  color: var(--ds-fg-1);
+}
+
+.ds-h3 {
+  font-family: var(--ds-font-heading);
+  font-size: var(--ds-text-xl);
+  line-height: var(--ds-leading-snug);
+  font-weight: var(--ds-weight-bold);
+  color: var(--ds-fg-1);
+}
+
+.ds-h4 {
+  font-family: var(--ds-font-sans);
+  font-size: var(--ds-text-base);
+  font-weight: var(--ds-weight-semibold);
+  color: var(--ds-fg-1);
+}
+
+/* Eyebrow — uppercase, tracked, tertiary; sits above every panel title */
+.ds-eyebrow {
+  font-family: var(--ds-font-sans);
+  font-size: var(--ds-eyebrow-size);
+  font-weight: var(--ds-eyebrow-weight);
+  letter-spacing: var(--ds-eyebrow-track);
+  text-transform: uppercase;
+  color: var(--ds-fg-3);
+}
+
+/* Body */
+.ds-p {
+  font-family: var(--ds-font-sans);
+  font-size: var(--ds-text-base);
+  line-height: var(--ds-leading-relaxed);
+  color: var(--ds-fg-2);
+}
+
+.ds-lead {
+  font-size: var(--ds-text-lg);
+  line-height: var(--ds-leading-relaxed);
+  color: var(--ds-fg-2);
+}
+
+.ds-small {
+  font-size: var(--ds-text-sm);
+  color: var(--ds-fg-2);
+}
+
+/* Code / mono */
+.ds-code {
+  font-family: var(--ds-font-mono);
+  font-size: 0.92em;
+  padding: 0.12em 0.4em;
+  border-radius: var(--ds-radius-sm);
+  background: var(--ds-bg-raised);
+  color: var(--ds-fg-1);
+  border: 1px solid var(--ds-border-subtle);
+}
+
+/* Links */
+.ds-link {
+  color: var(--ds-action-link);
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+  transition: border-color var(--ds-duration-fast) var(--ds-ease-standard);
+}
+.ds-link:hover {
+  border-bottom-color: currentColor;
+}

--- a/web/src/lib/tokens/gr-bridge.css
+++ b/web/src/lib/tokens/gr-bridge.css
@@ -1,0 +1,96 @@
+/* ============================================================================
+ * Lesser DS → greater-components token bridge
+ *
+ * The host design system writes `--ds-*` tokens. greater-components reads
+ * `--gr-*` tokens. This file is the single bridge layer that maps DS to GR
+ * so components from greater-components inherit the Agent Genesis identity
+ * automatically.
+ *
+ * Keep this file in lockstep with `ds.css` — every consumer GR token must
+ * either resolve to a DS token here or fall through to the GR default in
+ * `src/lib/greater/tokens/`. Do not duplicate DS tokens in this file;
+ * import `ds.css` first (handled by `index.ts`).
+ *
+ * The legacy `.theme-lesser` overrides at the bottom of this file
+ * override only the `--gr-*` mapping (the `--ds-*` overrides live in
+ * `ds.css`). No `:global()`; plain CSS only.
+ * ========================================================================== */
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Default bridge — DS → GR (Agent Genesis)
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  /* Color: primary scale */
+  --gr-color-primary-50:  var(--ds-primary-50);
+  --gr-color-primary-100: var(--ds-primary-100);
+  --gr-color-primary-200: var(--ds-primary-200);
+  --gr-color-primary-300: var(--ds-primary-300);
+  --gr-color-primary-400: var(--ds-primary-400);
+  --gr-color-primary-500: var(--ds-primary-500);
+  --gr-color-primary-600: var(--ds-primary-600);
+  --gr-color-primary-700: var(--ds-primary-700);
+  --gr-color-primary-800: var(--ds-primary-800);
+  --gr-color-primary-900: var(--ds-primary-900);
+
+  /* Color: secondary scale */
+  --gr-color-secondary-50:  var(--ds-secondary-50);
+  --gr-color-secondary-100: var(--ds-secondary-100);
+  --gr-color-secondary-200: var(--ds-secondary-200);
+  --gr-color-secondary-300: var(--ds-secondary-300);
+  --gr-color-secondary-400: var(--ds-secondary-400);
+  --gr-color-secondary-500: var(--ds-secondary-500);
+  --gr-color-secondary-600: var(--ds-secondary-600);
+  --gr-color-secondary-700: var(--ds-secondary-700);
+  --gr-color-secondary-800: var(--ds-secondary-800);
+  --gr-color-secondary-900: var(--ds-secondary-900);
+
+  /* Typography: family stacks */
+  --gr-typography-fontFamily-sans:    var(--ds-font-sans);
+  --gr-typography-fontFamily-heading: var(--ds-font-heading);
+  --gr-typography-fontFamily-serif:   var(--ds-font-serif);
+  --gr-typography-fontFamily-mono:    var(--ds-font-mono);
+
+  /* Semantic: background */
+  --gr-semantic-background-base:      var(--ds-bg-base);
+  --gr-semantic-background-primary:   var(--ds-bg-primary);
+  --gr-semantic-background-secondary: var(--ds-bg-secondary);
+  --gr-semantic-background-tertiary:  var(--ds-bg-tertiary);
+  --gr-semantic-background-surface:   var(--ds-bg-surface);
+
+  /* Semantic: border */
+  --gr-semantic-border-subtle:  var(--ds-border-subtle);
+  --gr-semantic-border-default: var(--ds-border-default);
+
+  /* Semantic: foreground */
+  --gr-semantic-foreground-primary:   var(--ds-fg-1);
+  --gr-semantic-foreground-secondary: var(--ds-fg-2);
+  --gr-semantic-foreground-tertiary:  var(--ds-fg-3);
+
+  /* Semantic: action / interactive */
+  --gr-semantic-action-primary-default: var(--ds-action-primary);
+  --gr-semantic-action-primary-hover:   var(--ds-action-primary-hover);
+  --gr-semantic-action-primary-active:  var(--ds-action-primary-active);
+  --gr-semantic-focus-ring:             var(--ds-border-focus);
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════════════
+ * Legacy `.theme-lesser` override — primary scale switches to Lesser purple
+ * The DS-side legacy overrides (foreground/background/etc.) live in
+ * `ds.css`; only the GR primary-scale remap belongs here.
+ * ═══════════════════════════════════════════════════════════════════════════ */
+
+.theme-lesser {
+  --gr-color-primary-50:  var(--ds-lesser-50);
+  --gr-color-primary-100: var(--ds-lesser-100);
+  --gr-color-primary-200: var(--ds-lesser-200);
+  --gr-color-primary-300: var(--ds-lesser-300);
+  --gr-color-primary-400: var(--ds-lesser-400);
+  --gr-color-primary-500: var(--ds-lesser-500);
+  --gr-color-primary-600: var(--ds-lesser-600);
+  --gr-color-primary-700: var(--ds-lesser-700);
+  --gr-color-primary-800: var(--ds-lesser-800);
+  --gr-color-primary-900: var(--ds-lesser-900);
+}

--- a/web/src/lib/tokens/index.ts
+++ b/web/src/lib/tokens/index.ts
@@ -1,0 +1,25 @@
+/* ============================================================================
+ * Lesser Design System — entry
+ *
+ * Single import surface for host's design tokens:
+ *
+ *   import 'src/lib/tokens';
+ *
+ * Loads:
+ *   - ds.css         — `--ds-*` tokens, `.theme-lesser` legacy DS overrides,
+ *                      and `.ds-*` semantic primitive classes
+ *   - gr-bridge.css  — `--gr-*` bridge mapping DS tokens to the upstream
+ *                      greater-components token scale (and the
+ *                      `.theme-lesser` GR primary-scale override)
+ *
+ * Order matters: `ds.css` defines the `--ds-*` source-of-truth, then
+ * `gr-bridge.css` reads those via `var(--ds-*)` to populate `--gr-*`. No
+ * consumers are wired yet (M0.2 is scaffold-only); components adopt
+ * incrementally as M0 progresses.
+ *
+ * Source: docs/design/web-ui-rework-2026-05-24/project/assets/tokens.css
+ * Project 39: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.2
+ * ========================================================================== */
+
+import './ds.css';
+import './gr-bridge.css';

--- a/web/src/routes/_shell.ts
+++ b/web/src/routes/_shell.ts
@@ -1,0 +1,118 @@
+/* ============================================================================
+ * Shell FaceModule factory (host web/)
+ *
+ * Every existing host page is represented by a FaceModule that emits a thin
+ * SSR shell (just a `<main data-facetheory-view>` mount-point) plus the
+ * hashed `face-client.ts` `<link rel="modulepreload">` head tags and the
+ * external hydration JSON sidecar at `/_facetheory/data/<routeId>.json`.
+ * The actual page rendering still happens client-side: `face-client.ts`
+ * dynamically mounts the existing `src/App.svelte` (whose in-house router at
+ * `src/lib/router.ts` keeps driving the per-page logic). This split keeps
+ * the SSR Lambda free of browser-only code (no `window`, `document`,
+ * `sessionStorage`) while still satisfying the M0.4 acceptance "every
+ * existing page renders via a FaceModule".
+ *
+ * Strict no-inline CSP is preserved:
+ *   - `csp: { inlineScripts: false, inlineStyles: false, rawHead: false }`
+ *     tells FaceTheory to validate the rendered HTML is strict-no-inline.
+ *   - No `content-security-policy` header is attached; CloudFront's
+ *     response-headers policy continues to attach host's canonical webCsp
+ *     byte-string as the only CSP source of truth.
+ *   - Head tags come from `viteAssetsForEntry` (external <script>/<link>
+ *     tags pointing to hashed assets), never inline.
+ *   - Hydration data lives in an external JSON sidecar via
+ *     `externalHydrationForEntry` — never inlined.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.4
+ * ========================================================================== */
+
+import {
+	externalHydrationForEntry,
+	viteAssetsForEntry,
+	type FaceCspPolicy,
+	type FaceModule,
+	type ViteManifest,
+} from '@theory-cloud/facetheory';
+
+/** Discriminator written into the hydration sidecar so the client knows which
+ *  route family was matched on the server. The client mounts `App.svelte`
+ *  unconditionally (its own router picks the page); the discriminator exists
+ *  for future per-route shell adoption (M0.6+) and for evidence/audit. */
+export interface ShellHydrationPayload {
+	readonly routeId: string;
+	readonly route: string;
+	readonly path: string;
+}
+
+export interface ShellFaceOptions {
+	/** FaceTheory route pattern; supports static segments, `{name}` params,
+	 *  and trailing `{name*}` / `{name+}` proxy patterns per `Router`.add(). */
+	readonly route: string;
+	/** Stable discriminator name written into the hydration sidecar. */
+	readonly routeId: string;
+}
+
+export interface ShellFaceFactoryDeps {
+	readonly manifest: ViteManifest;
+	readonly clientEntry: string;
+	readonly hydrationDataUrlBase: string;
+	readonly title?: string;
+}
+
+const STRICT_CSP_POLICY: FaceCspPolicy = Object.freeze({
+	inlineScripts: false,
+	inlineStyles: false,
+	rawHead: false,
+});
+
+/**
+ * Returns a `FaceModule` that:
+ *   1. Loads a tiny route-metadata payload on the server.
+ *   2. Renders a strict-no-inline-CSP HTML shell with manifest-resolved
+ *      asset head tags + external hydration sidecar.
+ *
+ * The factory takes the manifest + client entry as construction-time deps
+ * so the shell renders are pure functions of the request path (the manifest
+ * is loaded once at module init in `face-app.ts`).
+ */
+export function createShellFace(
+	options: ShellFaceOptions,
+	deps: ShellFaceFactoryDeps,
+): FaceModule {
+	const { route, routeId } = options;
+	const { manifest, clientEntry, hydrationDataUrlBase, title } = deps;
+	const hydrationDataUrl = `${hydrationDataUrlBase}${routeId}.json`;
+	const hasManifestEntry = Object.hasOwn(manifest, clientEntry);
+
+	return {
+		route,
+		mode: 'ssr',
+		load: async (ctx): Promise<ShellHydrationPayload> => ({
+			routeId,
+			route,
+			path: ctx.request.path,
+		}),
+		render: async (_ctx, data) => {
+			const assets = hasManifestEntry
+				? viteAssetsForEntry(manifest, clientEntry, { includeAssets: true })
+				: { bootstrapModule: '', headTags: [] };
+			const hydration = hasManifestEntry
+				? externalHydrationForEntry(manifest, clientEntry, data, { dataUrl: hydrationDataUrl })
+				: undefined;
+
+			const titleTag = title
+				? [{ type: 'title' as const, text: title }]
+				: [];
+
+			return {
+				csp: STRICT_CSP_POLICY,
+				headTags: [...titleTag, ...assets.headTags],
+				hydration,
+				// The mount point matches the legacy `index.html` `<div id="app">`
+				// so `App.svelte`'s `mount({ target: document.getElementById('app') })`
+				// keeps working with no client-side change.
+				html: '<div id="app" data-facetheory-view></div>',
+			};
+		},
+	};
+}

--- a/web/src/routes/_shell.ts
+++ b/web/src/routes/_shell.ts
@@ -37,11 +37,14 @@ import {
 /** Discriminator written into the hydration sidecar so the client knows which
  *  route family was matched on the server. The client mounts `App.svelte`
  *  unconditionally (its own router picks the page); the discriminator exists
- *  for future per-route shell adoption (M0.6+) and for evidence/audit. */
+ *  for future per-route shell adoption (M0.6+) and for evidence/audit. The
+ *  payload is intentionally per-routeId-static (not per-request) so the
+ *  matching sidecar URL `/_facetheory/data/<routeId>.json` can be served
+ *  deterministically by the host-side pre-router in `face-app.ts` — see the
+ *  sidecar-serving block there for the source of truth. */
 export interface ShellHydrationPayload {
 	readonly routeId: string;
 	readonly route: string;
-	readonly path: string;
 }
 
 export interface ShellFaceOptions {
@@ -87,10 +90,9 @@ export function createShellFace(
 	return {
 		route,
 		mode: 'ssr',
-		load: async (ctx): Promise<ShellHydrationPayload> => ({
+		load: async (): Promise<ShellHydrationPayload> => ({
 			routeId,
 			route,
-			path: ctx.request.path,
 		}),
 		render: async (_ctx, data) => {
 			const assets = hasManifestEntry

--- a/web/src/routes/account.ts
+++ b/web/src/routes/account.ts
@@ -1,0 +1,7 @@
+/* Account — `/account` (customer account settings). */
+import type { ShellFaceOptions } from './_shell';
+
+export const accountRoute: ShellFaceOptions = {
+	route: '/account',
+	routeId: 'account',
+};

--- a/web/src/routes/home.ts
+++ b/web/src/routes/home.ts
@@ -1,0 +1,7 @@
+/* Home — `/` (PortalLayout-wrapped). */
+import type { ShellFaceOptions } from './_shell';
+
+export const homeRoute: ShellFaceOptions = {
+	route: '/',
+	routeId: 'home',
+};

--- a/web/src/routes/index.ts
+++ b/web/src/routes/index.ts
@@ -1,0 +1,42 @@
+/* ============================================================================
+ * Host route table (FaceTheory FaceModules)
+ *
+ * One `ShellFaceOptions` per existing host page; `face-app.ts` builds the
+ * `FaceModule[]` via `createShellFace(opts, deps)` after loading the Vite
+ * manifest once at module init. Adding a new route family is one new file
+ * here plus one line in the `allRoutes` export.
+ *
+ * Route patterns follow FaceTheory's `Router` syntax:
+ *   - static segments:     `/account`
+ *   - trailing proxy:      `/portal/{rest*}`  (matches `/portal` and any
+ *                                              sub-path)
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.4
+ * ========================================================================== */
+
+import type { ShellFaceOptions } from './_shell';
+
+import { accountRoute } from './account';
+import { homeRoute } from './home';
+import { loginRoute } from './login';
+import { operatorRoute } from './operator';
+import { portalRoute } from './portal';
+import { safeAppRoute } from './safe-app';
+import { setupRoute } from './setup';
+import { tipRegistryRoute } from './tip-registry';
+import { trustRoute } from './trust';
+
+export const allRoutes: readonly ShellFaceOptions[] = Object.freeze([
+	homeRoute,
+	loginRoute,
+	setupRoute,
+	portalRoute,
+	operatorRoute,
+	trustRoute,
+	accountRoute,
+	tipRegistryRoute,
+	safeAppRoute,
+]);
+
+export type { ShellFaceOptions, ShellHydrationPayload } from './_shell';
+export { createShellFace } from './_shell';

--- a/web/src/routes/login.ts
+++ b/web/src/routes/login.ts
@@ -1,0 +1,7 @@
+/* Login — `/login` (no layout; wallet challenge/response + WebAuthn). */
+import type { ShellFaceOptions } from './_shell';
+
+export const loginRoute: ShellFaceOptions = {
+	route: '/login',
+	routeId: 'login',
+};

--- a/web/src/routes/operator.ts
+++ b/web/src/routes/operator.ts
@@ -1,0 +1,7 @@
+/* Operator — `/operator` and `/operator/...` (operator console). */
+import type { ShellFaceOptions } from './_shell';
+
+export const operatorRoute: ShellFaceOptions = {
+	route: '/operator/{rest*}',
+	routeId: 'operator',
+};

--- a/web/src/routes/portal.ts
+++ b/web/src/routes/portal.ts
@@ -1,0 +1,7 @@
+/* Portal — `/portal` and `/portal/...` (customer portal). */
+import type { ShellFaceOptions } from './_shell';
+
+export const portalRoute: ShellFaceOptions = {
+	route: '/portal/{rest*}',
+	routeId: 'portal',
+};

--- a/web/src/routes/safe-app.ts
+++ b/web/src/routes/safe-app.ts
@@ -1,0 +1,10 @@
+/* Safe App — `/safe-app` and `/safe-app/...` (the Safe-Apps SDK harness
+ * `App.svelte` switches into when loaded via SAFE_APP_BASE_PATH). The
+ * client-side `src/lib/router.ts` resolves the staged sub-target after
+ * hydration; the FaceModule's job here is just to emit the SSR shell. */
+import type { ShellFaceOptions } from './_shell';
+
+export const safeAppRoute: ShellFaceOptions = {
+	route: '/safe-app/{rest*}',
+	routeId: 'safe-app',
+};

--- a/web/src/routes/setup.ts
+++ b/web/src/routes/setup.ts
@@ -1,0 +1,8 @@
+/* Setup — `/setup` and `/setup/...` (first-run bootstrap). The trailing
+ * `{rest*}` proxy segment matches both the bare path and any sub-paths. */
+import type { ShellFaceOptions } from './_shell';
+
+export const setupRoute: ShellFaceOptions = {
+	route: '/setup/{rest*}',
+	routeId: 'setup',
+};

--- a/web/src/routes/tip-registry.ts
+++ b/web/src/routes/tip-registry.ts
@@ -1,0 +1,8 @@
+/* Tip registry — `/tip-registry` and `/tip-registry/register` (reskin of
+ * Safe-ready payload registration; on-chain contracts unchanged). */
+import type { ShellFaceOptions } from './_shell';
+
+export const tipRegistryRoute: ShellFaceOptions = {
+	route: '/tip-registry/{rest*}',
+	routeId: 'tip-registry',
+};

--- a/web/src/routes/trust.ts
+++ b/web/src/routes/trust.ts
@@ -1,0 +1,9 @@
+/* Trust — `/trust` and `/trust/...` (public attestation inspector reskin).
+ * The trust-API endpoints under `/.well-known/*` and `/attestations/*` are
+ * unchanged Lambda Function URL routes — only this UI shell ports. */
+import type { ShellFaceOptions } from './_shell';
+
+export const trustRoute: ShellFaceOptions = {
+	route: '/trust/{rest*}',
+	routeId: 'trust',
+};

--- a/web/src/server/face-app.ts
+++ b/web/src/server/face-app.ts
@@ -1,0 +1,150 @@
+/* ============================================================================
+ * FaceTheory server entry (host web/)
+ *
+ * Builds the host SSR FaceApp and exposes the Lambda Function URL streaming
+ * handler. M0.3 lands one minimal probe FaceModule at `/_facetheory/probe`
+ * proving the SSR + strict-no-inline-CSP + JSON-sidecar hydration path
+ * end-to-end; M0.4 replaces the probe with real Svelte FaceModules ported
+ * from the existing `src/pages/*` SPA routes via `createSvelteFace` +
+ * `renderSvelte` (from `@theory-cloud/facetheory/svelte`).
+ *
+ * CSP posture (preserves host's canonical webCsp byte-string):
+ *   - Each FaceModule sets `csp: { inlineScripts: false, inlineStyles: false,
+ *     rawHead: false }` so FaceTheory validates the rendered HTML is strict-
+ *     no-inline, but does *not* attach a CSP header itself. CloudFront's
+ *     response-headers policy continues to attach host's canonical webCsp
+ *     and safeAppCsp byte-strings (planning trust-and-safety walk,
+ *     docs/trust-and-safety-web-ui-rework-2026-05-24.md). FaceTheory's
+ *     `buildStrictCspHeader()` is intentionally not invoked here so the
+ *     CDN's CSP remains the single source of truth.
+ *
+ * Manifest contract:
+ *   - The client build (vite.config.ts `client` environment) emits a Vite
+ *     manifest at `dist/.vite/manifest.json` listing every client chunk and
+ *     its hashed asset path. The SSR build emits this entry as
+ *     `dist/server/face-app.mjs`, so the relative path is
+ *     `../.vite/manifest.json`. CDK packaging (M0.12) co-locates the
+ *     manifest with the Lambda bundle on the same relative layout.
+ *   - If the manifest can't be loaded (e.g. ahead of CDK packaging), the
+ *     probe degrades gracefully to literal HTML without asset tags rather
+ *     than crashing on module init.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+ * ========================================================================== */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+	createFaceApp,
+	createLambdaUrlStreamingHandler,
+	externalHydrationForEntry,
+	viteAssetsForEntry,
+	type FaceCspPolicy,
+	type FaceModule,
+	type ViteManifest,
+} from '@theory-cloud/facetheory';
+
+import type { FaceTheoryProbePayload } from '../client/face-client.ts';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CLIENT_ENTRY = 'src/client/face-client.ts';
+const PROBE_ROUTE = '/_facetheory/probe';
+const HYDRATION_DATA_URL = '/_facetheory/data/probe.json';
+
+/**
+ * Strict no-inline CSP validation policy. Tells FaceTheory to reject any
+ * rendered HTML that would require `'unsafe-inline'` or raw head HTML; the
+ * actual `content-security-policy` header is attached by CloudFront, not
+ * here, so host's canonical webCsp byte-string remains the only CSP truth.
+ */
+const STRICT_CSP_POLICY: FaceCspPolicy = Object.freeze({
+	inlineScripts: false,
+	inlineStyles: false,
+	rawHead: false,
+});
+
+// ─── Manifest loading ─────────────────────────────────────────────────────────
+
+const FACE_APP_DIR = dirname(fileURLToPath(import.meta.url));
+const MANIFEST_PATH = resolve(FACE_APP_DIR, '..', '.vite', 'manifest.json');
+
+function loadManifest(): ViteManifest {
+	try {
+		return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as ViteManifest;
+	} catch (err) {
+		// Render-time degrade rather than module-init crash. M0.12 ensures
+		// the manifest ships with the Lambda bundle in production.
+		console.warn(
+			'[face-app] client manifest not found at',
+			MANIFEST_PATH,
+			'— rendering probe without Vite asset tags',
+			err instanceof Error ? err.message : String(err),
+		);
+		return {};
+	}
+}
+
+const manifest = loadManifest();
+
+// ─── Probe FaceModule ─────────────────────────────────────────────────────────
+
+const probeFace: FaceModule = {
+	route: PROBE_ROUTE,
+	mode: 'ssr',
+	load: async (): Promise<FaceTheoryProbePayload> => ({
+		route: PROBE_ROUTE,
+		timestamp: new Date().toISOString(),
+	}),
+	render: async (_ctx, data) => {
+		const hasManifestEntry = Object.hasOwn(manifest, CLIENT_ENTRY);
+		const assets = hasManifestEntry
+			? viteAssetsForEntry(manifest, CLIENT_ENTRY, { includeAssets: true })
+			: { bootstrapModule: '', headTags: [] };
+		const hydration = hasManifestEntry
+			? externalHydrationForEntry(manifest, CLIENT_ENTRY, data, {
+					dataUrl: HYDRATION_DATA_URL,
+				})
+			: undefined;
+
+		return {
+			csp: STRICT_CSP_POLICY,
+			headTags: assets.headTags,
+			hydration,
+			html:
+				'<main data-facetheory-view>' +
+				'<h1>FaceTheory bootstrap probe</h1>' +
+				'<p>SSR + strict-no-inline-CSP + JSON-sidecar hydration ready.</p>' +
+				'<p>Real routes ported in M0.4.</p>' +
+				'</main>',
+		};
+	},
+};
+
+// ─── App + Lambda handler ─────────────────────────────────────────────────────
+
+export const app = createFaceApp({ faces: [probeFace] });
+
+/**
+ * Lazy Lambda handler. `createLambdaUrlStreamingHandler` reaches for
+ * `globalThis.awslambda` (an AWS-Lambda-runtime-only global). Constructing
+ * eagerly outside Lambda would throw at module load, so we trap that here:
+ * inside Lambda the eager construction wins, outside Lambda a stub throws
+ * only on invocation (you should not invoke this outside Lambda anyway).
+ */
+function createSafeHandler(): ReturnType<typeof createLambdaUrlStreamingHandler> {
+	try {
+		return createLambdaUrlStreamingHandler({ app });
+	} catch (err) {
+		const message =
+			'face-app handler invoked without globalThis.awslambda; this entry is for AWS Lambda runtime only';
+		console.warn('[face-app]', message, err instanceof Error ? err.message : String(err));
+		return (async () => {
+			throw new Error(message);
+		}) as ReturnType<typeof createLambdaUrlStreamingHandler>;
+	}
+}
+
+export const handler = createSafeHandler();

--- a/web/src/server/face-app.ts
+++ b/web/src/server/face-app.ts
@@ -2,11 +2,13 @@
  * FaceTheory server entry (host web/)
  *
  * Builds the host SSR FaceApp and exposes the Lambda Function URL streaming
- * handler. M0.3 lands one minimal probe FaceModule at `/_facetheory/probe`
- * proving the SSR + strict-no-inline-CSP + JSON-sidecar hydration path
- * end-to-end; M0.4 replaces the probe with real Svelte FaceModules ported
- * from the existing `src/pages/*` SPA routes via `createSvelteFace` +
- * `renderSvelte` (from `@theory-cloud/facetheory/svelte`).
+ * handler. M0.4 ports every existing host page onto its own FaceModule via
+ * the shell factory in `src/routes/_shell.ts`; the SSR Lambda emits a
+ * strict-no-inline-CSP HTML shell + external hydration sidecar, and the
+ * existing `src/App.svelte` (mounted by `src/client/face-client.ts`) keeps
+ * handling per-page routing and rendering after hydration. The M0.3 probe
+ * at `/_facetheory/probe` is retained as a per-request health signal that
+ * exercises the shell pipeline without claiming a user-facing route.
  *
  * CSP posture (preserves host's canonical webCsp byte-string):
  *   - Each FaceModule sets `csp: { inlineScripts: false, inlineStyles: false,
@@ -14,9 +16,14 @@
  *     no-inline, but does *not* attach a CSP header itself. CloudFront's
  *     response-headers policy continues to attach host's canonical webCsp
  *     and safeAppCsp byte-strings (planning trust-and-safety walk,
- *     docs/trust-and-safety-web-ui-rework-2026-05-24.md). FaceTheory's
- *     `buildStrictCspHeader()` is intentionally not invoked here so the
- *     CDN's CSP remains the single source of truth.
+ *     docs/trust-and-safety-web-ui-rework-2026-05-24.md).
+ *
+ * Browser-only-code isolation:
+ *   - This module imports zero browser-only modules. `src/App.svelte`,
+ *     `src/lib/router.ts`, `src/lib/session.ts` (which all reference
+ *     `window`/`document`/`sessionStorage` at module init) are imported
+ *     only from `src/client/face-client.ts` and `src/main.ts`, both of
+ *     which run in browser environments. SSR Lambda safety preserved.
  *
  * Manifest contract:
  *   - The client build (vite.config.ts `client` environment) emits a Vite
@@ -25,11 +32,10 @@
  *     `dist/server/face-app.mjs`, so the relative path is
  *     `../.vite/manifest.json`. CDK packaging (M0.12) co-locates the
  *     manifest with the Lambda bundle on the same relative layout.
- *   - If the manifest can't be loaded (e.g. ahead of CDK packaging), the
- *     probe degrades gracefully to literal HTML without asset tags rather
- *     than crashing on module init.
+ *   - If the manifest can't be loaded (e.g. ahead of CDK packaging), shells
+ *     degrade gracefully to empty `<head>` rather than crashing on init.
  *
- * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.4
  * ========================================================================== */
 
 import { readFileSync } from 'node:fs';
@@ -46,20 +52,16 @@ import {
 	type ViteManifest,
 } from '@theory-cloud/facetheory';
 
-import type { FaceTheoryProbePayload } from '../client/face-client.ts';
+import { allRoutes, createShellFace } from '../routes/index';
+import type { FaceTheoryProbePayload } from '../client/face-client';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 const CLIENT_ENTRY = 'src/client/face-client.ts';
+const HYDRATION_DATA_URL_BASE = '/_facetheory/data/';
 const PROBE_ROUTE = '/_facetheory/probe';
-const HYDRATION_DATA_URL = '/_facetheory/data/probe.json';
+const SHELL_TITLE = 'lesser.host';
 
-/**
- * Strict no-inline CSP validation policy. Tells FaceTheory to reject any
- * rendered HTML that would require `'unsafe-inline'` or raw head HTML; the
- * actual `content-security-policy` header is attached by CloudFront, not
- * here, so host's canonical webCsp byte-string remains the only CSP truth.
- */
 const STRICT_CSP_POLICY: FaceCspPolicy = Object.freeze({
 	inlineScripts: false,
 	inlineStyles: false,
@@ -75,12 +77,10 @@ function loadManifest(): ViteManifest {
 	try {
 		return JSON.parse(readFileSync(MANIFEST_PATH, 'utf8')) as ViteManifest;
 	} catch (err) {
-		// Render-time degrade rather than module-init crash. M0.12 ensures
-		// the manifest ships with the Lambda bundle in production.
 		console.warn(
 			'[face-app] client manifest not found at',
 			MANIFEST_PATH,
-			'— rendering probe without Vite asset tags',
+			'— rendering shells without Vite asset tags',
 			err instanceof Error ? err.message : String(err),
 		);
 		return {};
@@ -89,7 +89,7 @@ function loadManifest(): ViteManifest {
 
 const manifest = loadManifest();
 
-// ─── Probe FaceModule ─────────────────────────────────────────────────────────
+// ─── Probe FaceModule (M0.3 carryover; per-request health/SSR pipeline check) ─
 
 const probeFace: FaceModule = {
 	route: PROBE_ROUTE,
@@ -105,7 +105,7 @@ const probeFace: FaceModule = {
 			: { bootstrapModule: '', headTags: [] };
 		const hydration = hasManifestEntry
 			? externalHydrationForEntry(manifest, CLIENT_ENTRY, data, {
-					dataUrl: HYDRATION_DATA_URL,
+					dataUrl: `${HYDRATION_DATA_URL_BASE}probe.json`,
 				})
 			: undefined;
 
@@ -115,17 +115,27 @@ const probeFace: FaceModule = {
 			hydration,
 			html:
 				'<main data-facetheory-view>' +
-				'<h1>FaceTheory bootstrap probe</h1>' +
-				'<p>SSR + strict-no-inline-CSP + JSON-sidecar hydration ready.</p>' +
-				'<p>Real routes ported in M0.4.</p>' +
+				'<h1>FaceTheory probe</h1>' +
+				'<p>SSR + strict-no-inline-CSP + JSON-sidecar hydration OK.</p>' +
 				'</main>',
 		};
 	},
 };
 
+// ─── Route FaceModules (one per host page, all sharing the shell factory) ────
+
+const routeFaces: FaceModule[] = allRoutes.map((opts) =>
+	createShellFace(opts, {
+		manifest,
+		clientEntry: CLIENT_ENTRY,
+		hydrationDataUrlBase: HYDRATION_DATA_URL_BASE,
+		title: SHELL_TITLE,
+	}),
+);
+
 // ─── App + Lambda handler ─────────────────────────────────────────────────────
 
-export const app = createFaceApp({ faces: [probeFace] });
+export const app = createFaceApp({ faces: [probeFace, ...routeFaces] });
 
 /**
  * Lazy Lambda handler. `createLambdaUrlStreamingHandler` reaches for

--- a/web/src/server/face-app.ts
+++ b/web/src/server/face-app.ts
@@ -1,14 +1,24 @@
 /* ============================================================================
  * FaceTheory server entry (host web/)
  *
- * Builds the host SSR FaceApp and exposes the Lambda Function URL streaming
+ * Builds the host SSR FaceApp, wraps it with a `/_facetheory/data/*.json`
+ * sidecar pre-router, and exposes the Lambda Function URL streaming
  * handler. M0.4 ports every existing host page onto its own FaceModule via
  * the shell factory in `src/routes/_shell.ts`; the SSR Lambda emits a
- * strict-no-inline-CSP HTML shell + external hydration sidecar, and the
- * existing `src/App.svelte` (mounted by `src/client/face-client.ts`) keeps
- * handling per-page routing and rendering after hydration. The M0.3 probe
- * at `/_facetheory/probe` is retained as a per-request health signal that
- * exercises the shell pipeline without claiming a user-facing route.
+ * strict-no-inline-CSP HTML shell + external hydration sidecar URL, and
+ * the existing `src/App.svelte` (mounted by `src/client/face-client.ts`)
+ * keeps handling per-page routing and rendering. The M0.3 probe at
+ * `/_facetheory/probe` is retained as a per-request health signal.
+ *
+ * Why a sidecar pre-router (FaceTheory v3.3.0 limitation): FaceTheory's
+ * runtime always wraps FaceModule responses in `renderHTMLDocument(...)`
+ * (see `app.js#toHTTPResponse`), so JSON sidecars cannot be served from a
+ * FaceModule. ISR mode exposes `onHydrationSidecar` for persistence, but
+ * SSR mode has no equivalent. The host-side pre-router below shells the
+ * static `{routeId, route}` payload for `/_facetheory/data/<routeId>.json`
+ * before delegating to the FaceApp. Captured as a framework-feedback
+ * candidate (see memory note `mem-66a93e3b1c3a1ce1` for the related
+ * client-bundle export-map signal).
  *
  * CSP posture (preserves host's canonical webCsp byte-string):
  *   - Each FaceModule sets `csp: { inlineScripts: false, inlineStyles: false,
@@ -49,10 +59,12 @@ import {
 	viteAssetsForEntry,
 	type FaceCspPolicy,
 	type FaceModule,
+	type FaceRequest,
+	type FaceResponse,
 	type ViteManifest,
 } from '@theory-cloud/facetheory';
 
-import { allRoutes, createShellFace } from '../routes/index';
+import { allRoutes, createShellFace, type ShellHydrationPayload } from '../routes/index';
 import type { FaceTheoryProbePayload } from '../client/face-client';
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -90,6 +102,13 @@ function loadManifest(): ViteManifest {
 const manifest = loadManifest();
 
 // ─── Probe FaceModule (M0.3 carryover; per-request health/SSR pipeline check) ─
+//
+// The probe sidecar payload deliberately omits the per-request timestamp so
+// the static sidecar pre-router below can serve `/_facetheory/data/probe.json`
+// without a per-request re-render. The HTML response still includes the
+// timestamp for human eyeballs during lab soak.
+
+const PROBE_ROUTE_ID = 'probe';
 
 const probeFace: FaceModule = {
 	route: PROBE_ROUTE,
@@ -133,9 +152,132 @@ const routeFaces: FaceModule[] = allRoutes.map((opts) =>
 	}),
 );
 
-// ─── App + Lambda handler ─────────────────────────────────────────────────────
+// ─── FaceApp ──────────────────────────────────────────────────────────────────
 
 export const app = createFaceApp({ faces: [probeFace, ...routeFaces] });
+
+// ─── Sidecar pre-router ───────────────────────────────────────────────────────
+//
+// Map routeId → the static hydration payload the SSR shells reference via
+// `externalHydrationForEntry({ dataUrl: '/_facetheory/data/<routeId>.json' })`.
+// FaceTheory's runtime only serves SSG/ISR sidecars natively; for SSR we
+// serve the JSON ourselves here so the dataUrl actually resolves.
+
+interface SidecarEntry {
+	readonly contentType: string;
+	readonly cacheControl: string;
+	readonly payload: ShellHydrationPayload | { route: string };
+}
+
+const SIDECAR_PATH_PREFIX = HYDRATION_DATA_URL_BASE; // '/_facetheory/data/'
+const SIDECAR_PATH_SUFFIX = '.json';
+const SIDECAR_CONTENT_TYPE = 'application/json; charset=utf-8';
+const SIDECAR_CACHE_CONTROL = 'no-store';
+
+const sidecarById: ReadonlyMap<string, SidecarEntry> = new Map(
+	[
+		// Real shell routes — static `{ routeId, route }` payload per routeId.
+		...allRoutes.map<readonly [string, SidecarEntry]>((r) => [
+			r.routeId,
+			{
+				contentType: SIDECAR_CONTENT_TYPE,
+				cacheControl: SIDECAR_CACHE_CONTROL,
+				payload: { routeId: r.routeId, route: r.route },
+			},
+		]),
+		// M0.3 probe route — sidecar holds only the route name (the request-
+		// time timestamp the probe's render emits is intentionally not in the
+		// sidecar so the URL stays deterministic).
+		[
+			PROBE_ROUTE_ID,
+			{
+				contentType: SIDECAR_CONTENT_TYPE,
+				cacheControl: SIDECAR_CACHE_CONTROL,
+				payload: { route: PROBE_ROUTE },
+			},
+		],
+	],
+);
+
+function isSidecarPath(path: string): boolean {
+	return path.startsWith(SIDECAR_PATH_PREFIX) && path.endsWith(SIDECAR_PATH_SUFFIX);
+}
+
+function resolveSidecarRouteId(path: string): string | null {
+	const tail = path.slice(SIDECAR_PATH_PREFIX.length, path.length - SIDECAR_PATH_SUFFIX.length);
+	// Reject path traversal / nested segments / empty tail — sidecar URLs are
+	// single-segment routeIds only.
+	if (!tail || tail.includes('/') || tail.includes('..')) {
+		return null;
+	}
+	return tail;
+}
+
+function makeJsonResponse(status: number, body: string, headers: Record<string, string>): FaceResponse {
+	const normalized: Record<string, string[]> = {};
+	for (const [k, v] of Object.entries(headers)) {
+		normalized[k.toLowerCase()] = [v];
+	}
+	return {
+		status,
+		headers: normalized,
+		cookies: [],
+		body: new TextEncoder().encode(body),
+		isBase64: false,
+	};
+}
+
+function handleSidecarRequest(req: FaceRequest): FaceResponse {
+	if (req.method !== 'GET' && req.method !== 'HEAD') {
+		return makeJsonResponse(
+			405,
+			JSON.stringify({ error: 'method_not_allowed' }),
+			{ 'content-type': SIDECAR_CONTENT_TYPE, allow: 'GET, HEAD' },
+		);
+	}
+	const routeId = resolveSidecarRouteId(req.path);
+	if (routeId === null) {
+		return makeJsonResponse(
+			404,
+			JSON.stringify({ error: 'not_found' }),
+			{ 'content-type': SIDECAR_CONTENT_TYPE },
+		);
+	}
+	const entry = sidecarById.get(routeId);
+	if (!entry) {
+		return makeJsonResponse(
+			404,
+			JSON.stringify({ error: 'unknown_route_id', routeId }),
+			{ 'content-type': SIDECAR_CONTENT_TYPE },
+		);
+	}
+	return makeJsonResponse(
+		200,
+		JSON.stringify(entry.payload),
+		{
+			'content-type': entry.contentType,
+			'cache-control': entry.cacheControl,
+		},
+	);
+}
+
+/**
+ * Request handler that the Lambda streaming wrapper drives. Pre-routes
+ * `/_facetheory/data/*.json` to the static sidecar map, then delegates
+ * every other request to the FaceApp. Exported (alongside `app`) so unit
+ * tests + the M0.16 web build-time verifier can exercise the full handler
+ * tree without spinning up Lambda streaming.
+ */
+export const requestHandler: { handle: (req: FaceRequest) => Promise<FaceResponse> } = {
+	async handle(req: FaceRequest): Promise<FaceResponse> {
+		if (isSidecarPath(req.path)) {
+			return handleSidecarRequest(req);
+		}
+		return app.handle(req);
+	},
+};
+
+// ─── Lambda handler ───────────────────────────────────────────────────────────
 
 /**
  * Lazy Lambda handler. `createLambdaUrlStreamingHandler` reaches for
@@ -146,7 +288,7 @@ export const app = createFaceApp({ faces: [probeFace, ...routeFaces] });
  */
 function createSafeHandler(): ReturnType<typeof createLambdaUrlStreamingHandler> {
 	try {
-		return createLambdaUrlStreamingHandler({ app });
+		return createLambdaUrlStreamingHandler({ app: requestHandler });
 	} catch (err) {
 		const message =
 			'face-app handler invoked without globalThis.awslambda; this entry is for AWS Lambda runtime only';

--- a/web/svelte.config.js
+++ b/web/svelte.config.js
@@ -1,8 +1,19 @@
-import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
+
+// ============================================================================
+// Svelte config — host web/
+//
+// `vitePreprocess()` is SSR-compatible for Svelte 5: the Svelte 5 compiler
+// emits server-rendered HTML through the @sveltejs/vite-plugin-svelte SSR
+// path that FaceTheory's `renderSvelte` (from `@theory-cloud/facetheory/svelte`)
+// invokes. No additional preprocessing is needed for M0.3 bootstrap; the
+// compile-time behavior is unchanged from the pre-rework SPA build. M0.4
+// may extend this when the first ported Svelte FaceModule lands.
+//
+// Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+// ============================================================================
 
 /** @type {import("@sveltejs/vite-plugin-svelte").SvelteConfig} */
 export default {
-  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
-  // for more information about preprocessors
-  preprocess: vitePreprocess(),
-}
+	preprocess: vitePreprocess(),
+};

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -4,7 +4,29 @@ import { fileURLToPath } from 'node:url';
 import { svelte } from '@sveltejs/vite-plugin-svelte';
 import { defineConfig, loadEnv } from 'vite';
 
-// https://vite.dev/config/
+// ============================================================================
+// Vite config — host web/
+//
+// Two build environments (Vite 8 environments API):
+//
+//   client → CSR SPA (existing pages, unchanged byte-shape) + Vite manifest
+//            so FaceTheory's `viteAssetsForEntry` / `externalHydrationForEntry`
+//            can resolve hashed client chunks at SSR render time. The new
+//            `src/client/face-client.ts` is added as an additional entry so
+//            it appears in the manifest as the FaceTheory hydration bootstrap.
+//
+//   ssr    → SSR Lambda bundle from `src/server/face-app.ts` emitted to
+//            `dist/server/face-app.mjs`. The Lambda entry is M0.12's CDK
+//            wire-up; for now `npm run build` just produces the artifact.
+//
+// `builder.buildApp` ensures one `npm run build` invocation walks both
+// environments. The dev server still serves the existing CSR SPA via
+// `index.html → /src/main.ts`; M0.4 ports each existing page onto a
+// Svelte FaceModule.
+//
+// Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.3
+// ============================================================================
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig(({ mode }) => {
@@ -13,15 +35,19 @@ export default defineConfig(({ mode }) => {
 	const controlPlaneOrigin = env.LESSER_HOST_CONTROL_PLANE_ORIGIN || 'http://localhost:8787';
 	const trustOrigin = env.LESSER_HOST_TRUST_ORIGIN || controlPlaneOrigin;
 
+	const greaterAliases = {
+		'@equaltoai/greater-components-icons': path.resolve(__dirname, './src/lib/greater/icons'),
+		'@equaltoai/greater-components-primitives': path.resolve(__dirname, './src/lib/greater/primitives'),
+		'@equaltoai/greater-components-tokens': path.resolve(__dirname, './src/lib/greater/tokens'),
+		'@equaltoai/greater-components-utils': path.resolve(__dirname, './src/lib/greater/utils'),
+	};
+
 	return {
 		plugins: [svelte()],
 		resolve: {
 			alias: {
 				src: path.resolve(__dirname, './src'),
-				'@equaltoai/greater-components-icons': path.resolve(__dirname, './src/lib/greater/icons'),
-				'@equaltoai/greater-components-primitives': path.resolve(__dirname, './src/lib/greater/primitives'),
-				'@equaltoai/greater-components-tokens': path.resolve(__dirname, './src/lib/greater/tokens'),
-				'@equaltoai/greater-components-utils': path.resolve(__dirname, './src/lib/greater/utils'),
+				...greaterAliases,
 			},
 		},
 		server: {
@@ -35,6 +61,46 @@ export default defineConfig(({ mode }) => {
 
 				'/.well-known': { target: trustOrigin, changeOrigin: true, secure: false },
 				'/attestations': { target: trustOrigin, changeOrigin: true, secure: false },
+			},
+		},
+		environments: {
+			client: {
+				build: {
+					outDir: 'dist',
+					manifest: true,
+					rollupOptions: {
+						input: {
+							app: path.resolve(__dirname, 'index.html'),
+							'face-client': path.resolve(__dirname, 'src/client/face-client.ts'),
+						},
+					},
+				},
+			},
+			ssr: {
+				build: {
+					ssr: true,
+					outDir: 'dist/server',
+					emitAssets: false,
+					rollupOptions: {
+						input: {
+							'face-app': path.resolve(__dirname, 'src/server/face-app.ts'),
+						},
+						output: {
+							format: 'esm',
+							entryFileNames: '[name].mjs',
+							chunkFileNames: '[name].mjs',
+						},
+					},
+				},
+			},
+		},
+		builder: {
+			async buildApp(builder) {
+				// Client first so the manifest is on disk before any future
+				// SSR test that wants to load it; the two environments are
+				// otherwise independent.
+				await builder.build(builder.environments.client);
+				await builder.build(builder.environments.ssr);
 			},
 		},
 	};


### PR DESCRIPTION
## What this PR bundles

Two parallel-track contributions:

1. **Project 39 M0.1–M0.5**: FaceTheory v3.3.0 foundation for the `web/` rework (deps + tokens + SSR shell + route port + OAC transport). Five enumerated changes from `docs/enumerated-changes-web-ui-rework-2026-05-24.md`. Application-side only; lab deploy gates separately on M0.12 (CDK adoption) which itself waits on Signal C resolution at theory-cloud/AppTheory#593 + theory-cloud/FaceTheory#248.

2. **Project 40 planning baseline**: docs-only baseline for host's next major scope, *managed `/l/` client deployment for hosted Lesser instances*. Four planning artifacts prepared in parallel while M0.12 waits on upstream framework updates. The GitHub Project + parent / sibling issues already exist (Project 40, issues #460–#472); these docs are the authoritative local source-of-truth those issues reference.

Both contributions are Aron-direct, docs/code-only, no infrastructure changes, no CSP loosening, no instance-auth changes, no on-chain impact, no multi-tenant boundary traverse.

## Classification

- M0.1–M0.5: framework-feedback (idiomatic Theory Cloud adoption); UI-rework foundation.
- Planning docs: docs-only planning baseline for managed-provisioning + managed-update + consumer-release-verification + security + tenant-isolation + operational-reliability + CSP + governance + docs scopes.

## Surfaces affected

**M0.1–M0.5 (code):**
- `web/package.json`, `web/package-lock.json` — FaceTheory v3.3.0 pin from GitHub Release tarball.
- `web/src/lib/tokens/{ds.css,gr-bridge.css,index.ts}` — design tokens + GR bridge.
- `web/src/server/face-app.ts` — `createFaceApp` + Lambda streaming handler; sidecar pre-router; 10 FaceModules.
- `web/src/routes/**` — `_shell.ts` factory + 9 route files + `index.ts`.
- `web/src/client/face-client.ts` — reads hydration (inline or sidecar fetch), stages OAC transport, mounts `App.svelte`.
- `web/src/client/oac-form.ts` — idempotent `ensureAwsOacFormTransport()`.
- `web/vite.config.ts` — Vite 8 environments API (`client` + `ssr`); `builder.buildApp` runs both.
- `web/svelte.config.js` — doc-only SSR-compatibility note.

**Project 40 planning (docs):**
- `docs/roadmap-managed-client-deployment-2026-05-24.md`
- `docs/enumerated-changes-managed-client-deployment-2026-05-24.md`
- `docs/github-project-managed-client-deployment-2026-05-24.md`
- `docs/steward-briefs-managed-client-deployment-2026-05-24.md`

## Specialist walks referenced

- Framework consumption: `coordinate-framework-feedback` (commit 5579350) — FaceTheory v3.3.0 adoption verdict + Signals A/B/C/D
- Trust API / CSP / instance-auth: `audit-trust-and-safety` (24dcd86) — CSP shape change is delivery-path only; contract preserved
- Governance rubric: `maintain-governance-rubric` (b4b38c5) — 7 verifiers land later in M0

## Multi-tenant isolation impact

None. M0.1–M0.5 is foundation work; per-slug scoping preserved. Project 40 planning explicitly designs for tenant isolation (no tenant AWS credentials for custom-source builds; deploy-only role; tenant-bounded state) but ships no code in this PR.

## On-chain impact

None.

## Consumer impact

- M0.1–M0.5: none for managed operators (host-side web only; no managed-instance behavior change).
- Project 40 planning: zero today; sets up the next major capability that will affect managed operators and the Lesser/Simulacrum siblings via documented coordination.

## Tasks (M0.1–M0.5)

- [x] M0.1 — Add `@theory-cloud/facetheory` v3.3.0 dependency (#381) — e494a69
- [x] M0.2 — Add design tokens scaffold (#382) — 002f6a1
- [x] M0.3 — Bootstrap FaceTheory app + Svelte adapter (#383) — 238ed51
- [x] M0.4 — Port routes to FaceModule with JSON-sidecar hydration (#384) — de021b8
- [x] M0.5 — Wire `startAwsOacFormTransport` at client bootstrap (#385) — 74cb017
- [x] M0.4 review-rework — serve /_facetheory/data/*.json sidecars + fetch them client-side — 216fb96
- [x] Project 40 planning docs baseline — 2ddf9f1

## Validation (per task)

- `cd web && npm run lint && npm run typecheck && npm test && npm run build` — all PASS at every tip
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0 at every tip
- Built bundle assertions:
  - `dist/index.html` — no inline `<script>`/`<style>`/event handlers (external refs only)
  - `dist/.vite/manifest.json` — face-client + App + CSS entries present
  - `dist/assets/face-client-*.js` — 0 `node:` imports (SSR-only modules tree-shaken); contains the `__FACETHEORY_DATA_URL__` + `facetheory-hydration` constants proving the URL-read path is bundled; contains the OAC transport constants `data-facetheory-oac-form` + `x-amz-content-sha256`
  - `dist/server/face-app.mjs` — 0 window/document/sessionStorage refs (browser-only code isolated)
  - Offline probe against rebuilt SSR bundle confirms `/_facetheory/data/*.json` returns 200 JSON for matched routeIds, 404 JSON for unknown / path-traversal, 405 JSON for non-GET/HEAD; real routes (`/portal`, `/portal/foo`, `/`, etc.) unchanged
  - 0 marker hits for `data-facetheory-oac-form` in built HTML (no marked OAC forms emitted yet)

## Stage rollout plan (handoff after merge)

- [x] PR open
- [ ] Merged to main
- [ ] Deployed to lab — **gated on Signal C / M0.12** per planning
- [ ] Lab soak complete — gated
- [ ] Deployed to live — gated
- [ ] Post-deploy monitoring verified

This PR is application-side + docs only; CDK + framework-issue resolution land separately.

## Cross-repo coordination

- M0.1–M0.5: Signal C resolution tracked at theory-cloud/AppTheory#593 + theory-cloud/FaceTheory#248 gates the later CDK milestone, not this PR.
- M0.4 sidecar-serving gap surfaced and filed upstream as **theory-cloud/FaceTheory#250** (host's pre-router workaround already shipped in 216fb96).
- Project 40 planning identifies coordination points with the Lesser steward (CLI install contract, scoped role shape), Simulacrum steward (default-client release / checksum posture), and FaceTheory steward (#250 already filed). Sibling-repo issues already opened per the project tracking doc.

## Framework-feedback observations captured for the next walk

1. FaceTheory v3.3.0's top-level `.` export re-exports SSR-only modules alongside browser-safe `spa.js`. Importing `readFaceHydrationData` from the top-level surface triggers Vite `MODULE_EXTERNALIZED_FOR_BROWSER` warnings during the client build. Tree-shaking removes all SSR code from the emitted bundle, so behavior is correct, but a `./spa` or `./client` browser-safe subpath would let consumers avoid the warnings. Mentioned in theory-cloud/FaceTheory#250's secondary-signal section.

2. FaceTheory v3.3.0 lacks an SSR-mode `onHydrationSidecar` callback (or equivalent native sidecar serving) that's symmetric with ISR mode's `onHydrationSidecar`. Filed upstream as theory-cloud/FaceTheory#250 with four proposed fixes.

## Advisor-brief authorization

N/A — Aron-direct.

## Notes for reviewer

- The probe route at `/_facetheory/probe` is retained as a per-request SSR-pipeline health signal; can be removed at M3 if not useful.
- `index.html` + `main.ts` legacy CSR entry preserved as Vite dev fallback; no behavioral change to existing pages.
- Per-page Svelte SSR (vs shell-only) deferred to M0.6+ when greater-components shell primitives ship and the per-page components become SSR-safe.
- Project 40 planning docs are docs-only; review at your discretion, or merge based on M0.1–M0.5 alone and treat the docs as informational baseline.