### PR TITLE
Project 39 M0.6-M0.10: adopt greater-components shell + host-platform (greater-v0.10.0-rc.1)

### DIFF
--- a/web/components.json
+++ b/web/components.json
@@ -84,6 +84,13 @@
       "installedAt": "2026-05-25T05:07:35.219Z",
       "modified": false,
       "checksums": []
+    },
+    {
+      "name": "host-platform",
+      "version": "4b1e36473544ee640a6a3dd429139323c75d56c3",
+      "installedAt": "2026-05-25T05:13:30.723Z",
+      "modified": false,
+      "checksums": []
     }
   ]
 }

--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://greater.components.dev/schema.json",
   "version": "1.0.0",
-  "ref": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
+  "ref": "4b1e36473544ee640a6a3dd429139323c75d56c3",
   "installMode": "vendored",
   "style": "default",
   "rsc": false,
@@ -75,6 +75,13 @@
       "name": "headless",
       "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
       "installedAt": "2026-05-18T15:45:00.000Z",
+      "modified": false,
+      "checksums": []
+    },
+    {
+      "name": "shell",
+      "version": "4b1e36473544ee640a6a3dd429139323c75d56c3",
+      "installedAt": "2026-05-25T05:07:35.219Z",
       "modified": false,
       "checksums": []
     }

--- a/web/src/client/face-client.ts
+++ b/web/src/client/face-client.ts
@@ -42,6 +42,8 @@ import { readFaceHydrationData, readFaceHydrationDataUrl } from '@theory-cloud/f
 import App from '../App.svelte';
 import 'src/lib/styles/greater/tokens.css';
 import 'src/lib/styles/greater/primitives.css';
+import 'src/lib/styles/greater/shell.css';
+import 'src/lib/styles/greater/host-platform.css';
 import '../app.css';
 
 import { ensureAwsOacFormTransport } from './oac-form';

--- a/web/src/lib/components/ActivitySparkline.svelte
+++ b/web/src/lib/components/ActivitySparkline.svelte
@@ -1,0 +1,31 @@
+<!--
+@component
+Host's ActivitySparkline — thin re-export wrapper around the
+greater-components host-platform ActivitySparkline (vendored under
+`src/lib/greater/host-platform` at greater-v0.10.0-rc.1, vendored in M0.8
+alongside FleetCard + CostGauge).
+
+Gives consumers a stable host import path under `src/lib/components/`
+matching the M0.7/M0.8/M0.9 convention. All props, snippets, and types
+pass through unchanged; the upstream component implements every M0.10
+acceptance behavior:
+
+  - Inline sparkline takes numeric series + optional baseline
+  - SVG-rendered for crisp scaling at any size
+  - Strict-no-inline-CSP safe (.svelte + sibling .css authoring; SVG
+    elements emitted as DOM nodes, not via innerHTML)
+  - Consumes `--gr-*` token surface bridged to host's `--ds-*` palette
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.10
+Issue: equaltoai/lesser-host#390
+-->
+
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { ActivitySparkline } from 'src/lib/greater/host-platform';
+
+	type Props = ComponentProps<typeof ActivitySparkline>;
+	let props: Props = $props();
+</script>
+
+<ActivitySparkline {...props} />

--- a/web/src/lib/components/CommandPalette.svelte
+++ b/web/src/lib/components/CommandPalette.svelte
@@ -1,0 +1,32 @@
+<!--
+@component
+Host's CommandPalette — thin re-export wrapper around the greater-components
+shell CommandPalette (vendored under `src/lib/greater/shell` at
+greater-v0.10.0-rc.1, re-exported through `src/lib/shell`).
+
+This file gives consumers a stable host import path that matches host's
+existing `src/lib/components/` convention (PortalLayout.svelte,
+OperatorLayout.svelte, etc.) without introducing host-bespoke
+implementation. All props, snippets, and types pass through unchanged;
+behavior (⌘K open, fuzzy search via greater's fuzzy-filter, scoped
+result groups, keyboard navigation, focus-trap on open, ESC dismiss)
+is whatever the upstream component implements.
+
+Replacing this wrapper with a direct import from `src/lib/shell` is
+a future scope item if the indirection ever stops earning its keep —
+today it earns it by giving host's components/ directory a uniform
+import surface regardless of vendored vs host-bespoke origin.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.7
+Issue: equaltoai/lesser-host#387
+-->
+
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { CommandPalette } from 'src/lib/shell';
+
+	type Props = ComponentProps<typeof CommandPalette>;
+	let props: Props = $props();
+</script>
+
+<CommandPalette {...props} />

--- a/web/src/lib/components/CostGauge.svelte
+++ b/web/src/lib/components/CostGauge.svelte
@@ -1,0 +1,32 @@
+<!--
+@component
+Host's CostGauge — thin re-export wrapper around the greater-components
+host-platform CostGauge (vendored under `src/lib/greater/host-platform` at
+greater-v0.10.0-rc.1, vendored in M0.8 alongside FleetCard).
+
+Gives consumers a stable host import path under `src/lib/components/`
+matching the M0.7/M0.8 convention. All props, snippets, and types pass
+through unchanged; the upstream component implements every M0.9
+acceptance behavior:
+
+  - Radial gauge with current/limit/currency props
+  - Colored arc indicates consumption
+  - ARIA labels for screen readers (Arch PR #670 a11y review gated the
+    ARIA meter contract enforcement + accessible name composition via
+    `labelledby`)
+  - Strict-no-inline-CSP safe (.svelte + sibling .css authoring)
+  - Consumes `--gr-*` token surface bridged to host's `--ds-*` palette
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.9
+Issue: equaltoai/lesser-host#389
+-->
+
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { CostGauge } from 'src/lib/greater/host-platform';
+
+	type Props = ComponentProps<typeof CostGauge>;
+	let props: Props = $props();
+</script>
+
+<CostGauge {...props} />

--- a/web/src/lib/components/FleetCard.svelte
+++ b/web/src/lib/components/FleetCard.svelte
@@ -1,0 +1,29 @@
+<!--
+@component
+Host's FleetCard — thin re-export wrapper around the greater-components
+host-platform FleetCard (vendored under `src/lib/greater/host-platform` at
+greater-v0.10.0-rc.1).
+
+Gives consumers a stable host import path under `src/lib/components/`
+alongside CommandPalette.svelte, PortalLayout.svelte, OperatorLayout.svelte.
+All props, snippets, and types pass through unchanged; the upstream
+component implements every M0.8 acceptance behavior:
+
+  - Card renders with slug, status pulse dot, cost gauge slot,
+    sparkline slot, metadata line
+  - Strict-no-inline-CSP safe (.svelte + sibling .css authoring)
+  - Consumes `--gr-*` token surface bridged to host's `--ds-*` palette
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.8
+Issue: equaltoai/lesser-host#388
+-->
+
+<script lang="ts">
+	import type { ComponentProps } from 'svelte';
+	import { FleetCard } from 'src/lib/greater/host-platform';
+
+	type Props = ComponentProps<typeof FleetCard>;
+	let props: Props = $props();
+</script>
+
+<FleetCard {...props} />

--- a/web/src/lib/greater/host-platform/components/ActivitySparkline.css
+++ b/web/src/lib/greater/host-platform/components/ActivitySparkline.css
@@ -1,0 +1,48 @@
+.gr-host-platform-activity-sparkline {
+	display: block;
+	min-width: 0;
+	min-height: 1.5rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-activity-sparkline__svg {
+	display: block;
+	width: 100%;
+	height: auto;
+	max-height: 4rem;
+	overflow: visible;
+}
+
+.gr-host-platform-activity-sparkline__path {
+	stroke-width: var(--gr-host-platform-sparkline-stroke);
+}
+
+.gr-host-platform-activity-sparkline__empty {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	min-height: 1.75rem;
+	padding: 0 0.5rem;
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px dashed var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+}
+
+/* Tones — paired with the required `label` (or surrounding textual cue), never color-only. */
+.gr-host-platform-activity-sparkline--tone-default {
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+.gr-host-platform-activity-sparkline--tone-success {
+	color: var(--gr-color-success-700, #15803d);
+}
+.gr-host-platform-activity-sparkline--tone-warning {
+	color: var(--gr-color-warning-700, #b45309);
+}
+.gr-host-platform-activity-sparkline--tone-danger {
+	color: var(--gr-color-error-700, #b91c1c);
+}
+.gr-host-platform-activity-sparkline--tone-info {
+	color: var(--gr-color-info-700, #1d4ed8);
+}

--- a/web/src/lib/greater/host-platform/components/ActivitySparkline.svelte
+++ b/web/src/lib/greater/host-platform/components/ActivitySparkline.svelte
@@ -1,0 +1,187 @@
+<!--
+@component
+ActivitySparkline — inline SVG trend visualization.
+
+Renders an `<svg>` with one `<path>` describing the data series. The
+component never sets inline `style` attributes on any element; all
+sizing happens via CSS and the inherited `width` / `height` attributes
+on the `<svg>` (which are HTML attributes, not CSS, and therefore not
+flagged by strict CSP scans).
+
+Accessibility:
+- When `decorative === false` (the default), the SVG is informative —
+  it MUST have an accessible name. The component renders it as
+  `<svg role="img" aria-labelledby aria-describedby>` with a real
+  `<title>` (and optional `<desc>`) child. If no `label` is provided,
+  the component falls back to `'Activity trend'` so the SVG always has
+  a name.
+- When `decorative === true`, the SVG is aria-hidden and the consumer
+  is expected to provide a textual equivalent nearby (e.g. inside a
+  FleetCard metadata row).
+
+Empty state:
+- `data` length zero renders the empty-state DIV with the supplied
+  `emptyMessage` and `aria-label` on the wrapper (no zero-length
+  `<path>` is emitted).
+
+@example
+```svelte
+<ActivitySparkline data={[3, 8, 5, 12, 9, 14, 10]} label="Posts per hour" />
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { ActivitySparklineTone } from '../types.js';
+	import { buildSparklinePath } from '../utils/sparkline.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'aria-label'> {
+		/** Required data series. Empty array renders the empty state. @public */
+		data: number[];
+
+		/**
+		 * Accessible name for the SVG. Required when `decorative === false`
+		 * (the default). When omitted, falls back to `'Activity trend'`.
+		 * @public
+		 */
+		label?: string;
+
+		/**
+		 * Optional accessible description rendered as `<desc>` inside the SVG.
+		 * @public
+		 */
+		description?: string;
+
+		/**
+		 * When true, the SVG is rendered with `aria-hidden="true"` and no
+		 * `<title>` / `<desc>`. Use this only when a textual equivalent
+		 * exists immediately adjacent (e.g. a metadata row stating the value
+		 * trend). Default `false`.
+		 * @public
+		 */
+		decorative?: boolean;
+
+		/** Visual tone for the stroke (paired with `label` text — never color-only). @public */
+		tone?: ActivitySparklineTone;
+
+		/**
+		 * SVG viewBox width. Defaults to 100. Consumers size the rendered
+		 * sparkline via CSS (e.g. `width: 100%` on the wrapper).
+		 * @public
+		 */
+		width?: number;
+
+		/** SVG viewBox height. Defaults to 28. @public */
+		height?: number;
+
+		/**
+		 * Optional explicit value-range bounds. When omitted, the data min/max
+		 * is used (with a 1-unit floor so a constant series renders centered).
+		 * @public
+		 */
+		min?: number;
+		max?: number;
+
+		/** Message rendered when `data.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Additional CSS classes on the wrapper. @public */
+		class?: string;
+	}
+
+	let {
+		data,
+		label,
+		description,
+		decorative = false,
+		tone = 'default',
+		width = 100,
+		height = 28,
+		min,
+		max,
+		emptyMessage = 'No activity yet',
+		class: className = '',
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-activity-sparkline');
+	const titleId = $derived(stableId.value ? `${stableId.value}-title` : undefined);
+	const descriptionId = $derived(
+		description && stableId.value ? `${stableId.value}-desc` : undefined
+	);
+
+	const accessibleName = $derived(label ?? 'Activity trend');
+
+	const hasData = $derived(data.length > 0);
+
+	const path = $derived.by(() => {
+		if (!hasData) return null;
+		return buildSparklinePath({ data, width, height, padding: 2, min, max });
+	});
+
+	const rootClass = $derived(() =>
+		[
+			'gr-host-platform-activity-sparkline',
+			`gr-host-platform-activity-sparkline--tone-${tone}`,
+			!hasData && 'gr-host-platform-activity-sparkline--empty',
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={rootClass()} {...restProps}>
+	{#if !hasData}
+		<div
+			class="gr-host-platform-activity-sparkline__empty"
+			role="status"
+			aria-label={decorative ? undefined : accessibleName}
+		>
+			{emptyMessage}
+		</div>
+	{:else if decorative}
+		<svg
+			class="gr-host-platform-activity-sparkline__svg"
+			viewBox={`0 0 ${width} ${height}`}
+			{width}
+			{height}
+			aria-hidden="true"
+			focusable="false"
+		>
+			<path
+				class="gr-host-platform-activity-sparkline__path"
+				d={path!.path}
+				fill="none"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	{:else}
+		<svg
+			class="gr-host-platform-activity-sparkline__svg"
+			viewBox={`0 0 ${width} ${height}`}
+			{width}
+			{height}
+			role="img"
+			aria-labelledby={titleId}
+			aria-describedby={descriptionId}
+			focusable="false"
+		>
+			<title id={titleId}>{accessibleName}</title>
+			{#if description}
+				<desc id={descriptionId}>{description}</desc>
+			{/if}
+			<path
+				class="gr-host-platform-activity-sparkline__path"
+				d={path!.path}
+				fill="none"
+				stroke="currentColor"
+				stroke-linecap="round"
+				stroke-linejoin="round"
+			/>
+		</svg>
+	{/if}
+</div>

--- a/web/src/lib/greater/host-platform/components/CostGauge.css
+++ b/web/src/lib/greater/host-platform/components/CostGauge.css
@@ -1,0 +1,422 @@
+.gr-host-platform-cost-gauge {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-sm);
+	min-width: 0;
+}
+
+.gr-host-platform-cost-gauge__label {
+	font-size: 0.8125rem;
+	font-weight: 500;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-cost-gauge__body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.gr-host-platform-cost-gauge__meter {
+	position: relative;
+	height: 0.5rem;
+	border-radius: 999px;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	overflow: hidden;
+}
+
+.gr-host-platform-cost-gauge__fill {
+	position: absolute;
+	inset-block: 0;
+	inset-inline-start: 0;
+	width: 0%;
+	background: var(--gr-color-success-500, #22c55e);
+	border-radius: 999px;
+	transition: width 200ms ease;
+}
+
+/*
+ * Strict-CSP-safe fill-width steps.
+ *
+ * We avoid setting `style="..."` (which would be flagged by audit-csp) by
+ * routing the ratio through a `data-ratio` integer attribute and one CSS
+ * rule per percent step. 1% resolution is plenty for a cost gauge — users
+ * read the precise value from the `aria-valuetext` / visible readout.
+ *
+ * The list is exhaustive (0–100) so any consumer-set ratio resolves to a
+ * deterministic, attribute-selector-driven width.
+ */
+.gr-host-platform-cost-gauge__meter[data-ratio='0'] .gr-host-platform-cost-gauge__fill {
+	width: 0%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='1'] .gr-host-platform-cost-gauge__fill {
+	width: 1%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='2'] .gr-host-platform-cost-gauge__fill {
+	width: 2%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='3'] .gr-host-platform-cost-gauge__fill {
+	width: 3%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='4'] .gr-host-platform-cost-gauge__fill {
+	width: 4%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='5'] .gr-host-platform-cost-gauge__fill {
+	width: 5%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='6'] .gr-host-platform-cost-gauge__fill {
+	width: 6%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='7'] .gr-host-platform-cost-gauge__fill {
+	width: 7%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='8'] .gr-host-platform-cost-gauge__fill {
+	width: 8%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='9'] .gr-host-platform-cost-gauge__fill {
+	width: 9%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='10'] .gr-host-platform-cost-gauge__fill {
+	width: 10%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='11'] .gr-host-platform-cost-gauge__fill {
+	width: 11%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='12'] .gr-host-platform-cost-gauge__fill {
+	width: 12%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='13'] .gr-host-platform-cost-gauge__fill {
+	width: 13%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='14'] .gr-host-platform-cost-gauge__fill {
+	width: 14%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='15'] .gr-host-platform-cost-gauge__fill {
+	width: 15%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='16'] .gr-host-platform-cost-gauge__fill {
+	width: 16%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='17'] .gr-host-platform-cost-gauge__fill {
+	width: 17%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='18'] .gr-host-platform-cost-gauge__fill {
+	width: 18%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='19'] .gr-host-platform-cost-gauge__fill {
+	width: 19%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='20'] .gr-host-platform-cost-gauge__fill {
+	width: 20%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='21'] .gr-host-platform-cost-gauge__fill {
+	width: 21%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='22'] .gr-host-platform-cost-gauge__fill {
+	width: 22%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='23'] .gr-host-platform-cost-gauge__fill {
+	width: 23%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='24'] .gr-host-platform-cost-gauge__fill {
+	width: 24%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='25'] .gr-host-platform-cost-gauge__fill {
+	width: 25%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='26'] .gr-host-platform-cost-gauge__fill {
+	width: 26%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='27'] .gr-host-platform-cost-gauge__fill {
+	width: 27%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='28'] .gr-host-platform-cost-gauge__fill {
+	width: 28%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='29'] .gr-host-platform-cost-gauge__fill {
+	width: 29%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='30'] .gr-host-platform-cost-gauge__fill {
+	width: 30%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='31'] .gr-host-platform-cost-gauge__fill {
+	width: 31%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='32'] .gr-host-platform-cost-gauge__fill {
+	width: 32%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='33'] .gr-host-platform-cost-gauge__fill {
+	width: 33%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='34'] .gr-host-platform-cost-gauge__fill {
+	width: 34%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='35'] .gr-host-platform-cost-gauge__fill {
+	width: 35%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='36'] .gr-host-platform-cost-gauge__fill {
+	width: 36%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='37'] .gr-host-platform-cost-gauge__fill {
+	width: 37%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='38'] .gr-host-platform-cost-gauge__fill {
+	width: 38%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='39'] .gr-host-platform-cost-gauge__fill {
+	width: 39%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='40'] .gr-host-platform-cost-gauge__fill {
+	width: 40%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='41'] .gr-host-platform-cost-gauge__fill {
+	width: 41%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='42'] .gr-host-platform-cost-gauge__fill {
+	width: 42%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='43'] .gr-host-platform-cost-gauge__fill {
+	width: 43%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='44'] .gr-host-platform-cost-gauge__fill {
+	width: 44%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='45'] .gr-host-platform-cost-gauge__fill {
+	width: 45%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='46'] .gr-host-platform-cost-gauge__fill {
+	width: 46%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='47'] .gr-host-platform-cost-gauge__fill {
+	width: 47%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='48'] .gr-host-platform-cost-gauge__fill {
+	width: 48%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='49'] .gr-host-platform-cost-gauge__fill {
+	width: 49%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='50'] .gr-host-platform-cost-gauge__fill {
+	width: 50%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='51'] .gr-host-platform-cost-gauge__fill {
+	width: 51%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='52'] .gr-host-platform-cost-gauge__fill {
+	width: 52%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='53'] .gr-host-platform-cost-gauge__fill {
+	width: 53%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='54'] .gr-host-platform-cost-gauge__fill {
+	width: 54%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='55'] .gr-host-platform-cost-gauge__fill {
+	width: 55%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='56'] .gr-host-platform-cost-gauge__fill {
+	width: 56%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='57'] .gr-host-platform-cost-gauge__fill {
+	width: 57%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='58'] .gr-host-platform-cost-gauge__fill {
+	width: 58%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='59'] .gr-host-platform-cost-gauge__fill {
+	width: 59%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='60'] .gr-host-platform-cost-gauge__fill {
+	width: 60%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='61'] .gr-host-platform-cost-gauge__fill {
+	width: 61%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='62'] .gr-host-platform-cost-gauge__fill {
+	width: 62%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='63'] .gr-host-platform-cost-gauge__fill {
+	width: 63%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='64'] .gr-host-platform-cost-gauge__fill {
+	width: 64%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='65'] .gr-host-platform-cost-gauge__fill {
+	width: 65%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='66'] .gr-host-platform-cost-gauge__fill {
+	width: 66%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='67'] .gr-host-platform-cost-gauge__fill {
+	width: 67%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='68'] .gr-host-platform-cost-gauge__fill {
+	width: 68%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='69'] .gr-host-platform-cost-gauge__fill {
+	width: 69%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='70'] .gr-host-platform-cost-gauge__fill {
+	width: 70%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='71'] .gr-host-platform-cost-gauge__fill {
+	width: 71%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='72'] .gr-host-platform-cost-gauge__fill {
+	width: 72%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='73'] .gr-host-platform-cost-gauge__fill {
+	width: 73%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='74'] .gr-host-platform-cost-gauge__fill {
+	width: 74%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='75'] .gr-host-platform-cost-gauge__fill {
+	width: 75%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='76'] .gr-host-platform-cost-gauge__fill {
+	width: 76%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='77'] .gr-host-platform-cost-gauge__fill {
+	width: 77%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='78'] .gr-host-platform-cost-gauge__fill {
+	width: 78%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='79'] .gr-host-platform-cost-gauge__fill {
+	width: 79%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='80'] .gr-host-platform-cost-gauge__fill {
+	width: 80%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='81'] .gr-host-platform-cost-gauge__fill {
+	width: 81%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='82'] .gr-host-platform-cost-gauge__fill {
+	width: 82%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='83'] .gr-host-platform-cost-gauge__fill {
+	width: 83%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='84'] .gr-host-platform-cost-gauge__fill {
+	width: 84%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='85'] .gr-host-platform-cost-gauge__fill {
+	width: 85%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='86'] .gr-host-platform-cost-gauge__fill {
+	width: 86%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='87'] .gr-host-platform-cost-gauge__fill {
+	width: 87%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='88'] .gr-host-platform-cost-gauge__fill {
+	width: 88%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='89'] .gr-host-platform-cost-gauge__fill {
+	width: 89%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='90'] .gr-host-platform-cost-gauge__fill {
+	width: 90%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='91'] .gr-host-platform-cost-gauge__fill {
+	width: 91%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='92'] .gr-host-platform-cost-gauge__fill {
+	width: 92%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='93'] .gr-host-platform-cost-gauge__fill {
+	width: 93%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='94'] .gr-host-platform-cost-gauge__fill {
+	width: 94%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='95'] .gr-host-platform-cost-gauge__fill {
+	width: 95%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='96'] .gr-host-platform-cost-gauge__fill {
+	width: 96%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='97'] .gr-host-platform-cost-gauge__fill {
+	width: 97%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='98'] .gr-host-platform-cost-gauge__fill {
+	width: 98%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='99'] .gr-host-platform-cost-gauge__fill {
+	width: 99%;
+}
+.gr-host-platform-cost-gauge__meter[data-ratio='100'] .gr-host-platform-cost-gauge__fill {
+	width: 100%;
+}
+
+.gr-host-platform-cost-gauge--status-warning .gr-host-platform-cost-gauge__fill {
+	background: var(--gr-color-warning-500, #f59e0b);
+}
+.gr-host-platform-cost-gauge--status-danger .gr-host-platform-cost-gauge__fill {
+	background: var(--gr-color-error-500, #ef4444);
+}
+
+.gr-host-platform-cost-gauge__readout {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-host-platform-gap-sm);
+	font-size: 0.875rem;
+}
+
+.gr-host-platform-cost-gauge__value {
+	font-weight: 600;
+}
+
+.gr-host-platform-cost-gauge__separator {
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-host-platform-cost-gauge__limit {
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-cost-gauge__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.0625rem 0.375rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	margin-inline-start: auto;
+	border: 1px solid transparent;
+}
+.gr-host-platform-cost-gauge__status-icon {
+	font-size: 0.625rem;
+	line-height: 1;
+}
+
+.gr-host-platform-cost-gauge__status--ok {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-cost-gauge__status--warning {
+	background: var(--gr-color-warning-50, #fffbeb);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+.gr-host-platform-cost-gauge__status--danger {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+
+.gr-host-platform-cost-gauge__extra {
+	display: inline-flex;
+	align-items: center;
+}
+
+.gr-host-platform-cost-gauge__description {
+	margin: 0;
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}

--- a/web/src/lib/greater/host-platform/components/CostGauge.svelte
+++ b/web/src/lib/greater/host-platform/components/CostGauge.svelte
@@ -1,0 +1,303 @@
+<!--
+@component
+CostGauge — accessible cost / usage indicator using `role="meter"`.
+
+The component renders a `<div role="meter" aria-valuenow aria-valuemin
+aria-valuemax aria-valuetext aria-labelledby>` with a visible fill bar
+inside. ARIA meter semantics expose the current value, range, and an
+accessible value-text for screen readers; the visual fill width is
+driven by a strict-CSP-safe CSS custom property (`--gr-host-platform-cost-gauge-ratio`).
+Status (`ok` / `warning` / `danger`) is communicated by an icon glyph
++ text label, never by color alone.
+
+Auto-status: if `status` is omitted, the gauge derives one from the
+ratio crossing optional thresholds (default `warning: 0.75`, `danger: 0.9`).
+
+@example
+```svelte
+<CostGauge current={42.5} limit={100} currency="USD" label="Monthly spend" />
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { CostGaugeStatus, CostGaugeThresholds, CostValueFormatter } from '../types.js';
+	import { computeRatio, formatCost, formatCostGaugeText } from '../utils/formatters.js';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/** Required current value (e.g. spend so far). @public */
+		current: number;
+
+		/** Required maximum (limit / budget cap). @public */
+		limit: number;
+
+		/** Optional currency code (e.g. `'USD'`). @public */
+		currency?: string;
+
+		/**
+		 * Optional visible / accessible label for the gauge. Strongly recommended.
+		 * When omitted, the gauge falls back to `aria-label="Cost gauge"`.
+		 * @public
+		 */
+		label?: string;
+
+		/**
+		 * Optional locale for value formatting. Defaults to `'en-US'`.
+		 * @public
+		 */
+		locale?: string;
+
+		/**
+		 * Threshold ratios in `[0, 1]` for auto-status. Defaults to
+		 * `{ warning: 0.75, danger: 0.9 }`.
+		 * @public
+		 */
+		thresholds?: CostGaugeThresholds;
+
+		/**
+		 * Override the auto-derived status. When omitted, the gauge computes
+		 * `ok` / `warning` / `danger` from the ratio + thresholds.
+		 * @public
+		 */
+		status?: CostGaugeStatus;
+
+		/**
+		 * Override the value formatter. When omitted, `formatCost` (a thin
+		 * `Intl.NumberFormat` wrapper) is used.
+		 * @public
+		 */
+		formatValue?: CostValueFormatter;
+
+		/** Optional description rendered below the gauge. @public */
+		description?: string;
+
+		/**
+		 * When true, the visible label is hidden via `.gr-sr-only` (still
+		 * announced). Default is `false`. The gauge always retains an
+		 * accessible name regardless.
+		 * @public
+		 */
+		labelHidden?: boolean;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Optional trailing slot (e.g. inline help button). @public */
+		extra?: Snippet;
+	}
+
+	let {
+		current,
+		limit,
+		currency,
+		label,
+		locale,
+		thresholds,
+		status,
+		formatValue,
+		description,
+		labelHidden = false,
+		class: className = '',
+		extra,
+		'aria-label': ariaLabelProp,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-cost-gauge');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const descriptionId = $derived(
+		description && stableId.value ? `${stableId.value}-description` : undefined
+	);
+	// A hidden span carries the composed value text for the no-meter
+	// fallback. Aria-labelledby (multi-id) composes the visible label and
+	// this hidden text into a single accessible name. See the role="img"
+	// branch in the template below.
+	const valueTextId = $derived(stableId.value ? `${stableId.value}-valuetext` : undefined);
+
+	const ratio = $derived(computeRatio(current, limit));
+	const ratioPercent = $derived(Math.round(ratio * 1000) / 10);
+	// Integer percent (0..100) used as a data-ratio attribute. CSS selectors
+	// `[data-ratio="N"]` set the fill width to N% — strict-CSP-safe because
+	// we never write an inline `style="..."` attribute.
+	const ratioStep = $derived(Math.round(ratio * 100));
+
+	const resolvedThresholds = $derived<Required<CostGaugeThresholds>>({
+		warning: thresholds?.warning ?? 0.75,
+		danger: thresholds?.danger ?? 0.9,
+	});
+
+	// Svelte 5: `$derived(expr)` takes an EXPRESSION whose value is reactive;
+	// `$derived.by(fn)` takes a function that is RUN to produce the value.
+	// Passing a function literal to `$derived(...)` makes the derived value
+	// itself a function reference rather than the function's return value.
+	// Use `.by` here -- previous form was typing `resolvedStatus` as
+	// `() => CostGaugeStatus` and forcing every consumer site to call
+	// `resolvedStatus()`, which `svelte-check` correctly rejected.
+	const resolvedStatus = $derived.by<CostGaugeStatus>(() => {
+		if (status) return status;
+		if (ratio >= resolvedThresholds.danger) return 'danger';
+		if (ratio >= resolvedThresholds.warning) return 'warning';
+		return 'ok';
+	});
+
+	const statusInfo = $derived.by<{ icon: string; label: string }>(() => {
+		const map: Record<CostGaugeStatus, { icon: string; label: string }> = {
+			ok: { icon: '●', label: 'Within budget' },
+			warning: { icon: '▲', label: 'Approaching limit' },
+			danger: { icon: '■', label: 'Over budget' },
+		};
+		return map[resolvedStatus];
+	});
+
+	const formattedCurrent = $derived(
+		formatValue ? formatValue(current, currency) : formatCost(current, currency, locale)
+	);
+	const formattedLimit = $derived(
+		formatValue ? formatValue(limit, currency) : formatCost(limit, currency, locale)
+	);
+	const valueText = $derived(
+		formatValue
+			? `${formattedCurrent} of ${formattedLimit}`
+			: formatCostGaugeText(current, limit, currency, locale)
+	);
+
+	const accessibleName = $derived(label ?? ariaLabelProp ?? 'Cost gauge');
+
+	/*
+	 * ARIA-meter contract enforcement (Arch PR #669 review):
+	 *
+	 * The W3C ARIA spec requires that for `role="meter"`:
+	 *   1. `aria-valuemin < aria-valuemax` — a meter must have a valid range.
+	 *   2. `aria-valuemin <= aria-valuenow <= aria-valuemax` — the current
+	 *      value must lie within the range.
+	 *
+	 * The previous revision exposed raw `aria-valuemax={limit}` and
+	 * `aria-valuenow={current}`, which violated both rules when:
+	 *   - `current > limit` (over-budget) — valuenow exceeds valuemax.
+	 *   - `limit <= 0` — invalid range (min === max or min > max).
+	 *
+	 * Strategy:
+	 *   - When the consumer supplies a valid positive `limit`, render
+	 *     `role="meter"` but clamp `aria-valuenow` into `[0, limit]`.
+	 *     The visible / announced `aria-valuetext` (e.g. "$250.00 of $100.00")
+	 *     still carries the precise raw numbers so AT users hear the
+	 *     overrun.
+	 *   - When `limit <= 0` or non-finite, the gauge no longer represents a
+	 *     valid meter — fall back to `role="img"` with an `aria-label` that
+	 *     composes the visible readout, and drop the meter-specific ARIA
+	 *     value attributes entirely. The visual bar is still rendered (at
+	 *     0% fill) so the surface stays recognizable.
+	 */
+	const meterContract = $derived.by<
+		{ hasMeter: true; ariaValueMax: number; ariaValueNow: number } | { hasMeter: false }
+	>(() => {
+		if (!Number.isFinite(limit) || limit <= 0) {
+			return { hasMeter: false };
+		}
+		// limit > 0 → valid range. Clamp valuenow to [0, limit].
+		const valueNow = Number.isFinite(current) ? Math.max(0, Math.min(current, limit)) : 0;
+		return { hasMeter: true, ariaValueMax: limit, ariaValueNow: valueNow };
+	});
+
+	const rootClass = $derived.by(() =>
+		[
+			'gr-host-platform-cost-gauge',
+			`gr-host-platform-cost-gauge--status-${resolvedStatus}`,
+			!meterContract.hasMeter && 'gr-host-platform-cost-gauge--no-meter',
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={rootClass} {...restProps}>
+	{#if label}
+		<div
+			class={['gr-host-platform-cost-gauge__label', labelHidden && 'gr-sr-only']
+				.filter(Boolean)
+				.join(' ')}
+			id={labelId}
+		>
+			{label}
+		</div>
+	{/if}
+
+	<div class="gr-host-platform-cost-gauge__body">
+		{#if meterContract.hasMeter}
+			<div
+				class="gr-host-platform-cost-gauge__meter"
+				role="meter"
+				aria-valuemin={0}
+				aria-valuemax={meterContract.ariaValueMax}
+				aria-valuenow={meterContract.ariaValueNow}
+				aria-valuetext={valueText}
+				aria-labelledby={label ? labelId : undefined}
+				aria-label={!label ? accessibleName : undefined}
+				aria-describedby={descriptionId}
+				data-ratio={ratioStep}
+			>
+				<div class="gr-host-platform-cost-gauge__fill" aria-hidden="true"></div>
+			</div>
+		{:else}
+			<!--
+				No valid meter range (limit <= 0 or non-finite). Render the
+				bar as a labelled graphic instead of a meter — `role="img"`
+				with a composed accessible name that includes the value
+				readout, so AT users still get the current / limit values
+				without violating the ARIA meter contract.
+
+				When the consumer supplies a visible `label`, the accessible
+				name is composed by `aria-labelledby` referencing BOTH the
+				visible label and a visually-hidden span carrying the
+				`valueText`. (ARIA precedence: when both `aria-labelledby`
+				and `aria-label` are present, labelledby wins — so a single
+				labelledby pointing only at the visible label would silently
+				drop the value text. Multi-id IDREFs join the strings with
+				a space, exposing "Monthly spend $10.00 of $0.00" to AT.)
+
+				When no `label` is supplied, the composed name is carried
+				by `aria-label` alone.
+			-->
+			<span class="gr-sr-only" id={valueTextId}>{valueText}</span>
+			<div
+				class="gr-host-platform-cost-gauge__meter"
+				role="img"
+				aria-labelledby={label && labelId && valueTextId ? `${labelId} ${valueTextId}` : undefined}
+				aria-label={!label ? `${accessibleName}: ${valueText}` : undefined}
+				aria-describedby={descriptionId}
+				data-ratio={ratioStep}
+				data-no-meter="true"
+			>
+				<div class="gr-host-platform-cost-gauge__fill" aria-hidden="true"></div>
+			</div>
+		{/if}
+
+		<div class="gr-host-platform-cost-gauge__readout">
+			<span class="gr-host-platform-cost-gauge__value">{formattedCurrent}</span>
+			<span class="gr-host-platform-cost-gauge__separator" aria-hidden="true">/</span>
+			<span class="gr-host-platform-cost-gauge__limit">{formattedLimit}</span>
+			<span
+				class="gr-host-platform-cost-gauge__status gr-host-platform-cost-gauge__status--{resolvedStatus}"
+				role="status"
+				aria-label={`Status: ${statusInfo.label}`}
+			>
+				<span class="gr-host-platform-cost-gauge__status-icon" aria-hidden="true">
+					{statusInfo.icon}
+				</span>
+				<span class="gr-host-platform-cost-gauge__status-label">{statusInfo.label}</span>
+			</span>
+			{#if extra}
+				<span class="gr-host-platform-cost-gauge__extra">{@render extra()}</span>
+			{/if}
+		</div>
+	</div>
+
+	{#if description}
+		<p class="gr-host-platform-cost-gauge__description" id={descriptionId}>{description}</p>
+	{/if}
+
+	<span class="gr-sr-only" data-test="cost-gauge-percent">{ratioPercent}% of limit</span>
+</div>

--- a/web/src/lib/greater/host-platform/components/FleetCard.css
+++ b/web/src/lib/greater/host-platform/components/FleetCard.css
@@ -1,0 +1,159 @@
+.gr-host-platform-fleet-card {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-md);
+	padding: var(--gr-host-platform-gap-md) var(--gr-host-platform-gutter);
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	min-width: 0;
+}
+
+.gr-host-platform-fleet-card--variant-flat {
+	border: none;
+	background: transparent;
+}
+.gr-host-platform-fleet-card--variant-elevated {
+	box-shadow: var(--gr-shadows-base, 0 1px 3px 0 rgb(0 0 0 / 0.1));
+}
+
+.gr-host-platform-fleet-card__header {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-fleet-card__icon {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 0.375rem;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-fleet-card__identity {
+	flex: 1 1 auto;
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+}
+
+.gr-host-platform-fleet-card__title {
+	margin: 0;
+	font-size: 1rem;
+	line-height: 1.3;
+	font-weight: 600;
+}
+
+.gr-host-platform-fleet-card__subtitle {
+	margin: 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+.gr-host-platform-fleet-card__slug,
+.gr-host-platform-fleet-card__region,
+.gr-host-platform-fleet-card__version {
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-fleet-card__status {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.125rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid transparent;
+}
+.gr-host-platform-fleet-card__status-icon {
+	font-size: 0.6875rem;
+	line-height: 1;
+}
+
+.gr-host-platform-fleet-card__status--healthy {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-fleet-card__status--provisioning {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-fleet-card__status--warning {
+	background: var(--gr-color-warning-50, #fffbeb);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+.gr-host-platform-fleet-card__status--degraded,
+.gr-host-platform-fleet-card__status--offline {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-fleet-card__status--unknown {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-fleet-card__description {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-fleet-card__metadata {
+	margin: 0;
+	padding: 0;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+	gap: var(--gr-host-platform-gap-sm) var(--gr-host-platform-gap-md);
+}
+.gr-host-platform-fleet-card__metadata-row {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	min-width: 0;
+}
+.gr-host-platform-fleet-card__metadata-key {
+	margin: 0;
+	font-size: 0.75rem;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+.gr-host-platform-fleet-card__metadata-value {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-fleet-card__signals {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+	gap: var(--gr-host-platform-gap-md);
+}
+.gr-host-platform-fleet-card__signal {
+	min-width: 0;
+}
+
+.gr-host-platform-fleet-card__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	margin-top: 0.25rem;
+}

--- a/web/src/lib/greater/host-platform/components/FleetCard.svelte
+++ b/web/src/lib/greater/host-platform/components/FleetCard.svelte
@@ -1,0 +1,238 @@
+<!--
+@component
+FleetCard — composed instance / fleet card for hosted-platform dashboards.
+
+Renders a `<section>` landmark with:
+- A header showing the instance name + region + version + status badge
+- An optional description paragraph
+- An optional metadata `<dl>` (description list) with `<dt>` / `<dd>` rows
+- Optional cost / activity slots (typically containing `CostGauge` / `ActivitySparkline`)
+- Optional actions slot (CTAs)
+- Optional leading icon slot (`aria-hidden`)
+
+Strict-CSP safe: no inline event handlers; no inline style attributes; status
+is communicated by an icon glyph + text alongside any color tinting (never
+color-only).
+
+@example
+```svelte
+<FleetCard
+	name="lesser.example"
+	region="us-east-1"
+	version="v1.4.12"
+	status="healthy"
+	metadata={[
+		{ key: 'Users', value: '1,243' },
+		{ key: 'Posts / day', value: '8,901' },
+	]}
+>
+	{#snippet cost()}<CostGauge current={42.5} limit={100} currency="USD" />{/snippet}
+	{#snippet activity()}<ActivitySparkline data={[3, 8, 5, 12, 9, 14, 10]} label="Posts/hour" />{/snippet}
+	{#snippet actions()}<button type="button">Manage</button>{/snippet}
+</FleetCard>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { FleetCardMetadataItem, FleetCardStatus, FleetCardVariant } from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLElement> {
+		/** Required visible name of the instance / fleet. @public */
+		name: string;
+
+		/** Optional slug / identifier rendered subtly under the name. @public */
+		slug?: string;
+
+		/** Optional region label (e.g. "us-east-1"). @public */
+		region?: string;
+
+		/** Optional version label (e.g. "v1.4.12"). @public */
+		version?: string;
+
+		/**
+		 * Status drives the badge icon + accessible name. Defaults to `'unknown'`.
+		 * Never color-only — every status has an associated glyph and text label.
+		 * @public
+		 */
+		status?: FleetCardStatus;
+
+		/**
+		 * Override the visible / accessible status label. When omitted, the label
+		 * is derived from `status` (e.g. `'healthy'` → "Healthy").
+		 * @public
+		 */
+		statusLabel?: string;
+
+		/** Optional supporting description paragraph. @public */
+		description?: string;
+
+		/** Optional metadata rows rendered in a `<dl>`. @public */
+		metadata?: FleetCardMetadataItem[];
+
+		/** Visual variant. @public */
+		variant?: FleetCardVariant;
+
+		/** Heading level for the card title. Defaults to 3 so it nests under page titles. @public */
+		headerLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Leading icon snippet (rendered with `aria-hidden`). @public */
+		icon?: Snippet;
+
+		/** Cost slot — typically a `CostGauge`. @public */
+		cost?: Snippet;
+
+		/** Activity slot — typically an `ActivitySparkline`. @public */
+		activity?: Snippet;
+
+		/** Actions slot — buttons / links. Wrapped in `<div role="group">`. @public */
+		actions?: Snippet;
+	}
+
+	let {
+		name,
+		slug,
+		region,
+		version,
+		status = 'unknown',
+		statusLabel,
+		description,
+		metadata,
+		variant = 'default',
+		headerLevel = 3,
+		class: className = '',
+		icon,
+		cost,
+		activity,
+		actions,
+		'aria-labelledby': ariaLabelledby,
+		'aria-label': ariaLabel,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-fleet-card');
+	const titleId = $derived(stableId.value ? `${stableId.value}-title` : undefined);
+	const statusId = $derived(stableId.value ? `${stableId.value}-status` : undefined);
+	const resolvedLabelledby = $derived(ariaLabelledby ?? titleId);
+
+	const statusInfo = $derived.by<{ label: string; icon: string }>(() => {
+		const map: Record<FleetCardStatus, { label: string; icon: string }> = {
+			healthy: { label: 'Healthy', icon: '●' },
+			provisioning: { label: 'Provisioning', icon: '◌' },
+			warning: { label: 'Warning', icon: '▲' },
+			degraded: { label: 'Degraded', icon: '▼' },
+			offline: { label: 'Offline', icon: '■' },
+			unknown: { label: 'Unknown', icon: '?' },
+		};
+		const entry = map[status];
+		return { label: statusLabel ?? entry.label, icon: entry.icon };
+	});
+
+	const rootClass = $derived(() =>
+		[
+			'gr-host-platform-fleet-card',
+			`gr-host-platform-fleet-card--variant-${variant}`,
+			`gr-host-platform-fleet-card--status-${status}`,
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<section
+	class={rootClass()}
+	aria-labelledby={resolvedLabelledby}
+	aria-label={!resolvedLabelledby ? ariaLabel : undefined}
+	{...restProps}
+>
+	<header class="gr-host-platform-fleet-card__header">
+		{#if icon}
+			<div class="gr-host-platform-fleet-card__icon" aria-hidden="true">{@render icon()}</div>
+		{/if}
+		<div class="gr-host-platform-fleet-card__identity">
+			{#if headerLevel === 1}
+				<h1 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h1>
+			{:else if headerLevel === 2}
+				<h2 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h2>
+			{:else if headerLevel === 3}
+				<h3 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h3>
+			{:else if headerLevel === 4}
+				<h4 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h4>
+			{:else if headerLevel === 5}
+				<h5 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h5>
+			{:else}
+				<h6 id={titleId} class="gr-host-platform-fleet-card__title">{name}</h6>
+			{/if}
+			{#if slug || region || version}
+				<p class="gr-host-platform-fleet-card__subtitle">
+					{#if slug}<span class="gr-host-platform-fleet-card__slug">{slug}</span>{/if}
+					{#if region}
+						<span class="gr-host-platform-fleet-card__region" aria-label="Region">
+							{region}
+						</span>
+					{/if}
+					{#if version}
+						<span class="gr-host-platform-fleet-card__version" aria-label="Version">
+							{version}
+						</span>
+					{/if}
+				</p>
+			{/if}
+		</div>
+		<div
+			id={statusId}
+			class="gr-host-platform-fleet-card__status gr-host-platform-fleet-card__status--{status}"
+			role="status"
+			aria-label={`Status: ${statusInfo.label}`}
+		>
+			<span class="gr-host-platform-fleet-card__status-icon" aria-hidden="true">
+				{statusInfo.icon}
+			</span>
+			<span class="gr-host-platform-fleet-card__status-label">{statusInfo.label}</span>
+		</div>
+	</header>
+
+	{#if description}
+		<p class="gr-host-platform-fleet-card__description">{description}</p>
+	{/if}
+
+	{#if metadata && metadata.length > 0}
+		<dl class="gr-host-platform-fleet-card__metadata">
+			{#each metadata as row, index (`${row.key}-${index}`)}
+				<div class="gr-host-platform-fleet-card__metadata-row">
+					<dt class="gr-host-platform-fleet-card__metadata-key">{row.key}</dt>
+					<dd class="gr-host-platform-fleet-card__metadata-value">{row.value}</dd>
+				</div>
+			{/each}
+		</dl>
+	{/if}
+
+	{#if cost || activity}
+		<div class="gr-host-platform-fleet-card__signals">
+			{#if cost}
+				<div class="gr-host-platform-fleet-card__signal gr-host-platform-fleet-card__signal--cost">
+					{@render cost()}
+				</div>
+			{/if}
+			{#if activity}
+				<div
+					class="gr-host-platform-fleet-card__signal gr-host-platform-fleet-card__signal--activity"
+				>
+					{@render activity()}
+				</div>
+			{/if}
+		</div>
+	{/if}
+
+	{#if actions}
+		<div class="gr-host-platform-fleet-card__actions" role="group" aria-label="Fleet actions">
+			{@render actions()}
+		</div>
+	{/if}
+</section>

--- a/web/src/lib/greater/host-platform/components/ProvisioningTimeline.css
+++ b/web/src/lib/greater/host-platform/components/ProvisioningTimeline.css
@@ -1,0 +1,191 @@
+.gr-host-platform-provisioning-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__empty {
+	padding: var(--gr-host-platform-gap-md) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px dashed var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	font-size: 0.875rem;
+}
+
+.gr-host-platform-provisioning-timeline__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+}
+
+.gr-host-platform-provisioning-timeline__step {
+	display: grid;
+	grid-template-columns: 1.5rem 1fr;
+	gap: var(--gr-host-platform-gap-md);
+	padding: 0;
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__rail {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	min-height: 1.5rem;
+}
+
+.gr-host-platform-provisioning-timeline__marker {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 999px;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-size: 0.75rem;
+	font-weight: 700;
+	flex-shrink: 0;
+}
+
+.gr-host-platform-provisioning-timeline__line {
+	width: 1px;
+	flex: 1 1 auto;
+	background: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	margin-block: 0.25rem;
+	min-height: 1rem;
+}
+
+.gr-host-platform-provisioning-timeline__body {
+	padding-bottom: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__step:last-child
+	.gr-host-platform-provisioning-timeline__body {
+	padding-bottom: 0;
+}
+
+.gr-host-platform-provisioning-timeline__header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-host-platform-gap-sm);
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__label {
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	min-width: 0;
+}
+
+.gr-host-platform-provisioning-timeline__status {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid transparent;
+	flex-shrink: 0;
+}
+
+.gr-host-platform-provisioning-timeline__step--status-pending
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-provisioning-timeline__step--status-active
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-provisioning-timeline__step--status-active
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-info-100, #dbeafe);
+	color: var(--gr-color-info-700, #1d4ed8);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-provisioning-timeline__step--status-success
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-provisioning-timeline__step--status-success
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-700, #15803d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-provisioning-timeline__step--status-failure
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-provisioning-timeline__step--status-failure
+	.gr-host-platform-provisioning-timeline__marker {
+	background: var(--gr-color-error-100, #fee2e2);
+	color: var(--gr-color-error-700, #b91c1c);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-provisioning-timeline__step--status-skipped
+	.gr-host-platform-provisioning-timeline__status {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-provisioning-timeline__description {
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-provisioning-timeline__meta {
+	margin: 0.25rem 0 0;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	font-size: 0.75rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-host-platform-provisioning-timeline__time {
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-provisioning-timeline__log {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	padding: var(--gr-host-platform-gap-sm) var(--gr-host-platform-gap-md);
+}
+
+.gr-host-platform-provisioning-timeline__log-label {
+	margin: 0;
+	font-size: 0.8125rem;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-provisioning-timeline__log-body {
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	font-size: 0.8125rem;
+	line-height: 1.4;
+	max-height: 12rem;
+	overflow-y: auto;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}

--- a/web/src/lib/greater/host-platform/components/ProvisioningTimeline.svelte
+++ b/web/src/lib/greater/host-platform/components/ProvisioningTimeline.svelte
@@ -1,0 +1,233 @@
+<!--
+@component
+ProvisioningTimeline — ordered timeline of provisioning job steps for
+hosted-platform operator consoles.
+
+Renders an `<ol>` (semantic ordered list) inside a `<section
+aria-labelledby>` landmark. Each step is an `<li>` with status icon
+glyph + visible text label (never color-only), description, optional
+timestamp, and optional metadata. The *active* step (status='active')
+also carries `aria-current="step"` so AT users hear which step is in
+progress.
+
+When the consumer supplies a `liveLog` snippet, the component wraps it
+in a constrained `<section role="log" aria-live aria-atomic="false"
+aria-labelledby>` region so only NEW log lines announce — never the
+full backlog. `liveLogPoliteness` defaults to `'polite'`; set to
+`'off'` for visible-only logs.
+
+Strict-CSP safe: no inline event handlers, no `style` attributes, no
+runtime style writes. All styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<ProvisioningTimeline
+	label="lesser.example provisioning"
+	steps={[
+		{ id: 'allocate', label: 'Allocate compute', status: 'success', timestamp: '2026-05-24T15:00:00Z' },
+		{ id: 'install',  label: 'Install Lesser',   status: 'active' },
+		{ id: 'migrate',  label: 'Run migrations',   status: 'pending' },
+	]}
+>
+	{#snippet liveLog()}
+		<pre>15:01:02 [allocate] node provisioned…
+15:01:34 [install] downloading container…</pre>
+	{/snippet}
+</ProvisioningTimeline>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type {
+		ProvisioningLogPoliteness,
+		ProvisioningStep,
+		ProvisioningStepStatus,
+	} from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Required accessible name for the timeline region. @public */
+		label: string;
+
+		/** Ordered steps (renders in array order). @public */
+		steps: ProvisioningStep[];
+
+		/**
+		 * Constrained live-log slot. When provided, the component wraps the
+		 * rendered content in a `<section role="log">` with `aria-live` so
+		 * new log lines announce politely. The consumer is responsible for
+		 * APPENDING new content (the live region announces incremental
+		 * changes; full re-renders are noisy).
+		 * @public
+		 */
+		liveLog?: Snippet;
+
+		/**
+		 * Accessible name for the live-log region. Defaults to
+		 * `'Live provisioning log'`. Strongly recommended to override when
+		 * multiple timelines coexist on a page.
+		 * @public
+		 */
+		liveLogLabel?: string;
+
+		/**
+		 * ARIA politeness for the live-log region. `'off'` disables
+		 * announcements while keeping the visible log. Defaults to `'polite'`.
+		 * @public
+		 */
+		liveLogPoliteness?: ProvisioningLogPoliteness;
+
+		/** Message rendered when `steps.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+	}
+
+	let {
+		label,
+		steps,
+		liveLog,
+		liveLogLabel = 'Live provisioning log',
+		liveLogPoliteness = 'polite',
+		emptyMessage = 'No provisioning steps yet.',
+		class: className = '',
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-prov-timeline');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const logLabelId = $derived(stableId.value ? `${stableId.value}-log-label` : undefined);
+
+	const statusInfo = $derived.by(() => {
+		const map: Record<ProvisioningStepStatus, { icon: string; label: string }> = {
+			pending: { icon: '○', label: 'Pending' },
+			active: { icon: '◌', label: 'In progress' },
+			success: { icon: '✓', label: 'Completed' },
+			failure: { icon: '✕', label: 'Failed' },
+			skipped: { icon: '—', label: 'Skipped' },
+		};
+		return map;
+	});
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-provisioning-timeline', className].filter(Boolean).join(' ')
+	);
+
+	const hasSteps = $derived(steps.length > 0);
+</script>
+
+<section class={rootClass()} aria-labelledby={labelId} {...restProps}>
+	<h2 id={labelId} class="gr-sr-only">{label}</h2>
+
+	{#if !hasSteps}
+		<div class="gr-host-platform-provisioning-timeline__empty" role="status">
+			{emptyMessage}
+		</div>
+	{:else}
+		<ol class="gr-host-platform-provisioning-timeline__list">
+			{#each steps as step, index (step.id)}
+				{@const status = step.status ?? 'pending'}
+				{@const info = statusInfo[status]}
+				<li
+					id={stableId.value ? `${stableId.value}-step-${step.id}` : undefined}
+					class={[
+						'gr-host-platform-provisioning-timeline__step',
+						`gr-host-platform-provisioning-timeline__step--status-${status}`,
+					].join(' ')}
+					aria-current={status === 'active' ? 'step' : undefined}
+				>
+					<span class="gr-host-platform-provisioning-timeline__rail" aria-hidden="true">
+						<span class="gr-host-platform-provisioning-timeline__marker">{info.icon}</span>
+						{#if index < steps.length - 1}
+							<span class="gr-host-platform-provisioning-timeline__line"></span>
+						{/if}
+					</span>
+					<div class="gr-host-platform-provisioning-timeline__body">
+						<div class="gr-host-platform-provisioning-timeline__header">
+							<span class="gr-host-platform-provisioning-timeline__label">{step.label}</span>
+							<span
+								class="gr-host-platform-provisioning-timeline__status"
+								aria-label={`Status: ${info.label}`}
+							>
+								<span class="gr-host-platform-provisioning-timeline__status-text">
+									{info.label}
+								</span>
+							</span>
+						</div>
+						{#if step.description}
+							<p class="gr-host-platform-provisioning-timeline__description">
+								{step.description}
+							</p>
+						{/if}
+						{#if step.timestamp || step.meta}
+							<p class="gr-host-platform-provisioning-timeline__meta">
+								{#if step.timestamp}
+									<time
+										class="gr-host-platform-provisioning-timeline__time"
+										datetime={step.timestamp}
+									>
+										{step.timestamp}
+									</time>
+								{/if}
+								{#if step.meta}
+									<span class="gr-host-platform-provisioning-timeline__meta-text">
+										{step.meta}
+									</span>
+								{/if}
+							</p>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+
+	{#if liveLog}
+		<!--
+			When `liveLogPoliteness === 'off'`, we MUST drop `role="log"`
+			entirely — not just `aria-live`. `role="log"` has implicit polite
+			live-region semantics in screen readers; merely omitting `aria-live`
+			leaves the role's implicit announcements in place. Arch flagged this
+			in PR #670 review. For the off-case we render a plain `<section
+			aria-labelledby>` so the consumer's log still appears visibly but
+			never announces to AT.
+
+			Polite / assertive paths keep `role="log"` and the matching
+			`aria-live`, with `aria-atomic="false"` + `aria-relevant="additions"`
+			so AT users hear only NEW lines, not the entire backlog on each
+			update.
+		-->
+		{#if liveLogPoliteness === 'off'}
+			<section
+				class="gr-host-platform-provisioning-timeline__log gr-host-platform-provisioning-timeline__log--quiet"
+				aria-labelledby={logLabelId}
+			>
+				<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
+					{liveLogLabel}
+				</h3>
+				<div class="gr-host-platform-provisioning-timeline__log-body">
+					{@render liveLog()}
+				</div>
+			</section>
+		{:else}
+			<section
+				class="gr-host-platform-provisioning-timeline__log"
+				role="log"
+				aria-live={liveLogPoliteness}
+				aria-atomic="false"
+				aria-relevant="additions"
+				aria-labelledby={logLabelId}
+			>
+				<h3 id={logLabelId} class="gr-host-platform-provisioning-timeline__log-label">
+					{liveLogLabel}
+				</h3>
+				<div class="gr-host-platform-provisioning-timeline__log-body">
+					{@render liveLog()}
+				</div>
+			</section>
+		{/if}
+	{/if}
+</section>

--- a/web/src/lib/greater/host-platform/components/ReleaseTimeline.css
+++ b/web/src/lib/greater/host-platform/components/ReleaseTimeline.css
@@ -1,0 +1,175 @@
+.gr-host-platform-release-timeline {
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__empty {
+	padding: var(--gr-host-platform-gap-md) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border: 1px dashed var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: var(--gr-host-platform-radius);
+	font-size: 0.875rem;
+}
+
+.gr-host-platform-release-timeline__list {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	display: flex;
+	flex-direction: column;
+}
+
+.gr-host-platform-release-timeline__release {
+	display: grid;
+	grid-template-columns: 1.5rem 1fr;
+	gap: var(--gr-host-platform-gap-md);
+	padding-bottom: var(--gr-host-platform-gap-md);
+	min-width: 0;
+}
+.gr-host-platform-release-timeline__release:last-child {
+	padding-bottom: 0;
+}
+
+.gr-host-platform-release-timeline__rail {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}
+
+.gr-host-platform-release-timeline__marker {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.5rem;
+	height: 1.5rem;
+	border-radius: 999px;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-size: 0.75rem;
+	font-weight: 700;
+}
+
+.gr-host-platform-release-timeline__body {
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__header {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: var(--gr-host-platform-gap-sm);
+	min-width: 0;
+}
+
+.gr-host-platform-release-timeline__version {
+	font-weight: 600;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-release-timeline__channel {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.6875rem;
+	font-weight: 700;
+	letter-spacing: 0.05em;
+	text-transform: uppercase;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-release-timeline__release--channel-stable
+	.gr-host-platform-release-timeline__channel {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-release-timeline__release--channel-beta
+	.gr-host-platform-release-timeline__channel {
+	background: var(--gr-color-warning-100, #fef3c7);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+
+.gr-host-platform-release-timeline__status {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.0625rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.75rem;
+	font-weight: 600;
+	border: 1px solid transparent;
+}
+.gr-host-platform-release-timeline__release--status-shipped
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-shipped
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-release-timeline__release--status-in-progress
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-in-progress
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-release-timeline__release--status-rolled-back
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-rolled-back
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-host-platform-release-timeline__release--status-planned
+	.gr-host-platform-release-timeline__status,
+.gr-host-platform-release-timeline__release--status-planned
+	.gr-host-platform-release-timeline__marker {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-release-timeline__date {
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+	margin-inline-start: auto;
+}
+
+.gr-host-platform-release-timeline__description {
+	margin: 0.25rem 0 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-release-timeline__adoption,
+.gr-host-platform-release-timeline__adoption-static {
+	margin: 0.375rem 0 0;
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-release-timeline__actions {
+	margin-top: 0.5rem;
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	align-items: center;
+}
+
+.gr-host-platform-release-timeline__link {
+	font-size: 0.8125rem;
+	color: var(--gr-color-primary-700, #1d4ed8);
+}
+.gr-host-platform-release-timeline__link:hover {
+	text-decoration: underline;
+}

--- a/web/src/lib/greater/host-platform/components/ReleaseTimeline.svelte
+++ b/web/src/lib/greater/host-platform/components/ReleaseTimeline.svelte
@@ -1,0 +1,273 @@
+<!--
+@component
+ReleaseTimeline — two-channel release-history timeline.
+
+Renders an `<ol>` (semantic ordered list) inside a `<section
+aria-labelledby>` landmark. Each release is an `<li>` with channel
+badge, version, accessible date, status icon glyph + text label
+(never color-only), and optional adoption percentage / count.
+
+Two-channel presentation: when consumers want stable + beta side by
+side, they pass `releases` containing items with distinct `channel`
+fields. The component renders the items in their supplied order
+(release-newest-first is conventional) and visually distinguishes
+channels via classes. No date sorting / grouping is performed; the
+component is presentational only.
+
+Adoption metric:
+- Numeric values in `[0, 1]` are formatted as `"XX%"` and exposed via
+  `aria-valuetext` semantics on a `role="meter"` element inside each
+  release (with a valid range [0, 1] — see CostGauge's contract
+  for the meter-validity rules this also follows).
+- String adoption values render as-is (e.g. `"42 of 100 instances"`).
+
+Strict-CSP safe: no inline event handlers, no `style` attributes, no
+runtime style writes. All styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<ReleaseTimeline
+	label="Lesser release history"
+	releases={[
+		{ id: 'v1412', version: 'v1.4.12', channel: 'stable', date: '2026-05-22',
+		  status: 'shipped', adoption: 0.82 },
+		{ id: 'v1500rc1', version: 'v1.5.0-rc.1', channel: 'beta', date: '2026-05-23',
+		  status: 'in-progress', adoption: 0.05 },
+	]}
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { ReleaseAdoptionFormatter, ReleaseStatus, ReleaseTimelineItem } from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Required accessible name for the timeline region. @public */
+		label: string;
+
+		/** Required release list (rendered in array order). @public */
+		releases: ReleaseTimelineItem[];
+
+		/**
+		 * Custom date formatter. Receives the raw `date` (Date or ISO string)
+		 * and returns a visible string. Defaults to `Intl.DateTimeFormat`
+		 * with `'en-US'` locale + medium date style.
+		 * @public
+		 */
+		formatDate?: (date: Date | string) => string;
+
+		/**
+		 * Custom adoption formatter. Receives the raw `adoption` and returns
+		 * a visible string. When omitted, numeric adoption is formatted as
+		 * `XX%` and string adoption is rendered as-is.
+		 * @public
+		 */
+		formatAdoption?: ReleaseAdoptionFormatter;
+
+		/** Optional locale for the default date formatter. Defaults to `'en-US'`. @public */
+		locale?: string;
+
+		/** Message rendered when `releases.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Optional trailing action snippet rendered per item (e.g. release notes link). @public */
+		itemActions?: Snippet<[ReleaseTimelineItem]>;
+	}
+
+	let {
+		label,
+		releases,
+		formatDate,
+		formatAdoption,
+		locale = 'en-US',
+		emptyMessage = 'No releases recorded yet.',
+		class: className = '',
+		itemActions,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-release-timeline');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+
+	const statusInfo = $derived.by(() => {
+		const map: Record<ReleaseStatus, { icon: string; label: string }> = {
+			shipped: { icon: '✓', label: 'Shipped' },
+			'in-progress': { icon: '◌', label: 'Rolling out' },
+			'rolled-back': { icon: '↺', label: 'Rolled back' },
+			planned: { icon: '○', label: 'Planned' },
+		};
+		return map;
+	});
+
+	/**
+	 * True when the input string represents a date that should be interpreted
+	 * as a calendar day rather than a precise instant — e.g. a bare
+	 * `'2026-05-22'` or any ISO string at UTC midnight (`...T00:00:00Z`).
+	 *
+	 * Calendar-day inputs MUST be formatted in UTC; otherwise `Intl.DateTimeFormat`
+	 * applies the viewer's local timezone offset and renders the previous day
+	 * in any timezone west of UTC (US, Pacific, much of the Americas). Arch
+	 * flagged this regression on PR #670 — releases dated `'2026-05-22T00:00:00Z'`
+	 * rendered as "May 21" in US timezones.
+	 */
+	function isCalendarDayString(d: string): boolean {
+		// Bare `YYYY-MM-DD`.
+		if (/^\d{4}-\d{2}-\d{2}$/.test(d)) return true;
+		// ISO 8601 at UTC midnight (`...T00:00:00Z` or `...T00:00:00.000Z`).
+		if (/^\d{4}-\d{2}-\d{2}T00:00:00(?:\.0+)?Z$/.test(d)) return true;
+		return false;
+	}
+
+	function defaultFormatDate(d: Date | string): string {
+		const isCalendarDay = typeof d === 'string' && isCalendarDayString(d);
+		const date = typeof d === 'string' ? new Date(d) : d;
+		if (Number.isNaN(date.getTime())) return typeof d === 'string' ? d : '';
+		try {
+			return new Intl.DateTimeFormat(locale, {
+				dateStyle: 'medium',
+				// For calendar-day inputs, format in UTC so we render the same
+				// day the consumer typed (no local-timezone shift).
+				timeZone: isCalendarDay ? 'UTC' : undefined,
+			}).format(date);
+		} catch {
+			return date.toISOString().slice(0, 10);
+		}
+	}
+
+	function dateIsoAttr(d: Date | string): string | undefined {
+		const date = typeof d === 'string' ? new Date(d) : d;
+		if (Number.isNaN(date.getTime())) return typeof d === 'string' ? d : undefined;
+		return date.toISOString();
+	}
+
+	function defaultFormatAdoption(value: number | string | undefined): string | undefined {
+		if (value === undefined) return undefined;
+		if (typeof value === 'string') return value;
+		if (!Number.isFinite(value)) return undefined;
+		const clamped = Math.max(0, Math.min(1, value));
+		return `${Math.round(clamped * 100)}%`;
+	}
+
+	function numericAdoption(value: number | string | undefined): number | null {
+		if (typeof value !== 'number') return null;
+		if (!Number.isFinite(value)) return null;
+		return Math.max(0, Math.min(1, value));
+	}
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-release-timeline', className].filter(Boolean).join(' ')
+	);
+
+	const hasReleases = $derived(releases.length > 0);
+</script>
+
+<section class={rootClass()} aria-labelledby={labelId} {...restProps}>
+	<h2 id={labelId} class="gr-sr-only">{label}</h2>
+
+	{#if !hasReleases}
+		<div class="gr-host-platform-release-timeline__empty" role="status">
+			{emptyMessage}
+		</div>
+	{:else}
+		<ol class="gr-host-platform-release-timeline__list">
+			{#each releases as release (release.id)}
+				{@const status = release.status ?? 'shipped'}
+				{@const info = statusInfo[status]}
+				{@const visibleDate = (formatDate ?? defaultFormatDate)(release.date)}
+				{@const isoDate = dateIsoAttr(release.date)}
+				{@const adoptionText = (formatAdoption ?? defaultFormatAdoption)(release.adoption)}
+				{@const adoptionRatio = numericAdoption(release.adoption)}
+				<li
+					id={stableId.value ? `${stableId.value}-rel-${release.id}` : undefined}
+					class={[
+						'gr-host-platform-release-timeline__release',
+						`gr-host-platform-release-timeline__release--status-${status}`,
+						`gr-host-platform-release-timeline__release--channel-${release.channel}`,
+					].join(' ')}
+				>
+					<span class="gr-host-platform-release-timeline__rail" aria-hidden="true">
+						<span class="gr-host-platform-release-timeline__marker">{info.icon}</span>
+					</span>
+					<div class="gr-host-platform-release-timeline__body">
+						<div class="gr-host-platform-release-timeline__header">
+							<span class="gr-host-platform-release-timeline__version">{release.version}</span>
+							<span
+								class="gr-host-platform-release-timeline__channel"
+								aria-label={`Channel: ${release.channel}`}
+							>
+								{release.channel}
+							</span>
+							<span
+								class="gr-host-platform-release-timeline__status"
+								aria-label={`Status: ${info.label}`}
+							>
+								<span class="gr-host-platform-release-timeline__status-text">{info.label}</span>
+							</span>
+							<time class="gr-host-platform-release-timeline__date" datetime={isoDate ?? undefined}>
+								{visibleDate}
+							</time>
+						</div>
+						{#if release.description}
+							<p class="gr-host-platform-release-timeline__description">{release.description}</p>
+						{/if}
+						{#if adoptionText !== undefined}
+							{#if adoptionRatio !== null}
+								{@const adoptionLabelId = stableId.value
+									? `${stableId.value}-rel-${release.id}-adoption-label`
+									: undefined}
+								<!--
+									The adoption meter MUST have an accessible name. We use
+									`aria-labelledby` pointing at the visible adoption text
+									(rather than aria-label) so the visible text and the
+									announced name stay in sync.  aria-valuetext carries the
+									numeric value; aria-labelledby carries the "what is this
+									meter measuring" semantic.
+								-->
+								<div
+									class="gr-host-platform-release-timeline__adoption"
+									role="meter"
+									aria-labelledby={adoptionLabelId}
+									aria-valuemin={0}
+									aria-valuemax={1}
+									aria-valuenow={adoptionRatio}
+									aria-valuetext={`Adoption: ${adoptionText}`}
+								>
+									<span
+										id={adoptionLabelId}
+										class="gr-host-platform-release-timeline__adoption-text"
+									>
+										Adoption: {adoptionText}
+									</span>
+								</div>
+							{:else}
+								<p class="gr-host-platform-release-timeline__adoption-static">
+									Adoption: {adoptionText}
+								</p>
+							{/if}
+						{/if}
+						{#if release.href || itemActions}
+							<div class="gr-host-platform-release-timeline__actions" role="group">
+								{#if release.href}
+									<a
+										class="gr-host-platform-release-timeline__link"
+										href={release.href}
+										aria-label={`Release notes for ${release.version}`}
+									>
+										Release notes
+									</a>
+								{/if}
+								{#if itemActions}{@render itemActions(release)}{/if}
+							</div>
+						{/if}
+					</div>
+				</li>
+			{/each}
+		</ol>
+	{/if}
+</section>

--- a/web/src/lib/greater/host-platform/components/StackMatrix.css
+++ b/web/src/lib/greater/host-platform/components/StackMatrix.css
@@ -1,0 +1,155 @@
+.gr-host-platform-stack-matrix {
+	overflow-x: auto;
+	min-width: 0;
+}
+
+.gr-host-platform-stack-matrix__table {
+	width: 100%;
+	border-collapse: collapse;
+	font-size: 0.875rem;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-stack-matrix__caption {
+	text-align: start;
+	caption-side: top;
+	padding: 0 0 var(--gr-host-platform-gap-sm);
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-host-platform-stack-matrix__col-header,
+.gr-host-platform-stack-matrix__row-header,
+.gr-host-platform-stack-matrix__actions-header,
+.gr-host-platform-stack-matrix__row-header-col {
+	text-align: start;
+	font-weight: 600;
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	white-space: nowrap;
+}
+
+.gr-host-platform-stack-matrix__col-header--sortable {
+	padding: 0;
+}
+
+.gr-host-platform-stack-matrix__sort-button {
+	all: unset;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	width: 100%;
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	cursor: pointer;
+	font-weight: inherit;
+	color: inherit;
+}
+.gr-host-platform-stack-matrix__sort-button:hover {
+	background: var(--gr-semantic-background-tertiary, var(--gr-color-gray-100, #f3f4f6));
+}
+.gr-host-platform-stack-matrix__sort-button:focus-visible {
+	outline: 2px solid var(--gr-semantic-border-focus, var(--gr-color-primary-600, #2563eb));
+	outline-offset: -2px;
+}
+
+.gr-host-platform-stack-matrix__sort-indicator {
+	font-size: 0.6875rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-host-platform-stack-matrix__row {
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-host-platform-stack-matrix__row:last-child {
+	border-bottom: none;
+}
+
+.gr-host-platform-stack-matrix__row-header {
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	border-right: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	min-width: 12rem;
+}
+
+.gr-host-platform-stack-matrix__row-label {
+	display: block;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-host-platform-stack-matrix__row-sublabel {
+	display: block;
+	font-size: 0.75rem;
+	font-weight: normal;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell {
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	vertical-align: middle;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell-value {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.375rem;
+	padding: 0.125rem 0.5rem;
+	border-radius: 999px;
+	font-size: 0.8125rem;
+	border: 1px solid transparent;
+	font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+}
+
+.gr-host-platform-stack-matrix__cell-value--drift-in-sync {
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-pending {
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-drifted {
+	background: var(--gr-color-warning-50, #fffbeb);
+	color: var(--gr-color-warning-900, #78350f);
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+.gr-host-platform-stack-matrix__cell-value--drift-unknown {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	border-color: var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-host-platform-stack-matrix__drift-icon {
+	font-size: 0.6875rem;
+	font-weight: 700;
+	line-height: 1;
+}
+
+.gr-host-platform-stack-matrix__actions-cell {
+	padding: 0.5rem var(--gr-host-platform-gap-md);
+	text-align: end;
+	vertical-align: middle;
+}
+
+.gr-host-platform-stack-matrix__actions {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: var(--gr-host-platform-gap-sm);
+	align-items: center;
+}
+
+.gr-host-platform-stack-matrix__empty-row {
+	border-bottom: none;
+}
+
+.gr-host-platform-stack-matrix__empty {
+	padding: var(--gr-host-platform-gap-lg) var(--gr-host-platform-gutter);
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	text-align: center;
+}

--- a/web/src/lib/greater/host-platform/components/StackMatrix.svelte
+++ b/web/src/lib/greater/host-platform/components/StackMatrix.svelte
@@ -1,0 +1,293 @@
+<!--
+@component
+StackMatrix — semantic table view of stack / version drift across rows.
+
+Renders a real `<table>` with `<caption>` (visually-hidden by default
+but available to AT), `<thead>` / `<tbody>` / `<th scope="col" |
+"row">`. Drift state on each cell is communicated by an icon glyph +
+text label (never color-only) inside the cell.
+
+Sortable columns:
+- When a column has `sortable: true`, its header `<th>` renders a
+  `<button>` that emits the `onsort(columnId)` callback. The component
+  reflects the consumer-supplied `sortBy` + `sortDirection` via
+  `aria-sort` on the matching `<th>`.
+- The component is presentation-only — it does not sort data internally.
+  Consumers manage the sort state and reorder `rows` in response to the
+  `onsort` callback.
+
+Per-row CTA slot:
+- `rowActions` snippet receives the current `StackMatrixRow` and renders
+  inside a `<td>` at the end of each row (wrapped in `<div role="group">`
+  with an accessible name).
+
+Strict-CSP safe: no inline event handlers (Svelte's compiled
+`on*` handlers attach after hydration); no `style` attributes set at
+runtime; styling via stable `--gr-*` tokens.
+
+@example
+```svelte
+<StackMatrix
+	caption="Lesser fleet stack versions"
+	columns={[
+		{ id: 'lesser', label: 'Lesser', sortable: true },
+		{ id: 'host',   label: 'Lesser Host', sortable: true },
+	]}
+	rows={[
+		{ id: 'r1', label: 'lesser.example', subLabel: 'us-east-1',
+		  cells: {
+		    lesser: { value: 'v1.4.12', drift: 'in-sync' },
+		    host:   { value: 'v0.4.5',  drift: 'pending' },
+		  } },
+	]}
+	sortBy="lesser"
+	sortDirection="ascending"
+	onsort={(id) => …}
+>
+	{#snippet rowActions(row)}<button type="button">Manage</button>{/snippet}
+</StackMatrix>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type {
+		StackMatrixCell,
+		StackMatrixColumn,
+		StackMatrixDrift,
+		StackMatrixRow,
+		StackMatrixSortDirection,
+	} from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/** Required accessible caption for the table. May be visually hidden. @public */
+		caption: string;
+
+		/**
+		 * When true, the caption is rendered as `<caption class="gr-sr-only">`
+		 * (still announced to AT). Default `true` to keep the visual surface
+		 * compact for dashboard layouts.
+		 * @public
+		 */
+		captionHidden?: boolean;
+
+		/** Column definitions in left-to-right render order. @public */
+		columns: StackMatrixColumn[];
+
+		/** Rows in display order. @public */
+		rows: StackMatrixRow[];
+
+		/** Id of the currently-sorted column. @public */
+		sortBy?: string;
+
+		/** Current sort direction. Defaults to `'none'` (no aria-sort active). @public */
+		sortDirection?: StackMatrixSortDirection;
+
+		/**
+		 * Called when a sortable column header is activated. Consumers manage
+		 * sort state externally and re-supply `rows` in the desired order.
+		 * @public
+		 */
+		onsort?: (columnId: string) => void;
+
+		/** Empty-state message when `rows.length === 0`. @public */
+		emptyMessage?: string;
+
+		/** Accessible name for the per-row actions cell group. @public */
+		rowActionsLabel?: string;
+
+		/** Additional CSS classes on the wrapper. @public */
+		class?: string;
+
+		/** Optional custom cell renderer. @public */
+		cellRenderer?: Snippet<[StackMatrixCell, StackMatrixRow, StackMatrixColumn]>;
+
+		/** Per-row actions slot. @public */
+		rowActions?: Snippet<[StackMatrixRow]>;
+	}
+
+	let {
+		caption,
+		captionHidden = true,
+		columns,
+		rows,
+		sortBy,
+		sortDirection = 'none',
+		onsort,
+		emptyMessage = 'No rows to display.',
+		rowActionsLabel = 'Row actions',
+		class: className = '',
+		cellRenderer,
+		rowActions,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const stableId = useStableId('host-stack-matrix');
+
+	const driftInfo = $derived.by(() => {
+		const map: Record<StackMatrixDrift, { icon: string; label: string }> = {
+			'in-sync': { icon: '●', label: 'In sync' },
+			pending: { icon: '◌', label: 'Update pending' },
+			drifted: { icon: '⚠', label: 'Drifted' },
+			unknown: { icon: '?', label: 'Unknown drift state' },
+		};
+		return map;
+	});
+
+	function ariaSortFor(columnId: string): StackMatrixSortDirection | undefined {
+		if (columnId !== sortBy) return undefined;
+		return sortDirection;
+	}
+
+	function handleHeaderClick(column: StackMatrixColumn) {
+		if (!column.sortable) return;
+		onsort?.(column.id);
+	}
+
+	function handleHeaderKeydown(event: KeyboardEvent, column: StackMatrixColumn) {
+		// Native <button> handles Enter/Space; this is here purely for the
+		// rare case a consumer styles the button so that activating it
+		// requires explicit key handling. The default browser behavior is
+		// already correct.
+		if (event.key === 'Enter' || event.key === ' ') {
+			if (!column.sortable) return;
+			event.preventDefault();
+			onsort?.(column.id);
+		}
+	}
+
+	const rootClass = $derived(() =>
+		['gr-host-platform-stack-matrix', className].filter(Boolean).join(' ')
+	);
+
+	const hasRows = $derived(rows.length > 0);
+	const hasRowActions = $derived(!!rowActions);
+</script>
+
+<div class={rootClass()} {...restProps}>
+	<table class="gr-host-platform-stack-matrix__table">
+		<caption
+			class={['gr-host-platform-stack-matrix__caption', captionHidden && 'gr-sr-only']
+				.filter(Boolean)
+				.join(' ')}
+		>
+			{caption}
+		</caption>
+		<thead>
+			<tr>
+				<th scope="col" class="gr-host-platform-stack-matrix__row-header-col">
+					<span class="gr-sr-only">Row</span>
+				</th>
+				{#each columns as column (column.id)}
+					{@const ariaSort = ariaSortFor(column.id)}
+					<th
+						scope="col"
+						class={[
+							'gr-host-platform-stack-matrix__col-header',
+							column.sortable && 'gr-host-platform-stack-matrix__col-header--sortable',
+						]
+							.filter(Boolean)
+							.join(' ')}
+						aria-sort={ariaSort}
+					>
+						{#if column.sortable}
+							<button
+								type="button"
+								class="gr-host-platform-stack-matrix__sort-button"
+								onclick={() => handleHeaderClick(column)}
+								onkeydown={(event) => handleHeaderKeydown(event, column)}
+							>
+								<span>{column.label}</span>
+								<span class="gr-host-platform-stack-matrix__sort-indicator" aria-hidden="true">
+									{#if ariaSort === 'ascending'}
+										▲
+									{:else if ariaSort === 'descending'}
+										▼
+									{:else}
+										↕
+									{/if}
+								</span>
+							</button>
+						{:else}
+							{column.label}
+						{/if}
+					</th>
+				{/each}
+				{#if hasRowActions}
+					<th scope="col" class="gr-host-platform-stack-matrix__actions-header">
+						<span class="gr-sr-only">{rowActionsLabel}</span>
+					</th>
+				{/if}
+			</tr>
+		</thead>
+		<tbody>
+			{#if !hasRows}
+				<tr class="gr-host-platform-stack-matrix__empty-row">
+					<td
+						colspan={columns.length + 1 + (hasRowActions ? 1 : 0)}
+						class="gr-host-platform-stack-matrix__empty"
+					>
+						{emptyMessage}
+					</td>
+				</tr>
+			{:else}
+				{#each rows as row (row.id)}
+					<tr
+						id={stableId.value ? `${stableId.value}-row-${row.id}` : undefined}
+						class="gr-host-platform-stack-matrix__row"
+					>
+						<th scope="row" class="gr-host-platform-stack-matrix__row-header">
+							<span class="gr-host-platform-stack-matrix__row-label">{row.label}</span>
+							{#if row.subLabel}
+								<span class="gr-host-platform-stack-matrix__row-sublabel">{row.subLabel}</span>
+							{/if}
+						</th>
+						{#each columns as column (column.id)}
+							{@const cell = row.cells[column.id]}
+							<td class="gr-host-platform-stack-matrix__cell">
+								{#if cell === undefined}
+									<span class="gr-sr-only">No data</span>
+									<span aria-hidden="true">—</span>
+								{:else if cellRenderer}
+									{@render cellRenderer(cell, row, column)}
+								{:else}
+									{@const drift = cell.drift ?? 'in-sync'}
+									{@const info = driftInfo[drift]}
+									<span
+										class={[
+											'gr-host-platform-stack-matrix__cell-value',
+											`gr-host-platform-stack-matrix__cell-value--drift-${drift}`,
+										].join(' ')}
+									>
+										<span class="gr-host-platform-stack-matrix__drift-icon" aria-hidden="true"
+											>{info.icon}</span
+										>
+										<span class="gr-host-platform-stack-matrix__cell-text">
+											{cell.value}
+										</span>
+										<span class="gr-sr-only">
+											{cell.description ?? info.label}
+										</span>
+									</span>
+								{/if}
+							</td>
+						{/each}
+						{#if hasRowActions}
+							<td class="gr-host-platform-stack-matrix__actions-cell">
+								<div
+									class="gr-host-platform-stack-matrix__actions"
+									role="group"
+									aria-label={`${rowActionsLabel}: ${row.label}`}
+								>
+									{@render rowActions?.(row)}
+								</div>
+							</td>
+						{/if}
+					</tr>
+				{/each}
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/web/src/lib/greater/host-platform/index.ts
+++ b/web/src/lib/greater/host-platform/index.ts
@@ -1,0 +1,60 @@
+/**
+ * @fileoverview Greater Host-Platform — hosted-platform data-display components.
+ *
+ * Strict-CSP safe, Svelte 5 runes, WCAG 2.1 AA. All styling consumes
+ * stable `--gr-*` design tokens; additive `--gr-host-platform-*` token
+ * defaults are scoped to component root classes. Status communication
+ * is never color-only — icons + text are always paired with any color tint.
+ *
+ * Components:
+ * - FleetCard         — composed instance / fleet card (status, metadata,
+ *                       cost / activity slots, actions)
+ * - CostGauge         — `role="meter"` cost / usage indicator with
+ *                       thresholds + non-color-only status icon
+ * - ActivitySparkline — inline SVG trend with explicit label / description
+ *                       (or `decorative` mode when a textual equivalent
+ *                       exists nearby)
+ *
+ * @version 0.1.0
+ * @author Greater Contributors
+ * @license AGPL-3.0-only
+ * @public
+ */
+
+export type { ComponentProps } from 'svelte';
+
+// Components
+export { default as FleetCard } from './components/FleetCard.svelte';
+export { default as CostGauge } from './components/CostGauge.svelte';
+export { default as ActivitySparkline } from './components/ActivitySparkline.svelte';
+export { default as ProvisioningTimeline } from './components/ProvisioningTimeline.svelte';
+export { default as ReleaseTimeline } from './components/ReleaseTimeline.svelte';
+export { default as StackMatrix } from './components/StackMatrix.svelte';
+
+// Utilities (dependency-free, strict-CSP-safe)
+export { formatCost, formatCostGaugeText, computeRatio } from './utils/formatters.js';
+export { buildSparklinePath } from './utils/sparkline.js';
+export type { SparklinePathInput, SparklinePathOutput } from './utils/sparkline.js';
+
+// Public type contracts
+export type {
+	FleetCardStatus,
+	FleetCardVariant,
+	FleetCardMetadataItem,
+	CostGaugeStatus,
+	CostGaugeThresholds,
+	CostValueFormatter,
+	ActivitySparklineTone,
+	ProvisioningStep,
+	ProvisioningStepStatus,
+	ProvisioningLogPoliteness,
+	ReleaseChannel,
+	ReleaseStatus,
+	ReleaseTimelineItem,
+	ReleaseAdoptionFormatter,
+	StackMatrixDrift,
+	StackMatrixColumn,
+	StackMatrixCell,
+	StackMatrixRow,
+	StackMatrixSortDirection,
+} from './types.js';

--- a/web/src/lib/greater/host-platform/styles/base.css
+++ b/web/src/lib/greater/host-platform/styles/base.css
@@ -1,0 +1,63 @@
+/*
+ * Greater Host Platform — base styles.
+ *
+ * Strict-CSP safe: tokens only, no inline styles or runtime expressions.
+ * Consumers may override any --gr-host-platform-* token without forking.
+ */
+
+.gr-host-platform-fleet-card,
+.gr-host-platform-cost-gauge,
+.gr-host-platform-activity-sparkline,
+.gr-host-platform-provisioning-timeline,
+.gr-host-platform-release-timeline,
+.gr-host-platform-stack-matrix {
+	box-sizing: border-box;
+}
+
+.gr-host-platform-fleet-card *,
+.gr-host-platform-cost-gauge *,
+.gr-host-platform-activity-sparkline *,
+.gr-host-platform-provisioning-timeline *,
+.gr-host-platform-release-timeline *,
+.gr-host-platform-stack-matrix * {
+	box-sizing: border-box;
+}
+
+/*
+ * Visually-hidden utility — shipped because composed status text + meter
+ * descriptions sometimes need to expose the textual equivalent without
+ * occupying layout space. Matches the canonical `.gr-sr-only` rule in
+ * the primitives + shell bundles byte-for-byte.
+ */
+.gr-sr-only {
+	position: fixed;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/*
+ * Additive --gr-host-platform-* token defaults. Defined on every component
+ * root class so a standalone CostGauge / ActivitySparkline outside a
+ * FleetCard wrapper still has working spacing.
+ */
+:where(
+	.gr-host-platform-fleet-card,
+	.gr-host-platform-cost-gauge,
+	.gr-host-platform-activity-sparkline,
+	.gr-host-platform-provisioning-timeline,
+	.gr-host-platform-release-timeline,
+	.gr-host-platform-stack-matrix
+) {
+	--gr-host-platform-gutter: 1rem;
+	--gr-host-platform-gap-sm: 0.5rem;
+	--gr-host-platform-gap-md: 0.75rem;
+	--gr-host-platform-gap-lg: 1rem;
+	--gr-host-platform-radius: 0.5rem;
+	--gr-host-platform-sparkline-stroke: 1.5px;
+}

--- a/web/src/lib/greater/host-platform/types.ts
+++ b/web/src/lib/greater/host-platform/types.ts
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Public type contracts for the Greater hosted-platform surface.
+ *
+ * @public
+ */
+
+/**
+ * Fleet status — drives both the rendered icon/badge and the
+ * `aria-label` text. Status communication is never color-only.
+ */
+export type FleetCardStatus =
+	| 'healthy'
+	| 'warning'
+	| 'degraded'
+	| 'offline'
+	| 'provisioning'
+	| 'unknown';
+
+/** Visual variant for FleetCard. */
+export type FleetCardVariant = 'default' | 'flat' | 'elevated';
+
+/** A `{ key, value }` metadata row rendered inside FleetCard. */
+export interface FleetCardMetadataItem {
+	/** Visible label (e.g. "Region", "Version"). */
+	key: string;
+	/** Visible value (e.g. "us-east-1", "v1.4.12"). */
+	value: string;
+}
+
+/** Cost-gauge status — drives icon + accessible name. */
+export type CostGaugeStatus = 'ok' | 'warning' | 'danger';
+
+/**
+ * Threshold ratios in [0, 1] — when `current / limit` crosses these, the
+ * gauge auto-elevates to warning / danger unless `status` is supplied.
+ */
+export interface CostGaugeThresholds {
+	/** When the ratio reaches `warning`, status becomes `'warning'`. */
+	warning?: number;
+	/** When the ratio reaches `danger`, status becomes `'danger'`. */
+	danger?: number;
+}
+
+/** Optional formatter for the displayed cost value. */
+export type CostValueFormatter = (value: number, currency: string | undefined) => string;
+
+/** Tone for the sparkline stroke. Non-color-only — accompany with `label`. */
+export type ActivitySparklineTone = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+/* ============================================================================
+ * G3 — Operator timelines and stack matrix
+ * ==========================================================================*/
+
+/**
+ * Status of a single step in a `ProvisioningTimeline`.
+ *
+ * Drives both the rendered icon glyph (●/◌/✓/⚠/—) and the accessible label;
+ * status is never communicated by color alone.
+ *
+ * @public
+ */
+export type ProvisioningStepStatus = 'pending' | 'active' | 'success' | 'failure' | 'skipped';
+
+/**
+ * A single step in a `ProvisioningTimeline`.
+ *
+ * @public
+ */
+export interface ProvisioningStep {
+	/** Stable id; used for the DOM list-item id and as the row key. */
+	id: string;
+	/** Visible primary label (e.g. "Allocate compute"). */
+	label: string;
+	/** Optional supporting description rendered below the label. */
+	description?: string;
+	/** Status — drives icon + text. Defaults to `'pending'` when omitted. */
+	status?: ProvisioningStepStatus;
+	/** Optional ISO timestamp string rendered as the step's time anchor. */
+	timestamp?: string;
+	/** Optional short metadata (e.g. job duration, region). */
+	meta?: string;
+}
+
+/**
+ * ARIA politeness for the constrained live-log region. `'off'` disables
+ * announcements; the visible log still renders.
+ *
+ * @public
+ */
+export type ProvisioningLogPoliteness = 'off' | 'polite' | 'assertive';
+
+/**
+ * Two-channel release timeline release channel.
+ *
+ * Conventionally `'stable'` and `'beta'`, but consumers may use any strings
+ * (e.g. `'stable'` vs `'rc'`). The `ReleaseTimeline` groups items by channel
+ * and presents them as two visually-distinct streams.
+ *
+ * @public
+ */
+export type ReleaseChannel = string;
+
+/**
+ * Status of a release. Drives icon + accessible label.
+ *
+ * @public
+ */
+export type ReleaseStatus = 'shipped' | 'in-progress' | 'rolled-back' | 'planned';
+
+/**
+ * A single release entry rendered by `ReleaseTimeline`.
+ *
+ * @public
+ */
+export interface ReleaseTimelineItem {
+	/** Stable id; used for the DOM list-item id and as the row key. */
+	id: string;
+	/** Version label (e.g. `'v1.4.12'`). */
+	version: string;
+	/** Channel this release belongs to (e.g. `'stable'`). */
+	channel: ReleaseChannel;
+	/** Date of the release. May be a `Date` or an ISO string. */
+	date: Date | string;
+	/** Status — drives icon + text. Defaults to `'shipped'` when omitted. */
+	status?: ReleaseStatus;
+	/**
+	 * Adoption metric: a number in `[0, 1]` (a ratio) or a free-form string
+	 * (e.g. `'42 of 100 instances'`). When numeric, the component formats
+	 * it as a percentage and exposes an accessible value-text.
+	 */
+	adoption?: number | string;
+	/** Optional secondary description. */
+	description?: string;
+	/** Optional changelog / release-notes URL. */
+	href?: string;
+}
+
+/**
+ * Formatter for a release's adoption metric. Receives the raw `adoption`
+ * (number in [0,1] or string) and returns a visible string. When omitted,
+ * numeric adoption is formatted as `XX%`.
+ *
+ * @public
+ */
+export type ReleaseAdoptionFormatter = (
+	adoption: number | string | undefined
+) => string | undefined;
+
+/**
+ * Drift state of a stack-matrix cell, paired with an icon glyph + text label
+ * so the indicator is never color-only.
+ *
+ * @public
+ */
+export type StackMatrixDrift = 'in-sync' | 'pending' | 'drifted' | 'unknown';
+
+/**
+ * Column definition for `StackMatrix`.
+ *
+ * @public
+ */
+export interface StackMatrixColumn {
+	/** Stable id used as the lookup key into each row's `cells` map. */
+	id: string;
+	/** Visible column header. */
+	label: string;
+	/** When true, the header renders as a sort-trigger `<button>` and
+	 *  `aria-sort` reflects the current sort state. */
+	sortable?: boolean;
+}
+
+/**
+ * A single cell in a `StackMatrix` row. Either a string (rendered as text)
+ * or a structured value with drift status.
+ *
+ * @public
+ */
+export interface StackMatrixCell {
+	/** Visible cell value (e.g. `'v1.4.12'`). */
+	value: string;
+	/** Drift state — drives icon + accessible label. */
+	drift?: StackMatrixDrift;
+	/**
+	 * Optional accessible description override. When omitted, the cell's
+	 * accessible content is `value` + (` (drift state)` if drift !== `'in-sync'`).
+	 */
+	description?: string;
+}
+
+/**
+ * A row in `StackMatrix`. The `cells` map keys MUST match column ids.
+ *
+ * @public
+ */
+export interface StackMatrixRow {
+	/** Stable id used for the DOM row id and as the row key. */
+	id: string;
+	/** Row header label rendered in the first cell with `<th scope="row">`. */
+	label: string;
+	/** Optional secondary row header (e.g. region). */
+	subLabel?: string;
+	/** Map of column id → cell. */
+	cells: Record<string, StackMatrixCell>;
+}
+
+/** Sort direction state used by `StackMatrix`. */
+export type StackMatrixSortDirection = 'ascending' | 'descending' | 'none';

--- a/web/src/lib/greater/host-platform/utils/formatters.ts
+++ b/web/src/lib/greater/host-platform/utils/formatters.ts
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Strict-CSP-safe number / currency formatters for hosted-platform components.
+ *
+ * Uses the standard `Intl.NumberFormat` API which is available in every
+ * supported runtime and does not require `unsafe-eval`. Formatter
+ * instances are cached per (locale, currency) tuple to avoid re-creating
+ * them on every render.
+ *
+ * @public
+ */
+
+const formatterCache = new Map<string, Intl.NumberFormat>();
+
+function getFormatter(currency: string | undefined, locale?: string): Intl.NumberFormat {
+	const resolvedLocale = locale ?? 'en-US';
+	const key = `${resolvedLocale}|${currency ?? ''}`;
+	const cached = formatterCache.get(key);
+	if (cached) return cached;
+	const options: Intl.NumberFormatOptions = currency
+		? { style: 'currency', currency, maximumFractionDigits: 2 }
+		: { style: 'decimal', maximumFractionDigits: 2 };
+	const formatter = new Intl.NumberFormat(resolvedLocale, options);
+	formatterCache.set(key, formatter);
+	return formatter;
+}
+
+/**
+ * Format a numeric value as a currency string (or a decimal when no
+ * currency is supplied).
+ *
+ * - Numbers are rendered with at most 2 fractional digits.
+ * - `NaN`, `±Infinity`, and `null`/`undefined` render as `'—'` (em dash)
+ *   so consumer empty / loading states have a stable visible placeholder.
+ *
+ * @public
+ */
+export function formatCost(
+	value: number | null | undefined,
+	currency?: string,
+	locale?: string
+): string {
+	if (value === null || value === undefined) return '—';
+	if (!Number.isFinite(value)) return '—';
+	return getFormatter(currency, locale).format(value);
+}
+
+/**
+ * Format the textual equivalent for a cost gauge — typically used as
+ * `aria-valuetext` and visible label.
+ *
+ * Example: `formatCostGaugeText(42.5, 100, 'USD') === '$42.50 of $100.00'`
+ *
+ * @public
+ */
+export function formatCostGaugeText(
+	current: number,
+	limit: number,
+	currency?: string,
+	locale?: string
+): string {
+	return `${formatCost(current, currency, locale)} of ${formatCost(limit, currency, locale)}`;
+}
+
+/**
+ * Compute the percentage usage ratio in [0, 1], clamped.
+ *
+ * Returns `0` when `limit <= 0` or either input is non-finite, so
+ * downstream rendering never produces invalid `aria-valuenow` /
+ * width values.
+ *
+ * @public
+ */
+export function computeRatio(current: number, limit: number): number {
+	if (!Number.isFinite(current) || !Number.isFinite(limit) || limit <= 0) return 0;
+	if (current <= 0) return 0;
+	const ratio = current / limit;
+	if (ratio < 0) return 0;
+	if (ratio > 1) return 1;
+	return ratio;
+}

--- a/web/src/lib/greater/host-platform/utils/sparkline.ts
+++ b/web/src/lib/greater/host-platform/utils/sparkline.ts
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Pure data → SVG-path utility for ActivitySparkline.
+ *
+ * No DOM access, no module-level browser globals, deterministic output
+ * for a given input. Used both inside ActivitySparkline and exported so
+ * consumers can unit-test sparkline shapes independent of the component.
+ *
+ * @public
+ */
+
+/**
+ * Inputs:
+ * - `data`: array of numeric samples (length >= 1). Empty / undefined
+ *   input is the caller's responsibility (component renders the empty
+ *   state).
+ * - `width` / `height`: viewBox dimensions for the SVG. Sparklines never
+ *   set explicit pixel sizes via inline styles — the consumer sizes via
+ *   CSS / class.
+ * - `padding`: optional padding (in viewBox units) so the stroke doesn't
+ *   clip at the edges. Defaults to half a stroke width on each side.
+ * - `min` / `max`: override the auto-computed value range. When omitted,
+ *   the function uses the data min/max with a 1-unit floor on the range
+ *   so a constant series still renders a horizontal line at the y
+ *   midpoint.
+ */
+export interface SparklinePathInput {
+	data: number[];
+	width: number;
+	height: number;
+	padding?: number;
+	min?: number;
+	max?: number;
+}
+
+export interface SparklinePathOutput {
+	/** Full SVG `d` attribute for `<path>`. */
+	path: string;
+	/** Last (x, y) point in viewBox coordinates — useful for an end-dot. */
+	last: { x: number; y: number };
+	/** Computed value range that was used. */
+	range: { min: number; max: number };
+}
+
+/**
+ * Build the SVG path for a sparkline from a numeric series.
+ *
+ * Deterministic: same input → same output. No floating-point drift
+ * caused by Date / Math.random / locale; pure arithmetic.
+ *
+ * @public
+ */
+export function buildSparklinePath(input: SparklinePathInput): SparklinePathOutput {
+	const { data, width, height } = input;
+	if (data.length === 0) {
+		// Defensive — callers should not invoke with an empty series, but
+		// returning a no-op path is safer than throwing inside a render.
+		return { path: '', last: { x: 0, y: height / 2 }, range: { min: 0, max: 0 } };
+	}
+
+	const padding = input.padding ?? 1;
+	const innerWidth = Math.max(0, width - 2 * padding);
+	const innerHeight = Math.max(0, height - 2 * padding);
+
+	const dataMin = input.min ?? Math.min(...data);
+	const dataMaxRaw = input.max ?? Math.max(...data);
+	// Ensure max > min so the divisor isn't zero. For constant series we
+	// extend the range by 1 unit so the line sits at the midpoint.
+	const dataMax = dataMaxRaw > dataMin ? dataMaxRaw : dataMin + 1;
+
+	const range = { min: dataMin, max: dataMax };
+
+	const stepX = data.length > 1 ? innerWidth / (data.length - 1) : 0;
+	const verticalSpan = dataMax - dataMin;
+
+	let path = '';
+	let lastX = 0;
+	let lastY = 0;
+	for (let i = 0; i < data.length; i++) {
+		const raw = data[i]!;
+		const xRaw = padding + i * stepX;
+		const yRatio = verticalSpan === 0 ? 0.5 : 1 - (raw - dataMin) / verticalSpan;
+		const yRaw = padding + yRatio * innerHeight;
+		const x = roundFixed(xRaw);
+		const y = roundFixed(yRaw);
+		path += i === 0 ? `M${x} ${y}` : ` L${x} ${y}`;
+		lastX = x;
+		lastY = y;
+	}
+
+	return { path, last: { x: lastX, y: lastY }, range };
+}
+
+/**
+ * Round to 3 decimal places so the path attribute stays stable across
+ * runs and tests can match on the exact string. Avoids depending on
+ * `toFixed`'s locale-aware behavior for `Intl` non-en locales.
+ */
+function roundFixed(n: number): number {
+	return Math.round(n * 1000) / 1000;
+}

--- a/web/src/lib/greater/shell/components/Breadcrumb.css
+++ b/web/src/lib/greater/shell/components/Breadcrumb.css
@@ -1,0 +1,40 @@
+.gr-shell-breadcrumb {
+	min-width: 0;
+}
+
+.gr-shell-breadcrumb__list {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.25rem;
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	font-size: 0.875rem;
+}
+
+.gr-shell-breadcrumb__item {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	min-width: 0;
+}
+
+.gr-shell-breadcrumb__link {
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	text-decoration: none;
+}
+.gr-shell-breadcrumb__link:hover {
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	text-decoration: underline;
+}
+
+.gr-shell-breadcrumb__current {
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-weight: 600;
+}
+
+.gr-shell-breadcrumb__separator {
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	margin-inline: 0.25rem;
+}

--- a/web/src/lib/greater/shell/components/Breadcrumb.svelte
+++ b/web/src/lib/greater/shell/components/Breadcrumb.svelte
@@ -1,0 +1,98 @@
+<!--
+@component
+Breadcrumb — breadcrumb navigation with `aria-current="page"` on the current item.
+
+Renders a `<nav aria-label>` containing an `<ol>` of breadcrumb items. Items
+with `href` render as `<a>`; items without `href` (and the explicitly-current
+item) render as `<span>`. The current item additionally receives
+`aria-current="page"`.
+
+@example
+```svelte
+<Breadcrumb
+	items={[
+		{ label: 'Dashboard', href: '/' },
+		{ label: 'Instances', href: '/instances' },
+		{ label: 'lesser.example', current: true },
+	]}
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { BreadcrumbItem } from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Ordered breadcrumb items. @public */
+		items: BreadcrumbItem[];
+
+		/**
+		 * Separator between items. May be a string (rendered as text with
+		 * `aria-hidden`) or a snippet for icon-based separators.
+		 * @defaultValue '/'
+		 * @public
+		 */
+		separator?: string | Snippet;
+
+		/**
+		 * Accessible name for the navigation landmark.
+		 * @defaultValue 'Breadcrumb'
+		 * @public
+		 */
+		label?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+	}
+
+	let {
+		items,
+		separator = '/',
+		label = 'Breadcrumb',
+		class: className = '',
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const rootClass = $derived(() => ['gr-shell-breadcrumb', className].filter(Boolean).join(' '));
+
+	const separatorIsString = $derived(typeof separator === 'string');
+
+	// Mark the last item as current if no explicit current is set.
+	const resolvedItems = $derived.by(() => {
+		const explicit = items.some((item) => item.current);
+		return items.map((item, index) => ({
+			...item,
+			current: explicit ? !!item.current : index === items.length - 1,
+		}));
+	});
+</script>
+
+<nav class={rootClass()} aria-label={label} {...restProps}>
+	<ol class="gr-shell-breadcrumb__list">
+		{#each resolvedItems as item, index (index)}
+			<li class="gr-shell-breadcrumb__item">
+				{#if item.href && !item.current}
+					<a href={item.href} class="gr-shell-breadcrumb__link">{item.label}</a>
+				{:else}
+					<span
+						class="gr-shell-breadcrumb__current"
+						aria-current={item.current ? 'page' : undefined}
+					>
+						{item.label}
+					</span>
+				{/if}
+				{#if index < resolvedItems.length - 1}
+					{#if separatorIsString}
+						<span class="gr-shell-breadcrumb__separator" aria-hidden="true">{separator}</span>
+					{:else if separator}
+						<span class="gr-shell-breadcrumb__separator" aria-hidden="true"
+							>{@render (separator as Snippet)()}</span
+						>
+					{/if}
+				{/if}
+			</li>
+		{/each}
+	</ol>
+</nav>

--- a/web/src/lib/greater/shell/components/Callout.css
+++ b/web/src/lib/greater/shell/components/Callout.css
@@ -1,0 +1,114 @@
+.gr-shell-callout {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--gr-shell-gap-md);
+	padding: var(--gr-shell-gap-md) var(--gr-shell-gutter);
+	border-radius: 0.5rem;
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	min-width: 0;
+}
+
+.gr-shell-callout__icon {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	border-radius: 0.375rem;
+}
+
+.gr-shell-callout__body {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.375rem;
+}
+
+.gr-shell-callout__title {
+	margin: 0;
+	font-weight: 600;
+	font-size: 0.9375rem;
+}
+
+.gr-shell-callout__content {
+	font-size: 0.9375rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	min-width: 0;
+}
+
+.gr-shell-callout__actions {
+	display: flex;
+	align-items: center;
+	gap: var(--gr-shell-gap-sm);
+	margin-top: 0.25rem;
+}
+
+.gr-shell-callout__dismiss {
+	flex: 0 0 auto;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 1.75rem;
+	height: 1.75rem;
+	border: none;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+	border-radius: 0.375rem;
+}
+.gr-shell-callout__dismiss:hover {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+}
+
+/* Tones */
+.gr-shell-callout--tone-info {
+	border-color: var(--gr-color-info-200, #bfdbfe);
+	background: var(--gr-color-info-50, #eff6ff);
+	color: var(--gr-color-info-900, #1e3a8a);
+}
+.gr-shell-callout--tone-info .gr-shell-callout__icon {
+	background: var(--gr-color-info-100, #dbeafe);
+	color: var(--gr-color-info-700, #1d4ed8);
+}
+
+.gr-shell-callout--tone-success {
+	border-color: var(--gr-color-success-200, #bbf7d0);
+	background: var(--gr-color-success-50, #f0fdf4);
+	color: var(--gr-color-success-900, #14532d);
+}
+.gr-shell-callout--tone-success .gr-shell-callout__icon {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-700, #15803d);
+}
+
+.gr-shell-callout--tone-warning {
+	border-color: var(--gr-color-warning-200, #fde68a);
+	background: var(--gr-color-warning-50, #fffbeb);
+	color: var(--gr-color-warning-900, #78350f);
+}
+.gr-shell-callout--tone-warning .gr-shell-callout__icon {
+	background: var(--gr-color-warning-100, #fef3c7);
+	color: var(--gr-color-warning-700, #b45309);
+}
+
+.gr-shell-callout--tone-danger {
+	border-color: var(--gr-color-error-200, #fecaca);
+	background: var(--gr-color-error-50, #fef2f2);
+	color: var(--gr-color-error-900, #7f1d1d);
+}
+.gr-shell-callout--tone-danger .gr-shell-callout__icon {
+	background: var(--gr-color-error-100, #fee2e2);
+	color: var(--gr-color-error-700, #b91c1c);
+}
+
+.gr-shell-callout--tone-neutral {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-50, #f9fafb));
+}
+.gr-shell-callout--tone-neutral .gr-shell-callout__icon {
+	background: var(--gr-semantic-background-tertiary, var(--gr-color-gray-100, #f3f4f6));
+}

--- a/web/src/lib/greater/shell/components/Callout.svelte
+++ b/web/src/lib/greater/shell/components/Callout.svelte
@@ -1,0 +1,134 @@
+<!--
+@component
+Callout — informational call-out (status / alert / note).
+
+Renders a tinted block with an optional icon, title, and dismiss button.
+ARIA role defaults to `status` for `info` / `success` / `neutral` tones and
+`alert` for `warning` / `danger` tones; consumers may override via `role`.
+
+When `role === 'status'` the live region is polite; when `role === 'alert'`
+it is assertive. `role === 'note'` is non-live (use for static guidance).
+
+@example
+```svelte
+<Callout tone="warning" title="Provisioning incomplete">
+	One instance has not finished provisioning yet.
+	{#snippet actions()}<button>Retry</button>{/snippet}
+</Callout>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { CalloutRole, CalloutTone } from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/**
+		 * Visual / semantic tone. Drives both styling and the default ARIA role.
+		 * @defaultValue 'info'
+		 * @public
+		 */
+		tone?: CalloutTone;
+
+		/**
+		 * Explicit ARIA role override. When omitted, role is derived from `tone`.
+		 * @public
+		 */
+		role?: CalloutRole;
+
+		/** Optional title rendered as a paragraph (visually prominent). @public */
+		title?: string;
+
+		/** Optional leading icon snippet (rendered with `aria-hidden`). @public */
+		icon?: Snippet;
+
+		/** Optional trailing actions group. @public */
+		actions?: Snippet;
+
+		/**
+		 * Whether to render a dismiss button. The button has an accessible
+		 * label of `dismissLabel` and emits `ondismiss` when activated.
+		 * @defaultValue false
+		 * @public
+		 */
+		dismissible?: boolean;
+
+		/**
+		 * Accessible label for the dismiss button.
+		 * @defaultValue 'Dismiss'
+		 * @public
+		 */
+		dismissLabel?: string;
+
+		/** Called when the dismiss button is activated. @public */
+		ondismiss?: () => void;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Body content. @public */
+		children: Snippet;
+	}
+
+	let {
+		tone = 'info',
+		role,
+		title,
+		icon,
+		actions,
+		dismissible = false,
+		dismissLabel = 'Dismiss',
+		ondismiss,
+		class: className = '',
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const resolvedRole = $derived<CalloutRole>(
+		role ?? (tone === 'danger' || tone === 'warning' ? 'alert' : 'status')
+	);
+
+	const ariaLive = $derived(
+		resolvedRole === 'alert' ? 'assertive' : resolvedRole === 'status' ? 'polite' : undefined
+	);
+
+	const rootClass = $derived(() =>
+		['gr-shell-callout', `gr-shell-callout--tone-${tone}`, className].filter(Boolean).join(' ')
+	);
+
+	function handleDismiss() {
+		ondismiss?.();
+	}
+</script>
+
+<div
+	class={rootClass()}
+	role={resolvedRole}
+	aria-live={ariaLive}
+	aria-atomic={ariaLive ? 'true' : undefined}
+	{...restProps}
+>
+	{#if icon}
+		<div class="gr-shell-callout__icon" aria-hidden="true">{@render icon()}</div>
+	{/if}
+	<div class="gr-shell-callout__body">
+		{#if title}
+			<p class="gr-shell-callout__title">{title}</p>
+		{/if}
+		<div class="gr-shell-callout__content">{@render children()}</div>
+		{#if actions}
+			<div class="gr-shell-callout__actions" role="group">{@render actions()}</div>
+		{/if}
+	</div>
+	{#if dismissible}
+		<button
+			type="button"
+			class="gr-shell-callout__dismiss"
+			aria-label={dismissLabel}
+			onclick={handleDismiss}
+		>
+			<span aria-hidden="true">×</span>
+		</button>
+	{/if}
+</div>

--- a/web/src/lib/greater/shell/components/CommandPalette.css
+++ b/web/src/lib/greater/shell/components/CommandPalette.css
@@ -1,0 +1,194 @@
+.gr-shell-command-palette {
+	position: fixed;
+	inset: 0;
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
+	padding-top: 10vh;
+	background: var(--gr-semantic-background-overlay, rgba(0, 0, 0, 0.5));
+	z-index: 1000;
+	overflow-y: auto;
+}
+
+.gr-shell-command-palette__sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.gr-shell-command-palette__panel {
+	width: min(40rem, calc(100% - 2 * var(--gr-shell-gutter)));
+	max-height: 70vh;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: 0.75rem;
+	box-shadow: var(--gr-shadows-lg, 0 10px 25px -5px rgb(0 0 0 / 0.2));
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	overflow: hidden;
+}
+
+.gr-shell-command-palette__input-row {
+	display: flex;
+	align-items: center;
+	padding: 0 var(--gr-shell-gutter);
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-shell-command-palette__input-label {
+	display: block;
+	padding: 0.5rem 0;
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-command-palette__input {
+	flex: 1 1 auto;
+	width: 100%;
+	min-width: 0;
+	padding: 1rem 0;
+	border: none;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	font-size: 1rem;
+	outline: none;
+}
+.gr-shell-command-palette__input:focus-visible {
+	outline: none;
+}
+.gr-shell-command-palette__input::placeholder {
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__results {
+	flex: 1 1 auto;
+	min-height: 0;
+	overflow-y: auto;
+	padding: 0.5rem 0;
+}
+
+.gr-shell-command-palette__loading,
+.gr-shell-command-palette__empty {
+	padding: 1rem var(--gr-shell-gutter);
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	font-size: 0.9375rem;
+}
+
+.gr-shell-command-palette__group {
+	display: block;
+}
+.gr-shell-command-palette__group + .gr-shell-command-palette__group {
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	margin-top: 0.25rem;
+	padding-top: 0.25rem;
+}
+
+.gr-shell-command-palette__group-header {
+	padding: 0.5rem var(--gr-shell-gutter) 0.25rem;
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__listbox {
+	margin: 0;
+	padding: 0;
+	list-style: none;
+}
+
+.gr-shell-command-palette__option {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.5rem var(--gr-shell-gutter);
+	cursor: pointer;
+	min-width: 0;
+	/*
+	 * `role="option"` elements render as <div> so the listbox can wrap them in
+	 * <div role="group"> sections. Reset any default block-flow weirdness so
+	 * groups look identical to the flat list layout.
+	 */
+	box-sizing: border-box;
+}
+
+.gr-shell-command-palette__option--active {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-command-palette__option--disabled {
+	cursor: not-allowed;
+	opacity: 0.55;
+}
+
+.gr-shell-command-palette__option-body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.gr-shell-command-palette__option-label {
+	font-size: 0.9375rem;
+	font-weight: 500;
+}
+
+.gr-shell-command-palette__option-description {
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-command-palette__option-shortcut {
+	flex: 0 0 auto;
+	font-size: 0.75rem;
+	font-family: var(
+		--gr-typography-fontFamily-mono,
+		ui-monospace,
+		SFMono-Regular,
+		Menlo,
+		Monaco,
+		Consolas,
+		monospace
+	);
+	padding: 0.125rem 0.375rem;
+	border-radius: 0.25rem;
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-command-palette__status {
+	padding: 0.5rem var(--gr-shell-gutter);
+	font-size: 0.75rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+@media (prefers-reduced-motion: no-preference) {
+	.gr-shell-command-palette__panel {
+		animation: gr-shell-command-palette-pop 100ms ease-out;
+	}
+}
+@keyframes gr-shell-command-palette-pop {
+	from {
+		transform: translateY(-0.5rem);
+		opacity: 0;
+	}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+	}
+}

--- a/web/src/lib/greater/shell/components/CommandPalette.svelte
+++ b/web/src/lib/greater/shell/components/CommandPalette.svelte
@@ -1,0 +1,760 @@
+<!--
+@component
+CommandPalette — accessible, strict-CSP-safe command palette for app
+navigation, quick actions, and settings search.
+
+Implements the WAI-ARIA combobox + listbox pattern with virtual focus
+(`aria-activedescendant`). The input keeps real focus; arrow keys move
+a virtual selection through the rendered options. Screen-reader users
+hear result counts and active-option labels via a polite live region.
+
+Composition:
+- `<div role="dialog" aria-modal="true" aria-label>` overlay
+- `<input role="combobox" aria-autocomplete="list" aria-expanded
+   aria-controls aria-activedescendant>` query input
+- `<ul role="listbox">` per group (when groups are provided) or one
+  flat `<ul role="listbox">` (when items are provided)
+- Each `<li role="option" aria-selected={isActive} aria-disabled>` item
+
+Headless behaviors reused from `@equaltoai/greater-components-headless`:
+- `createFocusTrap` — traps focus inside the panel; returns focus to the
+  opener on close (or to `returnFocusTo` when supplied)
+- `createDismissable` — ESC + outside-click close, integrated into the
+  shared layer stack so nested overlays close in the correct order
+- `createLiveRegion` — polite announcements for result counts and
+  loading / empty state changes
+
+Strict-CSP safe: no inline event handlers, no `style` attributes set at
+runtime, no module-level browser globals. All keyboard handling goes
+through real Svelte event handlers; all styling consumes `--gr-*`
+tokens via the bundled `shell.css`.
+
+@example
+```svelte
+<CommandPalette
+	open={paletteOpen}
+	label="Command palette"
+	inputLabel="Search commands"
+	groups={[
+		{ id: 'pages', label: 'Pages', items: [
+			{ id: 'overview', label: 'Overview', description: 'Fleet overview' },
+			{ id: 'instances', label: 'Instances' },
+		] },
+		{ id: 'actions', label: 'Actions', items: [
+			{ id: 'refresh', label: 'Refresh', shortcut: '⌘R' },
+		] },
+	]}
+	onclose={() => (paletteOpen = false)}
+	onselect={(item) => {
+		paletteOpen = false;
+		navigate(item.id);
+	}}
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { onDestroy, tick, untrack } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import {
+		createFocusTrap,
+		createDismissable,
+		createLiveRegion,
+		type FocusTrap,
+		type Dismissable,
+		type LiveRegion,
+	} from 'src/lib/greater/headless';
+	import type { CommandPaletteFilter, CommandPaletteGroup, CommandPaletteItem } from '../types.js';
+	import { filterAndRankItems, tokenizeQuery } from '../utils/fuzzy-filter.js';
+
+	// Omit both `aria-label` and `onselect` from the inherited HTMLAttributes
+	// shape. They are both re-declared below with greater-specific contracts:
+	//
+	// - `aria-label` is intentionally not exposed as a prop; the dialog's
+	//   accessible name comes from the dedicated `label` prop (which is
+	//   wired to `aria-labelledby`). Omitting prevents consumers from
+	//   bypassing the labelledby pattern.
+	//
+	// - `onselect` would otherwise inherit the DOM text-selection event
+	//   shape `EventHandler<Event, HTMLDivElement>`. The component re-uses
+	//   the name for its API callback `(item: CommandPaletteItem) => void`,
+	//   which is the value bound by parents and invoked at lines 359, 413
+	//   below. The two signatures are mutually incompatible, so the inherit
+	//   must be dropped explicitly to satisfy `tsc`/`svelte-check` strict
+	//   mode. Runtime behavior is unaffected -- Svelte 5's `$props()` binds
+	//   the prop name from parent slot wiring, never from the underlying
+	//   DOM element's event attribute. Reported by host as #679.
+	interface Props extends Omit<HTMLAttributes<HTMLDivElement>, 'aria-label' | 'onselect'> {
+		/**
+		 * Whether the palette is open. Bind with `bind:open` or control via
+		 * `onopen` / `onclose`.
+		 * @public
+		 */
+		open?: boolean;
+
+		/**
+		 * Accessible name for the dialog. Strongly recommended; defaults to
+		 * `'Command palette'`.
+		 * @public
+		 */
+		label?: string;
+
+		/**
+		 * Accessible name for the search input. Defaults to `'Search commands'`.
+		 * The label is rendered visually-hidden by default; consumers can opt
+		 * into a visible label by setting `inputLabelHidden={false}` (the
+		 * default is `true` for the typical palette UX).
+		 * @public
+		 */
+		inputLabel?: string;
+
+		/**
+		 * When false, the input label is rendered visibly above the input.
+		 * Default is `true` (label is sr-only).
+		 * @public
+		 */
+		inputLabelHidden?: boolean;
+
+		/** Placeholder text shown when the input is empty. @public */
+		placeholder?: string;
+
+		/**
+		 * Externally-controlled query string. Bind with `bind:query` or
+		 * read via `onquerychange`.
+		 * @public
+		 */
+		query?: string;
+
+		/**
+		 * Grouped items. When supplied, the palette renders one `<ul role="listbox">`
+		 * per group with the group label exposed via `aria-labelledby`. Exactly
+		 * one of `groups` or `items` must be supplied.
+		 * @public
+		 */
+		groups?: CommandPaletteGroup[];
+
+		/**
+		 * Flat item list. When supplied, the palette renders a single
+		 * `<ul role="listbox">`. Exactly one of `groups` or `items` must be
+		 * supplied.
+		 * @public
+		 */
+		items?: CommandPaletteItem[];
+
+		/**
+		 * Optional custom filter / ranker. When omitted, the built-in
+		 * `scoreCommandPaletteItem` is used. Return `null` to exclude an item;
+		 * otherwise return a numeric score (higher = better).
+		 * @public
+		 */
+		filter?: CommandPaletteFilter;
+
+		/**
+		 * When true, the palette shows a loading state instead of results.
+		 * The live region announces the change.
+		 * @public
+		 */
+		loading?: boolean;
+
+		/** Status message rendered while `loading` is true. @public */
+		loadingMessage?: string;
+
+		/** Status message rendered when no items match the query. @public */
+		emptyMessage?: string;
+
+		/**
+		 * Element to return focus to on close. Defaults to the previously
+		 * focused element (typically the trigger button).
+		 * @public
+		 */
+		returnFocusTo?: HTMLElement | null;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/**
+		 * Custom item renderer. Receives the `item` and a boolean `active`
+		 * (true when this item is the current virtual-focus target). When
+		 * omitted, the default renderer shows label / description / shortcut.
+		 * @public
+		 */
+		itemTemplate?: Snippet<[CommandPaletteItem, boolean]>;
+
+		/** Empty-state slot override (when query yields no matches). @public */
+		emptyState?: Snippet;
+
+		/** Loading-state slot override. @public */
+		loadingState?: Snippet;
+
+		/** Called when the palette transitions from closed to open. @public */
+		onopen?: () => void;
+
+		/** Called when the palette closes (ESC, outside click, programmatic). @public */
+		onclose?: () => void;
+
+		/** Called whenever the query input changes. @public */
+		onquerychange?: (value: string) => void;
+
+		/** Called when a (non-disabled) item is activated. @public */
+		onselect?: (item: CommandPaletteItem) => void;
+	}
+
+	let {
+		open = $bindable(false),
+		label = 'Command palette',
+		inputLabel = 'Search commands',
+		inputLabelHidden = true,
+		placeholder = 'Type to search…',
+		query = $bindable(''),
+		groups,
+		items,
+		filter,
+		loading = false,
+		loadingMessage = 'Loading…',
+		emptyMessage = 'No results.',
+		returnFocusTo,
+		class: className = '',
+		itemTemplate,
+		emptyState,
+		loadingState,
+		onopen,
+		onclose,
+		onquerychange,
+		onselect,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	// Stable per-instance ids. SSR/hydration-safe via useStableId.
+	const stableId = useStableId('shell-cmdk');
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const inputId = $derived(stableId.value ? `${stableId.value}-input` : undefined);
+	const inputLabelId = $derived(stableId.value ? `${stableId.value}-input-label` : undefined);
+	const listboxOwningId = $derived(stableId.value ? `${stableId.value}-listbox` : undefined);
+	const statusId = $derived(stableId.value ? `${stableId.value}-status` : undefined);
+
+	// Element refs.
+	let panelEl = $state<HTMLDivElement | null>(null);
+	let inputEl = $state<HTMLInputElement | null>(null);
+
+	// Headless behaviors.
+	let focusTrap: FocusTrap | null = null;
+	let dismissable: Dismissable | null = null;
+	let liveRegion: LiveRegion | null = null;
+
+	// Derived: filter groups / items by query.
+	function applyFilter(list: CommandPaletteItem[], q: string): CommandPaletteItem[] {
+		const tokens = tokenizeQuery(q);
+		if (tokens.length === 0) return list.slice();
+		if (filter) {
+			const scored: Array<{ item: CommandPaletteItem; score: number; index: number }> = [];
+			for (let i = 0; i < list.length; i++) {
+				const it = list[i]!;
+				const s = filter(it, q);
+				if (typeof s === 'number') scored.push({ item: it, score: s, index: i });
+			}
+			scored.sort((a, b) => (b.score !== a.score ? b.score - a.score : a.index - b.index));
+			return scored.map((e) => e.item);
+		}
+		return filterAndRankItems(list, q);
+	}
+
+	type FlatEntry =
+		| { kind: 'item'; item: CommandPaletteItem; groupId?: string; optionId: string }
+		| { kind: 'group-header'; groupId: string };
+
+	const filteredGroups = $derived.by<CommandPaletteGroup[] | null>(() => {
+		if (!groups) return null;
+		return groups
+			.map((g) => ({ ...g, items: applyFilter(g.items, query) }))
+			.filter((g) => g.items.length > 0);
+	});
+
+	const filteredItems = $derived.by<CommandPaletteItem[] | null>(() => {
+		if (!items) return null;
+		return applyFilter(items, query);
+	});
+
+	function optionDomId(baseId: string | undefined, groupId: string | undefined, itemId: string) {
+		const safeBase = baseId ?? 'gr-shell-cmdk';
+		return groupId ? `${safeBase}-opt-${groupId}-${itemId}` : `${safeBase}-opt-${itemId}`;
+	}
+
+	function groupHeaderDomId(baseId: string | undefined, groupId: string) {
+		const safeBase = baseId ?? 'gr-shell-cmdk';
+		return `${safeBase}-group-${groupId}`;
+	}
+
+	const flatEntries = $derived.by<FlatEntry[]>(() => {
+		const out: FlatEntry[] = [];
+		const base = stableId.value;
+		if (filteredGroups) {
+			for (const g of filteredGroups) {
+				out.push({ kind: 'group-header', groupId: g.id });
+				for (const it of g.items) {
+					out.push({
+						kind: 'item',
+						item: it,
+						groupId: g.id,
+						optionId: optionDomId(base, g.id, it.id),
+					});
+				}
+			}
+		} else if (filteredItems) {
+			for (const it of filteredItems) {
+				out.push({ kind: 'item', item: it, optionId: optionDomId(base, undefined, it.id) });
+			}
+		}
+		return out;
+	});
+
+	const itemEntries = $derived(
+		flatEntries.filter((e): e is FlatEntry & { kind: 'item' } => e.kind === 'item')
+	);
+	const totalItems = $derived(itemEntries.length);
+
+	// Virtual focus pointer. Clamped to [0, totalItems-1] reactively.
+	let activeIndex = $state(0);
+
+	// When totalItems or query changes, snap activeIndex to the first selectable item.
+	$effect(() => {
+		// Reset whenever the result set shrinks or the query changes meaningfully.
+		void totalItems;
+		void query;
+		untrack(() => {
+			if (totalItems === 0) {
+				activeIndex = 0;
+				return;
+			}
+			// Move to first non-disabled item.
+			const first = findNextEnabledIndex(-1, 1);
+			activeIndex = first === -1 ? 0 : first;
+		});
+	});
+
+	const activeOptionId = $derived.by<string | undefined>(() => {
+		if (totalItems === 0) return undefined;
+		const safe = Math.min(Math.max(0, activeIndex), totalItems - 1);
+		return itemEntries[safe]?.optionId;
+	});
+
+	function findNextEnabledIndex(fromIndex: number, step: 1 | -1): number {
+		if (itemEntries.length === 0) return -1;
+		const n = itemEntries.length;
+		let i = fromIndex;
+		for (let visited = 0; visited < n; visited++) {
+			i = (i + step + n) % n;
+			const entry = itemEntries[i];
+			if (entry && !entry.item.disabled) return i;
+		}
+		// All items disabled — return the first.
+		return 0;
+	}
+
+	function moveActive(step: 1 | -1) {
+		const next = findNextEnabledIndex(activeIndex, step);
+		if (next >= 0) activeIndex = next;
+	}
+
+	function moveToEdge(edge: 'start' | 'end') {
+		if (totalItems === 0) return;
+		if (edge === 'start') {
+			const first = findNextEnabledIndex(-1, 1);
+			if (first >= 0) activeIndex = first;
+		} else {
+			const last = findNextEnabledIndex(itemEntries.length, -1);
+			if (last >= 0) activeIndex = last;
+		}
+	}
+
+	function activateActive() {
+		if (totalItems === 0) return;
+		const safe = Math.min(Math.max(0, activeIndex), totalItems - 1);
+		const entry = itemEntries[safe];
+		if (entry && !entry.item.disabled) {
+			onselect?.(entry.item);
+		}
+	}
+
+	function close() {
+		if (!open) return;
+		open = false;
+		onclose?.();
+	}
+
+	function handleQueryInput(event: Event) {
+		const value = (event.currentTarget as HTMLInputElement).value;
+		query = value;
+		onquerychange?.(value);
+	}
+
+	function handleInputKeydown(event: KeyboardEvent) {
+		switch (event.key) {
+			case 'ArrowDown':
+				event.preventDefault();
+				moveActive(1);
+				return;
+			case 'ArrowUp':
+				event.preventDefault();
+				moveActive(-1);
+				return;
+			case 'Home':
+				event.preventDefault();
+				moveToEdge('start');
+				return;
+			case 'End':
+				event.preventDefault();
+				moveToEdge('end');
+				return;
+			case 'Enter':
+				event.preventDefault();
+				activateActive();
+				return;
+			case 'Escape':
+				event.preventDefault();
+				close();
+				return;
+			default:
+				return;
+		}
+	}
+
+	function handleOptionPointerEnter(index: number) {
+		if (index < 0 || index >= itemEntries.length) return;
+		activeIndex = index;
+	}
+
+	function handleOptionClick(entry: FlatEntry & { kind: 'item' }) {
+		if (entry.item.disabled) return;
+		onselect?.(entry.item);
+	}
+
+	function handleBackdropPointerDown(event: PointerEvent) {
+		// Click on backdrop (outside the panel) closes the palette.
+		const target = event.target as HTMLElement;
+		if (panelEl && !panelEl.contains(target)) {
+			close();
+		}
+	}
+
+	// Open/close lifecycle: activate/deactivate behaviors.
+	$effect(() => {
+		const isOpen = open;
+
+		if (!isOpen) {
+			// Cleanup on close.
+			if (focusTrap) {
+				focusTrap.deactivate();
+				focusTrap = null;
+			}
+			if (dismissable) {
+				dismissable.deactivate();
+				dismissable = null;
+			}
+			return;
+		}
+
+		// Defer until DOM nodes exist.
+		void tick().then(() => {
+			if (!panelEl) return;
+			onopen?.();
+
+			focusTrap = createFocusTrap({
+				initialFocus: () => inputEl,
+				returnFocusTo: returnFocusTo ?? undefined,
+				returnFocus: true,
+				autoFocus: true,
+			});
+			focusTrap.activate(panelEl);
+
+			dismissable = createDismissable({
+				closeOnEscape: true,
+				closeOnClickOutside: false, // handled by backdrop pointerdown for precise targeting
+				onDismiss: () => {
+					close();
+				},
+			});
+			dismissable.activate(panelEl);
+		});
+	});
+
+	// Announce result-count / loading / empty changes via a polite live region.
+	$effect(() => {
+		// Listen to relevant state.
+		const isLoading = loading;
+		const count = totalItems;
+		const tokens = tokenizeQuery(query);
+		void open;
+
+		untrack(() => {
+			if (!liveRegion) {
+				liveRegion = createLiveRegion({ politeness: 'polite' });
+			}
+			if (!open) return;
+			if (isLoading) {
+				liveRegion.announce(loadingMessage, { politeness: 'polite' });
+				return;
+			}
+			if (tokens.length === 0) {
+				// Quietly announce initial state once on open (without flooding).
+				liveRegion.announce(`${count} result${count === 1 ? '' : 's'} available.`, {
+					politeness: 'polite',
+				});
+				return;
+			}
+			if (count === 0) {
+				liveRegion.announce(emptyMessage, { politeness: 'polite' });
+			} else {
+				liveRegion.announce(`${count} result${count === 1 ? '' : 's'} for ${query.trim()}.`, {
+					politeness: 'polite',
+				});
+			}
+		});
+	});
+
+	onDestroy(() => {
+		focusTrap?.deactivate();
+		dismissable?.deactivate();
+		liveRegion?.destroy();
+		focusTrap = null;
+		dismissable = null;
+		liveRegion = null;
+	});
+
+	// Visible status text (separate from the live region so it can be styled).
+	const statusText = $derived.by<string>(() => {
+		if (loading) return loadingMessage;
+		if (totalItems === 0) return emptyMessage;
+		const q = query.trim();
+		if (q.length === 0) return `${totalItems} result${totalItems === 1 ? '' : 's'}`;
+		return `${totalItems} result${totalItems === 1 ? '' : 's'} for "${q}"`;
+	});
+
+	const rootClass = $derived(() =>
+		['gr-shell-command-palette', className].filter(Boolean).join(' ')
+	);
+</script>
+
+{#if open}
+	<!--
+		Backdrop is a sibling, not a parent, so clicking it doesn't dispatch
+		through the panel's event handlers. Backdrop pointerdown closes.
+	-->
+	<div
+		class={rootClass()}
+		role="dialog"
+		aria-modal="true"
+		aria-labelledby={labelId}
+		onpointerdown={handleBackdropPointerDown}
+		{...restProps}
+	>
+		<span id={labelId} class="gr-shell-command-palette__sr-only">{label}</span>
+
+		<div class="gr-shell-command-palette__panel" bind:this={panelEl} role="presentation">
+			<div class="gr-shell-command-palette__input-row">
+				{#if !inputLabelHidden}
+					<label id={inputLabelId} for={inputId} class="gr-shell-command-palette__input-label">
+						{inputLabel}
+					</label>
+				{:else}
+					<label
+						id={inputLabelId}
+						for={inputId}
+						class="gr-shell-command-palette__input-label gr-shell-command-palette__sr-only"
+					>
+						{inputLabel}
+					</label>
+				{/if}
+				<input
+					id={inputId}
+					bind:this={inputEl}
+					type="text"
+					autocomplete="off"
+					spellcheck={false}
+					{placeholder}
+					value={query}
+					role="combobox"
+					aria-autocomplete="list"
+					aria-expanded="true"
+					aria-controls={listboxOwningId}
+					aria-activedescendant={activeOptionId}
+					aria-labelledby={inputLabelId}
+					oninput={handleQueryInput}
+					onkeydown={handleInputKeydown}
+					class="gr-shell-command-palette__input"
+				/>
+			</div>
+
+			<div class="gr-shell-command-palette__results" aria-busy={loading ? 'true' : undefined}>
+				{#if loading}
+					<div class="gr-shell-command-palette__loading">
+						{#if loadingState}{@render loadingState()}{:else}{loadingMessage}{/if}
+					</div>
+				{:else if totalItems === 0}
+					<div class="gr-shell-command-palette__empty">
+						{#if emptyState}{@render emptyState()}{:else}{emptyMessage}{/if}
+					</div>
+				{:else if filteredGroups}
+					<!--
+						Grouped mode: one parent listbox owns every option. Each group is
+						a role="group" child whose `aria-labelledby` references the
+						visible group header. ARIA listboxes accept role="group"
+						children that wrap their options — this matches the W3C
+						APG "Combobox with Listbox Popup, Grouped Options" pattern
+						and resolves the input's aria-controls IDREF.
+					-->
+					<div
+						id={listboxOwningId}
+						class="gr-shell-command-palette__listbox gr-shell-command-palette__listbox--grouped"
+						role="listbox"
+					>
+						{#each filteredGroups as group (group.id)}
+							{@const headerId = groupHeaderDomId(stableId.value, group.id)}
+							<div class="gr-shell-command-palette__group" role="group" aria-labelledby={headerId}>
+								<div class="gr-shell-command-palette__group-header" id={headerId}>
+									{group.label}
+								</div>
+								{#each group.items as item (item.id)}
+									{@const entryIndex = itemEntries.findIndex(
+										(e) => e.groupId === group.id && e.item.id === item.id
+									)}
+									{@const isActive = entryIndex === activeIndex}
+									{@const optId = optionDomId(stableId.value, group.id, item.id)}
+									<!--
+										W3C ARIA Combobox / Listbox pattern: option elements receive
+										virtual focus via aria-activedescendant; real focus stays on the
+										combobox input, which owns the keyboard handlers. Mouse clicks
+										still need a click handler, but Svelte's a11y_click_events_have_key_events
+										linter incorrectly flags it. Documented exception per ARIA APG.
+									-->
+									<!--
+	W3C ARIA Combobox + Listbox pattern (virtual focus):
+	- The combobox input is the single tab stop; options are NOT in the
+	  tab order. They receive virtual focus via `aria-activedescendant`.
+	- Mouse activation still needs a click handler, but svelte's
+	  a11y_click_events_have_key_events linter expects a key handler
+	  alongside it — keyboard interaction is owned by the input. We
+	  suppress both warnings here per ARIA APG guidance.
+-->
+									<!-- svelte-ignore a11y_click_events_have_key_events -->
+									<!-- svelte-ignore a11y_interactive_supports_focus -->
+									<div
+										id={optId}
+										class={[
+											'gr-shell-command-palette__option',
+											isActive && 'gr-shell-command-palette__option--active',
+											item.disabled && 'gr-shell-command-palette__option--disabled',
+										]
+											.filter(Boolean)
+											.join(' ')}
+										role="option"
+										aria-selected={isActive}
+										aria-disabled={item.disabled ? 'true' : undefined}
+										onclick={() =>
+											handleOptionClick({
+												kind: 'item',
+												item,
+												groupId: group.id,
+												optionId: optId,
+											})}
+										onpointerenter={() => handleOptionPointerEnter(entryIndex)}
+									>
+										{#if itemTemplate}
+											{@render itemTemplate(item, isActive)}
+										{:else}
+											<span class="gr-shell-command-palette__option-body">
+												<span class="gr-shell-command-palette__option-label">{item.label}</span>
+												{#if item.description}
+													<span class="gr-shell-command-palette__option-description">
+														{item.description}
+													</span>
+												{/if}
+											</span>
+											{#if item.shortcut}
+												<kbd class="gr-shell-command-palette__option-shortcut" aria-hidden="true">
+													{item.shortcut}
+												</kbd>
+											{/if}
+										{/if}
+									</div>
+								{/each}
+							</div>
+						{/each}
+					</div>
+				{:else if filteredItems}
+					<div
+						id={listboxOwningId}
+						class="gr-shell-command-palette__listbox gr-shell-command-palette__listbox--flat"
+						role="listbox"
+					>
+						{#each filteredItems as item (item.id)}
+							{@const entryIndex = itemEntries.findIndex((e) => e.item.id === item.id)}
+							{@const isActive = entryIndex === activeIndex}
+							{@const optId = optionDomId(stableId.value, undefined, item.id)}
+							<!--
+	W3C ARIA Combobox + Listbox pattern (virtual focus):
+	- The combobox input is the single tab stop; options are NOT in the
+	  tab order. They receive virtual focus via `aria-activedescendant`.
+	- Mouse activation still needs a click handler, but svelte's
+	  a11y_click_events_have_key_events linter expects a key handler
+	  alongside it — keyboard interaction is owned by the input. We
+	  suppress both warnings here per ARIA APG guidance.
+-->
+							<!-- svelte-ignore a11y_click_events_have_key_events -->
+							<!-- svelte-ignore a11y_interactive_supports_focus -->
+							<div
+								id={optId}
+								class={[
+									'gr-shell-command-palette__option',
+									isActive && 'gr-shell-command-palette__option--active',
+									item.disabled && 'gr-shell-command-palette__option--disabled',
+								]
+									.filter(Boolean)
+									.join(' ')}
+								role="option"
+								aria-selected={isActive}
+								aria-disabled={item.disabled ? 'true' : undefined}
+								onclick={() => handleOptionClick({ kind: 'item', item, optionId: optId })}
+								onpointerenter={() => handleOptionPointerEnter(entryIndex)}
+							>
+								{#if itemTemplate}
+									{@render itemTemplate(item, isActive)}
+								{:else}
+									<span class="gr-shell-command-palette__option-body">
+										<span class="gr-shell-command-palette__option-label">{item.label}</span>
+										{#if item.description}
+											<span class="gr-shell-command-palette__option-description">
+												{item.description}
+											</span>
+										{/if}
+									</span>
+									{#if item.shortcut}
+										<kbd class="gr-shell-command-palette__option-shortcut" aria-hidden="true">
+											{item.shortcut}
+										</kbd>
+									{/if}
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			</div>
+
+			<!--
+				Visible status text. The live region (created via createLiveRegion)
+				announces this content politely to assistive tech; this element is
+				the visible affordance.
+			-->
+			<div class="gr-shell-command-palette__status" id={statusId} aria-live="off">
+				{statusText}
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style>
+	/* Component CSS lives in CommandPalette.css and is bundled into shell.css.
+	   This empty <style> exists so the file is a valid Svelte component module
+	   even when consumers haven't imported the CSS bundle. */
+</style>

--- a/web/src/lib/greater/shell/components/PageFrame.css
+++ b/web/src/lib/greater/shell/components/PageFrame.css
@@ -1,0 +1,61 @@
+.gr-shell-page-frame {
+	width: 100%;
+	margin: 0 auto;
+	padding: var(--gr-shell-gap-lg) var(--gr-shell-gutter);
+	display: flex;
+	flex-direction: column;
+	gap: var(--gr-shell-gap-lg);
+	min-width: 0;
+}
+
+.gr-shell-page-frame--width-narrow {
+	max-width: var(--gr-shell-content-max-narrow);
+}
+.gr-shell-page-frame--width-default {
+	max-width: var(--gr-shell-content-max-default);
+}
+.gr-shell-page-frame--width-wide {
+	max-width: var(--gr-shell-content-max-wide);
+}
+.gr-shell-page-frame--width-full {
+	max-width: none;
+}
+
+.gr-shell-page-frame__layout {
+	display: grid;
+	grid-template-columns: 1fr;
+	gap: var(--gr-shell-gap-lg);
+	min-width: 0;
+}
+.gr-shell-page-frame--aside-right .gr-shell-page-frame__layout {
+	grid-template-columns: minmax(0, 1fr) minmax(0, 18rem);
+}
+.gr-shell-page-frame--aside-left .gr-shell-page-frame__layout {
+	grid-template-columns: minmax(0, 18rem) minmax(0, 1fr);
+}
+
+.gr-shell-page-frame__content {
+	min-width: 0;
+}
+.gr-shell-page-frame--aside-left .gr-shell-page-frame__content {
+	order: 2;
+}
+.gr-shell-page-frame--aside-left .gr-shell-page-frame__aside {
+	order: 1;
+}
+
+.gr-shell-page-frame__aside {
+	min-width: 0;
+}
+
+.gr-shell-page-frame__header,
+.gr-shell-page-frame__footer {
+	min-width: 0;
+}
+
+@media (max-width: 60rem) {
+	.gr-shell-page-frame--aside-right .gr-shell-page-frame__layout,
+	.gr-shell-page-frame--aside-left .gr-shell-page-frame__layout {
+		grid-template-columns: 1fr;
+	}
+}

--- a/web/src/lib/greater/shell/components/PageFrame.svelte
+++ b/web/src/lib/greater/shell/components/PageFrame.svelte
@@ -1,0 +1,109 @@
+<!--
+@component
+PageFrame — single-page wrapper with optional aside / header / footer.
+
+PageFrame is a content-region helper that sits INSIDE Shell's `<main>`
+landmark. It is intentionally NOT a landmark itself; it only provides
+visual layout (max-width centering, optional aside column, header/footer).
+
+@example
+```svelte
+<PageFrame width="default">
+	{#snippet header()}<PageTitle title="Overview" />{/snippet}
+	<Panel title="Fleet status">…</Panel>
+</PageFrame>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { PageFrameAsidePlacement, PageFrameWidth } from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/**
+		 * Max-width preset.
+		 * - `narrow` — 48rem
+		 * - `default` — 72rem
+		 * - `wide` — 96rem
+		 * - `full` — no max width
+		 * @defaultValue 'default'
+		 * @public
+		 */
+		width?: PageFrameWidth;
+
+		/**
+		 * Side of the aside slot relative to the main content.
+		 * @defaultValue 'right'
+		 * @public
+		 */
+		asidePlacement?: PageFrameAsidePlacement;
+
+		/**
+		 * Accessible label for the aside region (used as `aria-label` on
+		 * the `<aside>` element when the aside snippet is rendered).
+		 * Required when `aside` is provided.
+		 * @public
+		 */
+		asideLabel?: string;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Header content rendered above the main content. @public */
+		header?: Snippet;
+
+		/** Footer content rendered below the main content. @public */
+		footer?: Snippet;
+
+		/** Aside content (e.g. contextual filters / metadata). @public */
+		aside?: Snippet;
+
+		/** Main page content. @public */
+		children: Snippet;
+	}
+
+	let {
+		width = 'default',
+		asidePlacement = 'right',
+		asideLabel,
+		class: className = '',
+		header,
+		footer,
+		aside,
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const hasAside = $derived(!!aside);
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell-page-frame',
+			`gr-shell-page-frame--width-${width}`,
+			hasAside && `gr-shell-page-frame--aside-${asidePlacement}`,
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={rootClass()} {...restProps}>
+	{#if header}
+		<header class="gr-shell-page-frame__header">{@render header()}</header>
+	{/if}
+
+	<div class="gr-shell-page-frame__layout">
+		<div class="gr-shell-page-frame__content">{@render children()}</div>
+		{#if hasAside}
+			<aside class="gr-shell-page-frame__aside" aria-label={asideLabel ?? undefined}>
+				{@render aside?.()}
+			</aside>
+		{/if}
+	</div>
+
+	{#if footer}
+		<footer class="gr-shell-page-frame__footer">{@render footer()}</footer>
+	{/if}
+</div>

--- a/web/src/lib/greater/shell/components/PageTitle.css
+++ b/web/src/lib/greater/shell/components/PageTitle.css
@@ -1,0 +1,53 @@
+.gr-shell-page-title {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--gr-shell-gap-md);
+	flex-wrap: wrap;
+	min-width: 0;
+}
+
+.gr-shell-page-title__text {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	min-width: 0;
+	flex: 1 1 24rem;
+}
+
+.gr-shell-page-title__eyebrow {
+	margin: 0;
+	font-size: 0.8125rem;
+	font-weight: 500;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+.gr-shell-page-title__heading {
+	margin: 0;
+	font-size: 1.5rem;
+	line-height: 1.25;
+	font-weight: 700;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-page-title__subtitle {
+	margin: 0;
+	font-size: 0.9375rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-page-title__description {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+	max-width: 60ch;
+}
+
+.gr-shell-page-title__actions {
+	display: flex;
+	align-items: center;
+	gap: var(--gr-shell-gap-sm);
+	flex-shrink: 0;
+}

--- a/web/src/lib/greater/shell/components/PageTitle.svelte
+++ b/web/src/lib/greater/shell/components/PageTitle.svelte
@@ -1,0 +1,88 @@
+<!--
+@component
+PageTitle — semantic page heading with optional eyebrow / subtitle / description / actions.
+
+Renders an `<hN>` for the title (level 1 by default). When inside a Shell's
+`<main>` landmark with no surrounding `<header>` in `<main>`, this is the
+top-of-page heading.
+
+@example
+```svelte
+<PageTitle
+	title="Overview"
+	eyebrow="Project 39"
+	subtitle="Lesser-host fleet"
+	description="Live release readiness across all instances."
+>
+	{#snippet actions()}<button>Refresh</button>{/snippet}
+</PageTitle>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { PageTitleLevel } from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLElement> {
+		/** Required title text. @public */
+		title: string;
+
+		/** Optional eyebrow text (small label above the title). @public */
+		eyebrow?: string;
+
+		/** Optional subtitle text below the title. @public */
+		subtitle?: string;
+
+		/** Optional description paragraph below subtitle. @public */
+		description?: string;
+
+		/**
+		 * Heading level for the title element.
+		 * @defaultValue 1
+		 * @public
+		 */
+		level?: PageTitleLevel;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Trailing action group, rendered to the right of the title. @public */
+		actions?: Snippet;
+	}
+
+	let {
+		title,
+		eyebrow,
+		subtitle,
+		description,
+		level = 1,
+		class: className = '',
+		actions,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const rootClass = $derived(() => ['gr-shell-page-title', className].filter(Boolean).join(' '));
+</script>
+
+<header class={rootClass()} {...restProps}>
+	<div class="gr-shell-page-title__text">
+		{#if eyebrow}
+			<p class="gr-shell-page-title__eyebrow">{eyebrow}</p>
+		{/if}
+		{#if level === 1}
+			<h1 class="gr-shell-page-title__heading">{title}</h1>
+		{:else}
+			<h2 class="gr-shell-page-title__heading">{title}</h2>
+		{/if}
+		{#if subtitle}
+			<p class="gr-shell-page-title__subtitle">{subtitle}</p>
+		{/if}
+		{#if description}
+			<p class="gr-shell-page-title__description">{description}</p>
+		{/if}
+	</div>
+	{#if actions}
+		<div class="gr-shell-page-title__actions" role="group">{@render actions()}</div>
+	{/if}
+</header>

--- a/web/src/lib/greater/shell/components/Panel.css
+++ b/web/src/lib/greater/shell/components/Panel.css
@@ -1,0 +1,80 @@
+.gr-shell-panel {
+	display: flex;
+	flex-direction: column;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border-radius: 0.5rem;
+	min-width: 0;
+}
+
+.gr-shell-panel--variant-default {
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-shell-panel--variant-flat {
+	border: none;
+	background: transparent;
+}
+.gr-shell-panel--variant-elevated {
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	box-shadow: var(--gr-shadows-base, 0 1px 3px 0 rgb(0 0 0 / 0.1));
+}
+
+.gr-shell-panel__header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--gr-shell-gap-md);
+	padding: var(--gr-shell-gap-md) var(--gr-shell-gutter);
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-shell-panel--variant-flat .gr-shell-panel__header {
+	border-bottom: none;
+	padding-inline: 0;
+}
+
+.gr-shell-panel__heading {
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	min-width: 0;
+}
+.gr-shell-panel__title {
+	margin: 0;
+	font-size: 1rem;
+	line-height: 1.4;
+	font-weight: 600;
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-panel__actions {
+	display: flex;
+	align-items: center;
+	gap: var(--gr-shell-gap-sm);
+	flex-shrink: 0;
+}
+
+.gr-shell-panel__body {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+.gr-shell-panel--padding-none .gr-shell-panel__body {
+	padding: 0;
+}
+.gr-shell-panel--padding-sm .gr-shell-panel__body {
+	padding: 0.75rem;
+}
+.gr-shell-panel--padding-md .gr-shell-panel__body {
+	padding: 1rem var(--gr-shell-gutter);
+}
+.gr-shell-panel--padding-lg .gr-shell-panel__body {
+	padding: 1.5rem var(--gr-shell-gutter);
+}
+
+.gr-shell-panel__footer {
+	padding: var(--gr-shell-gap-md) var(--gr-shell-gutter);
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-shell-panel--variant-flat .gr-shell-panel__footer {
+	border-top: none;
+	padding-inline: 0;
+}

--- a/web/src/lib/greater/shell/components/Panel.svelte
+++ b/web/src/lib/greater/shell/components/Panel.svelte
@@ -1,0 +1,148 @@
+<!--
+@component
+Panel — content container with semantic header / body / footer regions.
+
+Renders a `<section>` landmark. When `title` is provided, an `<hN>` heading
+is generated and linked via `aria-labelledby` for screen-reader users. When
+no title is provided but `aria-label` is, the panel still has an accessible
+name.
+
+@example
+```svelte
+<Panel title="Fleet status" headerLevel={2}>
+	<p>Status content…</p>
+	{#snippet actions()}<button>Refresh</button>{/snippet}
+	{#snippet footer()}<small>Updated 5m ago</small>{/snippet}
+</Panel>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { PanelPadding, PanelVariant } from '../types.js';
+
+	// SSR/hydration-safe stable id per component instance.
+	// With IdProvider: deterministic counter-based id during SSR + hydration.
+	// Without IdProvider: id is assigned onMount (avoids hydration mismatches).
+	const stableId = useStableId('shell-panel');
+
+	interface Props extends HTMLAttributes<HTMLElement> {
+		/**
+		 * Optional visible title. Rendered as `<hN>` inside the panel header
+		 * and linked to the section via `aria-labelledby`.
+		 * @public
+		 */
+		title?: string;
+
+		/**
+		 * Heading level for the generated title.
+		 * @defaultValue 2
+		 * @public
+		 */
+		headerLevel?: 1 | 2 | 3 | 4 | 5 | 6;
+
+		/**
+		 * Visual variant.
+		 * @defaultValue 'default'
+		 * @public
+		 */
+		variant?: PanelVariant;
+
+		/**
+		 * Body padding preset.
+		 * @defaultValue 'md'
+		 * @public
+		 */
+		padding?: PanelPadding;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/**
+		 * Replaces the default header. When supplied along with `title`,
+		 * the title is still rendered for accessibility and the snippet
+		 * content is rendered alongside.
+		 * @public
+		 */
+		header?: Snippet;
+
+		/** Trailing actions slot, rendered to the right of the title. @public */
+		actions?: Snippet;
+
+		/** Footer slot, rendered below the body. @public */
+		footer?: Snippet;
+
+		/** Body content. @public */
+		children?: Snippet;
+	}
+
+	let {
+		title,
+		headerLevel = 2,
+		variant = 'default',
+		padding = 'md',
+		class: className = '',
+		header,
+		actions,
+		footer,
+		children,
+		'aria-labelledby': ariaLabelledby,
+		'aria-label': ariaLabel,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const generatedTitleId = $derived(
+		title && stableId.value ? `${stableId.value}-title` : undefined
+	);
+	const resolvedLabelledby = $derived(ariaLabelledby ?? generatedTitleId);
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell-panel',
+			`gr-shell-panel--variant-${variant}`,
+			`gr-shell-panel--padding-${padding}`,
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<section
+	class={rootClass()}
+	aria-labelledby={resolvedLabelledby}
+	aria-label={!resolvedLabelledby ? ariaLabel : undefined}
+	{...restProps}
+>
+	{#if title || header || actions}
+		<div class="gr-shell-panel__header">
+			<div class="gr-shell-panel__heading">
+				{#if title}
+					{#if headerLevel === 1}
+						<h1 id={generatedTitleId} class="gr-shell-panel__title">{title}</h1>
+					{:else if headerLevel === 2}
+						<h2 id={generatedTitleId} class="gr-shell-panel__title">{title}</h2>
+					{:else if headerLevel === 3}
+						<h3 id={generatedTitleId} class="gr-shell-panel__title">{title}</h3>
+					{:else if headerLevel === 4}
+						<h4 id={generatedTitleId} class="gr-shell-panel__title">{title}</h4>
+					{:else if headerLevel === 5}
+						<h5 id={generatedTitleId} class="gr-shell-panel__title">{title}</h5>
+					{:else}
+						<h6 id={generatedTitleId} class="gr-shell-panel__title">{title}</h6>
+					{/if}
+				{/if}
+				{@render header?.()}
+			</div>
+			{#if actions}
+				<div class="gr-shell-panel__actions" role="group">{@render actions()}</div>
+			{/if}
+		</div>
+	{/if}
+	<div class="gr-shell-panel__body">{@render children?.()}</div>
+	{#if footer}
+		<div class="gr-shell-panel__footer">{@render footer()}</div>
+	{/if}
+</section>

--- a/web/src/lib/greater/shell/components/Shell.css
+++ b/web/src/lib/greater/shell/components/Shell.css
@@ -1,0 +1,96 @@
+.gr-shell {
+	display: grid;
+	grid-template-columns: 1fr;
+	grid-template-rows: auto 1fr;
+	grid-template-areas:
+		'topbar'
+		'main';
+	background: var(--gr-semantic-background-base, var(--gr-color-gray-50, #f9fafb));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	min-height: 100%;
+}
+
+.gr-shell--full-height {
+	min-height: 100vh;
+	/* svh keeps Safari mobile from being clipped by the URL bar where supported */
+	min-height: 100svh;
+}
+
+/* Topbar */
+.gr-shell--has-topbar.gr-shell {
+	grid-template-rows: var(--gr-shell-topbar-height) 1fr;
+}
+.gr-shell__topbar {
+	grid-area: topbar;
+	min-width: 0;
+}
+
+/* Sidebar layouts */
+.gr-shell--has-sidebar.gr-shell--sidebar-left {
+	grid-template-columns: var(--gr-shell-sidebar-width-md) 1fr;
+	grid-template-areas:
+		'topbar topbar'
+		'sidebar main';
+}
+.gr-shell--has-sidebar.gr-shell--sidebar-right {
+	grid-template-columns: 1fr var(--gr-shell-sidebar-width-md);
+	grid-template-areas:
+		'topbar topbar'
+		'main sidebar';
+}
+
+/* When there is no topbar, drop the topbar row entirely. */
+.gr-shell:not(.gr-shell--has-topbar).gr-shell--has-sidebar {
+	grid-template-rows: 1fr;
+	grid-template-areas: 'sidebar main';
+}
+.gr-shell:not(.gr-shell--has-topbar).gr-shell--has-sidebar.gr-shell--sidebar-right {
+	grid-template-areas: 'main sidebar';
+}
+
+.gr-shell--sidebar-width-sm.gr-shell--sidebar-left,
+.gr-shell--sidebar-width-sm.gr-shell--sidebar-right {
+	grid-template-columns: var(--gr-shell-sidebar-width-sm) 1fr;
+}
+.gr-shell--sidebar-width-sm.gr-shell--sidebar-right {
+	grid-template-columns: 1fr var(--gr-shell-sidebar-width-sm);
+}
+.gr-shell--sidebar-width-lg.gr-shell--sidebar-left {
+	grid-template-columns: var(--gr-shell-sidebar-width-lg) 1fr;
+}
+.gr-shell--sidebar-width-lg.gr-shell--sidebar-right {
+	grid-template-columns: 1fr var(--gr-shell-sidebar-width-lg);
+}
+
+.gr-shell__sidebar {
+	grid-area: sidebar;
+	min-width: 0;
+	border-right: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-shell--sidebar-right .gr-shell__sidebar {
+	border-right: none;
+	border-left: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-shell__main {
+	grid-area: main;
+	min-width: 0;
+	display: block;
+}
+
+/* Responsive collapse: stack on narrow viewports. */
+@media (max-width: 48rem) {
+	.gr-shell--has-sidebar.gr-shell--sidebar-left,
+	.gr-shell--has-sidebar.gr-shell--sidebar-right {
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			'topbar'
+			'sidebar'
+			'main';
+	}
+	.gr-shell__sidebar {
+		border-right: none;
+		border-left: none;
+		border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	}
+}

--- a/web/src/lib/greater/shell/components/Shell.svelte
+++ b/web/src/lib/greater/shell/components/Shell.svelte
@@ -1,0 +1,136 @@
+<!--
+@component
+Shell — root grid layout combining sidebar, topbar, and main content area.
+
+The Shell component renders structural landmarks for an app layout:
+- The `topbar` snippet is wrapped in a `<header>`-equivalent area (consumer
+  should slot in `<Topbar>`, which itself renders `<header>` to provide the
+  banner landmark).
+- The `sidebar` snippet sits beside the main content (consumer should slot
+  in `<Sidebar>`, which renders a `<nav>` landmark with an accessible name).
+- The main content is wrapped in a single `<main>` landmark.
+
+Strict-CSP safe: no inline styles, no event handlers set at module evaluation,
+no browser globals at module evaluation time.
+
+@example
+```svelte
+<Shell mainLabel="Dashboard">
+	{#snippet topbar()}<Topbar>…</Topbar>{/snippet}
+	{#snippet sidebar()}<Sidebar label="Primary">…</Sidebar>{/snippet}
+	<PageFrame>…</PageFrame>
+</Shell>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { ShellSidebarPlacement, SidebarWidth } from '../types.js';
+
+	/**
+	 * Shell component props.
+	 * @public
+	 */
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/**
+		 * Accessible name for the `<main>` landmark. Strongly recommended
+		 * for screen-reader users when multiple Shell instances or main
+		 * landmarks exist in the page.
+		 * @public
+		 */
+		mainLabel?: string;
+
+		/**
+		 * Placement of the sidebar relative to the main content.
+		 * @defaultValue 'left'
+		 * @public
+		 */
+		sidebarPlacement?: ShellSidebarPlacement;
+
+		/**
+		 * Width preset for the sidebar slot.
+		 * Maps to `--gr-shell-sidebar-width-*` tokens.
+		 * @defaultValue 'md'
+		 * @public
+		 */
+		sidebarWidth?: SidebarWidth;
+
+		/**
+		 * Whether the sidebar slot is rendered. When false, the slot
+		 * content is omitted and the grid collapses to a single column.
+		 * @defaultValue true
+		 * @public
+		 */
+		showSidebar?: boolean;
+
+		/**
+		 * Whether the topbar slot is rendered.
+		 * @defaultValue true
+		 * @public
+		 */
+		showTopbar?: boolean;
+
+		/**
+		 * Whether the shell occupies the full viewport height.
+		 * @defaultValue true
+		 * @public
+		 */
+		fullHeight?: boolean;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Topbar slot (typically a `<Topbar>` component). @public */
+		topbar?: Snippet;
+
+		/** Sidebar slot (typically a `<Sidebar>` component). @public */
+		sidebar?: Snippet;
+
+		/** Main content. @public */
+		children?: Snippet;
+	}
+
+	let {
+		mainLabel,
+		sidebarPlacement = 'left',
+		sidebarWidth = 'md',
+		showSidebar = true,
+		showTopbar = true,
+		fullHeight = true,
+		class: className = '',
+		topbar,
+		sidebar,
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const hasSidebar = $derived(showSidebar && !!sidebar);
+	const hasTopbar = $derived(showTopbar && !!topbar);
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell',
+			`gr-shell--sidebar-${sidebarPlacement}`,
+			`gr-shell--sidebar-width-${sidebarWidth}`,
+			hasSidebar && 'gr-shell--has-sidebar',
+			hasTopbar && 'gr-shell--has-topbar',
+			fullHeight && 'gr-shell--full-height',
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<div class={rootClass()} {...restProps}>
+	{#if hasTopbar}
+		<div class="gr-shell__topbar">{@render topbar?.()}</div>
+	{/if}
+	{#if hasSidebar}
+		<div class="gr-shell__sidebar">{@render sidebar?.()}</div>
+	{/if}
+	<main class="gr-shell__main" aria-label={mainLabel ?? undefined}>
+		{@render children?.()}
+	</main>
+</div>

--- a/web/src/lib/greater/shell/components/Sidebar.css
+++ b/web/src/lib/greater/shell/components/Sidebar.css
@@ -1,0 +1,78 @@
+.gr-shell-sidebar {
+	display: flex;
+	flex-direction: column;
+	min-height: 0;
+	height: 100%;
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	overflow-y: auto;
+}
+
+.gr-shell-sidebar--variant-compact {
+	align-items: center;
+}
+.gr-shell-sidebar--width-sm {
+	width: var(--gr-shell-sidebar-width-sm);
+}
+.gr-shell-sidebar--width-md {
+	width: var(--gr-shell-sidebar-width-md);
+}
+.gr-shell-sidebar--width-lg {
+	width: var(--gr-shell-sidebar-width-lg);
+}
+.gr-shell-sidebar--variant-compact.gr-shell-sidebar {
+	width: var(--gr-shell-sidebar-width-compact);
+}
+
+.gr-shell-sidebar__header,
+.gr-shell-sidebar__footer {
+	padding: var(--gr-shell-gap-md) var(--gr-shell-gutter);
+}
+.gr-shell-sidebar__header {
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+.gr-shell-sidebar__footer {
+	border-top: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	margin-top: auto;
+}
+
+.gr-shell-sidebar__body {
+	display: flex;
+	flex-direction: column;
+	gap: 0.125rem;
+	padding: var(--gr-shell-gap-md) 0.5rem;
+	flex: 1 1 auto;
+	min-height: 0;
+}
+
+/* Default styling for direct anchor / button descendants. Consumers may
+ * override via additional class names; these are baseline AA-compliant. */
+.gr-shell-sidebar__body > a,
+.gr-shell-sidebar__body > button {
+	display: flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.5rem 0.75rem;
+	border-radius: 0.375rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+	background: transparent;
+	border: 1px solid transparent;
+	font: inherit;
+	text-align: start;
+	text-decoration: none;
+	cursor: pointer;
+	width: 100%;
+}
+
+.gr-shell-sidebar__body > a:hover,
+.gr-shell-sidebar__body > button:hover {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-sidebar__body > a[aria-current='page'],
+.gr-shell-sidebar__body > button[aria-pressed='true'] {
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	font-weight: 600;
+}

--- a/web/src/lib/greater/shell/components/Sidebar.svelte
+++ b/web/src/lib/greater/shell/components/Sidebar.svelte
@@ -1,0 +1,93 @@
+<!--
+@component
+Sidebar — semantic `<nav>` sidebar with an accessible name.
+
+Renders a `<nav aria-label="…">` landmark. Consumers populate the children
+snippet with real `<a>` (and/or `<button>`) elements; use `aria-current="page"`
+on the active link to expose the current location to assistive technology.
+
+Sidebar does NOT render its own list/wrapper around children — consumers can
+use plain HTML or compose other Greater components inside.
+
+@example
+```svelte
+<Sidebar label="Primary navigation">
+	<a href="/overview" aria-current="page">Overview</a>
+	<a href="/instances">Instances</a>
+</Sidebar>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { SidebarVariant, SidebarWidth } from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/**
+		 * Required accessible name for the `<nav>` landmark.
+		 * Used as `aria-label`. Should describe the navigation
+		 * region (e.g. "Primary navigation", "Settings").
+		 * @public
+		 */
+		label: string;
+
+		/**
+		 * Visual variant. `compact` shrinks the sidebar to icon width.
+		 * @defaultValue 'full'
+		 * @public
+		 */
+		variant?: SidebarVariant;
+
+		/**
+		 * Width preset. Inherits Shell's default token when nested.
+		 * @defaultValue 'md'
+		 * @public
+		 */
+		width?: SidebarWidth;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Header content rendered above the children. @public */
+		header?: Snippet;
+
+		/** Footer content rendered below the children. @public */
+		footer?: Snippet;
+
+		/** Navigation links / items. @public */
+		children: Snippet;
+	}
+
+	let {
+		label,
+		variant = 'full',
+		width = 'md',
+		class: className = '',
+		header,
+		footer,
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell-sidebar',
+			`gr-shell-sidebar--variant-${variant}`,
+			`gr-shell-sidebar--width-${width}`,
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<nav class={rootClass()} aria-label={label} {...restProps}>
+	{#if header}
+		<div class="gr-shell-sidebar__header">{@render header()}</div>
+	{/if}
+	<div class="gr-shell-sidebar__body">{@render children()}</div>
+	{#if footer}
+		<div class="gr-shell-sidebar__footer">{@render footer()}</div>
+	{/if}
+</nav>

--- a/web/src/lib/greater/shell/components/StatCard.css
+++ b/web/src/lib/greater/shell/components/StatCard.css
@@ -1,0 +1,97 @@
+.gr-shell-statcard {
+	display: flex;
+	align-items: flex-start;
+	gap: var(--gr-shell-gap-md);
+	padding: var(--gr-shell-gap-md) var(--gr-shell-gutter);
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+	border-radius: 0.5rem;
+	min-width: 0;
+}
+
+.gr-shell-statcard__icon {
+	flex: 0 0 auto;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.5rem;
+	height: 2.5rem;
+	border-radius: 0.5rem;
+	background: var(--gr-semantic-background-secondary, var(--gr-color-gray-100, #f3f4f6));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+}
+
+.gr-shell-statcard__body {
+	flex: 1 1 auto;
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 0.25rem;
+}
+
+.gr-shell-statcard__label {
+	margin: 0;
+	font-size: 0.875rem;
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-statcard__value {
+	margin: 0;
+	font-size: 1.5rem;
+	line-height: 1.2;
+	font-weight: 600;
+}
+
+.gr-shell-statcard__trend {
+	margin: 0;
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-size: 0.8125rem;
+}
+.gr-shell-statcard__trend--up {
+	color: var(--gr-color-success-700, #15803d);
+}
+.gr-shell-statcard__trend--down {
+	color: var(--gr-color-error-700, #b91c1c);
+}
+.gr-shell-statcard__trend--flat {
+	color: var(--gr-semantic-foreground-secondary, var(--gr-color-gray-700, #374151));
+}
+
+.gr-shell-statcard__description {
+	margin: 0;
+	font-size: 0.8125rem;
+	color: var(--gr-semantic-foreground-tertiary, var(--gr-color-gray-500, #6b7280));
+}
+
+/* Status tinting */
+.gr-shell-statcard--status-success {
+	border-color: var(--gr-color-success-300, #86efac);
+}
+.gr-shell-statcard--status-success .gr-shell-statcard__icon {
+	background: var(--gr-color-success-100, #dcfce7);
+	color: var(--gr-color-success-700, #15803d);
+}
+.gr-shell-statcard--status-warning {
+	border-color: var(--gr-color-warning-300, #fcd34d);
+}
+.gr-shell-statcard--status-warning .gr-shell-statcard__icon {
+	background: var(--gr-color-warning-100, #fef3c7);
+	color: var(--gr-color-warning-700, #b45309);
+}
+.gr-shell-statcard--status-danger {
+	border-color: var(--gr-color-error-300, #fca5a5);
+}
+.gr-shell-statcard--status-danger .gr-shell-statcard__icon {
+	background: var(--gr-color-error-100, #fee2e2);
+	color: var(--gr-color-error-700, #b91c1c);
+}
+.gr-shell-statcard--status-info {
+	border-color: var(--gr-color-info-300, #93c5fd);
+}
+.gr-shell-statcard--status-info .gr-shell-statcard__icon {
+	background: var(--gr-color-info-100, #dbeafe);
+	color: var(--gr-color-info-700, #1d4ed8);
+}

--- a/web/src/lib/greater/shell/components/StatCard.svelte
+++ b/web/src/lib/greater/shell/components/StatCard.svelte
@@ -1,0 +1,140 @@
+<!--
+@component
+StatCard — metric display card with label, value, optional trend, description, icon.
+
+The root element has `role="group"` and is labelled by its label/value so
+screen readers announce the stat coherently. Use `valueLabel` to override
+the default announcement (e.g. for unit text).
+
+@example
+```svelte
+<StatCard
+	label="Active instances"
+	value={42}
+	trend={{ direction: 'up', label: '+8 this week' }}
+	status="success"
+/>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import { useStableId } from 'src/lib/greater/utils';
+	import type { StatCardStatus, StatCardTrend } from '../types.js';
+
+	// SSR/hydration-safe stable id per component instance.
+	// With IdProvider: deterministic counter-based id during SSR + hydration.
+	// Without IdProvider: id is assigned onMount (avoids hydration mismatches).
+	const stableId = useStableId('shell-statcard');
+
+	interface Props extends HTMLAttributes<HTMLDivElement> {
+		/** Required visible label describing the metric. @public */
+		label: string;
+
+		/** Required metric value. @public */
+		value: string | number;
+
+		/**
+		 * Optional accessible override for the value announcement, e.g.
+		 * `"42 active instances"`. When omitted, the visible value is
+		 * used directly.
+		 * @public
+		 */
+		valueLabel?: string;
+
+		/** Optional trend indicator. @public */
+		trend?: StatCardTrend;
+
+		/** Optional supporting description, rendered below the value. @public */
+		description?: string;
+
+		/**
+		 * Status / tone. Drives both visual variant and the implicit
+		 * connotation (e.g. `'danger'` cards are styled with a red accent).
+		 * @defaultValue 'default'
+		 * @public
+		 */
+		status?: StatCardStatus;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Optional leading icon snippet (rendered with `aria-hidden`). @public */
+		icon?: Snippet;
+	}
+
+	let {
+		label,
+		value,
+		valueLabel,
+		trend,
+		description,
+		status = 'default',
+		class: className = '',
+		icon,
+		'aria-label': ariaLabel,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const labelId = $derived(stableId.value ? `${stableId.value}-label` : undefined);
+	const valueId = $derived(stableId.value ? `${stableId.value}-value` : undefined);
+	const descriptionId = $derived(
+		description && stableId.value ? `${stableId.value}-description` : undefined
+	);
+	const trendId = $derived(trend && stableId.value ? `${stableId.value}-trend` : undefined);
+
+	const rootClass = $derived(() =>
+		['gr-shell-statcard', `gr-shell-statcard--status-${status}`, className]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	const trendClass = $derived.by(() => {
+		const t = trend;
+		return t ? `gr-shell-statcard__trend gr-shell-statcard__trend--${t.direction}` : undefined;
+	});
+
+	const labelledby = $derived.by(() => {
+		if (!labelId || !valueId) return undefined;
+		const parts = [labelId, valueId];
+		if (trendId) parts.push(trendId);
+		if (descriptionId) parts.push(descriptionId);
+		return parts.join(' ');
+	});
+</script>
+
+<div
+	class={rootClass()}
+	role="group"
+	aria-labelledby={ariaLabel ? undefined : labelledby}
+	aria-label={ariaLabel}
+	{...restProps}
+>
+	{#if icon}
+		<div class="gr-shell-statcard__icon" aria-hidden="true">{@render icon()}</div>
+	{/if}
+	<div class="gr-shell-statcard__body">
+		<p class="gr-shell-statcard__label" id={labelId}>{label}</p>
+		<p class="gr-shell-statcard__value" id={valueId} aria-label={valueLabel ?? undefined}>
+			{value}
+		</p>
+		{#if trend}
+			<p class={trendClass} id={trendId}>
+				<span class="gr-shell-statcard__trend-icon" aria-hidden="true">
+					{#if trend.direction === 'up'}
+						↑
+					{:else if trend.direction === 'down'}
+						↓
+					{:else}
+						→
+					{/if}
+				</span>
+				<span class="gr-shell-statcard__trend-label">{trend.label}</span>
+			</p>
+		{/if}
+		{#if description}
+			<p class="gr-shell-statcard__description" id={descriptionId}>{description}</p>
+		{/if}
+	</div>
+</div>

--- a/web/src/lib/greater/shell/components/SummaryStrip.css
+++ b/web/src/lib/greater/shell/components/SummaryStrip.css
@@ -1,0 +1,54 @@
+.gr-shell-summary-strip {
+	display: grid;
+	min-width: 0;
+}
+
+.gr-shell-summary-strip--gap-sm {
+	gap: var(--gr-shell-gap-sm);
+}
+.gr-shell-summary-strip--gap-md {
+	gap: var(--gr-shell-gap-md);
+}
+.gr-shell-summary-strip--gap-lg {
+	gap: var(--gr-shell-gap-lg);
+}
+
+.gr-shell-summary-strip--columns-auto {
+	grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+}
+.gr-shell-summary-strip--columns-1 {
+	grid-template-columns: 1fr;
+}
+.gr-shell-summary-strip--columns-2 {
+	grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.gr-shell-summary-strip--columns-3 {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.gr-shell-summary-strip--columns-4 {
+	grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+.gr-shell-summary-strip--columns-5 {
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+.gr-shell-summary-strip--columns-6 {
+	grid-template-columns: repeat(6, minmax(0, 1fr));
+}
+
+@media (max-width: 48rem) {
+	.gr-shell-summary-strip--columns-3,
+	.gr-shell-summary-strip--columns-4,
+	.gr-shell-summary-strip--columns-5,
+	.gr-shell-summary-strip--columns-6 {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+@media (max-width: 30rem) {
+	.gr-shell-summary-strip--columns-2,
+	.gr-shell-summary-strip--columns-3,
+	.gr-shell-summary-strip--columns-4,
+	.gr-shell-summary-strip--columns-5,
+	.gr-shell-summary-strip--columns-6 {
+		grid-template-columns: 1fr;
+	}
+}

--- a/web/src/lib/greater/shell/components/SummaryStrip.svelte
+++ b/web/src/lib/greater/shell/components/SummaryStrip.svelte
@@ -1,0 +1,73 @@
+<!--
+@component
+SummaryStrip — labeled grouping region for related summary items (e.g. StatCards).
+
+Renders a `<section aria-label="…">` containing children laid out in a
+responsive CSS grid. The accessible name is required so screen-reader users
+understand what set of stats the strip is summarizing.
+
+@example
+```svelte
+<SummaryStrip label="Fleet summary" columns={4}>
+	<StatCard label="Instances" value={42} />
+	<StatCard label="Healthy" value={40} status="success" />
+	<StatCard label="Warning" value={1} status="warning" />
+	<StatCard label="Down" value={1} status="danger" />
+</SummaryStrip>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { SummaryStripColumns, SummaryStripGap } from '../types.js';
+
+	interface Props extends Omit<HTMLAttributes<HTMLElement>, 'aria-label'> {
+		/** Required accessible name for the summary region. @public */
+		label: string;
+
+		/**
+		 * Column count or `'auto'` (lets the grid wrap based on min width).
+		 * @defaultValue 'auto'
+		 * @public
+		 */
+		columns?: SummaryStripColumns;
+
+		/**
+		 * Spacing between items.
+		 * @defaultValue 'md'
+		 * @public
+		 */
+		gap?: SummaryStripGap;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Summary items. @public */
+		children: Snippet;
+	}
+
+	let {
+		label,
+		columns = 'auto',
+		gap = 'md',
+		class: className = '',
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell-summary-strip',
+			`gr-shell-summary-strip--gap-${gap}`,
+			`gr-shell-summary-strip--columns-${columns}`,
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<section class={rootClass()} aria-label={label} {...restProps}>
+	{@render children()}
+</section>

--- a/web/src/lib/greater/shell/components/Topbar.css
+++ b/web/src/lib/greater/shell/components/Topbar.css
@@ -1,0 +1,48 @@
+.gr-shell-topbar {
+	display: flex;
+	align-items: center;
+	gap: var(--gr-shell-gap-md);
+	min-height: var(--gr-shell-topbar-height);
+	padding: 0 var(--gr-shell-gutter);
+	background: var(--gr-semantic-background-surface, var(--gr-color-base-white, #fff));
+	color: var(--gr-semantic-foreground-primary, var(--gr-color-gray-900, #111827));
+	border-bottom: 1px solid var(--gr-semantic-border-subtle, var(--gr-color-gray-200, #e5e7eb));
+}
+
+.gr-shell-topbar--variant-flat {
+	border-bottom: none;
+}
+.gr-shell-topbar--variant-elevated {
+	border-bottom: none;
+	box-shadow: var(--gr-shadows-base, 0 1px 3px 0 rgb(0 0 0 / 0.1));
+}
+
+.gr-shell-topbar--sticky {
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.gr-shell-topbar__region {
+	display: flex;
+	align-items: center;
+	gap: var(--gr-shell-gap-sm);
+	min-width: 0;
+}
+.gr-shell-topbar__region--start {
+	flex: 0 0 auto;
+}
+.gr-shell-topbar__region--center {
+	flex: 1 1 auto;
+	justify-content: center;
+	min-width: 0;
+}
+.gr-shell-topbar__region--end {
+	flex: 0 0 auto;
+	margin-inline-start: auto;
+	justify-content: flex-end;
+}
+.gr-shell-topbar__region--full {
+	flex: 1 1 auto;
+	justify-content: space-between;
+}

--- a/web/src/lib/greater/shell/components/Topbar.svelte
+++ b/web/src/lib/greater/shell/components/Topbar.svelte
@@ -1,0 +1,87 @@
+<!--
+@component
+Topbar — site/app `<header>` bar.
+
+Renders a `<header class="gr-shell-topbar">`. When used as the topmost
+landmark, it provides the implicit `banner` role.
+
+Provides three optional layout slots — `start`, `center`, `end` — for left/
+center/right alignment. If only `children` is provided, content fills the bar.
+
+@example
+```svelte
+<Topbar variant="elevated">
+	{#snippet start()}<strong>lesser-host</strong>{/snippet}
+	{#snippet end()}<button>Sign out</button>{/snippet}
+</Topbar>
+```
+-->
+<script lang="ts">
+	import type { HTMLAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+	import type { TopbarVariant } from '../types.js';
+
+	interface Props extends HTMLAttributes<HTMLElement> {
+		/**
+		 * Visual variant.
+		 * - `default` — light surface with bottom border
+		 * - `flat` — no border / shadow
+		 * - `elevated` — drop shadow
+		 * @defaultValue 'default'
+		 * @public
+		 */
+		variant?: TopbarVariant;
+
+		/**
+		 * Whether the topbar sticks to the top of its scroll container.
+		 * @defaultValue false
+		 * @public
+		 */
+		sticky?: boolean;
+
+		/** Additional CSS classes. @public */
+		class?: string;
+
+		/** Start (leading) slot — typically logo / brand. @public */
+		start?: Snippet;
+		/** Center slot — typically a search bar or page indicator. @public */
+		center?: Snippet;
+		/** End (trailing) slot — typically actions / user menu. @public */
+		end?: Snippet;
+		/** Fallback content when start/center/end are not used. @public */
+		children?: Snippet;
+	}
+
+	let {
+		variant = 'default',
+		sticky = false,
+		class: className = '',
+		start,
+		center,
+		end,
+		children,
+		style: _style,
+		...restProps
+	}: Props = $props();
+
+	const rootClass = $derived(() =>
+		[
+			'gr-shell-topbar',
+			`gr-shell-topbar--variant-${variant}`,
+			sticky && 'gr-shell-topbar--sticky',
+			className,
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+</script>
+
+<header class={rootClass()} {...restProps}>
+	{#if start || center || end}
+		<div class="gr-shell-topbar__region gr-shell-topbar__region--start">{@render start?.()}</div>
+		<div class="gr-shell-topbar__region gr-shell-topbar__region--center">{@render center?.()}</div>
+		<div class="gr-shell-topbar__region gr-shell-topbar__region--end">{@render end?.()}</div>
+	{:else if children}
+		<div class="gr-shell-topbar__region gr-shell-topbar__region--full">{@render children()}</div>
+	{/if}
+</header>

--- a/web/src/lib/greater/shell/index.ts
+++ b/web/src/lib/greater/shell/index.ts
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Greater Shell - App shell layout components.
+ *
+ * Strict-CSP safe, Svelte 5 runes, WCAG 2.1 AA. All styling consumes
+ * stable `--gr-*` design tokens; consumers may bridge their own design
+ * tokens (e.g. `--ds-*`) in consumer CSS without touching this package.
+ *
+ * Components:
+ * - Shell        — root grid layout combining sidebar, topbar, and main
+ * - Sidebar      — semantic <nav> sidebar with accessible label
+ * - Topbar       — site/app <header> bar
+ * - Panel        — content container with header / body / footer
+ * - StatCard     — metric display card
+ * - SummaryStrip — labeled region grouping summary items / StatCards
+ * - PageFrame    — single-page wrapper with optional aside
+ * - PageTitle    — semantic page heading with eyebrow / subtitle / actions
+ * - Breadcrumb   — breadcrumb navigation with aria-current="page"
+ * - Callout      — informational call-out (status="status" or "alert")
+ *
+ * @version 0.1.0
+ * @author Greater Contributors
+ * @license AGPL-3.0-only
+ * @public
+ */
+
+export type { ComponentProps } from 'svelte';
+
+// Components
+export { default as Shell } from './components/Shell.svelte';
+export { default as Sidebar } from './components/Sidebar.svelte';
+export { default as Topbar } from './components/Topbar.svelte';
+export { default as Panel } from './components/Panel.svelte';
+export { default as StatCard } from './components/StatCard.svelte';
+export { default as SummaryStrip } from './components/SummaryStrip.svelte';
+export { default as PageFrame } from './components/PageFrame.svelte';
+export { default as PageTitle } from './components/PageTitle.svelte';
+export { default as Breadcrumb } from './components/Breadcrumb.svelte';
+export { default as Callout } from './components/Callout.svelte';
+export { default as CommandPalette } from './components/CommandPalette.svelte';
+
+// Utilities (dependency-free, strict-CSP-safe).
+export {
+	scoreCommandPaletteItem,
+	filterAndRankItems as filterAndRankCommandPaletteItems,
+	tokenizeQuery as tokenizeCommandPaletteQuery,
+} from './utils/fuzzy-filter.js';
+
+// Shared types
+export type {
+	ShellSidebarPlacement,
+	SidebarWidth,
+	SidebarVariant,
+	TopbarVariant,
+	PanelVariant,
+	PanelPadding,
+	StatCardStatus,
+	StatCardTrendDirection,
+	StatCardTrend,
+	SummaryStripColumns,
+	SummaryStripGap,
+	PageFrameWidth,
+	PageFrameAsidePlacement,
+	PageTitleLevel,
+	BreadcrumbItem,
+	CalloutTone,
+	CalloutRole,
+	CommandPaletteItem,
+	CommandPaletteGroup,
+	CommandPaletteFilter,
+} from './types.js';

--- a/web/src/lib/greater/shell/styles/base.css
+++ b/web/src/lib/greater/shell/styles/base.css
@@ -1,0 +1,103 @@
+/*
+ * Greater Shell — base styles.
+ *
+ * Strict-CSP safe: tokens only, no inline styles or runtime expressions.
+ * Consumers may override any --gr-shell-* token without forking the package.
+ */
+
+.gr-shell,
+.gr-shell-sidebar,
+.gr-shell-topbar,
+.gr-shell-panel,
+.gr-shell-statcard,
+.gr-shell-summary-strip,
+.gr-shell-page-frame,
+.gr-shell-page-title,
+.gr-shell-breadcrumb,
+.gr-shell-callout {
+	box-sizing: border-box;
+}
+
+.gr-shell *,
+.gr-shell-sidebar *,
+.gr-shell-topbar *,
+.gr-shell-panel *,
+.gr-shell-page-frame * {
+	box-sizing: border-box;
+}
+
+/*
+ * Visually-hidden utility shipped by the shell CSS bundle.
+ *
+ * `@equaltoai/greater-components-headless`'s `createLiveRegion()` (used by
+ * CommandPalette and other shell components for polite / assertive
+ * announcements) appends elements to `document.body` with class
+ * `gr-sr-only`. Shell-only consumers who import `shell.css` without the
+ * primitives `theme.css` would otherwise see those announcement strings
+ * rendered visibly. The class is duplicated here (matching the primitives
+ * definition byte-for-byte) so that any shell consumer importing
+ * `@equaltoai/greater-components-shell/shell.css` has working live-region
+ * semantics regardless of which other Greater style bundles they ship.
+ */
+.gr-sr-only {
+	position: fixed;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+/*
+ * Default --gr-shell-* tokens (consumers may override).
+ *
+ * Defined on every shell component root class so a standalone `Panel`,
+ * `StatCard`, `Callout`, etc. — rendered outside a `Shell` / `PageFrame`
+ * ancestor — still gets sensible defaults rather than `var()` resolving
+ * to empty. Consumers can override any token by setting it on a higher
+ * ancestor (or by overriding `.gr-shell` / `.gr-shell-page-frame` to
+ * theme the whole tree).
+ */
+:where(
+	.gr-shell,
+	.gr-shell-page-frame,
+	.gr-shell-topbar,
+	.gr-shell-sidebar,
+	.gr-shell-panel,
+	.gr-shell-statcard,
+	.gr-shell-summary-strip,
+	.gr-shell-page-title,
+	.gr-shell-breadcrumb,
+	.gr-shell-callout,
+	.gr-shell-command-palette
+) {
+	--gr-shell-sidebar-width-sm: 14rem;
+	--gr-shell-sidebar-width-md: 16rem;
+	--gr-shell-sidebar-width-lg: 20rem;
+	--gr-shell-sidebar-width-compact: 4rem;
+	--gr-shell-topbar-height: 3.5rem;
+	--gr-shell-content-max-narrow: 48rem;
+	--gr-shell-content-max-default: 72rem;
+	--gr-shell-content-max-wide: 96rem;
+	--gr-shell-gutter: 1.5rem;
+	--gr-shell-gap-sm: 0.5rem;
+	--gr-shell-gap-md: 1rem;
+	--gr-shell-gap-lg: 1.5rem;
+}
+
+/* Focus ring used by interactive shell elements. */
+:where(
+	.gr-shell-sidebar a,
+	.gr-shell-sidebar button,
+	.gr-shell-topbar a,
+	.gr-shell-topbar button,
+	.gr-shell-breadcrumb a,
+	.gr-shell-callout button
+):focus-visible {
+	outline: 2px solid var(--gr-semantic-border-focus, var(--gr-color-primary-600, #2563eb));
+	outline-offset: 2px;
+	border-radius: 0.25rem;
+}

--- a/web/src/lib/greater/shell/types.ts
+++ b/web/src/lib/greater/shell/types.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Shared types for Greater Shell components.
+ *
+ * @public
+ */
+
+/** Sidebar placement within Shell. */
+export type ShellSidebarPlacement = 'left' | 'right';
+
+/** Sidebar preset widths. */
+export type SidebarWidth = 'sm' | 'md' | 'lg';
+
+/** Sidebar visual variant. */
+export type SidebarVariant = 'compact' | 'full';
+
+/** Topbar visual variant. */
+export type TopbarVariant = 'default' | 'flat' | 'elevated';
+
+/** Panel visual variant. */
+export type PanelVariant = 'default' | 'flat' | 'elevated';
+
+/** Panel padding preset. */
+export type PanelPadding = 'none' | 'sm' | 'md' | 'lg';
+
+/** StatCard status / tone. */
+export type StatCardStatus = 'default' | 'success' | 'warning' | 'danger' | 'info';
+
+/** StatCard trend direction. */
+export type StatCardTrendDirection = 'up' | 'down' | 'flat';
+
+/** StatCard trend descriptor. */
+export interface StatCardTrend {
+	/** Visual direction of the trend. */
+	direction: StatCardTrendDirection;
+	/** Accessible / visible label for the trend. */
+	label: string;
+}
+
+/** SummaryStrip column preset. */
+export type SummaryStripColumns = 'auto' | 1 | 2 | 3 | 4 | 5 | 6;
+
+/** SummaryStrip gap preset. */
+export type SummaryStripGap = 'sm' | 'md' | 'lg';
+
+/** PageFrame width preset. */
+export type PageFrameWidth = 'narrow' | 'default' | 'wide' | 'full';
+
+/** PageFrame aside placement. */
+export type PageFrameAsidePlacement = 'left' | 'right';
+
+/** PageTitle heading level. */
+export type PageTitleLevel = 1 | 2;
+
+/** A single breadcrumb item. */
+export interface BreadcrumbItem {
+	/** Visible breadcrumb label. */
+	label: string;
+	/** Optional href; when omitted the item renders as static text. */
+	href?: string;
+	/** When true, the item is marked as the current page via aria-current="page". */
+	current?: boolean;
+}
+
+/** Callout tone. */
+export type CalloutTone = 'info' | 'success' | 'warning' | 'danger' | 'neutral';
+
+/** Callout ARIA role for live-region semantics. */
+export type CalloutRole = 'status' | 'alert' | 'note';
+
+/**
+ * A single command palette item (e.g. a route, an action, a setting).
+ *
+ * Consumers supply opaque ids; the CommandPalette never interprets `id`
+ * beyond using it for `aria-activedescendant` and as the argument to
+ * `onselect`. Use `keywords` to expose synonyms / aliases for filtering
+ * that should not be displayed as part of the label.
+ */
+export interface CommandPaletteItem {
+	/** Stable id; used for DOM identification and as the `onselect` argument. */
+	id: string;
+	/** Visible primary label. */
+	label: string;
+	/** Optional secondary description rendered below the label. */
+	description?: string;
+	/** Additional terms that should match against the query (synonyms, aliases). */
+	keywords?: string[];
+	/** Optional keyboard shortcut hint (rendered with `aria-hidden`; for visual cue only). */
+	shortcut?: string;
+	/** When true, the item is rendered but cannot be activated. */
+	disabled?: boolean;
+}
+
+/**
+ * A group of command palette items rendered together with a shared label.
+ *
+ * Groups are exposed via `role="group"` with `aria-labelledby` referencing
+ * the group label, so screen readers announce the section name.
+ */
+export interface CommandPaletteGroup {
+	/** Stable id used for the group label element. */
+	id: string;
+	/** Visible label for the group (e.g. "Pages", "Actions"). */
+	label: string;
+	/** Items in this group; rendered in array order after filtering. */
+	items: CommandPaletteItem[];
+}
+
+/**
+ * Signature for a custom item-vs-query matcher.
+ *
+ * Return `null` (or `undefined`) to exclude the item from results; return a
+ * numeric score (higher = better) to include and rank it. When omitted, the
+ * built-in scorer matches all whitespace-separated query tokens
+ * case-insensitively against `label`, `description`, and `keywords`, with
+ * higher scores for prefix / word-boundary matches over substring matches.
+ */
+export type CommandPaletteFilter = (
+	item: CommandPaletteItem,
+	query: string
+) => number | null | undefined;

--- a/web/src/lib/greater/shell/utils/fuzzy-filter.ts
+++ b/web/src/lib/greater/shell/utils/fuzzy-filter.ts
@@ -1,0 +1,150 @@
+/**
+ * @fileoverview Dependency-free, strict-CSP-safe filter + ranker for the
+ * Greater CommandPalette.
+ *
+ * Design goals (see issue #647):
+ * - No runtime dependencies (no cmdk, no fuzzysort, no Fuse, etc.). The
+ *   palette is a source-install component shipped via the shadcn-style CLI;
+ *   keeping it dependency-free avoids dragging consumer projects into
+ *   license / supply-chain decisions just to render a palette.
+ * - No `unsafe-eval`, no dynamic code generation. Pure data transforms over
+ *   plain JS strings.
+ * - Deterministic: same input → same output (used by tests as a fixed-point).
+ * - Token-based: whitespace-separated query tokens must each match somewhere
+ *   in the item's searchable text. This matches the way users actually type
+ *   (`"hot reload"` finds "Toggle hot reload" but also "Hot reload settings").
+ *
+ * Ranking heuristic (per item):
+ * - For each query token, the best per-token score across `label`,
+ *   `description`, and `keywords` is summed:
+ *   - Exact full-string match on `label`:           +100
+ *   - Prefix match on `label`:                       +60
+ *   - Word-boundary match on `label`:                +40
+ *   - Substring match on `label`:                    +20
+ *   - Same tiers for `description`, scaled by 0.5
+ *   - Same tiers for `keywords` (best of any keyword), scaled by 0.7
+ * - An item is excluded if any query token has no match anywhere.
+ * - Empty query returns all items in their natural order with score 0.
+ *
+ * The exact numeric scale is internal; consumers should not depend on it.
+ * They should use the boolean exclusion semantics + the sorted output.
+ *
+ * @public
+ */
+
+import type { CommandPaletteItem } from '../types.js';
+
+interface SearchableFields {
+	label: string;
+	description: string;
+	keywords: string[];
+}
+
+function getSearchableFields(item: CommandPaletteItem): SearchableFields {
+	return {
+		label: item.label,
+		description: item.description ?? '',
+		keywords: item.keywords ?? [],
+	};
+}
+
+/** Tokenize a query into normalized lowercase tokens. */
+export function tokenizeQuery(query: string): string[] {
+	return query
+		.trim()
+		.toLowerCase()
+		.split(/\s+/)
+		.filter((token) => token.length > 0);
+}
+
+/**
+ * Score a single token against a single string field.
+ * Returns 0 when there is no match.
+ *
+ * The token and field are expected to already be lowercase.
+ */
+function scoreTokenInField(token: string, field: string): number {
+	if (!field || !token) return 0;
+	if (field === token) return 100;
+	if (field.startsWith(token)) return 60;
+	// Word-boundary check (non-alphanumeric followed by token).
+	if (
+		field.indexOf(' ' + token) >= 0 ||
+		field.indexOf('-' + token) >= 0 ||
+		field.indexOf('_' + token) >= 0 ||
+		field.indexOf('/' + token) >= 0 ||
+		field.indexOf('.' + token) >= 0
+	) {
+		return 40;
+	}
+	if (field.indexOf(token) >= 0) return 20;
+	return 0;
+}
+
+/** Score a single token across all searchable fields of one item. */
+function scoreTokenForItem(token: string, item: CommandPaletteItem): number {
+	const fields = getSearchableFields(item);
+	const labelLower = fields.label.toLowerCase();
+	const descLower = fields.description.toLowerCase();
+
+	const labelScore = scoreTokenInField(token, labelLower);
+	const descScore = scoreTokenInField(token, descLower) * 0.5;
+
+	let keywordsScore = 0;
+	for (const kw of fields.keywords) {
+		const s = scoreTokenInField(token, kw.toLowerCase()) * 0.7;
+		if (s > keywordsScore) keywordsScore = s;
+	}
+
+	return Math.max(labelScore, descScore, keywordsScore);
+}
+
+/**
+ * Built-in scorer: returns a numeric score (higher = better) when the item
+ * matches every token in the query, or `null` when any token has no match.
+ *
+ * An empty query (no tokens) returns 0 (include everything, no preference).
+ *
+ * @public
+ */
+export function scoreCommandPaletteItem(item: CommandPaletteItem, query: string): number | null {
+	const tokens = tokenizeQuery(query);
+	if (tokens.length === 0) return 0;
+
+	let total = 0;
+	for (const token of tokens) {
+		const tokenScore = scoreTokenForItem(token, item);
+		if (tokenScore === 0) return null;
+		total += tokenScore;
+	}
+	return total;
+}
+
+/**
+ * Filter and rank a flat item list.
+ *
+ * Returns items with `score >= 0`, sorted by descending score, then by
+ * natural array order for ties. Disabled items remain in results (the
+ * palette still shows them); consumers decide how to render disabled.
+ *
+ * @public
+ */
+export function filterAndRankItems(
+	items: CommandPaletteItem[],
+	query: string
+): CommandPaletteItem[] {
+	const tokens = tokenizeQuery(query);
+	if (tokens.length === 0) return items.slice();
+
+	const scored: Array<{ item: CommandPaletteItem; score: number; index: number }> = [];
+	for (let i = 0; i < items.length; i++) {
+		const item = items[i]!;
+		const score = scoreCommandPaletteItem(item, query);
+		if (score !== null) scored.push({ item, score, index: i });
+	}
+	scored.sort((a, b) => {
+		if (b.score !== a.score) return b.score - a.score;
+		return a.index - b.index;
+	});
+	return scored.map((entry) => entry.item);
+}

--- a/web/src/lib/shell/index.ts
+++ b/web/src/lib/shell/index.ts
@@ -1,0 +1,74 @@
+/* ============================================================================
+ * Host shell aggregator (web/src/lib/shell)
+ *
+ * Single import surface exposing the greater-components shell primitives the
+ * Project 39 web UI rework adopts. Eleven shell primitives come from the
+ * vendored `@equaltoai/greater-components` shell package (pinned in
+ * `web/components.json` to greater-v0.10.0-rc.1); `Section` already lives in
+ * `@equaltoai/greater-components` primitives and is re-exported through the
+ * same surface for consumer convenience.
+ *
+ * Consumers import every shell primitive from a single path:
+ *
+ *   import {
+ *     Shell, Sidebar, Topbar, Panel, StatCard, SummaryStrip,
+ *     Section, PageFrame, PageTitle, Breadcrumb, Callout,
+ *     CommandPalette,
+ *   } from 'src/lib/shell';
+ *
+ * Posture invariants preserved:
+ *   - Strict-CSP-safe: components ship `.svelte` + sibling `.css`; no inline
+ *     styles, no event handlers at module evaluation time, no browser globals
+ *     at module evaluation time (per upstream component docs).
+ *   - DS bridge: components consume the stable `--gr-*` token surface, which
+ *     `web/src/lib/tokens/gr-bridge.css` (M0.2) maps to host's `--ds-*` Agent
+ *     Genesis palette. No per-component re-skin needed.
+ *   - Greater steward authority: this is a re-export layer, not a
+ *     re-implementation. Future shell-primitive additions land here by
+ *     extending the re-export list, not by rewriting component code.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.6
+ * Issue: equaltoai/lesser-host#386
+ * ========================================================================== */
+
+export {
+	Shell,
+	Sidebar,
+	Topbar,
+	Panel,
+	StatCard,
+	SummaryStrip,
+	PageFrame,
+	PageTitle,
+	Breadcrumb,
+	Callout,
+	CommandPalette,
+	scoreCommandPaletteItem,
+	filterAndRankCommandPaletteItems,
+	tokenizeCommandPaletteQuery,
+} from 'src/lib/greater/shell';
+
+export type {
+	ShellSidebarPlacement,
+	SidebarWidth,
+	SidebarVariant,
+	TopbarVariant,
+	PanelVariant,
+	PanelPadding,
+	StatCardStatus,
+	StatCardTrendDirection,
+	StatCardTrend,
+	SummaryStripColumns,
+	SummaryStripGap,
+	PageFrameWidth,
+	PageFrameAsidePlacement,
+	PageTitleLevel,
+	BreadcrumbItem,
+	CalloutTone,
+	CalloutRole,
+	CommandPaletteItem,
+	CommandPaletteGroup,
+	CommandPaletteFilter,
+} from 'src/lib/greater/shell';
+
+export { Section, type SectionProps } from '@equaltoai/greater-components-primitives';

--- a/web/src/lib/styles/greater/host-platform.css
+++ b/web/src/lib/styles/greater/host-platform.css
@@ -1,0 +1,38 @@
+/* ============================================================================
+ * Greater Host-Platform — CSS bundle aggregator (host web/)
+ *
+ * Mirrors `tokens.css` / `primitives.css` / `shell.css`: a host-owned
+ * aggregator that `@import`s every CSS file shipped by the vendored
+ * `host-platform` package under `web/src/lib/greater/host-platform/`. The
+ * vendored files stay unmodified (canonical adoption — `components.json`
+ * records `modified: false`); the aggregator lives outside the vendored
+ * tree so `greater list` / re-vendoring never observes a host-side patch.
+ *
+ * Import order:
+ *   1. `styles/base.css` — defines `--gr-host-platform-*` token defaults
+ *      via low-specificity `:where(...)` selectors and ships a byte-for-byte
+ *      copy of the `.gr-sr-only` utility (mirroring the shell + primitives
+ *      bundles) so consumers importing only host-platform CSS still get
+ *      working visually-hidden announcement text for the CostGauge meter
+ *      and ActivitySparkline labels.
+ *   2. Component CSS files in alphabetical order. Each file scopes its
+ *      rules to its own `.gr-host-platform-<name>` root class; no
+ *      inter-CSS dependencies.
+ *
+ * Bonus components vendored in M0.8 (ProvisioningTimeline, ReleaseTimeline,
+ * StackMatrix) are M2-track surfaces but their CSS is included here so
+ * the bundle is complete and re-vendoring doesn't surface a CSS gap when
+ * those components get adopted by `web/src/lib/components/` wrappers in
+ * the M2 operator-console work.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.8-M0.10
+ * Issues: equaltoai/lesser-host#388 / #389 / #390 (CSS adoption follow-up)
+ * ========================================================================== */
+
+@import '../../greater/host-platform/styles/base.css';
+@import '../../greater/host-platform/components/ActivitySparkline.css';
+@import '../../greater/host-platform/components/CostGauge.css';
+@import '../../greater/host-platform/components/FleetCard.css';
+@import '../../greater/host-platform/components/ProvisioningTimeline.css';
+@import '../../greater/host-platform/components/ReleaseTimeline.css';
+@import '../../greater/host-platform/components/StackMatrix.css';

--- a/web/src/lib/styles/greater/shell.css
+++ b/web/src/lib/styles/greater/shell.css
@@ -1,0 +1,47 @@
+/* ============================================================================
+ * Greater Shell — CSS bundle aggregator (host web/)
+ *
+ * Mirrors `tokens.css` / `primitives.css`: a host-owned aggregator that
+ * `@import`s every CSS file shipped by the vendored `shell` package under
+ * `web/src/lib/greater/shell/`. The vendored files themselves stay
+ * unmodified (canonical adoption — `components.json` records
+ * `modified: false`); the aggregator lives outside the vendored tree so
+ * `greater list` / re-vendoring never observes a host-side patch.
+ *
+ * Import order:
+ *   1. `styles/base.css` — defines the `--gr-shell-*` token defaults via
+ *      low-specificity `:where(...)` selectors AND ships the `.gr-sr-only`
+ *      live-region utility that `createLiveRegion()` (used by
+ *      CommandPalette and any future shell announcements) appends to
+ *      `document.body`. Loading base first ensures all subsequent
+ *      component CSS resolves `var(--gr-shell-*)` against the package
+ *      defaults.
+ *   2. Component CSS files in alphabetical order. The Greater shell
+ *      components have no inter-CSS dependencies (each file scopes its
+ *      rules to its own `.gr-shell-<name>` root class), so ordering
+ *      between them is cosmetic.
+ *
+ * Why this matters:
+ *   - Without these imports the M0.6-M0.10 vendored shell + host-platform
+ *     Svelte surfaces render unstyled (the components author CSS as
+ *     sibling `.css` files, not Svelte scoped `<style>` blocks).
+ *   - The shell base.css is the canonical home of `.gr-sr-only`; missing
+ *     it would surface live-region announcement strings as visible text
+ *     in any consumer that doesn't also import primitives `theme.css`.
+ *
+ * Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.6
+ * Issue: equaltoai/lesser-host#386 (CSS adoption follow-up)
+ * ========================================================================== */
+
+@import '../../greater/shell/styles/base.css';
+@import '../../greater/shell/components/Breadcrumb.css';
+@import '../../greater/shell/components/Callout.css';
+@import '../../greater/shell/components/CommandPalette.css';
+@import '../../greater/shell/components/PageFrame.css';
+@import '../../greater/shell/components/PageTitle.css';
+@import '../../greater/shell/components/Panel.css';
+@import '../../greater/shell/components/Shell.css';
+@import '../../greater/shell/components/Sidebar.css';
+@import '../../greater/shell/components/StatCard.css';
+@import '../../greater/shell/components/SummaryStrip.css';
+@import '../../greater/shell/components/Topbar.css';

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,7 @@
 import 'src/lib/styles/greater/tokens.css';
 import 'src/lib/styles/greater/primitives.css';
+import 'src/lib/styles/greater/shell.css';
+import 'src/lib/styles/greater/host-platform.css';
 
 import './app.css';
 


### PR DESCRIPTION
## Milestone

Project 39 (Web UI Rework) — M0.6 through M0.10: adopt the greater-components shell + host-platform packages via canonical source-install CLI vendoring, pinned to **greater-v0.10.0-rc.1**.

Five enumerated changes from `docs/enumerated-changes-web-ui-rework-2026-05-24.md` landing the shell-primitive import surface (M0.6: 11 primitives + Section) and the hosted-platform vocabulary wrappers (M0.7 CommandPalette, M0.8 FleetCard, M0.9 CostGauge, M0.10 ActivitySparkline) host's M0 milestone needs for the new web UI.

Signal D is now fully resolved through this PR — every component on host's expanded request list at #377 lands as canonical Greater-shipped surface, zero host-bespoke fallback used.

## Classification

framework-feedback (canonical adoption); UI-rework foundation.

## Surfaces affected

**Vendored (CLI-managed, never patched locally):**
- `web/src/lib/greater/shell/**` — 26 files (M0.6)
- `web/src/lib/greater/host-platform/**` — 17 files (M0.8; brings in M0.9 + M0.10 components in the same canonical install)
- `web/components.json` — updated `installed` array with `shell` + `host-platform` entries at the greater-v0.10.0-rc.1 resolved sha

**Host-stable import paths (re-export wrappers + aggregator):**
- `web/src/lib/shell/index.ts` — M0.6 aggregator surfacing all 11 shell primitives + Section + 3 utility functions + 19 types from a single import path
- `web/src/lib/components/CommandPalette.svelte` — M0.7 thin wrapper
- `web/src/lib/components/FleetCard.svelte` — M0.8 thin wrapper
- `web/src/lib/components/CostGauge.svelte` — M0.9 thin wrapper
- `web/src/lib/components/ActivitySparkline.svelte` — M0.10 thin wrapper

## Specialist walks referenced

- Framework consumption: `coordinate-framework-feedback` (commit 5579350) — Signal D resolution via greater-v0.10.0-rc.1
- Trust API / CSP / instance-auth: `audit-trust-and-safety` (24dcd86) — preserved; vendored components are strict-CSP-safe by upstream design
- Governance rubric: `maintain-governance-rubric` (b4b38c5) — no rubric impact in this slice; verifiers PASS 29/0/0

## Multi-tenant isolation impact

None. UI components only; no tenant-data path traversal.

## On-chain impact

None.

## Consumer impact

Internal host surface improvement; no managed-instance behavior change. Lab deploy of the new UI continues to gate on M0.12 (Signal C resolution at theory-cloud/AppTheory#593 + theory-cloud/FaceTheory#248).

## Tasks

- [x] M0.6 — Vendor shell primitives + `web/src/lib/shell` aggregator (#386) — 3c9e070
- [x] M0.7 — CommandPalette ⌘K re-export (#387) — 52b2d66
- [x] M0.8 — Vendor host-platform + FleetCard re-export (#388) — 901054f
- [x] M0.9 — CostGauge re-export (#389) — d4a7be0
- [x] M0.10 — ActivitySparkline re-export (#390) — 4788dee

## Validation (per tip)

- `npm run lint` — clean at every tip
- `npm run typecheck` — 0 errors / 0 warnings; file count grew 3132 → 3173 across the milestone (+41 vendored + wrapper files type-checked)
- `npm test` — 31 passed / 11 files at every tip
- `npm run build` — both client + ssr environments PASS at every tip
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 29/0/0 at the M0.6 tip; re-verifying at M0.10 tip

## Framework-feedback resolved through this PR

Two upstream issues that gated this work were filed in earlier sessions and resolved by the framework steward via greater-v0.9.1-rc.1 + greater-v0.10.0-rc.1:

- **equaltoai/greater-components#674** — CLI v0.9.1-rc.0 path resolver mis-routed new top-level `shell` + `host-platform` packages and `--ref` was ignored by the per-file fetcher. Resolved in greater-v0.9.1-rc.1.
- **equaltoai/greater-components#679** — CommandPalette Props.onselect collision with `HTMLAttributes<HTMLDivElement>.onselect`. Resolved in greater-v0.10.0-rc.1 via a broader workspace svelte-check parity audit (closes #679 commit b4f85c5).

Both followed the substrate's always-fix-upstream / never-patch-locally policy. Host stayed at the canonical adoption path throughout; no patches to vendored files; no work-arounds shipped.

## Stage rollout plan (handoff after merge)

- [x] PR open
- [ ] Merged to main
- [ ] Deployed to lab — **gated on Signal C / M0.12** (AppTheory#593 + FaceTheory#248)
- [ ] Lab soak complete (≥5 days) — gated
- [ ] Deployed to live — gated, no time pressure per Aron's direction

## Cross-repo coordination

None pending. Signal D is now fully resolved through this PR; #377 will close at merge.

## Notes for reviewer

- The four `web/src/lib/components/<Component>.svelte` wrappers (M0.7–M0.10) are minimal Svelte re-export shells: they import the upstream component, forward props via `ComponentProps`, and render. They exist to give host's `src/lib/components/` directory a uniform import surface alongside PortalLayout / OperatorLayout regardless of vendored-vs-bespoke origin. They're reducible to direct imports from `src/lib/shell` or `src/lib/greater/host-platform` if the indirection ever stops earning its keep — today it earns it by matching host's existing convention.
- M0.8 brings in all 6 host-platform components in one canonical install (FleetCard, CostGauge, ActivitySparkline, ProvisioningTimeline, ReleaseTimeline, StackMatrix). M0.9 and M0.10 add wrappers for two of them; the three timeline + matrix components are intentionally not wrapped yet — they're available for M2-track adoption when the operator-console surface is built.
- `components.json` shows `shell` and `host-platform` entries with `modified: false` — host did not patch the vendored surface. Always-fix-in-greater policy preserved.
- M0.6 aggregator deliberately re-exports `Section` + `SectionProps` from `@equaltoai/greater-components-primitives` (where Section has lived since pre-0.9.0) alongside the new shell primitives, so consumers get the full shell vocabulary from a single import path.