### PR TITLE
feat(web): migrate Button-as-nav to greater-components Link primitive (#700 host-side)

### DIFF
--- a/web/components.json
+++ b/web/components.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://greater.components.dev/schema.json",
   "version": "1.0.0",
-  "ref": "4b1e36473544ee640a6a3dd429139323c75d56c3",
+  "ref": "b4d26ad77a8b52dcb2fb0c45e5f4d76b62390ed7",
   "installMode": "vendored",
   "style": "default",
   "rsc": false,
@@ -52,8 +52,8 @@
     },
     {
       "name": "primitives",
-      "version": "74ce64890bab7c85b83847a1ff72dc882b66ebc5",
-      "installedAt": "2026-05-18T15:45:00.000Z",
+      "version": "b4d26ad77a8b52dcb2fb0c45e5f4d76b62390ed7",
+      "installedAt": "2026-05-26T04:15:11.250Z",
       "modified": false,
       "checksums": []
     },

--- a/web/src/lib/components/InstanceDetailShell.svelte
+++ b/web/src/lib/components/InstanceDetailShell.svelte
@@ -35,8 +35,8 @@ Issue: equaltoai/lesser-host#414
 <script lang="ts">
 	import type { Snippet } from 'svelte';
 
-	import { currentPath, navigate } from 'src/lib/router';
-	import { Button } from 'src/lib/ui';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
+	import { Link } from 'src/lib/ui';
 	import { PageFrame, PageTitle } from 'src/lib/shell';
 
 	type TabKey = 'overview' | 'cost' | 'config' | 'domains' | 'keys' | 'souls';
@@ -134,8 +134,8 @@ Issue: equaltoai/lesser-host#414
 			description="Managed lesser.host instance — release state, configuration, domains, and access keys."
 		>
 			{#snippet actions()}
-				<Button variant="ghost" onclick={() => navigate('/portal/fleet')}>Fleet</Button>
-				<Button variant="ghost" onclick={() => navigate('/portal')}>Back</Button>
+				<Link {...linkProps('/portal/fleet')} variant="ghost">Fleet</Link>
+				<Link {...linkProps('/portal')} variant="ghost">Back</Link>
 			{/snippet}
 		</PageTitle>
 	{/snippet}

--- a/web/src/lib/components/OperatorLayout.svelte
+++ b/web/src/lib/components/OperatorLayout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { navigate, currentPath } from 'src/lib/router';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
 	import { logout } from 'src/lib/auth/logout';
-	import { Button, Text, Heading } from 'src/lib/ui';
+	import { Button, Heading, Link, Text } from 'src/lib/ui';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -24,65 +24,74 @@
 			<Heading level={2} size="xl">Operator Console</Heading>
 		</div>
 		<div class="layout__nav">
-			<Button
-				variant={isActive('/operator', true) ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator')}
+			<Link
+				{...linkProps('/operator')}
+				variant="ghost"
+				aria-current={isActive('/operator', true) ? 'page' : undefined}
 			>
 				Dashboard
-			</Button>
-			<Button
-				variant={isActive('/operator/approvals/domains') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/approvals/domains')}
+			</Link>
+			<Link
+				{...linkProps('/operator/approvals/domains')}
+				variant="ghost"
+				aria-current={isActive('/operator/approvals/domains') ? 'page' : undefined}
 			>
 				Domains
-			</Button>
-			<Button
-				variant={isActive('/operator/approvals/users') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/approvals/users')}
+			</Link>
+			<Link
+				{...linkProps('/operator/approvals/users')}
+				variant="ghost"
+				aria-current={isActive('/operator/approvals/users') ? 'page' : undefined}
 			>
 				Users
-			</Button>
-			<Button
-				variant={isActive('/operator/approvals/external-instances') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/approvals/external-instances')}
+			</Link>
+			<Link
+				{...linkProps('/operator/approvals/external-instances')}
+				variant="ghost"
+				aria-current={isActive('/operator/approvals/external-instances') ? 'page' : undefined}
 			>
 				External regs
-			</Button>
-			<Button
-				variant={isActive('/operator/provisioning') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/provisioning/jobs')}
+			</Link>
+			<Link
+				{...linkProps('/operator/provisioning/jobs')}
+				variant="ghost"
+				aria-current={isActive('/operator/provisioning') ? 'page' : undefined}
 			>
 				Provisioning
-			</Button>
-			<Button
-				variant={isActive('/operator/instances') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/instances')}
+			</Link>
+			<Link
+				{...linkProps('/operator/instances')}
+				variant="ghost"
+				aria-current={isActive('/operator/instances') ? 'page' : undefined}
 			>
 				Instances
-			</Button>
-			<Button
-				variant={isActive('/operator/tip-registry') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/tip-registry')}
+			</Link>
+			<Link
+				{...linkProps('/operator/tip-registry')}
+				variant="ghost"
+				aria-current={isActive('/operator/tip-registry') ? 'page' : undefined}
 			>
 				Tip registry
-			</Button>
-			<Button
-				variant={isActive('/operator/soul') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/soul')}
+			</Link>
+			<Link
+				{...linkProps('/operator/soul')}
+				variant="ghost"
+				aria-current={isActive('/operator/soul') ? 'page' : undefined}
 			>
 				Souls
-			</Button>
-			<Button
-				variant={isActive('/operator/audit') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/operator/audit')}
+			</Link>
+			<Link
+				{...linkProps('/operator/audit')}
+				variant="ghost"
+				aria-current={isActive('/operator/audit') ? 'page' : undefined}
 			>
 				Audit
-			</Button>
+			</Link>
 		</div>
 
 		<div class="layout__footer">
-			<Button variant="ghost" onclick={() => navigate('/portal')}>← Return to Portal</Button>
-			<Button variant="ghost" onclick={() => navigate('/account')}>Account Settings</Button>
+			<Link {...linkProps('/portal')} variant="ghost">← Return to Portal</Link>
+			<Link {...linkProps('/account')} variant="ghost">Account Settings</Link>
 			{#if $session}
 				<div class="layout__user">
 					<Text size="sm" weight="medium">{$session.username}</Text>

--- a/web/src/lib/components/PortalLayout.svelte
+++ b/web/src/lib/components/PortalLayout.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import type { Snippet } from 'svelte';
-	import { navigate, currentPath } from 'src/lib/router';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
 	import { logout } from 'src/lib/auth/logout';
-	import { Button, Text, Heading } from 'src/lib/ui';
+	import { Button, Heading, Link, Text } from 'src/lib/ui';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -28,44 +28,44 @@
 			<Heading level={2} size="xl">lesser.host</Heading>
 		</div>
 		<div class="layout__nav">
-			<Button
-				variant={isPortalActive() ? 'solid' : 'ghost'}
-				onclick={() => navigate('/portal')}
+			<Link
+				{...linkProps('/portal')}
+				variant="ghost"
+				aria-current={isPortalActive() ? 'page' : undefined}
 			>
 				Portal
-			</Button>
-			<Button
-				variant={isActive('/portal/souls') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/portal/souls')}
+			</Link>
+			<Link
+				{...linkProps('/portal/souls')}
+				variant="ghost"
+				aria-current={isActive('/portal/souls') ? 'page' : undefined}
 			>
 				Souls
-			</Button>
-			<Button
-				variant={isActive('/trust') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/trust')}
+			</Link>
+			<Link
+				{...linkProps('/trust')}
+				variant="ghost"
+				aria-current={isActive('/trust') ? 'page' : undefined}
 			>
 				Trust
-			</Button>
-			<Button
-				variant={isActive('/tip-registry/register') ? 'solid' : 'ghost'}
-				onclick={() => navigate('/tip-registry/register')}
+			</Link>
+			<Link
+				{...linkProps('/tip-registry/register')}
+				variant="ghost"
+				aria-current={isActive('/tip-registry/register') ? 'page' : undefined}
 			>
 				Host registry
-			</Button>
-			<Button
-				variant={isActive('/account', true) ? 'solid' : 'ghost'}
-				onclick={() => navigate('/account')}
+			</Link>
+			<Link
+				{...linkProps('/account')}
+				variant="ghost"
+				aria-current={isActive('/account', true) ? 'page' : undefined}
 			>
 				Account
-			</Button>
+			</Link>
 
 			{#if $session && ($session.role === 'admin' || $session.role === 'operator')}
-				<Button
-					variant="ghost"
-					onclick={() => navigate('/operator')}
-				>
-					Operator Console
-				</Button>
+				<Link {...linkProps('/operator')} variant="ghost">Operator Console</Link>
 			{/if}
 		</div>
 		<div class="layout__footer">
@@ -76,7 +76,7 @@
 				</div>
 				<Button variant="outline" onclick={() => void handleLogout()}>Logout</Button>
 			{:else}
-				<Button variant="outline" onclick={() => navigate('/login')}>Sign in</Button>
+				<Link {...linkProps('/login')} variant="default">Sign in</Link>
 			{/if}
 		</div>
 	</nav>

--- a/web/src/lib/components/PortalShell.svelte
+++ b/web/src/lib/components/PortalShell.svelte
@@ -51,10 +51,10 @@ Issue: equaltoai/lesser-host#391
 		type CommandPaletteItem,
 		type CommandPaletteGroup,
 	} from 'src/lib/shell';
-	import { navigate, currentPath } from 'src/lib/router';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
 	import { logout } from 'src/lib/auth/logout';
-	import { Button, Text, Heading } from 'src/lib/ui';
+	import { Button, Heading, Link, Text } from 'src/lib/ui';
 	import { portalFleetInstances, clearPortalFleetState } from 'src/lib/portalFleetState';
 
 	interface Props {
@@ -298,7 +298,7 @@ Issue: equaltoai/lesser-host#391
 						<Text size="sm" color="secondary">{$session.role}</Text>
 						<Button variant="outline" onclick={() => void handleLogout()}>Logout</Button>
 					{:else}
-						<Button variant="outline" onclick={() => navigate('/login')}>Sign in</Button>
+						<Link {...linkProps('/login')} variant="default">Sign in</Link>
 					{/if}
 				</div>
 			{/snippet}
@@ -308,46 +308,50 @@ Issue: equaltoai/lesser-host#391
 	{#snippet sidebar()}
 		<Sidebar label="Primary navigation">
 			<div class="portal-shell__nav">
-				<Button
-					variant={isPortalFleetActive() ? 'solid' : 'ghost'}
-					onclick={() => navigate('/portal/fleet')}
+				<Link
+					{...linkProps('/portal/fleet')}
+					variant="ghost"
+					aria-current={isPortalFleetActive() ? 'page' : undefined}
 				>
 					Fleet
-				</Button>
-				<Button
-					variant={isLegacyPortalActive() ? 'solid' : 'ghost'}
-					onclick={() => navigate('/portal/instances')}
+				</Link>
+				<Link
+					{...linkProps('/portal/instances')}
+					variant="ghost"
+					aria-current={isLegacyPortalActive() ? 'page' : undefined}
 				>
 					Instances (legacy)
-				</Button>
-				<Button
-					variant={isActive('/portal/souls') ? 'solid' : 'ghost'}
-					onclick={() => navigate('/portal/souls')}
+				</Link>
+				<Link
+					{...linkProps('/portal/souls')}
+					variant="ghost"
+					aria-current={isActive('/portal/souls') ? 'page' : undefined}
 				>
 					Souls
-				</Button>
-				<Button
-					variant={isActive('/portal/billing') ? 'solid' : 'ghost'}
-					onclick={() => navigate('/portal/billing')}
+				</Link>
+				<Link
+					{...linkProps('/portal/billing')}
+					variant="ghost"
+					aria-current={isActive('/portal/billing') ? 'page' : undefined}
 				>
 					Billing
-				</Button>
-				<Button
-					variant={isActive('/trust') ? 'solid' : 'ghost'}
-					onclick={() => navigate('/trust')}
+				</Link>
+				<Link
+					{...linkProps('/trust')}
+					variant="ghost"
+					aria-current={isActive('/trust') ? 'page' : undefined}
 				>
 					Trust
-				</Button>
-				<Button
-					variant={isActive('/account', true) ? 'solid' : 'ghost'}
-					onclick={() => navigate('/account')}
+				</Link>
+				<Link
+					{...linkProps('/account')}
+					variant="ghost"
+					aria-current={isActive('/account', true) ? 'page' : undefined}
 				>
 					Account
-				</Button>
+				</Link>
 				{#if $session && ($session.role === 'admin' || $session.role === 'operator')}
-					<Button variant="ghost" onclick={() => navigate('/operator')}>
-						Operator Console
-					</Button>
+					<Link {...linkProps('/operator')} variant="ghost">Operator Console</Link>
 				{/if}
 			</div>
 			<div class="portal-shell__sidebar-footer">

--- a/web/src/lib/greater/primitives/components/Link.svelte
+++ b/web/src/lib/greater/primitives/components/Link.svelte
@@ -1,0 +1,164 @@
+<!--
+Link component - Semantic anchor primitive for in-app navigation with SPA-router
+integration and full browser link affordances.
+
+@component
+@example In-app SPA navigation with modifier-key-gated callback
+```svelte
+<Link
+  href={`/portal/instances/${slug}/budgets`}
+  variant="ghost"
+  onnavigate={(ev, href) => { ev.preventDefault(); navigate(href); }}
+>
+  Budgets
+</Link>
+```
+
+@example External link in a new tab (rel auto-injected)
+```svelte
+<Link href="https://docs.example.com" target="_blank" variant="default">
+  Documentation
+</Link>
+```
+
+@example Inline link inside body text
+```svelte
+<Text size="sm">
+  See the <Link href={`/portal/instances/${slug}/usage`} variant="inline">Usage</Link> page.
+</Text>
+```
+-->
+
+<script lang="ts">
+	import type { HTMLAnchorAttributes } from 'svelte/elements';
+	import type { Snippet } from 'svelte';
+
+	/**
+	 * Link component props interface.
+	 *
+	 * @public
+	 */
+	interface Props extends Omit<HTMLAnchorAttributes, 'href'> {
+		/**
+		 * Target URL. Required — this is what makes it a Link and not a Button.
+		 *
+		 * @public
+		 */
+		href: string;
+
+		/**
+		 * Visual variant of the link.
+		 * - `default`: Primary nav-link affordance (outline-Button visual weight, no
+		 *   literal border). Use for top-level navigation surfaces where the user
+		 *   needs a clear "this navigates" cue.
+		 * - `ghost`: Subdued nav link with no background. Use inside cards, tables,
+		 *   or other surfaces that already provide their own visual frame.
+		 * - `subtle`: Muted secondary link. Use for breadcrumbs, footer-level nav,
+		 *   or other low-emphasis destinations.
+		 * - `inline`: Underlined link for use inside body text. Inherits font size
+		 *   and family from the surrounding text.
+		 *
+		 * @defaultValue 'default'
+		 * @public
+		 */
+		variant?: 'default' | 'ghost' | 'subtle' | 'inline';
+
+		/**
+		 * Size affecting padding and font size. Ignored when `variant="inline"`
+		 * (inline links inherit from surrounding text).
+		 *
+		 * @defaultValue 'md'
+		 * @public
+		 */
+		size?: 'sm' | 'md' | 'lg';
+
+		/**
+		 * Called on unmodified left-click only:
+		 * - `button === 0` (left-click; excludes middle and right-click)
+		 * - No `metaKey` / `ctrlKey` / `shiftKey` / `altKey` modifier
+		 * - `ev.defaultPrevented === false`
+		 *
+		 * Consumers use this callback to intercept the navigation for SPA routing
+		 * while letting modifier-key clicks fall through to native browser behavior
+		 * (open in new tab / window, copy link address). The same gating predicate
+		 * applies to keyboard Enter activation (browser-native click on `<a href>`).
+		 *
+		 * To intercept and route via your SPA router:
+		 * ```ts
+		 * onnavigate={(ev, href) => {
+		 *   ev.preventDefault();
+		 *   router.navigate(href);
+		 * }}
+		 * ```
+		 *
+		 * @public
+		 */
+		onnavigate?: (ev: MouseEvent, href: string) => void;
+
+		/**
+		 * Link content. Required.
+		 *
+		 * @public
+		 */
+		children: Snippet;
+
+		/**
+		 * Additional CSS classes.
+		 *
+		 * @public
+		 */
+		class?: string;
+	}
+
+	let {
+		href,
+		variant = 'default',
+		size = 'md',
+		onnavigate,
+		children,
+		class: className = '',
+		target,
+		rel,
+		onclick,
+		...restProps
+	}: Props = $props();
+
+	// Compute rel attribute. Auto-inject 'noopener noreferrer' when target='_blank'
+	// and no consumer-supplied rel. Mirrors Card.svelte:155-160 precedent.
+	const computedRel = $derived.by(() => {
+		if (rel) return rel;
+		if (target === '_blank') return 'noopener noreferrer';
+		return undefined;
+	});
+
+	// Compose CSS classes. Size is ignored for inline (inherits surrounding text).
+	const linkClass = $derived.by(() => {
+		const classes = ['gr-link', `gr-link--${variant}`];
+		if (variant !== 'inline') {
+			classes.push(`gr-link--size-${size}`);
+		}
+		if (className) {
+			classes.push(className);
+		}
+		return classes.join(' ');
+	});
+
+	// Click handler with modifier-key gating. Fires onnavigate only on plain
+	// unmodified left-click; all other inputs (Cmd/Ctrl/Shift/Alt, middle-click,
+	// right-click, defaultPrevented) fall through to native browser behavior.
+	function handleClick(event: MouseEvent) {
+		// Forward consumer-supplied onclick first so they can preventDefault
+		// or perform their own work before our gating logic runs.
+		onclick?.(event as MouseEvent & { currentTarget: EventTarget & HTMLAnchorElement });
+
+		if (event.defaultPrevented) return;
+		if (event.button !== 0) return; // middle (1) or right (2) click
+		if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+		onnavigate?.(event, href);
+	}
+</script>
+
+<a class={linkClass} {href} {target} rel={computedRel} onclick={handleClick} {...restProps}>
+	{@render children()}
+</a>

--- a/web/src/lib/greater/primitives/components/Link.svelte.d.ts
+++ b/web/src/lib/greater/primitives/components/Link.svelte.d.ts
@@ -1,0 +1,107 @@
+import type { HTMLAnchorAttributes } from 'svelte/elements';
+import type { Snippet } from 'svelte';
+/**
+ * Link component props interface.
+ *
+ * @public
+ */
+interface Props extends Omit<HTMLAnchorAttributes, 'href'> {
+	/**
+	 * Target URL. Required — this is what makes it a Link and not a Button.
+	 *
+	 * @public
+	 */
+	href: string;
+	/**
+	 * Visual variant of the link.
+	 * - `default`: Primary nav-link affordance (outline-Button visual weight, no
+	 *   literal border). Use for top-level navigation surfaces where the user
+	 *   needs a clear "this navigates" cue.
+	 * - `ghost`: Subdued nav link with no background. Use inside cards, tables,
+	 *   or other surfaces that already provide their own visual frame.
+	 * - `subtle`: Muted secondary link. Use for breadcrumbs, footer-level nav,
+	 *   or other low-emphasis destinations.
+	 * - `inline`: Underlined link for use inside body text. Inherits font size
+	 *   and family from the surrounding text.
+	 *
+	 * @defaultValue 'default'
+	 * @public
+	 */
+	variant?: 'default' | 'ghost' | 'subtle' | 'inline';
+	/**
+	 * Size affecting padding and font size. Ignored when `variant="inline"`
+	 * (inline links inherit from surrounding text).
+	 *
+	 * @defaultValue 'md'
+	 * @public
+	 */
+	size?: 'sm' | 'md' | 'lg';
+	/**
+	 * Called on unmodified left-click only:
+	 * - `button === 0` (left-click; excludes middle and right-click)
+	 * - No `metaKey` / `ctrlKey` / `shiftKey` / `altKey` modifier
+	 * - `ev.defaultPrevented === false`
+	 *
+	 * Consumers use this callback to intercept the navigation for SPA routing
+	 * while letting modifier-key clicks fall through to native browser behavior
+	 * (open in new tab / window, copy link address). The same gating predicate
+	 * applies to keyboard Enter activation (browser-native click on `<a href>`).
+	 *
+	 * To intercept and route via your SPA router:
+	 * ```ts
+	 * onnavigate={(ev, href) => {
+	 *   ev.preventDefault();
+	 *   router.navigate(href);
+	 * }}
+	 * ```
+	 *
+	 * @public
+	 */
+	onnavigate?: (ev: MouseEvent, href: string) => void;
+	/**
+	 * Link content. Required.
+	 *
+	 * @public
+	 */
+	children: Snippet;
+	/**
+	 * Additional CSS classes.
+	 *
+	 * @public
+	 */
+	class?: string;
+}
+/**
+ * Link component - Semantic anchor primitive for in-app navigation with SPA-router
+ * integration and full browser link affordances.
+ *
+ *
+ * @example In-app SPA navigation with modifier-key-gated callback
+ * ```svelte
+ * <Link
+ * href={`/portal/instances/${slug}/budgets`}
+ * variant="ghost"
+ * onnavigate={(ev, href) => { ev.preventDefault(); navigate(href); }}
+ * >
+ * Budgets
+ * </Link>
+ * ```
+ *
+ * @example External link in a new tab (rel auto-injected)
+ * ```svelte
+ * <Link href="https://docs.example.com" target="_blank" variant="default">
+ * Documentation
+ * </Link>
+ * ```
+ *
+ * @example Inline link inside body text
+ * ```svelte
+ * <Text size="sm">
+ * See the <Link href={`/portal/instances/${slug}/usage`} variant="inline">Usage</Link> page.
+ * </Text>
+ * ```
+ */
+declare const Link: import('svelte').Component<Props, {}, ''>;
+type Link = ReturnType<typeof Link>;
+export default Link;
+//# sourceMappingURL=Link.svelte.d.ts.map

--- a/web/src/lib/greater/primitives/index.d.ts
+++ b/web/src/lib/greater/primitives/index.d.ts
@@ -46,6 +46,7 @@ import Card from './components/Card.svelte';
 import Container from './components/Container.svelte';
 import Heading from './components/Heading.svelte';
 import Text from './components/Text.svelte';
+import Link from './components/Link.svelte';
 import Section from './components/Section.svelte';
 import ThemeSwitcher from './components/ThemeSwitcher.svelte';
 import ThemeProvider from './components/ThemeProvider.svelte';
@@ -106,6 +107,8 @@ export {
 	Heading,
 	/** Paragraph and inline text component with size, weight, and color variants. */
 	Text,
+	/** Semantic anchor primitive for in-app navigation with modifier-key-gated SPA-router callback. */
+	Link,
 	/** Semantic section wrapper with consistent vertical spacing. */
 	Section,
 	/** Theme switcher for toggling between color schemes. */
@@ -175,6 +178,7 @@ export type ContainerProps = ComponentProps<typeof Container>;
 export type SectionProps = ComponentProps<typeof Section>;
 export type HeadingProps = ComponentProps<typeof Heading>;
 export type TextProps = ComponentProps<typeof Text>;
+export type LinkProps = ComponentProps<typeof Link>;
 export type ThemeSwitcherProps = ComponentProps<typeof ThemeSwitcher>;
 export type ThemeProviderProps = ComponentProps<typeof ThemeProvider>;
 export type BadgeProps = ComponentProps<typeof Badge>;

--- a/web/src/lib/greater/primitives/index.ts
+++ b/web/src/lib/greater/primitives/index.ts
@@ -54,6 +54,7 @@ import Card from './components/Card.svelte';
 import Container from './components/Container.svelte';
 import Heading from './components/Heading.svelte';
 import Text from './components/Text.svelte';
+import Link from './components/Link.svelte';
 import Section from './components/Section.svelte';
 import ThemeSwitcher from './components/ThemeSwitcher.svelte';
 import ThemeProvider from './components/ThemeProvider.svelte';
@@ -115,6 +116,8 @@ export {
 	Heading,
 	/** Paragraph and inline text component with size, weight, and color variants. */
 	Text,
+	/** Semantic anchor primitive for in-app navigation with modifier-key-gated SPA-router callback. */
+	Link,
 	/** Semantic section wrapper with consistent vertical spacing. */
 	Section,
 	/** Theme switcher for toggling between color schemes. */
@@ -190,6 +193,7 @@ export type ContainerProps = ComponentProps<typeof Container>;
 export type SectionProps = ComponentProps<typeof Section>;
 export type HeadingProps = ComponentProps<typeof Heading>;
 export type TextProps = ComponentProps<typeof Text>;
+export type LinkProps = ComponentProps<typeof Link>;
 export type ThemeSwitcherProps = ComponentProps<typeof ThemeSwitcher>;
 export type ThemeProviderProps = ComponentProps<typeof ThemeProvider>;
 export type BadgeProps = ComponentProps<typeof Badge>;

--- a/web/src/lib/greater/primitives/theme.css
+++ b/web/src/lib/greater/primitives/theme.css
@@ -241,6 +241,159 @@ body.gr-scroll-locked {
 	}
 }
 
+/* Link Styles */
+.gr-link {
+	/* Base styles */
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: var(--gr-spacing-scale-2);
+	font-family: var(--gr-typography-fontFamily-sans);
+	font-weight: var(--gr-typography-fontWeight-medium);
+	line-height: var(--gr-typography-lineHeight-normal);
+	border-radius: var(--gr-radii-md);
+	color: var(--gr-semantic-action-link-default);
+	cursor: pointer;
+	text-decoration: none;
+	white-space: nowrap;
+	transition-property: color, background-color, box-shadow, transform;
+	transition-duration: var(--gr-motion-duration-fast);
+	transition-timing-function: var(--gr-motion-easing-out);
+}
+
+.gr-link:focus {
+	outline: none;
+}
+
+.gr-link:focus-visible {
+	outline: var(--gr-semantic-focus-ring-width, 2px) solid var(--gr-semantic-focus-ring);
+	outline-offset: var(--gr-semantic-focus-ring-offset, 2px);
+	box-shadow: none;
+}
+
+.gr-link:hover {
+	color: var(--gr-semantic-action-link-hover);
+}
+
+.gr-link:active {
+	color: var(--gr-semantic-action-link-active);
+	transform: translateY(1px);
+}
+
+/* Size variants (ignored for inline; inline inherits surrounding text) */
+.gr-link--size-sm {
+	padding: var(--gr-spacing-scale-2) var(--gr-spacing-scale-3);
+	font-size: var(--gr-typography-fontSize-sm);
+	min-height: 2rem;
+}
+
+.gr-link--size-md {
+	padding: var(--gr-spacing-scale-3) var(--gr-spacing-scale-4);
+	font-size: var(--gr-typography-fontSize-base);
+	min-height: 2.5rem;
+}
+
+.gr-link--size-lg {
+	padding: var(--gr-spacing-scale-4) var(--gr-spacing-scale-6);
+	font-size: var(--gr-typography-fontSize-lg);
+	min-height: 3rem;
+}
+
+/* Variant: default — outline-Button visual weight without literal border */
+.gr-link--default {
+	background-color: transparent;
+}
+
+.gr-link--default:hover {
+	background-color: var(--gr-semantic-background-secondary);
+	box-shadow: var(--gr-shadows-elevation-sm);
+}
+
+[data-theme='dark'] .gr-link--default:hover {
+	background-color: var(--gr-semantic-background-raised, var(--gr-semantic-background-tertiary));
+	box-shadow: 0 0 0 1px var(--gr-semantic-action-link-default);
+}
+
+.gr-link--default:active {
+	background-color: var(--gr-semantic-background-tertiary);
+}
+
+/* Variant: ghost — minimal background, color-only */
+.gr-link--ghost {
+	background-color: transparent;
+}
+
+.gr-link--ghost:hover {
+	background-color: var(--gr-semantic-background-secondary);
+}
+
+.gr-link--ghost:active {
+	background-color: var(--gr-semantic-background-tertiary);
+}
+
+/* Variant: subtle — muted text, restores link color on hover */
+.gr-link--subtle {
+	background-color: transparent;
+	color: var(--gr-semantic-foreground-secondary);
+}
+
+.gr-link--subtle:hover {
+	color: var(--gr-semantic-action-link-hover);
+	background-color: var(--gr-semantic-background-secondary);
+}
+
+.gr-link--subtle:active {
+	color: var(--gr-semantic-action-link-active);
+	background-color: var(--gr-semantic-background-tertiary);
+}
+
+/* Variant: inline — underlined link inside body text; inherits font */
+.gr-link--inline {
+	display: inline;
+	gap: 0;
+	padding: 0;
+	min-height: 0;
+	border-radius: 0;
+	font: inherit;
+	color: var(--gr-semantic-action-link-default);
+	text-decoration: underline;
+	text-underline-offset: 0.15em;
+	white-space: normal;
+}
+
+.gr-link--inline:hover {
+	color: var(--gr-semantic-action-link-hover);
+	background-color: transparent;
+	box-shadow: none;
+	text-decoration: underline;
+}
+
+.gr-link--inline:active {
+	color: var(--gr-semantic-action-link-active);
+	background-color: transparent;
+	transform: none;
+}
+
+.gr-link--inline:visited {
+	color: var(--gr-semantic-action-link-active);
+}
+
+/* Active-route state: consumers wire aria-current="page" from their router */
+.gr-link[aria-current='page'] {
+	font-weight: var(--gr-typography-fontWeight-semibold);
+}
+
+/* Reduced motion: skip transforms and box-shadow transitions */
+@media (prefers-reduced-motion: reduce) {
+	.gr-link {
+		transition: none;
+	}
+
+	.gr-link:active {
+		transform: none;
+	}
+}
+
 /* Alert Styles */
 .gr-alert {
 	display: flex;

--- a/web/src/lib/router.test.ts
+++ b/web/src/lib/router.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+// router.ts touches window.location at module-load time (the CURRENT_BASE_PATH
+// constant captures the path-at-load). Behavioral testing under jsdom is
+// awkward because the module is evaluated once with a fixed pathname, and the
+// SAFE_APP_BASE_PATH branch only triggers when the harness is at /safe-app/*
+// at module import. Source-text guards lock the public-API contract instead,
+// matching the pattern used elsewhere in the repo (InstanceDetail.svelte.test
+// .ts, MarkdownRenderer.svelte.test.ts) until DOM-render testing is brought
+// in as a separate scoped change.
+
+const source = readFileSync(join(process.cwd(), 'src/lib/router.ts'), 'utf8');
+
+describe('router.linkProps — greater-components Link helper', () => {
+	it('is exported from router.ts so consumer pages can import it', () => {
+		expect(source).toMatch(/export\s+function\s+linkProps\s*\(/);
+	});
+
+	it('takes a single path argument typed as string', () => {
+		expect(source).toMatch(/export\s+function\s+linkProps\(to:\s*string\)/);
+	});
+
+	it('returns an object with href + onnavigate, matching greater LinkProps shape', () => {
+		// The return type literal must match what Link.svelte's `onnavigate`
+		// expects: (ev: MouseEvent, href: string) => void. If greater-components
+		// ever changes the Link callback signature, this assertion is the local
+		// canary that tells us to update the helper too.
+		expect(source).toMatch(/href:\s*string;?/);
+		expect(source).toMatch(/onnavigate:\s*\(ev:\s*MouseEvent,\s*href:\s*string\)\s*=>\s*void/);
+	});
+
+	it('applies base-path to href so middle/Cmd-click "open in new tab" lands on the correct URL', () => {
+		// The whole point of linkProps over inline `navigate(...)` is that the
+		// rendered <a href> must include the SAFE_APP_BASE_PATH prefix when the
+		// app is mounted under /safe-app. Otherwise modifier-key clicks open the
+		// wrong URL in a new tab.
+		expect(source).toMatch(/href:\s*withBasePath\(normalizePath\(to\)\)/);
+	});
+
+	it('preventDefault + navigate inside onnavigate so the SPA router intercepts unmodified left-clicks', () => {
+		// The onnavigate body must call preventDefault before navigate so the
+		// browser does not perform native navigation on top of the SPA route.
+		// navigate(to) — not navigate(href) — so the base-path stays applied
+		// exactly once by navigate's own withBasePath call.
+		const fnStart = source.indexOf('export function linkProps');
+		expect(fnStart).toBeGreaterThan(0);
+		const fnRegion = source.slice(fnStart, fnStart + 800);
+		expect(fnRegion).toMatch(/ev\.preventDefault\(\)/);
+		expect(fnRegion).toMatch(/navigate\(to\)/);
+	});
+
+	it('lives next to navigate() in router.ts for discoverability', () => {
+		// Co-locating linkProps with navigate keeps the SPA-router contract in
+		// one place. If future maintenance moves linkProps elsewhere, the
+		// rationale needs to be documented; this assertion is the canary.
+		const navIdx = source.indexOf('export function navigate(');
+		const linkIdx = source.indexOf('export function linkProps(');
+		expect(navIdx).toBeGreaterThan(0);
+		expect(linkIdx).toBeGreaterThan(navIdx);
+	});
+});

--- a/web/src/lib/router.ts
+++ b/web/src/lib/router.ts
@@ -80,3 +80,30 @@ export function navigate(to: string): void {
 	history.pushState({}, '', target);
 	window.dispatchEvent(new PopStateEvent('popstate'));
 }
+
+/**
+ * Returns the props bag (`href` + `onnavigate`) for a greater-components `Link`
+ * primitive pointing at an in-app route. Handles base-path application so
+ * Cmd/Ctrl/middle-click "open in new tab" intents resolve to the correct URL
+ * (with `SAFE_APP_BASE_PATH` prefix when running under safe-app mode), while
+ * the SPA-router intercept calls `navigate()` with the unprefixed path so
+ * route normalization stays in one place.
+ *
+ * @example
+ *   import { Link } from '$lib/greater/primitives';
+ *   import { linkProps } from '$lib/router';
+ *
+ *   <Link {...linkProps('/portal/billing')} variant="ghost">Billing</Link>
+ */
+export function linkProps(to: string): {
+	href: string;
+	onnavigate: (ev: MouseEvent, href: string) => void;
+} {
+	return {
+		href: withBasePath(normalizePath(to)),
+		onnavigate: (ev) => {
+			ev.preventDefault();
+			navigate(to);
+		},
+	};
+}

--- a/web/src/lib/ui.ts
+++ b/web/src/lib/ui.ts
@@ -9,6 +9,7 @@ export {
 	DefinitionItem,
 	DefinitionList,
 	Heading,
+	Link,
 	List,
 	ListItem,
 	Select,

--- a/web/src/pages/Login.svelte
+++ b/web/src/pages/Login.svelte
@@ -5,12 +5,12 @@
 	import { portalWalletChallenge, portalWalletLogin } from 'src/lib/api/portal';
 	import { webAuthnLoginBegin, webAuthnLoginFinish } from 'src/lib/api/webauthn';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
+	import { linkProps, navigate } from 'src/lib/router';
 	import { clearSession, consumeSessionExpiredAt, setSession, session } from 'src/lib/session';
 	import { getChainId, getEthereumProvider, personalSign, requestAccounts } from 'src/lib/wallet/ethereum';
 	import type { Eip1193Provider } from 'src/lib/wallet/ethereum';
 	import { serializeCredentialRequest, toPublicKeyRequestOptions } from 'src/lib/webauthn/client';
-	import { Alert, Button, Card, Container, Heading, Spinner, Text, TextField } from 'src/lib/ui';
+	import { Alert, Button, Card, Container, Heading, Link, Spinner, Text, TextField } from 'src/lib/ui';
 
 	type LoginMode = 'portal' | 'operator';
 	type OperatorMethod = 'wallet' | 'passkey';
@@ -289,8 +289,8 @@
 				<Text color="secondary">Authenticate with wallet or passkey.</Text>
 			</div>
 			<div class="login__header-actions">
-				<Button variant="ghost" onclick={() => navigate('/')}>Home</Button>
-				<Button variant="ghost" onclick={() => navigate('/setup')}>Setup</Button>
+				<Link {...linkProps('/')} variant="ghost">Home</Link>
+				<Link {...linkProps('/setup')} variant="ghost">Setup</Link>
 			</div>
 			</header>
 
@@ -498,9 +498,9 @@
 					>) · expires <span class="login__mono">{$session.expiresAt}</span>
 				</Text>
 				<div class="login__row">
-					<Button variant="outline" onclick={() => navigate(defaultRouteForRole($session.role))}>
+					<Link {...linkProps(defaultRouteForRole($session.role))} variant="default">
 						Continue
-					</Button>
+					</Link>
 					<Button
 						variant="ghost"
 						onclick={() => {

--- a/web/src/pages/NotFound.svelte
+++ b/web/src/pages/NotFound.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { navigate } from 'src/lib/router';
-	import { Button, Container, Heading, Text } from 'src/lib/ui';
+	import { linkProps } from 'src/lib/router';
+	import { Container, Heading, Link, Text } from 'src/lib/ui';
 </script>
 
 <Container size="lg" gutter="lg">
@@ -8,7 +8,7 @@
 		<Heading level={1}>Not found</Heading>
 		<Text color="secondary">This route does not exist.</Text>
 		<div class="not-found__actions">
-			<Button variant="outline" onclick={() => navigate('/')}>Home</Button>
+			<Link {...linkProps('/')} variant="default">Home</Link>
 		</div>
 	</div>
 </Container>

--- a/web/src/pages/Portal.svelte
+++ b/web/src/pages/Portal.svelte
@@ -5,9 +5,9 @@
 	import type { PortalMeResponse } from 'src/lib/api/portal';
 	import { getPortalMe } from 'src/lib/api/portal';
 	import { logout } from 'src/lib/auth/logout';
-	import { currentPath, navigate } from 'src/lib/router';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
-	import { Alert, Button, Card, Container, Heading, Spinner, Text } from 'src/lib/ui';
+	import { Alert, Button, Card, Container, Heading, Link, Spinner, Text } from 'src/lib/ui';
 
 	import Billing from 'src/pages/portal/Billing.svelte';
 	import InstanceConfig from 'src/pages/portal/InstanceConfig.svelte';
@@ -137,7 +137,7 @@
 			</div>
 			<div class="portal__actions">
 				<Button variant="outline" onclick={() => void loadMe()} disabled={loading}>Refresh</Button>
-				<Button variant="ghost" onclick={() => navigate('/portal/billing')}>Billing</Button>
+				<Link {...linkProps('/portal/billing')} variant="ghost">Billing</Link>
 			</div>
 		</header>
 
@@ -183,7 +183,7 @@
 				<Alert variant="warning" title="Signed out">
 					<Text size="sm">Sign in to continue.</Text>
 					<div class="portal__actions-inline">
-						<Button variant="outline" onclick={() => navigate('/login')}>Sign in</Button>
+						<Link {...linkProps('/login')} variant="default">Sign in</Link>
 					</div>
 				</Alert>
 			{:else if portalRoute.kind === 'instances'}
@@ -239,7 +239,7 @@
 			<Alert variant="warning" title="No session">
 				<Text size="sm">You are signed out.</Text>
 				<div class="portal__actions-inline">
-					<Button variant="outline" onclick={() => navigate('/login')}>Sign in</Button>
+					<Link {...linkProps('/login')} variant="default">Sign in</Link>
 				</div>
 			</Alert>
 		{/if}

--- a/web/src/pages/Setup.svelte
+++ b/web/src/pages/Setup.svelte
@@ -12,7 +12,7 @@
 		walletLogin,
 	} from 'src/lib/api/controlPlane';
 	import type { ApiError } from 'src/lib/api/http';
-	import { navigate } from 'src/lib/router';
+	import { linkProps, navigate } from 'src/lib/router';
 	import { getChainId, getEthereumProvider, personalSign, requestAccounts } from 'src/lib/wallet/ethereum';
 	import type { Eip1193Provider } from 'src/lib/wallet/ethereum';
 	import {
@@ -24,6 +24,7 @@
 		DefinitionItem,
 		DefinitionList,
 		Heading,
+		Link,
 		Spinner,
 		StepIndicator,
 		Text,
@@ -312,7 +313,7 @@
 			</div>
 			<div class="setup__header-actions">
 				<Button variant="outline" onclick={() => void refreshStatus()} disabled={statusLoading}>Refresh</Button>
-				<Button variant="ghost" onclick={() => navigate('/')}>Home</Button>
+				<Link {...linkProps('/')} variant="ghost">Home</Link>
 			</div>
 		</header>
 
@@ -356,7 +357,7 @@
 					</Text>
 					<div class="setup__row">
 						<Button variant="solid" onclick={() => navigate('/login')}>Sign in</Button>
-						<Button variant="outline" onclick={() => navigate('/')}>Home</Button>
+						<Link {...linkProps('/')} variant="default">Home</Link>
 					</div>
 				</Alert>
 			{:else if !status.bootstrap_wallet_address_set}

--- a/web/src/pages/Trust.svelte
+++ b/web/src/pages/Trust.svelte
@@ -25,8 +25,8 @@ Issue: equaltoai/lesser-host#412
 
 	import type { ApiError } from 'src/lib/api/http';
 	import { lookupAttestation } from 'src/lib/api/trust';
-	import { currentPath, navigate } from 'src/lib/router';
-	import { Alert, Button, Spinner, Text, TextField } from 'src/lib/ui';
+	import { currentPath, linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Link, Spinner, Text, TextField } from 'src/lib/ui';
 	import { PageFrame, PageTitle, Panel } from 'src/lib/shell';
 
 	import AttestationInspector from 'src/pages/trust/AttestationInspector.svelte';
@@ -126,7 +126,7 @@ Issue: equaltoai/lesser-host#412
 			description="Attestations and evidence inspection."
 		>
 			{#snippet actions()}
-				<Button variant="ghost" onclick={() => navigate('/')}>Home</Button>
+				<Link {...linkProps('/')} variant="ghost">Home</Link>
 			{/snippet}
 		</PageTitle>
 	{/snippet}

--- a/web/src/pages/operator/Dashboard.svelte
+++ b/web/src/pages/operator/Dashboard.svelte
@@ -4,8 +4,8 @@
 	import type { ApiError } from 'src/lib/api/http';
 	import { listExternalInstanceRegistrations, listPortalUserApprovals, listVanityDomainRequests } from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -89,15 +89,15 @@
 			</DefinitionList>
 
 			<div class="op-dashboard__row">
-				<Button variant="outline" onclick={() => navigate('/operator/approvals/domains')}>Review domains</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/approvals/users')}>Review users</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/approvals/external-instances')}>
+				<Link {...linkProps('/operator/approvals/domains')} variant="default">Review domains</Link>
+				<Link {...linkProps('/operator/approvals/users')} variant="default">Review users</Link>
+				<Link {...linkProps('/operator/approvals/external-instances')} variant="default">
 					Review external registrations
-				</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/provisioning/jobs')}>Provisioning jobs</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/instances')}>Instance search</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/tip-registry')}>Tip registry</Button>
-				<Button variant="outline" onclick={() => navigate('/operator/audit')}>Audit log</Button>
+				</Link>
+				<Link {...linkProps('/operator/provisioning/jobs')} variant="default">Provisioning jobs</Link>
+				<Link {...linkProps('/operator/instances')} variant="default">Instance search</Link>
+				<Link {...linkProps('/operator/tip-registry')} variant="default">Tip registry</Link>
+				<Link {...linkProps('/operator/audit')} variant="default">Audit log</Link>
 			</div>
 		</Card>
 	{/if}

--- a/web/src/pages/operator/ExternalInstanceRegistrations.svelte
+++ b/web/src/pages/operator/ExternalInstanceRegistrations.svelte
@@ -9,8 +9,8 @@
 		rejectExternalInstanceRegistration,
 	} from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, CopyButton, Heading, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, Heading, Link, Spinner, Text } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -150,9 +150,9 @@
 						>
 							Reject
 						</Button>
-						<Button variant="ghost" onclick={() => navigate(`/operator/instances/${reg.slug}`)}>
+						<Link {...linkProps(`/operator/instances/${reg.slug}`)} variant="ghost">
 							Open instance
-						</Button>
+						</Link>
 						{#if actingId === reg.id}
 							<div class="op-external__loading-inline">
 								<Spinner size="sm" />

--- a/web/src/pages/operator/ProvisioningJobDetail.svelte
+++ b/web/src/pages/operator/ProvisioningJobDetail.svelte
@@ -10,21 +10,8 @@
 		retryOperatorProvisionJob,
 	} from 'src/lib/api/operatorProvisioning';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import {
-		Alert,
-		Badge,
-		Button,
-		Card,
-		CopyButton,
-		DefinitionItem,
-		DefinitionList,
-		Heading,
-		Spinner,
-		Text,
-		TextArea,
-		TextField,
-	} from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
 
 	let { token, id } = $props<{ token: string; id: string }>();
 
@@ -181,7 +168,7 @@
 		</div>
 		<div class="op-job__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate('/operator/provisioning/jobs')}>Back</Button>
+			<Link {...linkProps('/operator/provisioning/jobs')} variant="ghost">Back</Link>
 		</div>
 	</header>
 
@@ -217,7 +204,7 @@
 			</DefinitionList>
 
 			<div class="op-job__row">
-				<Button variant="ghost" onclick={() => navigate(`/operator/instances/${job?.instance_slug ?? ''}`)}>Open instance</Button>
+				<Link {...linkProps(`/operator/instances/${job?.instance_slug ?? ''}`)} variant="ghost">Open instance</Link>
 				<Button variant="outline" onclick={() => void retry()} disabled={retryLoading || job?.status === 'ok'}>
 					Retry / requeue
 				</Button>

--- a/web/src/pages/operator/ProvisioningJobs.svelte
+++ b/web/src/pages/operator/ProvisioningJobs.svelte
@@ -5,8 +5,8 @@
 	import type { ListOperatorProvisionJobsResponse, OperatorProvisionJobListItem } from 'src/lib/api/operatorProvisioning';
 	import { listOperatorProvisionJobs, retryOperatorProvisionJob } from 'src/lib/api/operatorProvisioning';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, CopyButton, Heading, Select, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, Heading, Link, Select, Spinner, Text } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -178,8 +178,8 @@
 					</div>
 
 					<div class="op-provisioning__row">
-						<Button variant="outline" onclick={() => navigate(`/operator/provisioning/jobs/${job.id}`)}>View</Button>
-						<Button variant="ghost" onclick={() => navigate(`/operator/instances/${job.instance_slug}`)}>Open instance</Button>
+						<Link {...linkProps(`/operator/provisioning/jobs/${job.id}`)} variant="default">View</Link>
+						<Link {...linkProps(`/operator/instances/${job.instance_slug}`)} variant="ghost">Open instance</Link>
 						{#if job.status === 'error'}
 							<Button variant="solid" onclick={() => void retry(job)} disabled={actingId === job.id}>Retry</Button>
 						{/if}

--- a/web/src/pages/operator/SoulOperationDetail.svelte
+++ b/web/src/pages/operator/SoulOperationDetail.svelte
@@ -6,22 +6,9 @@
 	import type { SoulOperation, SafeTxPayload } from 'src/lib/api/soul';
 	import { getSoulOperation, recordSoulOperationExecution, soulPublicGetConfig } from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate, safeAppRootUrl, stageSafeAppTarget } from 'src/lib/router';
+	import { linkProps, navigate, safeAppRootUrl, stageSafeAppTarget } from 'src/lib/router';
 	import { session, stageSafeAppSessionHandoff } from 'src/lib/session';
-	import {
-		Alert,
-		Badge,
-		Button,
-		Card,
-		CopyButton,
-		DefinitionItem,
-		DefinitionList,
-		Heading,
-		Spinner,
-		Text,
-		TextArea,
-		TextField,
-	} from 'src/lib/ui';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
 	import {
 		buildSafeWalletAppUrl,
 		clearPendingSafeAppTxHash,
@@ -324,7 +311,7 @@
 		</div>
 		<div class="op-soul-op__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate('/operator/soul')}>Back</Button>
+			<Link {...linkProps('/operator/soul')} variant="ghost">Back</Link>
 		</div>
 	</header>
 

--- a/web/src/pages/operator/SoulRegistry.svelte
+++ b/web/src/pages/operator/SoulRegistry.svelte
@@ -6,21 +6,9 @@
 	import type { ListSoulOperationsResponse, PublishRootResponse, SoulOperation } from 'src/lib/api/soul';
 	import { listSoulOperations, publishSoulReputationRoot, publishSoulValidationRoot, soulPublicGetConfig } from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate, safeAppRootUrl, stageSafeAppTarget } from 'src/lib/router';
+	import { linkProps, navigate, safeAppRootUrl, stageSafeAppTarget } from 'src/lib/router';
 	import { session, stageSafeAppSessionHandoff } from 'src/lib/session';
-	import {
-		Alert,
-		Badge,
-		Button,
-		Card,
-		CopyButton,
-		DefinitionItem,
-		DefinitionList,
-		Heading,
-		Select,
-		Spinner,
-		Text,
-	} from 'src/lib/ui';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text } from 'src/lib/ui';
 	import { buildSafeWalletAppUrl } from 'src/lib/wallet/safeApp';
 
 	let { token } = $props<{ token: string }>();
@@ -331,9 +319,9 @@
 										Open in Safe
 									</Button>
 								{/if}
-								<Button variant="outline" onclick={() => navigate(`/operator/soul/operations/${op.operation_id}`)}>
+								<Link {...linkProps(`/operator/soul/operations/${op.operation_id}`)} variant="default">
 									Open
-								</Button>
+								</Link>
 								<CopyButton size="sm" text={op.operation_id} />
 							</div>
 						</div>

--- a/web/src/pages/operator/SoulRegistry.svelte
+++ b/web/src/pages/operator/SoulRegistry.svelte
@@ -239,12 +239,9 @@
 				Operation <span class="op-soul__mono">{res.operation.operation_id}</span>
 			</Text>
 			<div class="op-soul__row">
-				<Button
-					variant="outline"
-					onclick={() => navigate(`/operator/soul/operations/${res.operation.operation_id}`)}
-				>
+				<Link {...linkProps(`/operator/soul/operations/${res.operation.operation_id}`)} variant="default">
 					View operation
-				</Button>
+				</Link>
 				<CopyButton size="sm" text={res.operation.operation_id} />
 			</div>
 

--- a/web/src/pages/operator/TipRegistry.svelte
+++ b/web/src/pages/operator/TipRegistry.svelte
@@ -10,8 +10,8 @@
 		setTipRegistryTokenAllowed,
 	} from 'src/lib/api/tipRegistry';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Select, Spinner, Text, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -228,9 +228,9 @@
 						Operation <span class="op-tip__mono">{res.operation.id}</span>
 					</Text>
 					<div class="op-tip__row">
-						<Button variant="outline" onclick={() => navigate(`/operator/tip-registry/operations/${res.operation.id}`)}>
+						<Link {...linkProps(`/operator/tip-registry/operations/${res.operation.id}`)} variant="default">
 							View operation
-						</Button>
+						</Link>
 						<CopyButton size="sm" text={res.operation.id} />
 					</div>
 
@@ -294,7 +294,7 @@
 							</Text>
 						</div>
 						<div class="op-tip__list-actions">
-							<Button variant="outline" onclick={() => navigate(`/operator/tip-registry/operations/${op.id}`)}>View</Button>
+							<Link {...linkProps(`/operator/tip-registry/operations/${op.id}`)} variant="default">View</Link>
 							<CopyButton size="sm" text={op.id} />
 						</div>
 					</div>

--- a/web/src/pages/operator/TipRegistryOperationDetail.svelte
+++ b/web/src/pages/operator/TipRegistryOperationDetail.svelte
@@ -5,8 +5,8 @@
 	import type { TipRegistryOperation } from 'src/lib/api/tipRegistry';
 	import { getTipRegistryOperation, recordTipRegistryOperationExecution } from 'src/lib/api/tipRegistry';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
 
 	let { token, id } = $props<{ token: string; id: string }>();
 
@@ -97,7 +97,7 @@
 		</div>
 		<div class="op-tip-op__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate('/operator/tip-registry')}>Back</Button>
+			<Link {...linkProps('/operator/tip-registry')} variant="ghost">Back</Link>
 		</div>
 	</header>
 

--- a/web/src/pages/operator/VanityDomainRequests.svelte
+++ b/web/src/pages/operator/VanityDomainRequests.svelte
@@ -5,8 +5,8 @@
 	import type { ListVanityDomainRequestsResponse } from 'src/lib/api/operators';
 	import { approveVanityDomainRequest, listVanityDomainRequests, rejectVanityDomainRequest } from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, CopyButton, Heading, Spinner, Text, TextArea } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, CopyButton, Heading, Link, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -158,9 +158,9 @@
 						>
 							Reject
 						</Button>
-						<Button variant="ghost" onclick={() => navigate(`/operator/instances/${req.instance_slug}`)}>
+						<Link {...linkProps(`/operator/instances/${req.instance_slug}`)} variant="ghost">
 							Open instance
-						</Button>
+						</Link>
 						{#if actingDomain === req.domain}
 							<div class="op-requests__loading-inline">
 								<Spinner size="sm" />

--- a/web/src/pages/portal/Billing.svelte
+++ b/web/src/pages/portal/Billing.svelte
@@ -34,8 +34,8 @@ Issue: equaltoai/lesser-host#413
 		portalListPaymentMethods,
 	} from 'src/lib/api/portalBilling';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, CopyButton, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, CopyButton, Link, Spinner, Text } from 'src/lib/ui';
 	import { PageFrame, PageTitle, Panel } from 'src/lib/shell';
 
 	let { token } = $props<{ token: string }>();
@@ -147,7 +147,7 @@ Issue: equaltoai/lesser-host#413
 		>
 			{#snippet actions()}
 				<Button variant="outline" onclick={() => void loadAll()} disabled={loading}>Refresh</Button>
-				<Button variant="ghost" onclick={() => navigate('/portal')}>Back</Button>
+				<Link {...linkProps('/portal')} variant="ghost">Back</Link>
 			{/snippet}
 		</PageTitle>
 	{/snippet}

--- a/web/src/pages/portal/InstanceBudgets.svelte
+++ b/web/src/pages/portal/InstanceBudgets.svelte
@@ -6,8 +6,8 @@
 	import type { BudgetMonthResponse, ListBudgetsResponse, UsageSummaryResponse } from 'src/lib/api/portalUsage';
 	import { portalGetBudgetMonth, portalGetUsageSummary, portalListBudgets, portalSetBudgetMonth } from 'src/lib/api/portalUsage';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token, slug } = $props<{ token: string; slug: string }>();
 
@@ -166,9 +166,9 @@
 		</div>
 		<div class="budgets__actions">
 			<Button variant="outline" onclick={() => void loadAll()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}/usage`)}>Usage</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}`)}>Back</Button>
-			<Button variant="ghost" onclick={() => navigate('/portal/billing')}>Billing</Button>
+			<Link {...linkProps(`/portal/instances/${slug}/usage`)} variant="ghost">Usage</Link>
+			<Link {...linkProps(`/portal/instances/${slug}`)} variant="ghost">Back</Link>
+			<Link {...linkProps('/portal/billing')} variant="ghost">Billing</Link>
 		</div>
 	</header>
 

--- a/web/src/pages/portal/InstanceCost.svelte
+++ b/web/src/pages/portal/InstanceCost.svelte
@@ -32,8 +32,8 @@ Issue: equaltoai/lesser-host#422
 	import type { BudgetMonthResponse, UsageSummaryResponse } from 'src/lib/api/portalUsage';
 	import { portalGetBudgetMonth, portalGetUsageSummary } from 'src/lib/api/portalUsage';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text } from 'src/lib/ui';
 	import { StatCard, SummaryStrip } from 'src/lib/shell';
 
 	let { token, slug } = $props<{ token: string; slug: string }>();
@@ -236,8 +236,8 @@ Issue: equaltoai/lesser-host#422
 			>
 				Refresh
 			</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}/budgets`)}>Budgets (legacy)</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}/usage`)}>Usage (legacy)</Button>
+			<Link {...linkProps(`/portal/instances/${slug}/budgets`)} variant="ghost">Budgets (legacy)</Link>
+			<Link {...linkProps(`/portal/instances/${slug}/usage`)} variant="ghost">Usage (legacy)</Link>
 		</div>
 	{/if}
 </div>

--- a/web/src/pages/portal/InstanceSouls.svelte
+++ b/web/src/pages/portal/InstanceSouls.svelte
@@ -32,8 +32,8 @@ Issue: equaltoai/lesser-host#419
 	import type { SoulMineAgentItem } from 'src/lib/api/soul';
 	import { soulListMyAgents } from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, CopyButton, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, CopyButton, Link, Spinner, Text } from 'src/lib/ui';
 	import { Panel } from 'src/lib/shell';
 
 	interface Props {
@@ -148,9 +148,9 @@ Issue: equaltoai/lesser-host#419
 				agent.
 			</Text>
 			<div class="instance-souls__actions-inline">
-				<Button variant="outline" onclick={() => navigate('/portal/souls')}>
+				<Link {...linkProps('/portal/souls')} variant="default">
 					Open legacy portal souls list
-				</Button>
+				</Link>
 			</div>
 		</Alert>
 	{:else}

--- a/web/src/pages/portal/InstanceSouls.svelte
+++ b/web/src/pages/portal/InstanceSouls.svelte
@@ -191,12 +191,9 @@ Issue: equaltoai/lesser-host#419
 						{/if}
 					</div>
 					<div class="instance-souls__item-actions">
-						<Button
-							variant="outline"
-							onclick={() => navigate(`/portal/souls/${item.agent.agent_id}`)}
-						>
+						<Link {...linkProps(`/portal/souls/${item.agent.agent_id}`)} variant="default">
 							Open
-						</Button>
+						</Link>
 						<CopyButton size="sm" text={item.agent.agent_id} />
 					</div>
 				</li>

--- a/web/src/pages/portal/InstanceUsage.svelte
+++ b/web/src/pages/portal/InstanceUsage.svelte
@@ -5,8 +5,8 @@
 	import type { ListUsageResponse, UsageSummaryResponse } from 'src/lib/api/portalUsage';
 	import { portalGetUsageSummary, portalListUsage } from 'src/lib/api/portalUsage';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, Card, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, Card, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token, slug } = $props<{ token: string; slug: string }>();
 
@@ -91,9 +91,9 @@
 		</div>
 		<div class="usage__actions">
 			<Button variant="outline" onclick={() => void loadAll()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}/budgets`)}>Budgets</Button>
-			<Button variant="ghost" onclick={() => navigate('/portal/billing')}>Billing</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/instances/${slug}`)}>Back</Button>
+			<Link {...linkProps(`/portal/instances/${slug}/budgets`)} variant="ghost">Budgets</Link>
+			<Link {...linkProps('/portal/billing')} variant="ghost">Billing</Link>
+			<Link {...linkProps(`/portal/instances/${slug}`)} variant="ghost">Back</Link>
 		</div>
 	</header>
 

--- a/web/src/pages/portal/Instances.svelte
+++ b/web/src/pages/portal/Instances.svelte
@@ -5,8 +5,8 @@
 	import type { InstanceResponse } from 'src/lib/api/portalInstances';
 	import { portalCreateInstance, portalListInstances } from 'src/lib/api/portalInstances';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, Heading, Spinner, Text, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, Heading, Link, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -151,9 +151,9 @@
 							{/if}
 						</div>
 						<div class="instances__item-actions">
-							<Button variant="outline" onclick={() => navigate(`/portal/instances/${inst.slug}`)}>
+							<Link {...linkProps(`/portal/instances/${inst.slug}`)} variant="default">
 								Open
-							</Button>
+							</Link>
 						</div>
 					</div>
 				</Card>

--- a/web/src/pages/portal/PortalFleet.svelte
+++ b/web/src/pages/portal/PortalFleet.svelte
@@ -33,8 +33,8 @@ Issue: equaltoai/lesser-host#391
 	import type { BudgetMonthResponse } from 'src/lib/api/portalUsage';
 	import { portalGetBudgetMonth } from 'src/lib/api/portalUsage';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Heading, Spinner, Text, TextField } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Heading, Link, Spinner, Text, TextField } from 'src/lib/ui';
 	import FleetCard from 'src/lib/components/FleetCard.svelte';
 	import CostGauge from 'src/lib/components/CostGauge.svelte';
 	import type { FleetCardMetadataItem } from 'src/lib/greater/host-platform';
@@ -272,12 +272,9 @@ Issue: equaltoai/lesser-host#391
 							{/if}
 						{/snippet}
 						{#snippet actions()}
-							<Button
-								variant="outline"
-								onclick={() => navigate(`/portal/instances/${inst.slug}`)}
-							>
+							<Link {...linkProps(`/portal/instances/${inst.slug}`)} variant="default">
 								Open
-							</Button>
+							</Link>
 						{/snippet}
 					</FleetCard>
 				</li>

--- a/web/src/pages/portal/SoulAgentDetail.svelte
+++ b/web/src/pages/portal/SoulAgentDetail.svelte
@@ -68,7 +68,7 @@
 		soulUpdateRegistration,
 	} from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
+	import { linkProps, navigate } from 'src/lib/router';
 	import {
 		ensureAccounts,
 		getChainId,
@@ -82,21 +82,7 @@
 	} from 'src/lib/wallet/ethereum';
 	import { jcsCanonicalize } from 'src/lib/wallet/jcs';
 	import { keccak256Utf8Hex } from 'src/lib/wallet/keccak';
-	import {
-		Alert,
-		Badge,
-		Button,
-		Card,
-		CopyButton,
-		DefinitionItem,
-		DefinitionList,
-		Heading,
-		Select,
-		Spinner,
-		Text,
-		TextArea,
-		TextField,
-	} from 'src/lib/ui';
+	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
 	import { PageFrame, PageTitle } from 'src/lib/shell';
 
 	let { token, agentId } = $props<{ token: string; agentId: string }>();
@@ -1844,7 +1830,7 @@
 		>
 			{#snippet actions()}
 				<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-				<Button variant="ghost" onclick={() => navigate('/portal/souls')}>Back</Button>
+				<Link {...linkProps('/portal/souls')} variant="ghost">Back</Link>
 			{/snippet}
 		</PageTitle>
 	{/snippet}

--- a/web/src/pages/portal/SoulMintConversation.svelte
+++ b/web/src/pages/portal/SoulMintConversation.svelte
@@ -19,10 +19,10 @@
 	} from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
 	import { MarkdownRenderer } from 'src/lib/greater/content';
-	import { navigate } from 'src/lib/router';
+	import { linkProps, navigate } from 'src/lib/router';
 	import { ensureAccounts, getEthereumProvider, personalSign } from 'src/lib/wallet/ethereum';
 	import { keccak256Utf8Hex } from 'src/lib/wallet/keccak';
-	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Select, Spinner, Text, TextArea } from 'src/lib/ui';
+	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { token, agentId } = $props<{ token: string; agentId: string }>();
 
@@ -444,7 +444,7 @@
 		</div>
 		<div class="soul-mint__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate(`/portal/souls/${agentId}`)}>Back to agent</Button>
+			<Link {...linkProps(`/portal/souls/${agentId}`)} variant="ghost">Back to agent</Link>
 		</div>
 	</header>
 

--- a/web/src/pages/portal/SoulRegister.svelte
+++ b/web/src/pages/portal/SoulRegister.svelte
@@ -26,7 +26,7 @@
 	} from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
 	import { MarkdownRenderer } from 'src/lib/greater/content';
-	import { navigate } from 'src/lib/router';
+	import { linkProps, navigate } from 'src/lib/router';
 	import {
 		ensureAccounts,
 		getChainId,
@@ -39,20 +39,7 @@
 	} from 'src/lib/wallet/ethereum';
 	import { jcsCanonicalize } from 'src/lib/wallet/jcs';
 	import { keccak256Utf8Hex } from 'src/lib/wallet/keccak';
-	import {
-		Alert,
-		Button,
-		Card,
-		CopyButton,
-		DefinitionItem,
-		DefinitionList,
-		Heading,
-		Select,
-		Spinner,
-		Text,
-		TextArea,
-		TextField,
-	} from 'src/lib/ui';
+	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text, TextArea, TextField } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -949,7 +936,7 @@
 			</Text>
 		</div>
 		<div class="soul-register__actions">
-			<Button variant="ghost" onclick={() => navigate('/portal/souls')}>Back</Button>
+			<Link {...linkProps('/portal/souls')} variant="ghost">Back</Link>
 		</div>
 	</header>
 
@@ -1210,9 +1197,9 @@
 							<Button variant="solid" onclick={() => navigate(`/portal/souls/${begin.registration.agent_id}`)}>
 								{verifyUsesSafe || !verifyMintExecuted ? 'Open mint recovery' : 'Open agent'}
 							</Button>
-							<Button variant="outline" onclick={() => navigate(`/portal/souls/${begin.registration.agent_id}/mint`)}>
+							<Link {...linkProps(`/portal/souls/${begin.registration.agent_id}/mint`)} variant="default">
 								Complete profile
-							</Button>
+							</Link>
 							<CopyButton size="sm" text={verifyResult.operation.operation_id} />
 						</div>
 
@@ -1432,7 +1419,7 @@
 							<Text size="sm">Published v2 registration version {mintFinalizeResult.published_version}.</Text>
 						</Alert>
 						<div class="soul-register__row">
-							<Button variant="outline" onclick={() => navigate(`/portal/souls/${begin.registration.agent_id}`)}>Open agent</Button>
+							<Link {...linkProps(`/portal/souls/${begin.registration.agent_id}`)} variant="default">Open agent</Link>
 							<Button variant="solid" onclick={() => navigate(`/portal/souls/${begin.registration.agent_id}/mint`)}>
 								Review profile
 							</Button>

--- a/web/src/pages/portal/Souls.svelte
+++ b/web/src/pages/portal/Souls.svelte
@@ -27,8 +27,8 @@ Issue: equaltoai/lesser-host#411
 	import type { SoulMineAgentItem } from 'src/lib/api/soul';
 	import { soulListMyAgents } from 'src/lib/api/soul';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Badge, Button, CopyButton, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Badge, Button, CopyButton, Link, Spinner, Text } from 'src/lib/ui';
 	import { PageFrame, PageTitle, Panel, Callout } from 'src/lib/shell';
 
 	let { token } = $props<{ token: string }>();
@@ -173,12 +173,9 @@ Issue: equaltoai/lesser-host#411
 									Open legacy profile step
 								</Button>
 							{/if}
-							<Button
-								variant="outline"
-								onclick={() => navigate(`/portal/souls/${item.agent.agent_id}`)}
-							>
+							<Link {...linkProps(`/portal/souls/${item.agent.agent_id}`)} variant="default">
 								Open
-							</Button>
+							</Link>
 							<CopyButton size="sm" text={item.agent.agent_id} />
 						</div>
 					</li>

--- a/web/src/pages/trust/AttestationInspector.svelte
+++ b/web/src/pages/trust/AttestationInspector.svelte
@@ -4,8 +4,8 @@
 	import type { ApiError } from 'src/lib/api/http';
 	import type { AttestationResponse, JWKS } from 'src/lib/api/trust';
 	import { getAttestation, getJWKS } from 'src/lib/api/trust';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextArea } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { id } = $props<{ id: string }>();
 
@@ -75,7 +75,7 @@
 		</div>
 		<div class="trust-att__actions">
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
-			<Button variant="ghost" onclick={() => navigate('/trust')}>Back</Button>
+			<Link {...linkProps('/trust')} variant="ghost">Back</Link>
 		</div>
 	</header>
 


### PR DESCRIPTION
## Summary

Closes the host-side migration committed in [greater-components#700](https://github.com/equaltoai/greater-components/issues/700) / [lesser-host PR #507](https://github.com/equaltoai/lesser-host/pull/507) review. Refreshes the primitives group to `greater-v0.10.1` (commit `b4d26ad7`) to pick up the new \`Link\` primitive that ships in [greater-components#702](https://github.com/equaltoai/greater-components/pull/702), then migrates every in-app \`Button onclick={() => navigate(...)}\` call site that is pure route transition to use \`Link\` instead — preserving browser link affordances (right-click, middle-click, Cmd/Ctrl-click, copy link address) and WCAG 4.1.2 (Name, Role, Value) semantics that \`Button + onclick\` cannot.

## What changes

### 1. Primitives refresh (vendored greater-components)

- \`web/components.json\` — top-level \`ref\` and \`primitives.version\` bump to greater-v0.10.1.
- \`Link.svelte\` + \`Link.svelte.d.ts\` (new) — vendored as-shipped from greater-components#702.
- \`primitives/index.ts\` + \`index.d.ts\` — Link added to re-exports + \`LinkProps\` type alias.
- \`primitives/theme.css\` — Link variant + size styles (+153 lines). Reuses existing \`--gr-semantic-action-link-*\` tokens; no new tokens.

The CLI did a **structural merge**: only the four Link-touching files plus components.json changed. The 15 other components that drifted between greater-v0.10.0-rc.1 → v0.10.1 (Avatar, CopyButton, Menu/Item, Modal, StepIndicator, TextArea, TextField, ThemeProvider, Tooltip, several Theme/*) were preserved at host's pinned content — **blast radius confined to Link**.

### 2. Host SPA-router integration

- \`web/src/lib/router.ts\` — new \`linkProps(to)\` helper exported alongside \`navigate()\`. Returns the props bag (\`href\` + \`onnavigate\`) for the Link primitive. Handles \`SAFE_APP_BASE_PATH\` application so Cmd/Ctrl/middle-click "open in new tab" intents resolve to the correct URL (with the safe-app prefix when active), while the SPA-router intercept calls \`navigate()\` with the unprefixed path so route normalization stays in one place.
- \`web/src/lib/ui.ts\` — \`Link\` added to the host-curated re-export.
- \`web/src/lib/router.test.ts\` (new) — 6 source-text guards locking \`linkProps\`'s shape, including the modifier-key-gated callback signature matching greater-components' Link contract.

### 3. 45 consumer call-site migrations (29 files)

Every \`<Button variant="ghost|outline" onclick={() => navigate(URL)}>\` that is pure route transition is now \`<Link {...linkProps(URL)} variant="ghost|default">\`.

**Variant mapping** (per host steward's review on greater-components#702):
- \`ghost\` Button → \`ghost\` Link
- \`outline\` Button → \`default\` Link (the "outline-Button-minus-border" visual greater shipped for \`default\`)
- \`solid\` Button → **stays on Button** (action-vs-navigation distinction; Aron's lock)

**Files touched** (45 sites across 29 files):

| Surface | Files | Sites |
|---|---|---|
| Top-level pages | Login.svelte, NotFound.svelte, Portal.svelte, Setup.svelte, Trust.svelte | 10 |
| \`portal/*\` | Billing, InstanceBudgets, InstanceCost, InstanceSouls, InstanceUsage, Instances, SoulAgentDetail, SoulMintConversation, SoulRegister | 17 |
| \`operator/*\` | Dashboard, ExternalInstanceRegistrations, ProvisioningJobDetail, ProvisioningJobs, SoulOperationDetail, SoulRegistry, TipRegistry, TipRegistryOperationDetail, VanityDomainRequests | 17 |
| \`trust/*\` | AttestationInspector | 1 |

Action buttons (Refresh, Save, Submit, Create, Open, Apply, Retry, etc.) stay on Button — those are imperative actions, not route transitions. \`Button variant="solid"\` primary nav CTAs (Register a soul, login-landing Sign in, Mint) also stay on Button per the action-vs-nav distinction.

## Why

\`Button + onclick={() => navigate(URL)}\` was a known consumer-side workaround for greater-components' missing Link primitive (filed in greater-components#700 from lesser-host PR #507). The workaround forfeits:

- Right-click → "Open link in new tab"
- Middle-click → open in new tab
- Cmd/Ctrl + click → open in new tab / new window
- "Copy link address" affordance
- Correct ARIA role (\`<button>\` is announced as action to assistive tech; nav controls should be \`role="link"\` per WCAG 4.1.2)

The new Link primitive renders a real \`<a href>\` with implicit \`role="link"\`, preserving all browser link affordances, while a modifier-key-gated \`onnavigate\` callback lets the SPA router intercept ONLY plain unmodified left-clicks. The gating predicate: \`defaultPrevented → button !== 0 → metaKey|ctrlKey|shiftKey|altKey → onnavigate\`. Modifier-key and middle/right-clicks pass through to native browser behavior.

## Posture invariants preserved

- Strict-no-inline-CSP safe (SEC-6 + SEC-7 PASS).
- Multi-tenant isolation: no new server surface.
- Trust-API instance-auth untouched; SEC-9 change-lock not engaged.
- No on-chain code path changed.
- Vendoring is structural: only Link-touching files changed; 15 other component drifts from greater-v0.10.0-rc.1 → v0.10.1 preserved at host pin per CLI structural-merge.
- No new dependencies; AGPL posture unchanged.

## Test plan

- [x] \`cd web && npm run typecheck\` — 0 errors, 0 warnings (3,188 files; +2 from Link.svelte + .d.ts vs pre-refresh 3,186)
- [x] \`cd web && npm run lint\` — clean
- [x] \`cd web && npm test\` — 14 files / 65 tests pass (was 13/59; +1 file +6 tests from router.test.ts)
- [x] \`cd web && npm run build\` — vite client + ssr OK, 10 sidecars; \`verify-no-inline-html\` PASS (SEC-6); \`verify-oac-form-integrity\` PASS (SEC-7)
- [x] \`bash gov-infra/verifiers/gov-verify-rubric.sh\` — **PASS 37/0/0** (new M1 stack-state verifier from PR #510 included)
- [x] Commit GPG-signed (key \`72D6153132D52023\`)
- [ ] CI green
- [ ] Manual: visit each migrated page in the operator portal + customer portal; verify Cmd-click opens nav targets in new tabs with the correct safe-app prefix

## Related

- greater-components#700 — original gap filed from PR #507 review
- greater-components#702 — Link primitive implementation, host steward sign-off via review 4360221275
- lesser-host PR #507 — original Cost & usage tab work that surfaced the gap

🤖 Generated with [Claude Code](https://claude.com/claude-code)