### PR TITLE
Project 39 M1.11-M1.12: stack endpoint + cost-and-usage API minimum

### DIFF
--- a/internal/controlplane/handlers_instances.go
+++ b/internal/controlplane/handlers_instances.go
@@ -153,11 +153,21 @@ type setBudgetMonthRequest struct {
 }
 
 type budgetMonthResponse struct {
-	InstanceSlug    string    `json:"instance_slug"`
-	Month           string    `json:"month"`
-	IncludedCredits int64     `json:"included_credits"`
-	UsedCredits     int64     `json:"used_credits"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	InstanceSlug     string    `json:"instance_slug"`
+	Month            string    `json:"month"`
+	IncludedCredits  int64     `json:"included_credits"`
+	UsedCredits      int64     `json:"used_credits"`
+	RemainingCredits int64     `json:"remaining_credits"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
+
+// remainingBudgetCredits returns included minus used, floored at 0.
+func remainingBudgetCredits(included, used int64) int64 {
+	remaining := included - used
+	if remaining < 0 {
+		remaining = 0
+	}
+	return remaining
 }
 
 func instanceResponseFromModel(inst *models.Instance) instanceResponse {
@@ -989,10 +999,11 @@ func (s *Server) handleSetInstanceBudgetMonth(ctx *apptheory.Context) (*apptheor
 	}
 
 	return apptheory.JSON(http.StatusOK, budgetMonthResponse{
-		InstanceSlug:    slug,
-		Month:           month,
-		IncludedCredits: budget.IncludedCredits,
-		UsedCredits:     budget.UsedCredits,
-		UpdatedAt:       budget.UpdatedAt,
+		InstanceSlug:     slug,
+		Month:            month,
+		IncludedCredits:  budget.IncludedCredits,
+		UsedCredits:      budget.UsedCredits,
+		RemainingCredits: remainingBudgetCredits(budget.IncludedCredits, budget.UsedCredits),
+		UpdatedAt:        budget.UpdatedAt,
 	})
 }

--- a/internal/controlplane/handlers_portal_instances.go
+++ b/internal/controlplane/handlers_portal_instances.go
@@ -32,8 +32,9 @@ type portalUsageSummaryResponse struct {
 	DebitedCredits   int64 `json:"debited_credits"`
 	DiscountCredits  int64 `json:"discount_credits"`
 
-	IncludedCredits int64 `json:"included_credits,omitempty"`
-	UsedCredits     int64 `json:"used_credits,omitempty"`
+	IncludedCredits  int64 `json:"included_credits,omitempty"`
+	UsedCredits      int64 `json:"used_credits,omitempty"`
+	RemainingCredits int64 `json:"remaining_credits,omitempty"`
 }
 
 type portalBudgetsResponse struct {
@@ -531,11 +532,12 @@ func (s *Server) handlePortalListInstanceBudgets(ctx *apptheory.Context) (*appth
 	out := make([]budgetMonthResponse, 0, len(items))
 	for _, b := range items {
 		out = append(out, budgetMonthResponse{
-			InstanceSlug:    b.InstanceSlug,
-			Month:           b.Month,
-			IncludedCredits: b.IncludedCredits,
-			UsedCredits:     b.UsedCredits,
-			UpdatedAt:       b.UpdatedAt,
+			InstanceSlug:     b.InstanceSlug,
+			Month:            b.Month,
+			IncludedCredits:  b.IncludedCredits,
+			UsedCredits:      b.UsedCredits,
+			RemainingCredits: remainingBudgetCredits(b.IncludedCredits, b.UsedCredits),
+			UpdatedAt:        b.UpdatedAt,
 		})
 	}
 
@@ -574,11 +576,12 @@ func (s *Server) handlePortalGetInstanceBudgetMonth(ctx *apptheory.Context) (*ap
 	}
 
 	return apptheory.JSON(http.StatusOK, budgetMonthResponse{
-		InstanceSlug:    item.InstanceSlug,
-		Month:           item.Month,
-		IncludedCredits: item.IncludedCredits,
-		UsedCredits:     item.UsedCredits,
-		UpdatedAt:       item.UpdatedAt,
+		InstanceSlug:     item.InstanceSlug,
+		Month:            item.Month,
+		IncludedCredits:  item.IncludedCredits,
+		UsedCredits:      item.UsedCredits,
+		RemainingCredits: remainingBudgetCredits(item.IncludedCredits, item.UsedCredits),
+		UpdatedAt:        item.UpdatedAt,
 	})
 }
 
@@ -652,11 +655,12 @@ func (s *Server) handlePortalSetInstanceBudgetMonth(ctx *apptheory.Context) (*ap
 	s.tryWriteAuditLog(ctx, audit)
 
 	return apptheory.JSON(http.StatusOK, budgetMonthResponse{
-		InstanceSlug:    slug,
-		Month:           month,
-		IncludedCredits: budget.IncludedCredits,
-		UsedCredits:     budget.UsedCredits,
-		UpdatedAt:       budget.UpdatedAt,
+		InstanceSlug:     slug,
+		Month:            month,
+		IncludedCredits:  budget.IncludedCredits,
+		UsedCredits:      budget.UsedCredits,
+		RemainingCredits: remainingBudgetCredits(budget.IncludedCredits, budget.UsedCredits),
+		UpdatedAt:        budget.UpdatedAt,
 	})
 }
 
@@ -773,6 +777,7 @@ func (s *Server) handlePortalGetInstanceUsageSummary(ctx *apptheory.Context) (*a
 		First(&budget); err == nil {
 		out.IncludedCredits = budget.IncludedCredits
 		out.UsedCredits = budget.UsedCredits
+		out.RemainingCredits = remainingBudgetCredits(budget.IncludedCredits, budget.UsedCredits)
 	}
 
 	return apptheory.JSON(http.StatusOK, out)

--- a/internal/controlplane/handlers_portal_stack.go
+++ b/internal/controlplane/handlers_portal_stack.go
@@ -14,11 +14,11 @@ import (
 // Project 39 provisioning walk Change 5.1. Shape matches the existing M1.6
 // StackCard client TypeScript types.
 type instanceStackResponse struct {
-	Slug         string             `json:"slug"`
+	Slug         string              `json:"slug"`
 	Lesser       instanceStackLesser `json:"lesser"`
 	Body         instanceStackBody   `json:"body"`
 	MCP          instanceStackMCP    `json:"mcp"`
-	DriftSummary string             `json:"drift_summary,omitempty"`
+	DriftSummary string              `json:"drift_summary,omitempty"`
 }
 
 type instanceStackLesser struct {
@@ -80,7 +80,7 @@ func (s *Server) handlePortalGetInstanceStack(ctx *apptheory.Context) (*apptheor
 	jobs := categorizeLatestUpdateJobs(ctx, s, slug)
 	provJob := loadProvisionJobFallback(ctx, s, inst)
 
-	bodyEnabled := effectiveBodyEnabled(inst.BodyEnabled)
+	bodyEnabled := determineBodyEnabledForStack(inst, jobs.body, provJob)
 
 	lesser := buildStackLesser(jobs.lesser, provJob)
 	body := buildStackBody(bodyEnabled, jobs.body, provJob)
@@ -98,12 +98,19 @@ func (s *Server) handlePortalGetInstanceStack(ctx *apptheory.Context) (*apptheor
 }
 
 // categorizeLatestUpdateJobs queries recent update jobs via GSI1 and returns
-// the first (most-recently-created) for each component kind.
+// the latest successful (status=ok) job for each component kind. Jobs with
+// non-ok status (queued, running, error) are skipped — only successfully
+// deployed updates are eligible for current-version sourcing. When no
+// successful update exists for a kind, the field remains nil and the
+// per-component builder falls back to the provision job.
 func categorizeLatestUpdateJobs(ctx *apptheory.Context, s *Server, slug string) categorizedUpdateJobs {
 	items, _ := s.store.ListUpdateJobsByInstance(ctx.Context(), slug, 20)
 	var out categorizedUpdateJobs
 	for _, item := range items {
 		if item == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(item.Status)) != models.UpdateJobStatusOK {
 			continue
 		}
 		switch updateJobKind(item) {
@@ -135,6 +142,34 @@ func loadProvisionJobFallback(ctx *apptheory.Context, s *Server, inst *models.In
 	}
 	job, _ := s.store.GetProvisionJob(ctx.Context(), provisionJobID)
 	return job
+}
+
+// determineBodyEnabledForStack decides whether the body component is enabled
+// for the customer-readable stack contract. It checks actual body installation
+// evidence rather than relying on the config default (BodyEnabled nil→true),
+// so the already-merged StackCard can show its "Add agentic" CTA when body is
+// not installed.
+//
+// Evidence sources (any one is sufficient):
+//   - A successful body update job
+//   - ProvisionJob.BodyProvisionedAt is set
+//   - Instance.BodyProvisionedAt is set
+//
+// Explicit disable (BodyEnabled=false) takes precedence and always returns false.
+func determineBodyEnabledForStack(inst *models.Instance, bodyJob *models.UpdateJob, provJob *models.ProvisionJob) bool {
+	if inst != nil && inst.BodyEnabled != nil && !*inst.BodyEnabled {
+		return false
+	}
+	if bodyJob != nil {
+		return true
+	}
+	if provJob != nil && !provJob.BodyProvisionedAt.IsZero() {
+		return true
+	}
+	if inst != nil && !inst.BodyProvisionedAt.IsZero() {
+		return true
+	}
+	return false
 }
 
 // buildStackLesser constructs the Lesser stack row from update or provision info.

--- a/internal/controlplane/handlers_portal_stack.go
+++ b/internal/controlplane/handlers_portal_stack.go
@@ -1,0 +1,292 @@
+package controlplane
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// InstanceStackResponse is the customer-readable stack-state contract per
+// Project 39 provisioning walk Change 5.1. Shape matches the existing M1.6
+// StackCard client TypeScript types.
+type instanceStackResponse struct {
+	Slug         string             `json:"slug"`
+	Lesser       instanceStackLesser `json:"lesser"`
+	Body         instanceStackBody   `json:"body"`
+	MCP          instanceStackMCP    `json:"mcp"`
+	DriftSummary string             `json:"drift_summary,omitempty"`
+}
+
+type instanceStackLesser struct {
+	CurrentVersion string `json:"current_version,omitempty"`
+	TargetVersion  string `json:"target_version,omitempty"`
+	DeployedAt     string `json:"deployed_at,omitempty"`
+	SourceJobID    string `json:"source_job_id,omitempty"`
+	Drift          string `json:"drift,omitempty"`
+}
+
+type instanceStackBody struct {
+	Enabled        bool   `json:"enabled"`
+	CurrentVersion string `json:"current_version,omitempty"`
+	TargetVersion  string `json:"target_version,omitempty"`
+	DeployedAt     string `json:"deployed_at,omitempty"`
+	SourceJobID    string `json:"source_job_id,omitempty"`
+	Drift          string `json:"drift,omitempty"`
+}
+
+type instanceStackMCP struct {
+	WiredAt                 string `json:"wired_at,omitempty"`
+	WiredAgainstBodyVersion string `json:"wired_against_body_version,omitempty"`
+	CurrentBodyVersion      string `json:"current_body_version,omitempty"`
+	Drift                   string `json:"drift,omitempty"`
+}
+
+// stackDrift values match the StackDrift TypeScript union:
+//
+//	"ok"         — current matches target
+//	"stale"      — current is older than target
+//	"wire-stale" — MCP wired against an older body version than deployed
+//	"unknown"    — no target / no telemetry yet
+const (
+	stackDriftOK        = "ok"
+	stackDriftStale     = "stale"
+	stackDriftWireStale = "wire-stale"
+	stackDriftUnknown   = "unknown"
+)
+
+// categorizedUpdateJobs holds the latest update job per component kind.
+type categorizedUpdateJobs struct {
+	lesser *models.UpdateJob
+	body   *models.UpdateJob
+	mcp    *models.UpdateJob
+}
+
+// handlePortalGetInstanceStack returns the customer-readable stack state for
+// an instance. Ownership is enforced via requireInstanceAccess before any
+// stack-state read. The handler delegates row construction to per-component
+// helpers to keep cognitive complexity within the rubric threshold.
+func (s *Server) handlePortalGetInstanceStack(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+
+	slug := strings.ToLower(strings.TrimSpace(inst.Slug))
+
+	jobs := categorizeLatestUpdateJobs(ctx, s, slug)
+	provJob := loadProvisionJobFallback(ctx, s, inst)
+
+	bodyEnabled := effectiveBodyEnabled(inst.BodyEnabled)
+
+	lesser := buildStackLesser(jobs.lesser, provJob)
+	body := buildStackBody(bodyEnabled, jobs.body, provJob)
+	mcp := buildStackMCP(bodyEnabled, jobs.mcp, body.CurrentVersion, provJob)
+
+	summary := deriveDriftSummary(lesser.Drift, body.Drift, mcp.Drift, bodyEnabled)
+
+	return apptheory.JSON(http.StatusOK, instanceStackResponse{
+		Slug:         slug,
+		Lesser:       lesser,
+		Body:         body,
+		MCP:          mcp,
+		DriftSummary: summary,
+	})
+}
+
+// categorizeLatestUpdateJobs queries recent update jobs via GSI1 and returns
+// the first (most-recently-created) for each component kind.
+func categorizeLatestUpdateJobs(ctx *apptheory.Context, s *Server, slug string) categorizedUpdateJobs {
+	items, _ := s.store.ListUpdateJobsByInstance(ctx.Context(), slug, 20)
+	var out categorizedUpdateJobs
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		switch updateJobKind(item) {
+		case updateJobKindBody:
+			if out.body == nil {
+				out.body = item
+			}
+		case updateJobKindMCP:
+			if out.mcp == nil {
+				out.mcp = item
+			}
+		default:
+			if out.lesser == nil {
+				out.lesser = item
+			}
+		}
+	}
+	return out
+}
+
+// loadProvisionJobFallback loads the initial provisioning job when available.
+func loadProvisionJobFallback(ctx *apptheory.Context, s *Server, inst *models.Instance) *models.ProvisionJob {
+	if inst == nil {
+		return nil
+	}
+	provisionJobID := strings.TrimSpace(inst.ProvisionJobID)
+	if provisionJobID == "" {
+		return nil
+	}
+	job, _ := s.store.GetProvisionJob(ctx.Context(), provisionJobID)
+	return job
+}
+
+// buildStackLesser constructs the Lesser stack row from update or provision info.
+func buildStackLesser(job *models.UpdateJob, provJob *models.ProvisionJob) instanceStackLesser {
+	if job != nil {
+		return instanceStackLesser{
+			CurrentVersion: trimOrEmpty(job.LesserVersion),
+			TargetVersion:  trimOrEmpty(job.LesserVersion),
+			DeployedAt:     formatStackTime(job.UpdatedAt),
+			SourceJobID:    strings.TrimSpace(job.ID),
+			Drift:          computeLesserDrift(job),
+		}
+	}
+	if provJob != nil {
+		return instanceStackLesser{
+			CurrentVersion: trimOrEmpty(provJob.LesserVersion),
+			DeployedAt:     formatStackTime(provJob.UpdatedAt),
+			SourceJobID:    strings.TrimSpace(provJob.ID),
+			Drift:          stackDriftUnknown,
+		}
+	}
+	return instanceStackLesser{Drift: stackDriftUnknown}
+}
+
+// buildStackBody constructs the Body stack row.
+func buildStackBody(enabled bool, job *models.UpdateJob, provJob *models.ProvisionJob) instanceStackBody {
+	body := instanceStackBody{Enabled: enabled}
+	if !enabled {
+		body.Drift = stackDriftUnknown
+		return body
+	}
+	if job != nil {
+		body.CurrentVersion = trimOrEmpty(job.LesserBodyVersion)
+		body.TargetVersion = trimOrEmpty(job.LesserBodyVersion)
+		body.DeployedAt = formatStackTime(job.UpdatedAt)
+		body.SourceJobID = strings.TrimSpace(job.ID)
+		body.Drift = computeBodyDrift(job)
+		return body
+	}
+	body.Drift = stackDriftUnknown
+	if provJob != nil && !provJob.BodyProvisionedAt.IsZero() {
+		body.DeployedAt = formatStackTime(provJob.BodyProvisionedAt)
+	}
+	return body
+}
+
+// buildStackMCP constructs the MCP wiring row.
+func buildStackMCP(bodyEnabled bool, job *models.UpdateJob, currentBodyVersion string, provJob *models.ProvisionJob) instanceStackMCP {
+	if job != nil {
+		return instanceStackMCP{
+			WiredAt:                 formatStackTime(job.UpdatedAt),
+			WiredAgainstBodyVersion: trimOrEmpty(job.LesserBodyVersion),
+			CurrentBodyVersion:      trimOrEmpty(currentBodyVersion),
+			Drift:                   computeMCPDrift(job, currentBodyVersion),
+		}
+	}
+	mcp := instanceStackMCP{Drift: stackDriftUnknown}
+	if bodyEnabled && provJob != nil && !provJob.McpWiredAt.IsZero() {
+		mcp.WiredAt = formatStackTime(provJob.McpWiredAt)
+	}
+	return mcp
+}
+
+// computeLesserDrift returns the drift status for the Lesser component.
+func computeLesserDrift(job *models.UpdateJob) string {
+	if job == nil {
+		return stackDriftUnknown
+	}
+	if strings.ToLower(strings.TrimSpace(job.Status)) != models.UpdateJobStatusOK {
+		return stackDriftUnknown
+	}
+	return stackDriftOK
+}
+
+// computeBodyDrift returns the drift status for the Body component.
+func computeBodyDrift(job *models.UpdateJob) string {
+	if job == nil {
+		return stackDriftUnknown
+	}
+	if strings.ToLower(strings.TrimSpace(job.Status)) != models.UpdateJobStatusOK {
+		return stackDriftUnknown
+	}
+	return stackDriftOK
+}
+
+// computeMCPDrift returns the drift status for the MCP wiring. Returns
+// "wire-stale" when MCP was wired against a body version that differs from
+// the currently deployed body version (meaning a re-wire is needed).
+func computeMCPDrift(job *models.UpdateJob, currentBodyVersion string) string {
+	if job == nil {
+		return stackDriftUnknown
+	}
+	if strings.ToLower(strings.TrimSpace(job.Status)) != models.UpdateJobStatusOK {
+		return stackDriftUnknown
+	}
+	wiredAgainst := strings.TrimSpace(job.LesserBodyVersion)
+	currentBody := strings.TrimSpace(currentBodyVersion)
+	if wiredAgainst != "" && currentBody != "" && wiredAgainst != currentBody {
+		return stackDriftWireStale
+	}
+	return stackDriftOK
+}
+
+// deriveDriftSummary produces a single-line summary for the UI.
+func deriveDriftSummary(lesserDrift, bodyDrift, mcpDrift string, bodyEnabled bool) string {
+	stale, wireStale, unknowns := tallyDriftFlags(lesserDrift, bodyDrift, mcpDrift)
+
+	if wireStale && stale {
+		return "stale + MCP wire-stale"
+	}
+	if wireStale {
+		return "MCP wire-stale"
+	}
+	if stale {
+		return "stale components"
+	}
+	if unknowns >= 1 || !bodyEnabled {
+		return "partial telemetry"
+	}
+	return "up to date"
+}
+
+// tallyDriftFlags counts stale, wire-stale, and unknown drift flags.
+func tallyDriftFlags(lesserDrift, bodyDrift, mcpDrift string) (stale, wireStale bool, unknowns int) {
+	for _, d := range []string{lesserDrift, bodyDrift} {
+		switch strings.TrimSpace(d) {
+		case stackDriftStale:
+			stale = true
+		case stackDriftUnknown:
+			unknowns++
+		}
+	}
+	switch strings.TrimSpace(mcpDrift) {
+	case stackDriftWireStale:
+		wireStale = true
+	case stackDriftStale:
+		stale = true
+	case stackDriftUnknown:
+		unknowns++
+	}
+	return
+}
+
+// trimOrEmpty returns the trimmed string or "" if it's empty.
+func trimOrEmpty(s string) string {
+	return strings.TrimSpace(s)
+}
+
+// formatStackTime formats a time value for JSON output. Returns "" for zero times.
+func formatStackTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/controlplane/handlers_portal_stack_internal_test.go
+++ b/internal/controlplane/handlers_portal_stack_internal_test.go
@@ -1,0 +1,393 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// setupStackTestDB creates a test Server + AppTheory context + mock DB
+// primed for stack queries. Returns the mocks so tests can set expectations
+// for UpdateJob and ProvisionJob reads.
+type stackTestHarness struct {
+	s      *Server
+	ctx    *apptheory.Context
+	tdb    portalTestDB
+	qUpd   *ttmocks.MockQuery
+}
+
+func newStackTestHarness(t *testing.T, slug, owner string, bodyEnabled *bool) stackTestHarness {
+	t.Helper()
+
+	tdb := newPortalTestDB()
+	qUpd := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpd).Maybe()
+	addStandardMockQueryStubs(qUpd)
+
+	s := &Server{store: store.New(tdb.db)}
+
+	ctx := &apptheory.Context{AuthIdentity: owner}
+	ctx.Params = map[string]string{"slug": slug}
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:            slug,
+			Owner:           owner,
+			BodyEnabled:     bodyEnabled,
+			ProvisionJobID:  "prov-job-1",
+			HostedAccountID: "123456789012",
+		}
+	}).Maybe()
+
+	return stackTestHarness{s: s, ctx: ctx, tdb: tdb, qUpd: qUpd}
+}
+
+func TestHandlePortalGetInstanceStack_OwnerSuccess(t *testing.T) {
+	t.Parallel()
+
+	h := newStackTestHarness(t, "demo", "alice", nil)
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Return two successful update jobs: one lesser, one body.
+	h.qUpd.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{
+				ID:           "upd-lesser-1",
+				InstanceSlug: "demo",
+				Status:       models.UpdateJobStatusOK,
+				LesserVersion: "v1.2.7",
+				UpdatedAt:    now,
+			},
+			{
+				ID:               "upd-body-1",
+				InstanceSlug:     "demo",
+				Status:           models.UpdateJobStatusOK,
+				BodyOnly:         true,
+				LesserBodyVersion: "v0.3.0",
+				UpdatedAt:        now.Add(time.Minute),
+			},
+		}
+	}).Once()
+
+	// ProvisionJob fallback: body was provisioned and MCP wired.
+	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:               "prov-job-1",
+			InstanceSlug:     "demo",
+			Status:           models.ProvisionJobStatusOK,
+			LesserVersion:    "v1.2.6",
+			BodyEnabled:      true,
+			BodyProvisionedAt: now.Add(-24 * time.Hour),
+			McpWiredAt:       now.Add(-23 * time.Hour),
+			UpdatedAt:        now.Add(-24 * time.Hour),
+		}
+	}).Once()
+
+	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Equal(t, 200, resp.Status)
+
+	var body instanceStackResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	require.Equal(t, "demo", body.Slug)
+	// Lesser: latest ok update
+	require.Equal(t, "v1.2.7", body.Lesser.CurrentVersion)
+	require.Equal(t, "upd-lesser-1", body.Lesser.SourceJobID)
+	require.Equal(t, stackDriftOK, body.Lesser.Drift)
+	// Body: latest ok body update
+	require.True(t, body.Body.Enabled)
+	require.Equal(t, "v0.3.0", body.Body.CurrentVersion)
+	require.Equal(t, "upd-body-1", body.Body.SourceJobID)
+	require.Equal(t, stackDriftOK, body.Body.Drift)
+	// MCP: provision job timestamp
+	require.Equal(t, formatStackTime(now.Add(-23*time.Hour)), body.MCP.WiredAt)
+	require.Equal(t, stackDriftUnknown, body.MCP.Drift)
+}
+
+func TestHandlePortalGetInstanceStack_OtherSlugDenial(t *testing.T) {
+	t.Parallel()
+
+	// Build a dedicated test DB without the default harness instance mock.
+	// The harness Maybe() mock would return Owner=alice and bypass the denial.
+	db := ttmocks.NewMockExtendedDB()
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+
+	qInstance := new(ttmocks.MockQuery)
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
+	addStandardMockQueryStubs(qInstance)
+
+	s := &Server{store: store.New(db)}
+
+	ctx := &apptheory.Context{AuthIdentity: "alice"}
+	ctx.Params = map[string]string{"slug": "demo"}
+
+	// Instance owned by "bob" → requireInstanceAccess must reject alice.
+	qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "bob"}
+	}).Once()
+
+	// Crucially: no UpdateJob or ProvisionJob mock expectations should
+	// fire — ownership must fail before any stack-state query.
+
+	_, err := s.handlePortalGetInstanceStack(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok, "expected AppError, got %T: %v", err, err)
+	require.Equal(t, "app.forbidden", appErr.Code)
+}
+
+func TestHandlePortalGetInstanceStack_NoUpdateYetFallbackToProvisionJob(t *testing.T) {
+	t.Parallel()
+
+	h := newStackTestHarness(t, "demo", "alice", nil)
+
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	// No update jobs at all.
+	h.qUpd.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Once()
+
+	// Provision job exists with version and body info.
+	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:               "prov-job-1",
+			InstanceSlug:     "demo",
+			Status:           models.ProvisionJobStatusOK,
+			LesserVersion:    "v1.2.6",
+			BodyEnabled:      true,
+			BodyProvisionedAt: now,
+			McpWiredAt:       now.Add(time.Minute),
+			UpdatedAt:        now,
+		}
+	}).Once()
+
+	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body instanceStackResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	// Lesser falls back to provision job version.
+	require.Equal(t, "v1.2.6", body.Lesser.CurrentVersion)
+	require.Equal(t, "prov-job-1", body.Lesser.SourceJobID)
+	require.Equal(t, stackDriftUnknown, body.Lesser.Drift)
+
+	// Body: enabled with provision timestamp but unknown drift.
+	require.True(t, body.Body.Enabled)
+	require.Equal(t, formatStackTime(now), body.Body.DeployedAt)
+	require.Equal(t, stackDriftUnknown, body.Body.Drift)
+
+	// MCP: provision job wired timestamp.
+	require.Equal(t, formatStackTime(now.Add(time.Minute)), body.MCP.WiredAt)
+}
+
+func TestHandlePortalGetInstanceStack_BodyNotInstalled(t *testing.T) {
+	t.Parallel()
+
+	// Instance created without body provisioning — BodyEnabled nil
+	// means body was never deployed (effectiveBodyEnabled returns true
+	// but there is no provision job with BodyProvisionedAt).
+	h := newStackTestHarness(t, "demo", "alice", nil)
+
+	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+
+	// Only a lesser update job exists — no body or MCP updates.
+	h.qUpd.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{
+				ID:            "upd-lesser-1",
+				InstanceSlug:  "demo",
+				Status:        models.UpdateJobStatusOK,
+				LesserVersion: "v1.2.7",
+				UpdatedAt:     now,
+			},
+		}
+	}).Once()
+
+	// No provision job exists.
+	// The handler calls GetProvisionJob on the empty ProvisionJobID, but
+	// in the real DB that'd be a not-found or the instance's provisionJobID
+	// is the real one. Since we set ProvisionJobID to "prov-job-1", the
+	// store will try to load it. We need to mock this.
+	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body instanceStackResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	// Lesser has data from the update job.
+	require.Equal(t, "v1.2.7", body.Lesser.CurrentVersion)
+	require.Equal(t, stackDriftOK, body.Lesser.Drift)
+
+	// Body: enabled (effectiveBodyEnabled nil→true) but version info
+	// is empty because no body deploy happened.
+	require.True(t, body.Body.Enabled)
+	require.Empty(t, body.Body.CurrentVersion)
+	require.Equal(t, stackDriftUnknown, body.Body.Drift)
+
+	// MCP: unknown drift (no wiring evidence).
+	require.Equal(t, stackDriftUnknown, body.MCP.Drift)
+}
+
+func TestHandlePortalGetInstanceStack_MCPWireStale(t *testing.T) {
+	t.Parallel()
+
+	h := newStackTestHarness(t, "demo", "alice", nil)
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Body update to v0.4.0, then MCP wired against older v0.3.0.
+	h.qUpd.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{
+				ID:               "upd-body-2",
+				InstanceSlug:     "demo",
+				Status:           models.UpdateJobStatusOK,
+				BodyOnly:         true,
+				LesserBodyVersion: "v0.4.0",
+				UpdatedAt:        now,
+			},
+			{
+				ID:               "upd-mcp-1",
+				InstanceSlug:     "demo",
+				Status:           models.UpdateJobStatusOK,
+				MCPOnly:          true,
+				LesserBodyVersion: "v0.3.0", // wired against older version
+				UpdatedAt:        now.Add(-time.Hour),
+			},
+		}
+	}).Once()
+
+	// Provision job exists (don't actually need it here since update jobs cover everything).
+	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:           "prov-job-1",
+			InstanceSlug: "demo",
+			Status:       models.ProvisionJobStatusOK,
+			BodyEnabled:  true,
+		}
+	}).Once()
+
+	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body instanceStackResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	// Body is at v0.4.0.
+	require.Equal(t, "v0.4.0", body.Body.CurrentVersion)
+	require.Equal(t, stackDriftOK, body.Body.Drift)
+
+	// MCP wired against v0.3.0 → wire-stale against current body v0.4.0.
+	require.Equal(t, "v0.3.0", body.MCP.WiredAgainstBodyVersion)
+	require.Equal(t, "v0.4.0", body.MCP.CurrentBodyVersion)
+	require.Equal(t, stackDriftWireStale, body.MCP.Drift)
+}
+
+func TestComputeLesserDrift(t *testing.T) {
+	t.Parallel()
+
+	okJob := &models.UpdateJob{Status: models.UpdateJobStatusOK}
+	if got := computeLesserDrift(okJob); got != stackDriftOK {
+		t.Fatalf("computeLesserDrift(ok) = %q, want %q", got, stackDriftOK)
+	}
+
+	runningJob := &models.UpdateJob{Status: models.UpdateJobStatusRunning}
+	if got := computeLesserDrift(runningJob); got != stackDriftUnknown {
+		t.Fatalf("computeLesserDrift(running) = %q, want %q", got, stackDriftUnknown)
+	}
+
+	if got := computeLesserDrift(nil); got != stackDriftUnknown {
+		t.Fatalf("computeLesserDrift(nil) = %q, want %q", got, stackDriftUnknown)
+	}
+}
+
+func TestComputeMCPDrift_WireStale(t *testing.T) {
+	t.Parallel()
+
+	// MCP wired against v0.3.0, body now at v0.4.0.
+	job := &models.UpdateJob{
+		Status:            models.UpdateJobStatusOK,
+		LesserBodyVersion: "v0.3.0",
+	}
+	if got := computeMCPDrift(job, "v0.4.0"); got != stackDriftWireStale {
+		t.Fatalf("computeMCPDrift(v0.3.0 vs v0.4.0) = %q, want %q", got, stackDriftWireStale)
+	}
+
+	// MCP wired against same version.
+	job2 := &models.UpdateJob{
+		Status:            models.UpdateJobStatusOK,
+		LesserBodyVersion: "v0.4.0",
+	}
+	if got := computeMCPDrift(job2, "v0.4.0"); got != stackDriftOK {
+		t.Fatalf("computeMCPDrift(v0.4.0 vs v0.4.0) = %q, want %q", got, stackDriftOK)
+	}
+
+	// Unknown when job is not ok.
+	runningJob := &models.UpdateJob{
+		Status:            models.UpdateJobStatusRunning,
+		LesserBodyVersion: "v0.3.0",
+	}
+	if got := computeMCPDrift(runningJob, "v0.4.0"); got != stackDriftUnknown {
+		t.Fatalf("computeMCPDrift(running) = %q, want %q", got, stackDriftUnknown)
+	}
+}
+
+func TestDeriveDriftSummary(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		lesserDrift string
+		bodyDrift   string
+		mcpDrift    string
+		bodyEnabled bool
+		want        string
+	}{
+		{name: "all ok", lesserDrift: "ok", bodyDrift: "ok", mcpDrift: "ok", bodyEnabled: true, want: "up to date"},
+		{name: "wire-stale only", lesserDrift: "ok", bodyDrift: "ok", mcpDrift: "wire-stale", bodyEnabled: true, want: "MCP wire-stale"},
+		{name: "stale + wire-stale", lesserDrift: "stale", bodyDrift: "ok", mcpDrift: "wire-stale", bodyEnabled: true, want: "stale + MCP wire-stale"},
+		{name: "stale only", lesserDrift: "stale", bodyDrift: "ok", mcpDrift: "ok", bodyEnabled: true, want: "stale components"},
+		{name: "unknowns", lesserDrift: "unknown", bodyDrift: "unknown", mcpDrift: "unknown", bodyEnabled: true, want: "partial telemetry"},
+		{name: "body not installed", lesserDrift: "ok", bodyDrift: "unknown", mcpDrift: "unknown", bodyEnabled: false, want: "partial telemetry"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := deriveDriftSummary(tc.lesserDrift, tc.bodyDrift, tc.mcpDrift, tc.bodyEnabled)
+			if got != tc.want {
+				t.Fatalf("deriveDriftSummary = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/controlplane/handlers_portal_stack_internal_test.go
+++ b/internal/controlplane/handlers_portal_stack_internal_test.go
@@ -21,10 +21,10 @@ import (
 // primed for stack queries. Returns the mocks so tests can set expectations
 // for UpdateJob and ProvisionJob reads.
 type stackTestHarness struct {
-	s      *Server
-	ctx    *apptheory.Context
-	tdb    portalTestDB
-	qUpd   *ttmocks.MockQuery
+	s    *Server
+	ctx  *apptheory.Context
+	tdb  portalTestDB
+	qUpd *ttmocks.MockQuery
 }
 
 func newStackTestHarness(t *testing.T, slug, owner string, bodyEnabled *bool) stackTestHarness {
@@ -66,19 +66,19 @@ func TestHandlePortalGetInstanceStack_OwnerSuccess(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
-				ID:           "upd-lesser-1",
-				InstanceSlug: "demo",
-				Status:       models.UpdateJobStatusOK,
+				ID:            "upd-lesser-1",
+				InstanceSlug:  "demo",
+				Status:        models.UpdateJobStatusOK,
 				LesserVersion: "v1.2.7",
-				UpdatedAt:    now,
+				UpdatedAt:     now,
 			},
 			{
-				ID:               "upd-body-1",
-				InstanceSlug:     "demo",
-				Status:           models.UpdateJobStatusOK,
-				BodyOnly:         true,
+				ID:                "upd-body-1",
+				InstanceSlug:      "demo",
+				Status:            models.UpdateJobStatusOK,
+				BodyOnly:          true,
 				LesserBodyVersion: "v0.3.0",
-				UpdatedAt:        now.Add(time.Minute),
+				UpdatedAt:         now.Add(time.Minute),
 			},
 		}
 	}).Once()
@@ -87,14 +87,14 @@ func TestHandlePortalGetInstanceStack_OwnerSuccess(t *testing.T) {
 	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
 		*dest = models.ProvisionJob{
-			ID:               "prov-job-1",
-			InstanceSlug:     "demo",
-			Status:           models.ProvisionJobStatusOK,
-			LesserVersion:    "v1.2.6",
-			BodyEnabled:      true,
+			ID:                "prov-job-1",
+			InstanceSlug:      "demo",
+			Status:            models.ProvisionJobStatusOK,
+			LesserVersion:     "v1.2.6",
+			BodyEnabled:       true,
 			BodyProvisionedAt: now.Add(-24 * time.Hour),
-			McpWiredAt:       now.Add(-23 * time.Hour),
-			UpdatedAt:        now.Add(-24 * time.Hour),
+			McpWiredAt:        now.Add(-23 * time.Hour),
+			UpdatedAt:         now.Add(-24 * time.Hour),
 		}
 	}).Once()
 
@@ -172,14 +172,14 @@ func TestHandlePortalGetInstanceStack_NoUpdateYetFallbackToProvisionJob(t *testi
 	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
 		*dest = models.ProvisionJob{
-			ID:               "prov-job-1",
-			InstanceSlug:     "demo",
-			Status:           models.ProvisionJobStatusOK,
-			LesserVersion:    "v1.2.6",
-			BodyEnabled:      true,
+			ID:                "prov-job-1",
+			InstanceSlug:      "demo",
+			Status:            models.ProvisionJobStatusOK,
+			LesserVersion:     "v1.2.6",
+			BodyEnabled:       true,
 			BodyProvisionedAt: now,
-			McpWiredAt:       now.Add(time.Minute),
-			UpdatedAt:        now,
+			McpWiredAt:        now.Add(time.Minute),
+			UpdatedAt:         now,
 		}
 	}).Once()
 
@@ -208,8 +208,10 @@ func TestHandlePortalGetInstanceStack_BodyNotInstalled(t *testing.T) {
 	t.Parallel()
 
 	// Instance created without body provisioning — BodyEnabled nil
-	// means body was never deployed (effectiveBodyEnabled returns true
-	// but there is no provision job with BodyProvisionedAt).
+	// means body was never configured, and there is no body installation
+	// evidence (no successful body update, no BodyProvisionedAt timestamp).
+	// The stack contract must report body.enabled=false so the already-merged
+	// StackCard shows its "Add agentic" CTA.
 	h := newStackTestHarness(t, "demo", "alice", nil)
 
 	now := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
@@ -228,11 +230,8 @@ func TestHandlePortalGetInstanceStack_BodyNotInstalled(t *testing.T) {
 		}
 	}).Once()
 
-	// No provision job exists.
-	// The handler calls GetProvisionJob on the empty ProvisionJobID, but
-	// in the real DB that'd be a not-found or the instance's provisionJobID
-	// is the real one. Since we set ProvisionJobID to "prov-job-1", the
-	// store will try to load it. We need to mock this.
+	// No provision job evidence for body — GetProvisionJob returns not-found.
+	// The instance record also has BodyProvisionedAt at zero value.
 	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
@@ -246,13 +245,12 @@ func TestHandlePortalGetInstanceStack_BodyNotInstalled(t *testing.T) {
 	require.Equal(t, "v1.2.7", body.Lesser.CurrentVersion)
 	require.Equal(t, stackDriftOK, body.Lesser.Drift)
 
-	// Body: enabled (effectiveBodyEnabled nil→true) but version info
-	// is empty because no body deploy happened.
-	require.True(t, body.Body.Enabled)
+	// Body: not enabled (no installation evidence → StackCard "Add agentic" CTA).
+	require.False(t, body.Body.Enabled)
 	require.Empty(t, body.Body.CurrentVersion)
 	require.Equal(t, stackDriftUnknown, body.Body.Drift)
 
-	// MCP: unknown drift (no wiring evidence).
+	// MCP: unknown drift (no body installed → no meaningful wiring info).
 	require.Equal(t, stackDriftUnknown, body.MCP.Drift)
 }
 
@@ -268,20 +266,20 @@ func TestHandlePortalGetInstanceStack_MCPWireStale(t *testing.T) {
 		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
-				ID:               "upd-body-2",
-				InstanceSlug:     "demo",
-				Status:           models.UpdateJobStatusOK,
-				BodyOnly:         true,
+				ID:                "upd-body-2",
+				InstanceSlug:      "demo",
+				Status:            models.UpdateJobStatusOK,
+				BodyOnly:          true,
 				LesserBodyVersion: "v0.4.0",
-				UpdatedAt:        now,
+				UpdatedAt:         now,
 			},
 			{
-				ID:               "upd-mcp-1",
-				InstanceSlug:     "demo",
-				Status:           models.UpdateJobStatusOK,
-				MCPOnly:          true,
+				ID:                "upd-mcp-1",
+				InstanceSlug:      "demo",
+				Status:            models.UpdateJobStatusOK,
+				MCPOnly:           true,
 				LesserBodyVersion: "v0.3.0", // wired against older version
-				UpdatedAt:        now.Add(-time.Hour),
+				UpdatedAt:         now.Add(-time.Hour),
 			},
 		}
 	}).Once()
@@ -312,6 +310,80 @@ func TestHandlePortalGetInstanceStack_MCPWireStale(t *testing.T) {
 	require.Equal(t, "v0.3.0", body.MCP.WiredAgainstBodyVersion)
 	require.Equal(t, "v0.4.0", body.MCP.CurrentBodyVersion)
 	require.Equal(t, stackDriftWireStale, body.MCP.Drift)
+}
+
+func TestHandlePortalGetInstanceStack_NewerNonOKJobIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Regression: a newer queued/running/error update job must not be
+	// reported as the currently deployed version. The stack endpoint
+	// must source current-version data from the latest *successful*
+	// (status=ok) job per component kind.
+	h := newStackTestHarness(t, "demo", "alice", nil)
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Three jobs: older ok body, older ok lesser, newer error body.
+	// The newer error body job must be ignored; current-version data
+	// must come from the older ok jobs.
+	h.qUpd.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{
+				ID:                "upd-body-2",
+				InstanceSlug:      "demo",
+				Status:            models.UpdateJobStatusError,
+				BodyOnly:          true,
+				LesserBodyVersion: "v0.5.0", // newer but FAILED — must be ignored
+				UpdatedAt:         now,
+			},
+			{
+				ID:                "upd-body-1",
+				InstanceSlug:      "demo",
+				Status:            models.UpdateJobStatusOK,
+				BodyOnly:          true,
+				LesserBodyVersion: "v0.3.0", // older but SUCCESSFUL — must be used
+				UpdatedAt:         now.Add(-time.Hour),
+			},
+			{
+				ID:            "upd-lesser-1",
+				InstanceSlug:  "demo",
+				Status:        models.UpdateJobStatusOK,
+				LesserVersion: "v1.2.7",
+				UpdatedAt:     now.Add(-30 * time.Minute),
+			},
+		}
+	}).Once()
+
+	h.tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:                "prov-job-1",
+			InstanceSlug:      "demo",
+			Status:            models.ProvisionJobStatusOK,
+			BodyEnabled:       true,
+			BodyProvisionedAt: now.Add(-48 * time.Hour),
+			UpdatedAt:         now.Add(-48 * time.Hour),
+		}
+	}).Once()
+
+	resp, err := h.s.handlePortalGetInstanceStack(h.ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body instanceStackResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+
+	// Lesser: ok update job version, NOT skipped.
+	require.Equal(t, "v1.2.7", body.Lesser.CurrentVersion)
+	require.Equal(t, "upd-lesser-1", body.Lesser.SourceJobID)
+	require.Equal(t, stackDriftOK, body.Lesser.Drift)
+
+	// Body: must use the older OK job (v0.3.0), NOT the newer error job (v0.5.0).
+	require.True(t, body.Body.Enabled)
+	require.Equal(t, "v0.3.0", body.Body.CurrentVersion)
+	require.Equal(t, "upd-body-1", body.Body.SourceJobID)
+	require.Equal(t, stackDriftOK, body.Body.Drift)
 }
 
 func TestComputeLesserDrift(t *testing.T) {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -151,6 +151,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Get("/api/v1/portal/instances/{slug}/budgets", s.handlePortalListInstanceBudgets, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/budgets/{month}", s.handlePortalGetInstanceBudgetMonth, apptheory.RequireAuth())
 	app.Put("/api/v1/portal/instances/{slug}/budgets/{month}", s.handlePortalSetInstanceBudgetMonth, apptheory.RequireAuth())
+	app.Get("/api/v1/portal/instances/{slug}/stack", s.handlePortalGetInstanceStack, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/usage/{month}", s.handlePortalListInstanceUsage, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/usage/{month}/summary", s.handlePortalGetInstanceUsageSummary, apptheory.RequireAuth())
 


### PR DESCRIPTION
## Summary

- M1.11: `GET /api/v1/portal/instances/{slug}/stack` handler with ownership-before-read enforcement, per-component drift, and comprehensive tests
- M1.12: `remaining_credits` surfaced in `budgetMonthResponse` and `portalUsageSummaryResponse`

Closes #420
Closes #421

## Test plan

- [x] `go test ./...` — all packages pass (including 7 new stack tests)
- [x] `go vet ./...` — clean
- [x] `cd web && npm run typecheck` — 0/0/3184
- [x] `cd web && npm run lint` — clean
- [x] `cd web && npm test` — 12/50
- [x] `cd web && npm run build` — PASS (SEC-6 + SEC-7 verifiers)
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 36/0/0

🤖 Generated with [Claude Code](https://claude.com/claude-code)