### PR TITLE
feat(operators): add releases, drift, and MCP-remediation endpoints (#434, #435, #436)

### DIFF
--- a/internal/controlplane/drift.go
+++ b/internal/controlplane/drift.go
@@ -1,0 +1,185 @@
+package controlplane
+
+import (
+	"strings"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// fleetDriftComponent holds per-component drift telemetry for a single instance.
+type fleetDriftComponent struct {
+	Current string `json:"current"`
+	Target  string `json:"target"`
+	Drift   string `json:"drift"`
+}
+
+// fleetDriftMCP holds MCP-specific drift telemetry.
+type fleetDriftMCP struct {
+	WiredAgainst string `json:"wired_against"`
+	CurrentBody  string `json:"current_body"`
+	Drift        string `json:"drift"`
+}
+
+// fleetDriftEntry is a per-instance entry in the fleet drift response.
+type fleetDriftEntry struct {
+	Slug   string              `json:"slug"`
+	Lesser fleetDriftComponent `json:"lesser"`
+	Body   fleetDriftComponent `json:"body"`
+	MCP    fleetDriftMCP       `json:"mcp"`
+}
+
+// fleetDriftSummary aggregates per-component drift counts across the fleet.
+type fleetDriftSummary struct {
+	Total        int `json:"total"`
+	LesserStale  int `json:"lesser_stale"`
+	BodyStale    int `json:"body_stale"`
+	MCPWireStale int `json:"mcp_wire_stale"`
+}
+
+// fleetDriftResponse is the operator-facing fleet drift response per
+// Project 39 provisioning walk Change 5.3.
+type fleetDriftResponse struct {
+	Instances []fleetDriftEntry `json:"instances"`
+	Summary   fleetDriftSummary `json:"summary"`
+}
+
+// computeFleetDrift computes per-instance drift for the entire active fleet.
+// Targets come from config defaults; drift is computed per component.
+func computeFleetDrift(
+	instances []*models.Instance,
+	lesserTarget string,
+	bodyTarget string,
+) fleetDriftResponse {
+	entries := make([]fleetDriftEntry, 0, len(instances))
+	summary := fleetDriftSummary{Total: len(instances)}
+
+	for _, inst := range instances {
+		entry := computeInstanceDrift(inst, lesserTarget, bodyTarget)
+		entries = append(entries, entry)
+
+		if entry.Lesser.Drift == stackDriftStale {
+			summary.LesserStale++
+		}
+		if entry.Body.Drift == stackDriftStale {
+			summary.BodyStale++
+		}
+		if entry.MCP.Drift == stackDriftWireStale {
+			summary.MCPWireStale++
+		}
+	}
+
+	return fleetDriftResponse{Instances: entries, Summary: summary}
+}
+
+// computeInstanceDrift computes drift for a single instance against target versions.
+func computeInstanceDrift(
+	inst *models.Instance,
+	lesserTarget string,
+	bodyTarget string,
+) fleetDriftEntry {
+	slug := strings.TrimSpace(inst.Slug)
+	lesserCurrent := strings.TrimSpace(inst.LesserVersion)
+	bodyCurrent := strings.TrimSpace(inst.LesserBodyVersion)
+
+	entry := fleetDriftEntry{
+		Slug: slug,
+		Lesser: fleetDriftComponent{
+			Current: lesserCurrent,
+			Target:  strings.TrimSpace(lesserTarget),
+			Drift:   computeComponentDrift(lesserCurrent, lesserTarget),
+		},
+		Body: fleetDriftComponent{
+			Current: bodyCurrent,
+			Target:  strings.TrimSpace(bodyTarget),
+			Drift:   computeComponentDrift(bodyCurrent, bodyTarget),
+		},
+	}
+
+	// MCP drift: wired_against comes from the Instance's LesserBodyVersion
+	// (which reflects what MCP was wired against), current_body is the
+	// body version currently deployed.
+	mcpWiredAgainst := bodyCurrent // By default, MCP is wired against the deploy-time body version
+	mcpDrift := stackDriftUnknown
+	if bodyCurrent != "" {
+		// When MCP is wired, it's against the body version at time of wiring.
+		// We approximate this from the instance's stored body version.
+		// A true wire-stale condition exists when:
+		// 1. The instance has a body version
+		// 2. The body version is at target (i.e., no body drift)
+		// 3. But the MCP wiring may be out of sync
+		// For the fleet drift endpoint, we flag wire-stale when the
+		// body version is at target but there's a possible stale wiring
+		// (which is conservatively all instances with body != "").
+		//
+		// In practice, the caller (remediate-mcp-drift) uses a more precise
+		// check via update jobs. For the drift display, we conservatively
+		// mark body-up-to-date instances as potentially wire-stale if MCP
+		// hasn't been recently re-wired.
+		mcpDrift = computeFleetMCPDrift(inst, bodyCurrent, bodyTarget)
+	}
+
+	entry.MCP = fleetDriftMCP{
+		WiredAgainst: mcpWiredAgainst,
+		CurrentBody:  bodyCurrent,
+		Drift:        mcpDrift,
+	}
+
+	return entry
+}
+
+// computeComponentDrift determines whether a component version is stale
+// relative to its target version.
+func computeComponentDrift(current string, target string) string {
+	current = strings.TrimSpace(current)
+	target = strings.TrimSpace(target)
+
+	if current == "" || target == "" {
+		return stackDriftUnknown
+	}
+	if strings.EqualFold(current, target) {
+		return stackDriftOK
+	}
+	// Compare versions numerically if possible.
+	if compareVersions(current, target) < 0 {
+		return stackDriftStale
+	}
+	// current is newer than target — consider it ok (ahead of fleet).
+	return stackDriftOK
+}
+
+// computeFleetMCPDrift checks MCP wiring staleness. Returns "wire-stale" if
+// MCP was wired against a body version older than the currently deployed body
+// version and the current body version is at or below the target.
+//
+// For the fleet-level drift view, we use Instance timestamps as a heuristic:
+// if McpWiredAt is set and predates LesserBodyUpdateAt, and the body version
+// changed between the two timestamps, MCP is likely wire-stale.
+//
+// When MCP hasn't been explicitly wired (McpWiredAt is zero), we report
+// "ok" for instances with no body (MCP isn't applicable) and "unknown"
+// for instances with a body version.
+func computeFleetMCPDrift(inst *models.Instance, bodyCurrent string, bodyTarget string) string {
+	if bodyCurrent == "" {
+		return stackDriftUnknown
+	}
+
+	// If McpWiredAt is set and predates LesserBodyUpdateAt, MCP may be stale.
+	// But without per-job detail, the Instance-level heuristic is too coarse.
+	// For the fleet drift endpoint, we conservatively report "ok" when the
+	// body version is at target and MCP was wired at or after the body update.
+	// "wire-stale" only when MCP predates the last body update.
+	mcpWiredAt := inst.McpWiredAt
+	bodyUpdatedAt := inst.LesserBodyUpdateAt
+
+	if !mcpWiredAt.IsZero() && !bodyUpdatedAt.IsZero() && mcpWiredAt.Before(bodyUpdatedAt) {
+		return stackDriftWireStale
+	}
+
+	// If MCP has never been wired but body is present, it's unknown.
+	if mcpWiredAt.IsZero() {
+		return stackDriftUnknown
+	}
+
+	// Default: MCP wiring appears up-to-date.
+	return stackDriftOK
+}

--- a/internal/controlplane/drift.go
+++ b/internal/controlplane/drift.go
@@ -2,8 +2,6 @@ package controlplane
 
 import (
 	"strings"
-
-	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 // fleetDriftComponent holds per-component drift telemetry for a single instance.
@@ -43,18 +41,22 @@ type fleetDriftResponse struct {
 	Summary   fleetDriftSummary `json:"summary"`
 }
 
-// computeFleetDrift computes per-instance drift for the entire active fleet.
-// Targets come from config defaults; drift is computed per component.
+// computeFleetDrift computes per-instance drift for the entire active fleet
+// using UpdateJob + ProvisionJob + Instance evidence. Targets come from
+// config defaults; drift is computed per component.
 func computeFleetDrift(
-	instances []*models.Instance,
+	evidence []*instanceJobsEvidence,
 	lesserTarget string,
 	bodyTarget string,
 ) fleetDriftResponse {
-	entries := make([]fleetDriftEntry, 0, len(instances))
-	summary := fleetDriftSummary{Total: len(instances)}
+	entries := make([]fleetDriftEntry, 0, len(evidence))
+	summary := fleetDriftSummary{Total: len(evidence)}
 
-	for _, inst := range instances {
-		entry := computeInstanceDrift(inst, lesserTarget, bodyTarget)
+	for _, ev := range evidence {
+		if ev == nil {
+			continue
+		}
+		entry := computeInstanceDrift(ev, lesserTarget, bodyTarget)
 		entries = append(entries, entry)
 
 		if entry.Lesser.Drift == stackDriftStale {
@@ -71,60 +73,81 @@ func computeFleetDrift(
 	return fleetDriftResponse{Instances: entries, Summary: summary}
 }
 
-// computeInstanceDrift computes drift for a single instance against target versions.
+// computeInstanceDrift computes drift for a single instance against target
+// versions using evidence from update jobs, provisioning, and instance state.
+//
+// The MCP wired_against field is resolved from the latest successful MCP-only
+// UpdateJob (which records the body version MCP was wired against at job time).
+// The current_body field comes from the latest successful body update job (or
+// instance state as fallback).
+//
+// This replaces the previous timestamp-only heuristic which could emit
+// contradictory rows (wired_against == current_body while drift == wire-stale)
+// and could not distinguish which body version MCP was wired against.
 func computeInstanceDrift(
-	inst *models.Instance,
+	ev *instanceJobsEvidence,
 	lesserTarget string,
 	bodyTarget string,
 ) fleetDriftEntry {
-	slug := strings.TrimSpace(inst.Slug)
-	lesserCurrent := strings.TrimSpace(inst.LesserVersion)
-	bodyCurrent := strings.TrimSpace(inst.LesserBodyVersion)
+	if ev == nil || ev.instance == nil {
+		return fleetDriftEntry{}
+	}
+
+	slug := strings.TrimSpace(ev.instance.Slug)
+
+	// Lesser: use evidence-based current version.
+	lesserCurrent := lesserVersionFromEvidence(ev)
+	lesserTargetVal := strings.TrimSpace(lesserTarget)
 
 	entry := fleetDriftEntry{
 		Slug: slug,
 		Lesser: fleetDriftComponent{
 			Current: lesserCurrent,
-			Target:  strings.TrimSpace(lesserTarget),
-			Drift:   computeComponentDrift(lesserCurrent, lesserTarget),
-		},
-		Body: fleetDriftComponent{
-			Current: bodyCurrent,
-			Target:  strings.TrimSpace(bodyTarget),
-			Drift:   computeComponentDrift(bodyCurrent, bodyTarget),
+			Target:  lesserTargetVal,
+			Drift:   computeComponentDrift(lesserCurrent, lesserTargetVal),
 		},
 	}
 
-	// MCP drift: wired_against comes from the Instance's LesserBodyVersion
-	// (which reflects what MCP was wired against), current_body is the
-	// body version currently deployed.
-	mcpWiredAgainst := bodyCurrent // By default, MCP is wired against the deploy-time body version
-	mcpDrift := stackDriftUnknown
-	if bodyCurrent != "" {
-		// When MCP is wired, it's against the body version at time of wiring.
-		// We approximate this from the instance's stored body version.
-		// A true wire-stale condition exists when:
-		// 1. The instance has a body version
-		// 2. The body version is at target (i.e., no body drift)
-		// 3. But the MCP wiring may be out of sync
-		// For the fleet drift endpoint, we flag wire-stale when the
-		// body version is at target but there's a possible stale wiring
-		// (which is conservatively all instances with body != "").
-		//
-		// In practice, the caller (remediate-mcp-drift) uses a more precise
-		// check via update jobs. For the drift display, we conservatively
-		// mark body-up-to-date instances as potentially wire-stale if MCP
-		// hasn't been recently re-wired.
-		mcpDrift = computeFleetMCPDrift(inst, bodyCurrent, bodyTarget)
+	// Body: use evidence-based current version.
+	bodyCurrent := bodyVersionFromEvidence(ev)
+	bodyTargetVal := strings.TrimSpace(bodyTarget)
+
+	entry.Body = fleetDriftComponent{
+		Current: bodyCurrent,
+		Target:  bodyTargetVal,
+		Drift:   computeComponentDrift(bodyCurrent, bodyTargetVal),
 	}
+
+	// MCP: wired_against from latest MCP update evidence, current_body from
+	// latest body update evidence. Drift is wire-stale when the versions differ.
+	mcpWiredAgainst := mcpWiredAgainstFromEvidence(ev)
+	mcpCurrentBody := mcpCurrentBodyFromEvidence(ev)
+	mcpDrift := computeMCPEvidenceDrift(mcpWiredAgainst, mcpCurrentBody)
 
 	entry.MCP = fleetDriftMCP{
 		WiredAgainst: mcpWiredAgainst,
-		CurrentBody:  bodyCurrent,
+		CurrentBody:  mcpCurrentBody,
 		Drift:        mcpDrift,
 	}
 
 	return entry
+}
+
+// computeMCPEvidenceDrift determines MCP wiring drift from evidence-derived
+// versions. Returns "wire-stale" when MCP was wired against a different body
+// version than what is currently deployed (regardless of whether the body is
+// at the fleet target). Returns "unknown" when either version is empty.
+func computeMCPEvidenceDrift(wiredAgainst, currentBody string) string {
+	wiredAgainst = strings.TrimSpace(wiredAgainst)
+	currentBody = strings.TrimSpace(currentBody)
+
+	if wiredAgainst == "" || currentBody == "" {
+		return stackDriftUnknown
+	}
+	if wiredAgainst != currentBody {
+		return stackDriftWireStale
+	}
+	return stackDriftOK
 }
 
 // computeComponentDrift determines whether a component version is stale
@@ -144,42 +167,5 @@ func computeComponentDrift(current string, target string) string {
 		return stackDriftStale
 	}
 	// current is newer than target — consider it ok (ahead of fleet).
-	return stackDriftOK
-}
-
-// computeFleetMCPDrift checks MCP wiring staleness. Returns "wire-stale" if
-// MCP was wired against a body version older than the currently deployed body
-// version and the current body version is at or below the target.
-//
-// For the fleet-level drift view, we use Instance timestamps as a heuristic:
-// if McpWiredAt is set and predates LesserBodyUpdateAt, and the body version
-// changed between the two timestamps, MCP is likely wire-stale.
-//
-// When MCP hasn't been explicitly wired (McpWiredAt is zero), we report
-// "ok" for instances with no body (MCP isn't applicable) and "unknown"
-// for instances with a body version.
-func computeFleetMCPDrift(inst *models.Instance, bodyCurrent string, bodyTarget string) string {
-	if bodyCurrent == "" {
-		return stackDriftUnknown
-	}
-
-	// If McpWiredAt is set and predates LesserBodyUpdateAt, MCP may be stale.
-	// But without per-job detail, the Instance-level heuristic is too coarse.
-	// For the fleet drift endpoint, we conservatively report "ok" when the
-	// body version is at target and MCP was wired at or after the body update.
-	// "wire-stale" only when MCP predates the last body update.
-	mcpWiredAt := inst.McpWiredAt
-	bodyUpdatedAt := inst.LesserBodyUpdateAt
-
-	if !mcpWiredAt.IsZero() && !bodyUpdatedAt.IsZero() && mcpWiredAt.Before(bodyUpdatedAt) {
-		return stackDriftWireStale
-	}
-
-	// If MCP has never been wired but body is present, it's unknown.
-	if mcpWiredAt.IsZero() {
-		return stackDriftUnknown
-	}
-
-	// Default: MCP wiring appears up-to-date.
 	return stackDriftOK
 }

--- a/internal/controlplane/handlers_operator_drift.go
+++ b/internal/controlplane/handlers_operator_drift.go
@@ -1,0 +1,32 @@
+package controlplane
+
+import (
+	"net/http"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+// handleOperatorInstancesDrift returns fleet-wide drift telemetry for all
+// active instances against the configured default target versions.
+// Operator JWT required. Response shape per Project 39 provisioning walk
+// Change 5.3.
+func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if err := requireOperator(ctx); err != nil {
+		return nil, err
+	}
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+
+	instances, appErr := s.listActiveInstances(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
+	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
+
+	resp := computeFleetDrift(instances, lesserTarget, bodyTarget)
+	return apptheory.JSON(http.StatusOK, resp)
+}

--- a/internal/controlplane/handlers_operator_drift.go
+++ b/internal/controlplane/handlers_operator_drift.go
@@ -8,9 +8,10 @@ import (
 )
 
 // handleOperatorInstancesDrift returns fleet-wide drift telemetry for all
-// active instances against the configured default target versions.
-// Operator JWT required. Response shape per Project 39 provisioning walk
-// Change 5.3.
+// active instances against the configured default target versions. Uses
+// UpdateJob + ProvisionJob + Instance evidence to compute per-component
+// drift, including MCP wired_against vs current_body. Operator JWT required.
+// Response shape per Project 39 provisioning walk Change 5.3.
 func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	if err := requireOperator(ctx); err != nil {
 		return nil, err
@@ -24,9 +25,11 @@ func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheor
 		return nil, appErr
 	}
 
+	evidence := gatherFleetEvidence(ctx, s, instances)
+
 	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
 	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
 
-	resp := computeFleetDrift(instances, lesserTarget, bodyTarget)
+	resp := computeFleetDrift(evidence, lesserTarget, bodyTarget)
 	return apptheory.JSON(http.StatusOK, resp)
 }

--- a/internal/controlplane/handlers_operator_endpoints_internal_test.go
+++ b/internal/controlplane/handlers_operator_endpoints_internal_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,11 +21,13 @@ import (
 // --- Helper types for operator test DB mocking ---
 
 type operatorEndpointTestDB struct {
-	db        *ttmocks.MockExtendedDB
-	qInstance *ttmocks.MockQuery
-	qJob      *ttmocks.MockQuery
-	qAudit    *ttmocks.MockQuery
-	qUpdate   *ttmocks.MockQuery
+	db                *ttmocks.MockExtendedDB
+	qInstance         *ttmocks.MockQuery
+	qJob              *ttmocks.MockQuery
+	qAudit            *ttmocks.MockQuery
+	qUpdate           *ttmocks.MockQuery
+	createdUpdateJobs *[]*models.UpdateJob
+	createdAuditLogs  *[]*models.AuditLogEntry
 }
 
 func newOperatorEndpointTestDB() operatorEndpointTestDB {
@@ -33,12 +36,22 @@ func newOperatorEndpointTestDB() operatorEndpointTestDB {
 	qJob := new(ttmocks.MockQuery)
 	qAudit := new(ttmocks.MockQuery)
 	qUpdate := new(ttmocks.MockQuery)
+	createdUpdateJobs := []*models.UpdateJob{}
+	createdAuditLogs := []*models.AuditLogEntry{}
 
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qJob).Maybe()
-	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
-	db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Run(func(args mock.Arguments) {
+		if entry, ok := args.Get(0).(*models.AuditLogEntry); ok && strings.TrimSpace(entry.Action) != "" {
+			createdAuditLogs = append(createdAuditLogs, entry)
+		}
+	}).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Run(func(args mock.Arguments) {
+		if job, ok := args.Get(0).(*models.UpdateJob); ok && strings.TrimSpace(job.ID) != "" {
+			createdUpdateJobs = append(createdUpdateJobs, job)
+		}
+	}).Maybe()
 	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 	for _, q := range []*ttmocks.MockQuery{qInstance, qJob, qAudit, qUpdate} {
@@ -49,12 +62,61 @@ func newOperatorEndpointTestDB() operatorEndpointTestDB {
 		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("Create").Return(nil).Maybe()
 		q.On("CreateOrUpdate").Return(nil).Maybe()
-		q.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Maybe()
-		q.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Maybe()
 		addStandardMockQueryStubs(q)
 	}
 
-	return operatorEndpointTestDB{db: db, qInstance: qInstance, qJob: qJob, qAudit: qAudit, qUpdate: qUpdate}
+	// Instance.First and ProvisionJob.First are NOT defaulted here — broad
+	// Maybe() expectations shadow the per-test Once() rows that remediation and
+	// provision-evidence tests need to consume. Tests that need a GetInstance or
+	// ProvisionJob row set up explicit Once() expectations. Tests without a
+	// ProvisionJobID never call GetProvisionJob (loadProvisionJobFallback bails
+	// early), and non-remediation tests never call getInstance.
+
+	// UpdateJob.All is NOT defaulted here either. Evidence gathering and active
+	// job listing both call All on qUpdate, so a broad default shadows explicit
+	// per-test rows. Tests that need empty update histories call
+	// expectEmptyUpdateJobRows with the exact number of history/list calls.
+
+	return operatorEndpointTestDB{
+		db:                db,
+		qInstance:         qInstance,
+		qJob:              qJob,
+		qAudit:            qAudit,
+		qUpdate:           qUpdate,
+		createdUpdateJobs: &createdUpdateJobs,
+		createdAuditLogs:  &createdAuditLogs,
+	}
+}
+
+func expectUpdateJobRows(t *testing.T, tdb operatorEndpointTestDB, rows []*models.UpdateJob) {
+	t.Helper()
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = append([]*models.UpdateJob(nil), rows...)
+	}).Once()
+}
+
+func expectEmptyUpdateJobRows(t *testing.T, tdb operatorEndpointTestDB, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		expectUpdateJobRows(t, tdb, nil)
+	}
+}
+
+func createdUpdateJobs(t *testing.T, tdb operatorEndpointTestDB) []*models.UpdateJob {
+	t.Helper()
+	if tdb.createdUpdateJobs == nil {
+		return nil
+	}
+	return *tdb.createdUpdateJobs
+}
+
+func createdAuditLogs(t *testing.T, tdb operatorEndpointTestDB) []*models.AuditLogEntry {
+	t.Helper()
+	if tdb.createdAuditLogs == nil {
+		return nil
+	}
+	return *tdb.createdAuditLogs
 }
 
 func operatorAuthenticatedCtx() *apptheory.Context {
@@ -85,6 +147,36 @@ func makeInstance(slug, lesserVer, bodyVer string, bodyUpdateAt, mcpWiredAt time
 	}
 }
 
+func instanceWithProvisionJob(slug, lesserVer, provisionJobID string, updatedAt time.Time) *models.Instance {
+	return &models.Instance{
+		Slug:             slug,
+		Owner:            "alice",
+		Status:           models.InstanceStatusActive,
+		LesserVersion:    lesserVer,
+		ProvisionJobID:   provisionJobID,
+		UpdatedAt:        updatedAt,
+		HostedAccountID:  "123456789012",
+		HostedRegion:     "us-east-1",
+		HostedBaseDomain: slug + ".greater.website",
+	}
+}
+
+func instanceFull(slug, lesserVer, bodyVer, provisionJobID string, updatedAt time.Time) *models.Instance {
+	return &models.Instance{
+		Slug:               slug,
+		Owner:              "alice",
+		Status:             models.InstanceStatusActive,
+		LesserVersion:      lesserVer,
+		LesserBodyVersion:  bodyVer,
+		ProvisionJobID:     provisionJobID,
+		LesserBodyUpdateAt: updatedAt,
+		UpdatedAt:          updatedAt,
+		HostedAccountID:    "123456789012",
+		HostedRegion:       "us-east-1",
+		HostedBaseDomain:   slug + ".greater.website",
+	}
+}
+
 // --- #434: Operator releases endpoint ---
 
 func TestHandleOperatorReleases_HappyPath(t *testing.T) {
@@ -97,14 +189,47 @@ func TestHandleOperatorReleases_HappyPath(t *testing.T) {
 	}}
 
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	early := now.Add(-24 * time.Hour)
 
 	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
 		*dest = []*models.Instance{
-			makeInstance("alpha", "v1.4.2", "v0.3.0", now, now),
-			makeInstance("beta", "v1.4.1", "v0.2.9", now.Add(-time.Hour), now.Add(-time.Hour)),
-			makeInstance("gamma", "v1.4.2", "v0.3.0", now, now),
-			makeInstance("delta", "v1.4.2", "v0.2.9", now, now.Add(-time.Hour)),
+			instanceWithProvisionJob("alpha", "v1.4.2", "prov-alpha", now),
+			instanceWithProvisionJob("beta", "v1.4.1", "prov-beta", early),
+			instanceWithProvisionJob("gamma", "v1.4.2", "prov-gamma", now),
+		}
+	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 3)
+
+	// Provision jobs: variation — alpha got deployed earlier than instance says.
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:            "prov-alpha",
+			InstanceSlug:  "alpha",
+			Status:        models.ProvisionJobStatusOK,
+			LesserVersion: "v1.4.2",
+			UpdatedAt:     early, // earlier than instance.UpdatedAt
+		}
+	}).Once()
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:            "prov-beta",
+			InstanceSlug:  "beta",
+			Status:        models.ProvisionJobStatusOK,
+			LesserVersion: "v1.4.1",
+			UpdatedAt:     early,
+		}
+	}).Once()
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:            "prov-gamma",
+			InstanceSlug:  "gamma",
+			Status:        models.ProvisionJobStatusOK,
+			LesserVersion: "v1.4.2",
+			UpdatedAt:     now,
 		}
 	}).Once()
 
@@ -115,27 +240,19 @@ func TestHandleOperatorReleases_HappyPath(t *testing.T) {
 
 	var body operatorReleasesResponse
 	require.NoError(t, json.Unmarshal(resp.Body, &body))
-	require.Equal(t, 4, body.FleetTotal)
+	require.Equal(t, 3, body.FleetTotal)
 	require.Len(t, body.Channels, 2)
 
 	lesserCh := findChannel(body.Channels, "lesser")
 	require.NotNil(t, lesserCh)
 	require.Len(t, lesserCh.Versions, 2)
-	// v1.4.2 should be first (newest) and is_latest.
+	// v1.4.2 is newest and marked is_latest.
 	require.Equal(t, "v1.4.2", lesserCh.Versions[0].Version)
 	require.True(t, lesserCh.Versions[0].IsLatest)
-	require.Equal(t, 3, lesserCh.Versions[0].Adoption.Instances)
-	require.Equal(t, 75, lesserCh.Versions[0].Adoption.Percent)
+	require.Equal(t, 2, lesserCh.Versions[0].Adoption.Instances)
 	require.Equal(t, "v1.4.1", lesserCh.Versions[1].Version)
 	require.False(t, lesserCh.Versions[1].IsLatest)
 	require.Equal(t, 1, lesserCh.Versions[1].Adoption.Instances)
-
-	bodyCh := findChannel(body.Channels, "lesser-body")
-	require.NotNil(t, bodyCh)
-	require.Len(t, bodyCh.Versions, 2)
-	require.Equal(t, "v0.3.0", bodyCh.Versions[0].Version)
-	require.True(t, bodyCh.Versions[0].IsLatest)
-	require.Equal(t, 2, bodyCh.Versions[0].Adoption.Instances)
 }
 
 func TestHandleOperatorReleases_NoInstances(t *testing.T) {
@@ -197,9 +314,20 @@ func TestHandleOperatorReleases_FiltersInactive(t *testing.T) {
 	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
 		*dest = []*models.Instance{
-			makeInstance("active-a", "v1.4.2", "", time.Time{}, time.Time{}),
+			instanceWithProvisionJob("active-a", "v1.4.2", "prov-a", time.Now()),
 			{Slug: "disabled-b", Status: models.InstanceStatusDisabled, LesserVersion: "v1.4.1"},
 			{Slug: "", Status: models.InstanceStatusActive}, // empty slug, filtered
+		}
+	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 1)
+
+	// Only active-a gets evidence queries.
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID: "prov-a", InstanceSlug: "active-a",
+			Status: models.ProvisionJobStatusOK, LesserVersion: "v1.4.2",
+			UpdatedAt: time.Now(),
 		}
 	}).Once()
 
@@ -213,12 +341,150 @@ func TestHandleOperatorReleases_FiltersInactive(t *testing.T) {
 	require.Equal(t, 1, body.FleetTotal)
 }
 
+// TestHandleOperatorReleases_UsesProvisionJobTimestamps is the Blocker 1
+// regression: Instance-only aggregation would give released_at from
+// Instance.UpdatedAt (T2, late), but the ProvisionJob has an earlier
+// UpdatedAt (T1, early). The evidence-based path uses T1, proving it
+// reads from ProvisionJob, not just Instance fields.
+func TestHandleOperatorReleases_UsesProvisionJobTimestamps(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion: "v1.4.2",
+	}}
+
+	earlyProv := time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC)
+	lateInstance := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:            "late-marker",
+				Owner:           "alice",
+				Status:          models.InstanceStatusActive,
+				LesserVersion:   "v1.4.0",
+				ProvisionJobID:  "prov-late",
+				UpdatedAt:       lateInstance,
+				HostedAccountID: "123456789012",
+			},
+		}
+	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 1)
+
+	// ProvisionJob has updatedAt=earlyProv (T1), earlier than instance.UpdatedAt (T2).
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:            "prov-late",
+			InstanceSlug:  "late-marker",
+			Status:        models.ProvisionJobStatusOK,
+			LesserVersion: "v1.4.0",
+			UpdatedAt:     earlyProv,
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorReleases(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body operatorReleasesResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 1, body.FleetTotal)
+
+	lesserCh := findChannel(body.Channels, "lesser")
+	require.NotNil(t, lesserCh)
+	require.Len(t, lesserCh.Versions, 1)
+	require.Equal(t, "v1.4.0", lesserCh.Versions[0].Version)
+
+	// released_at must be from ProvisionJob (T1, early), NOT from Instance (T2, late).
+	require.Equal(t, earlyProv.UTC().Format(time.RFC3339), lesserCh.Versions[0].ReleasedAt,
+		"released_at should come from ProvisionJob evidence, not Instance.UpdatedAt")
+}
+
+func TestHandleOperatorReleases_AggregatesUpdateProvisionAndInstanceEvidence(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion: "v1.4.2",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	earlyProv := now.Add(-48 * time.Hour)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			// Instance marker is stale; successful update evidence should win.
+			{Slug: "from-update", Owner: "alice", Status: models.InstanceStatusActive, LesserVersion: "v1.4.0", UpdatedAt: now},
+			// ProvisionJob evidence should win over the instance marker.
+			{Slug: "from-provision", Owner: "alice", Status: models.InstanceStatusActive, LesserVersion: "v1.4.0", ProvisionJobID: "prov-evidence", UpdatedAt: now},
+			// No job evidence: instance state is the fallback.
+			{Slug: "from-instance", Owner: "alice", Status: models.InstanceStatusActive, LesserVersion: "v1.3.9", UpdatedAt: now},
+		}
+	}).Once()
+
+	expectUpdateJobRows(t, tdb, []*models.UpdateJob{{
+		ID:            "upd-lesser-1",
+		InstanceSlug:  "from-update",
+		Status:        models.UpdateJobStatusOK,
+		LesserVersion: "v1.4.2",
+		UpdatedAt:     now.Add(-1 * time.Hour),
+	}})
+	expectEmptyUpdateJobRows(t, tdb, 2)
+
+	tdb.qJob.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.ProvisionJob](t, args, 0)
+		*dest = models.ProvisionJob{
+			ID:            "prov-evidence",
+			InstanceSlug:  "from-provision",
+			Status:        models.ProvisionJobStatusOK,
+			LesserVersion: "v1.4.1",
+			UpdatedAt:     earlyProv,
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorReleases(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body operatorReleasesResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 3, body.FleetTotal)
+
+	lesserCh := findChannel(body.Channels, "lesser")
+	require.NotNil(t, lesserCh)
+	require.Len(t, lesserCh.Versions, 3)
+	require.Equal(t, 1, findReleaseVersion(t, lesserCh, "v1.4.2").Adoption.Instances,
+		"successful UpdateJob evidence must contribute adoption")
+	require.Equal(t, 1, findReleaseVersion(t, lesserCh, "v1.4.1").Adoption.Instances,
+		"successful ProvisionJob evidence must contribute adoption")
+	require.Equal(t, 1, findReleaseVersion(t, lesserCh, "v1.3.9").Adoption.Instances,
+		"Instance state remains the fallback when no job evidence exists")
+}
+
 func findChannel(channels []operatorReleaseChannel, id string) *operatorReleaseChannel {
 	for i := range channels {
 		if channels[i].ID == id {
 			return &channels[i]
 		}
 	}
+	return nil
+}
+
+func findReleaseVersion(t *testing.T, channel *operatorReleaseChannel, version string) *operatorReleaseVersion {
+	t.Helper()
+	require.NotNil(t, channel)
+	for i := range channel.Versions {
+		if channel.Versions[i].Version == version {
+			return &channel.Versions[i]
+		}
+	}
+	require.Failf(t, "version missing", "version %q not found in channel %q", version, channel.ID)
 	return nil
 }
 
@@ -242,6 +508,7 @@ func TestHandleOperatorInstancesDrift_AllOK(t *testing.T) {
 			makeInstance("ok2", "v1.4.2", "v0.3.0", now, now),
 		}
 	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 2)
 
 	ctx := operatorAuthenticatedCtx()
 	resp, err := s.handleOperatorInstancesDrift(ctx)
@@ -273,6 +540,7 @@ func TestHandleOperatorInstancesDrift_LesserStale(t *testing.T) {
 			makeInstance("ok1", "v1.4.2", "", now, time.Time{}),
 		}
 	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 2)
 
 	ctx := operatorAuthenticatedCtx()
 	resp, err := s.handleOperatorInstancesDrift(ctx)
@@ -302,6 +570,7 @@ func TestHandleOperatorInstancesDrift_BodyStale(t *testing.T) {
 			makeInstance("oldbody", "", "v0.2.5", now, time.Time{}),
 		}
 	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 1)
 
 	ctx := operatorAuthenticatedCtx()
 	resp, err := s.handleOperatorInstancesDrift(ctx)
@@ -313,7 +582,13 @@ func TestHandleOperatorInstancesDrift_BodyStale(t *testing.T) {
 	require.Equal(t, 1, body.Summary.BodyStale)
 }
 
-func TestHandleOperatorInstancesDrift_MCPWireStale(t *testing.T) {
+// TestHandleOperatorInstancesDrift_MCPWireStaleEvidence is the Blocker 2
+// doc-shaped regression: body deployed at v0.2.6 (from latest body update job),
+// MCP last wired against v0.2.5 (from latest MCP-only update job). Response
+// shows wired_against=v0.2.5, current_body=v0.2.6, drift=wire-stale.
+// This FAILS with the old timestamp-only heuristic because timestamps alone
+// can't distinguish which body version MCP was wired against.
+func TestHandleOperatorInstancesDrift_MCPWireStaleEvidence(t *testing.T) {
 	t.Parallel()
 
 	tdb := newOperatorEndpointTestDB()
@@ -322,21 +597,44 @@ func TestHandleOperatorInstancesDrift_MCPWireStale(t *testing.T) {
 	}}
 
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
-	// MCP wired before body update → wire-stale.
-	mcpTime := now.Add(-24 * time.Hour)
-	bodyTime := now
 
 	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
 		*dest = []*models.Instance{
 			{
-				Slug:               "wired-stale",
+				Slug:               "wire-stale-ev",
 				Owner:              "alice",
 				Status:             models.InstanceStatusActive,
-				LesserBodyVersion:  "v0.3.0",
-				LesserBodyUpdateAt: bodyTime,
-				McpWiredAt:         mcpTime,
-				UpdatedAt:          bodyTime,
+				LesserBodyVersion:  "v0.2.6",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         now,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+			},
+		}
+	}).Once()
+
+	// Body update job deployed v0.2.6.
+	// MCP-only update job wired against v0.2.5.
+	// Evidence layer takes the latest per kind, so wire-stale shows.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID:                "upd-body-1",
+				InstanceSlug:      "wire-stale-ev",
+				Status:            models.UpdateJobStatusOK,
+				BodyOnly:          true,
+				LesserBodyVersion: "v0.2.6",
+				UpdatedAt:         now.Add(-1 * time.Hour),
+			},
+			{
+				ID:                "upd-mcp-1",
+				InstanceSlug:      "wire-stale-ev",
+				Status:            models.UpdateJobStatusOK,
+				MCPOnly:           true,
+				LesserBodyVersion: "v0.2.5",
+				UpdatedAt:         now.Add(-2 * time.Hour),
 			},
 		}
 	}).Once()
@@ -348,7 +646,15 @@ func TestHandleOperatorInstancesDrift_MCPWireStale(t *testing.T) {
 
 	var body fleetDriftResponse
 	require.NoError(t, json.Unmarshal(resp.Body, &body))
-	require.Equal(t, 1, body.Summary.MCPWireStale)
+	require.Equal(t, 1, body.Summary.Total)
+	require.Equal(t, 1, body.Summary.MCPWireStale, "MCP should be wire-stale")
+
+	entry := body.Instances[0]
+	require.Equal(t, "v0.2.5", entry.MCP.WiredAgainst,
+		"wired_against should be from MCP-only update job (v0.2.5)")
+	require.Equal(t, "v0.2.6", entry.MCP.CurrentBody,
+		"current_body should be from body update job (v0.2.6)")
+	require.Equal(t, stackDriftWireStale, entry.MCP.Drift)
 }
 
 func TestHandleOperatorInstancesDrift_UnknownTargetVersion(t *testing.T) {
@@ -366,6 +672,7 @@ func TestHandleOperatorInstancesDrift_UnknownTargetVersion(t *testing.T) {
 			makeInstance("x", "v1.4.2", "v0.3.0", now, now),
 		}
 	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 1)
 
 	ctx := operatorAuthenticatedCtx()
 	resp, err := s.handleOperatorInstancesDrift(ctx)
@@ -416,6 +723,7 @@ func TestHandleOperatorRemediateMCPDrift_NoWireStale(t *testing.T) {
 			makeInstance("ok1", "v1.4.2", "v0.3.0", now, now),
 		}
 	}).Once()
+	expectEmptyUpdateJobRows(t, tdb, 1)
 
 	ctx := operatorAuthenticatedCtx()
 	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
@@ -429,22 +737,268 @@ func TestHandleOperatorRemediateMCPDrift_NoWireStale(t *testing.T) {
 	require.Equal(t, 0, body.Skipped)
 }
 
-func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
+// TestHandleOperatorRemediateMCPDrift_VersionFromDeployedBody is the Blocker 3
+// regression: ManagedLesserBodyDefaultVersion is "v0.4.0" (config target), but
+// deployed current body is "v0.2.5" (from drift evidence). The created MCP-only
+// UpdateJob must use v0.2.5 (deployed), NOT v0.4.0 (config target).
+func TestHandleOperatorRemediateMCPDrift_VersionFromDeployedBody(t *testing.T) {
 	t.Parallel()
 
 	tdb := newOperatorEndpointTestDB()
 
-	// Set up Instance scan + getInstance + no active MCP jobs (GSI2 empty).
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion:     "v1.4.2",
+		ManagedLesserBodyDefaultVersion: "v0.4.0", // config target — must NOT be used
+		ManagedInstanceRoleName:         "ManagedInstanceRole",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Fleets scan: one instance with body v0.2.5 deployed, MCP wired against v0.2.4.
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:               "deployed-025",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.2.5",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         now,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "deployed-025.greater.website",
+				LesserVersion:      "v1.4.2",
+			},
+		}
+	}).Once()
+
+	// Evidence: body update job deployed v0.2.5, MCP job wired v0.2.4 → wire-stale.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID:                "upd-body-1",
+				InstanceSlug:      "deployed-025",
+				Status:            models.UpdateJobStatusOK,
+				BodyOnly:          true,
+				LesserBodyVersion: "v0.2.5",
+				UpdatedAt:         now.Add(-1 * time.Hour),
+			},
+			{
+				ID:                "upd-mcp-1",
+				InstanceSlug:      "deployed-025",
+				Status:            models.UpdateJobStatusOK,
+				MCPOnly:           true,
+				LesserBodyVersion: "v0.2.4",
+				UpdatedAt:         now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
+	// GSI2 active jobs: empty (no existing MCP-only jobs).
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{}
+	}).Once()
+
+	// getInstance for remediation.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:                           "deployed-025",
+			Owner:                          "alice",
+			Status:                         models.InstanceStatusActive,
+			LesserBodyVersion:              "v0.2.5",
+			HostedAccountID:                "123456789012",
+			HostedRegion:                   "us-east-1",
+			HostedBaseDomain:               "deployed-025.greater.website",
+			LesserHostInstanceKeySecretARN: "",
+			LesserVersion:                  "v1.4.2",
+		}
+	}).Once()
+
+	// Job creation — the created job's LesserBodyVersion must be the
+	// deployed body version (v0.2.5), not config target (v0.4.0).
+	// We verify this indirectly: the drift entry's Body.Current is v0.2.5,
+	// and the handler creates a job (confirmed by AssertCalled below).
+	tdb.qUpdate.On("Create").Return(nil).Once()
+
+	tdb.qAudit.On("Create").Return(nil).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.CreatedJobIDs, 1)
+	require.Equal(t, 1, body.Created)
+	require.Equal(t, 0, body.Skipped)
+
+	// Verify the UpdateJob was created. We check Mock.AssertExpectations
+	// to confirm qUpdate.Create was called exactly once.
+	tdb.qUpdate.AssertCalled(t, "Create")
+
+	jobs := createdUpdateJobs(t, tdb)
+	require.Len(t, jobs, 1)
+	require.True(t, jobs[0].MCPOnly)
+	require.Equal(t, "v0.2.5", jobs[0].LesserBodyVersion,
+		"MCP remediation must wire against deployed current_body, not config target v0.4.0")
+}
+
+// TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList is the Blocker 3
+// regression: the audit record must include the affected slug list, not just a
+// count. Pre-rework, the audit Target was "fleet:mcp-remediation:N-slugs";
+// post-rework, it must be "fleet:mcp-remediation:slugs=slug1,slug2;jobs=job1,job2".
+func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+
 	s := &Server{store: store.New(tdb.db), cfg: config.Config{
 		ManagedLesserBodyDefaultVersion: "v0.3.0",
 		ManagedInstanceRoleName:         "ManagedInstanceRole",
 	}}
 
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
-	mcpTime := now.Add(-24 * time.Hour)
-	bodyTime := now
 
-	// Instance scan for drift.
+	// Two wire-stale instances.
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:               "ws-audit-1",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         now,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "ws-audit-1.greater.website",
+				LesserVersion:      "v1.4.2",
+			},
+			{
+				Slug:               "ws-audit-2",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         now,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "ws-audit-2.greater.website",
+				LesserVersion:      "v1.4.2",
+			},
+		}
+	}).Once()
+
+	// Evidence for ws-audit-1: body v0.3.0 deployed, MCP v0.2.9 → wire-stale.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID: "b1", InstanceSlug: "ws-audit-1", Status: models.UpdateJobStatusOK,
+				BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+			},
+			{
+				ID: "m1", InstanceSlug: "ws-audit-1", Status: models.UpdateJobStatusOK,
+				MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
+	// Evidence for ws-audit-2: body v0.3.0 deployed, MCP v0.2.9 → wire-stale.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID: "b2", InstanceSlug: "ws-audit-2", Status: models.UpdateJobStatusOK,
+				BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+			},
+			{
+				ID: "m2", InstanceSlug: "ws-audit-2", Status: models.UpdateJobStatusOK,
+				MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
+	// GSI2 active jobs: empty.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{}
+	}).Once()
+
+	// getInstance for ws-audit-1.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug: "ws-audit-1", Owner: "alice", Status: models.InstanceStatusActive,
+			LesserBodyVersion: "v0.3.0", HostedAccountID: "123456789012",
+			HostedRegion: "us-east-1", HostedBaseDomain: "ws-audit-1.greater.website",
+			LesserHostInstanceKeySecretARN: "", LesserVersion: "v1.4.2",
+		}
+	}).Once()
+
+	// getInstance for ws-audit-2.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug: "ws-audit-2", Owner: "alice", Status: models.InstanceStatusActive,
+			LesserBodyVersion: "v0.3.0", HostedAccountID: "123456789012",
+			HostedRegion: "us-east-1", HostedBaseDomain: "ws-audit-2.greater.website",
+			LesserHostInstanceKeySecretARN: "", LesserVersion: "v1.4.2",
+		}
+	}).Once()
+
+	// Two UpdateJob creates.
+	tdb.qUpdate.On("Create").Return(nil).Once()
+	tdb.qUpdate.On("Create").Return(nil).Once()
+
+	// Capture happens in the DB.Model recorder; Create remains a no-op.
+	tdb.qAudit.On("Create").Return(nil).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.CreatedJobIDs, 2)
+	require.Equal(t, 2, body.Created)
+	require.Equal(t, 0, body.Skipped)
+
+	// Verify audit was called.
+	tdb.qAudit.AssertCalled(t, "Create")
+
+	audits := createdAuditLogs(t, tdb)
+	require.Len(t, audits, 1)
+	require.Contains(t, audits[0].Target, "slugs=ws-audit-1,ws-audit-2")
+	require.Contains(t, audits[0].Target, ";jobs=")
+	for _, id := range body.CreatedJobIDs {
+		require.Contains(t, audits[0].Target, id)
+	}
+}
+
+func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+		ManagedInstanceRoleName:         "ManagedInstanceRole",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	// Instance scan: one wire-stale instance.
 	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
 		*dest = []*models.Instance{
@@ -453,37 +1007,51 @@ func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
 				Owner:              "alice",
 				Status:             models.InstanceStatusActive,
 				LesserBodyVersion:  "v0.3.0",
-				LesserBodyUpdateAt: bodyTime,
-				McpWiredAt:         mcpTime,
-				UpdatedAt:          bodyTime,
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         now,
+				UpdatedAt:          now,
 				HostedAccountID:    "123456789012",
 				HostedRegion:       "us-east-1",
 				HostedBaseDomain:   "wired-stale.greater.website",
+				LesserVersion:      "v1.4.2",
 			},
 		}
 	}).Once()
 
-	// GSI2 active jobs: empty (no existing MCP-only jobs).
+	// Evidence: body v0.3.0 deployed, MCP wired v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID: "b1", InstanceSlug: "wired-stale", Status: models.UpdateJobStatusOK,
+				BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+			},
+			{
+				ID: "m1", InstanceSlug: "wired-stale", Status: models.UpdateJobStatusOK,
+				MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
+	// GSI2 active jobs: empty.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
 		*dest = []*models.UpdateJob{}
 	}).Once()
 
-	// getInstance call for the wire-stale slug.
+	// getInstance for wired-stale.
 	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
 		*dest = models.Instance{
-			Slug:                           "wired-stale",
-			Owner:                          "alice",
-			Status:                         models.InstanceStatusActive,
-			LesserBodyVersion:              "v0.3.0",
-			HostedAccountID:                "123456789012",
-			HostedRegion:                   "us-east-1",
-			HostedBaseDomain:               "wired-stale.greater.website",
-			LesserHostInstanceKeySecretARN: "",
-			LesserVersion:                  "v1.4.2",
+			Slug: "wired-stale", Owner: "alice", Status: models.InstanceStatusActive,
+			LesserBodyVersion: "v0.3.0", HostedAccountID: "123456789012",
+			HostedRegion: "us-east-1", HostedBaseDomain: "wired-stale.greater.website",
+			LesserHostInstanceKeySecretARN: "", LesserVersion: "v1.4.2",
 		}
 	}).Once()
+
+	// UpdateJob create.
+	tdb.qUpdate.On("Create").Return(nil).Once()
 
 	// Audit.
 	tdb.qAudit.On("Create").Return(nil).Once()
@@ -511,7 +1079,6 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 	}}
 
 	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
-	mcpTime := now.Add(-24 * time.Hour)
 
 	// Instance scan: two wire-stale instances.
 	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
@@ -523,7 +1090,7 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 				Status:             models.InstanceStatusActive,
 				LesserBodyVersion:  "v0.3.0",
 				LesserBodyUpdateAt: now,
-				McpWiredAt:         mcpTime,
+				McpWiredAt:         now,
 				UpdatedAt:          now,
 				HostedAccountID:    "123456789012",
 				HostedRegion:       "us-east-1",
@@ -535,7 +1102,7 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 				Status:             models.InstanceStatusActive,
 				LesserBodyVersion:  "v0.3.0",
 				LesserBodyUpdateAt: now,
-				McpWiredAt:         mcpTime,
+				McpWiredAt:         now,
 				UpdatedAt:          now,
 				HostedAccountID:    "123456789012",
 				HostedRegion:       "us-east-1",
@@ -544,9 +1111,39 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 		}
 	}).Once()
 
+	// Evidence for ws-1: body v0.3.0, MCP v0.2.9 → wire-stale.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID: "b1", InstanceSlug: "ws-1", Status: models.UpdateJobStatusOK,
+				BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+			},
+			{
+				ID: "m1", InstanceSlug: "ws-1", Status: models.UpdateJobStatusOK,
+				MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
+	// Evidence for ws-2: body v0.3.0, MCP v0.2.9 → wire-stale.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := args.Get(0).(*[]*models.UpdateJob)
+		*dest = []*models.UpdateJob{
+			{
+				ID: "b2", InstanceSlug: "ws-2", Status: models.UpdateJobStatusOK,
+				BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+			},
+			{
+				ID: "m2", InstanceSlug: "ws-2", Status: models.UpdateJobStatusOK,
+				MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+			},
+		}
+	}).Once()
+
 	// GSI2 active jobs: ws-1 already has an active MCP-only job.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		dest := args.Get(0).(*[]*models.UpdateJob)
 		*dest = []*models.UpdateJob{
 			{
 				ID:           "existing-mcp-1",
@@ -557,20 +1154,14 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 		}
 	}).Once()
 
-	// Only ws-2 should get a new job; ws-1 is skipped.
-	// getInstance for ws-2.
+	// Only ws-2 gets remediation. getInstance for ws-2.
 	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
 		*dest = models.Instance{
-			Slug:                           "ws-2",
-			Owner:                          "alice",
-			Status:                         models.InstanceStatusActive,
-			LesserBodyVersion:              "v0.3.0",
-			HostedAccountID:                "123456789012",
-			HostedRegion:                   "us-east-1",
-			HostedBaseDomain:               "ws-2.greater.website",
-			LesserHostInstanceKeySecretARN: "",
-			LesserVersion:                  "v1.4.2",
+			Slug: "ws-2", Owner: "alice", Status: models.InstanceStatusActive,
+			LesserBodyVersion: "v0.3.0", HostedAccountID: "123456789012",
+			HostedRegion: "us-east-1", HostedBaseDomain: "ws-2.greater.website",
+			LesserHostInstanceKeySecretARN: "", LesserVersion: "v1.4.2",
 		}
 	}).Once()
 
@@ -590,6 +1181,8 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 	require.Len(t, body.CreatedJobIDs, 1)
 	require.Equal(t, 1, body.Created)
 	require.Equal(t, 1, body.Skipped)
+	tdb.qUpdate.AssertCalled(t, "Index", "gsi2")
+	tdb.qUpdate.AssertCalled(t, "Where", "gsi2PK", "=", "UPDATE_ACTIVE")
 }
 
 func TestHandleOperatorRemediateMCPDrift_Unauthorized(t *testing.T) {
@@ -625,6 +1218,23 @@ func TestComputeComponentDrift(t *testing.T) {
 	}
 	if got := computeComponentDrift("v1.4.2", ""); got != stackDriftUnknown {
 		t.Fatalf("empty target: got %q, want %q", got, stackDriftUnknown)
+	}
+}
+
+func TestComputeMCPEvidenceDrift(t *testing.T) {
+	t.Parallel()
+
+	if got := computeMCPEvidenceDrift("v0.2.5", "v0.2.6"); got != stackDriftWireStale {
+		t.Fatalf("different versions: got %q, want %q", got, stackDriftWireStale)
+	}
+	if got := computeMCPEvidenceDrift("v0.2.6", "v0.2.6"); got != stackDriftOK {
+		t.Fatalf("same version: got %q, want %q", got, stackDriftOK)
+	}
+	if got := computeMCPEvidenceDrift("", "v0.2.6"); got != stackDriftUnknown {
+		t.Fatalf("empty wired_against: got %q, want %q", got, stackDriftUnknown)
+	}
+	if got := computeMCPEvidenceDrift("v0.2.5", ""); got != stackDriftUnknown {
+		t.Fatalf("empty current_body: got %q, want %q", got, stackDriftUnknown)
 	}
 }
 
@@ -664,10 +1274,10 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
-func TestComputeFleetDrift_EmptyInstances(t *testing.T) {
+func TestComputeFleetDrift_EmptyEvidence(t *testing.T) {
 	t.Parallel()
 
-	resp := computeFleetDrift([]*models.Instance{}, "v1.4.2", "v0.3.0")
+	resp := computeFleetDrift([]*instanceJobsEvidence{}, "v1.4.2", "v0.3.0")
 	require.Empty(t, resp.Instances)
 	require.Equal(t, 0, resp.Summary.Total)
 }
@@ -677,12 +1287,181 @@ func TestBuildOperatorReleasesResponse_EmptyStringVersionsIgnored(t *testing.T) 
 
 	// Instance with empty LesserVersion should be counted in fleet_total
 	// but not attributed to any version.
-	instances := []*models.Instance{
-		{Slug: "no-version", Owner: "alice", Status: models.InstanceStatusActive},
+	inst := &models.Instance{Slug: "no-version", Owner: "alice", Status: models.InstanceStatusActive}
+	evidence := []*instanceJobsEvidence{
+		{instance: inst},
 	}
 
-	resp := buildOperatorReleasesResponse(instances, "v1.4.2", "v0.3.0")
+	resp := buildOperatorReleasesResponse(evidence, "v1.4.2", "v0.3.0")
 	require.Equal(t, 1, resp.FleetTotal)
 	require.Empty(t, resp.Channels[0].Versions)
 	require.Empty(t, resp.Channels[1].Versions)
+}
+
+// --- Evidence helper unit tests ---
+
+func TestGatherInstanceJobsEvidence_KeepsNewestSuccessfulPerKind(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	inst := &models.Instance{Slug: "newest-wins", Status: models.InstanceStatusActive}
+
+	expectUpdateJobRows(t, tdb, []*models.UpdateJob{
+		{
+			ID:                "body-new",
+			InstanceSlug:      "newest-wins",
+			Status:            models.UpdateJobStatusOK,
+			BodyOnly:          true,
+			LesserBodyVersion: "v0.3.0",
+			CreatedAt:         now,
+			UpdatedAt:         now,
+		},
+		{
+			ID:                "body-old",
+			InstanceSlug:      "newest-wins",
+			Status:            models.UpdateJobStatusOK,
+			BodyOnly:          true,
+			LesserBodyVersion: "v0.2.9",
+			CreatedAt:         now.Add(-24 * time.Hour),
+			UpdatedAt:         now.Add(-24 * time.Hour),
+		},
+		{
+			ID:                "mcp-new",
+			InstanceSlug:      "newest-wins",
+			Status:            models.UpdateJobStatusOK,
+			MCPOnly:           true,
+			LesserBodyVersion: "v0.2.9",
+			CreatedAt:         now,
+			UpdatedAt:         now,
+		},
+		{
+			ID:                "mcp-old",
+			InstanceSlug:      "newest-wins",
+			Status:            models.UpdateJobStatusOK,
+			MCPOnly:           true,
+			LesserBodyVersion: "v0.2.8",
+			CreatedAt:         now.Add(-24 * time.Hour),
+			UpdatedAt:         now.Add(-24 * time.Hour),
+		},
+		{
+			ID:            "lesser-new",
+			InstanceSlug:  "newest-wins",
+			Status:        models.UpdateJobStatusOK,
+			LesserVersion: "v1.4.2",
+			CreatedAt:     now,
+			UpdatedAt:     now,
+		},
+		{
+			ID:            "lesser-old",
+			InstanceSlug:  "newest-wins",
+			Status:        models.UpdateJobStatusOK,
+			LesserVersion: "v1.4.1",
+			CreatedAt:     now.Add(-24 * time.Hour),
+			UpdatedAt:     now.Add(-24 * time.Hour),
+		},
+	})
+
+	ev := gatherInstanceJobsEvidence(operatorAuthenticatedCtx(), s, inst)
+	require.NotNil(t, ev)
+	require.Equal(t, "body-new", ev.latestBodyUpdate.ID)
+	require.Equal(t, "mcp-new", ev.latestMCPUpdate.ID)
+	require.Equal(t, "lesser-new", ev.latestLesserUpdate.ID)
+}
+
+func TestLesserVersionFromEvidence_UpdateJobPreferred(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserVersion: "v1.0.0", UpdatedAt: now},
+		latestLesserUpdate: &models.UpdateJob{
+			LesserVersion: "v1.2.0",
+			UpdatedAt:     now.Add(-1 * time.Hour),
+		},
+		provisionJob: &models.ProvisionJob{
+			LesserVersion: "v0.9.0",
+			UpdatedAt:     now.Add(-24 * time.Hour),
+		},
+	}
+
+	require.Equal(t, "v1.2.0", lesserVersionFromEvidence(ev))
+}
+
+func TestLesserVersionFromEvidence_ProvisionFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserVersion: "v1.0.0", UpdatedAt: now},
+		provisionJob: &models.ProvisionJob{
+			LesserVersion: "v0.9.0",
+			UpdatedAt:     now.Add(-24 * time.Hour),
+		},
+	}
+
+	require.Equal(t, "v0.9.0", lesserVersionFromEvidence(ev))
+}
+
+func TestLesserVersionFromEvidence_InstanceFallback(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserVersion: "v1.0.0", UpdatedAt: now},
+	}
+
+	require.Equal(t, "v1.0.0", lesserVersionFromEvidence(ev))
+}
+
+func TestMCPWiredAgainstFromEvidence_MCPUpdatePreferred(t *testing.T) {
+	t.Parallel()
+
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserBodyVersion: "v0.3.0"},
+		latestMCPUpdate: &models.UpdateJob{
+			LesserBodyVersion: "v0.2.5",
+		},
+	}
+
+	require.Equal(t, "v0.2.5", mcpWiredAgainstFromEvidence(ev))
+}
+
+func TestMCPWiredAgainstFromEvidence_NoMCPUpdateEvidence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserBodyVersion: "v0.3.0", McpWiredAt: now},
+		provisionJob: &models.ProvisionJob{
+			McpWiredAt: now.Add(-24 * time.Hour),
+		},
+	}
+
+	require.Empty(t, mcpWiredAgainstFromEvidence(ev),
+		"wired_against should only come from successful MCP-only UpdateJob evidence")
+}
+
+func TestBodyVersionFromEvidence_BodyUpdatePreferred(t *testing.T) {
+	t.Parallel()
+
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserBodyVersion: "v0.3.0"},
+		latestBodyUpdate: &models.UpdateJob{
+			LesserBodyVersion: "v0.2.6",
+		},
+	}
+
+	require.Equal(t, "v0.2.6", bodyVersionFromEvidence(ev))
+}
+
+func TestBodyVersionFromEvidence_InstanceFallback(t *testing.T) {
+	t.Parallel()
+
+	ev := &instanceJobsEvidence{
+		instance: &models.Instance{LesserBodyVersion: "v0.3.0"},
+	}
+
+	require.Equal(t, "v0.3.0", bodyVersionFromEvidence(ev))
 }

--- a/internal/controlplane/handlers_operator_endpoints_internal_test.go
+++ b/internal/controlplane/handlers_operator_endpoints_internal_test.go
@@ -1,0 +1,688 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// --- Helper types for operator test DB mocking ---
+
+type operatorEndpointTestDB struct {
+	db        *ttmocks.MockExtendedDB
+	qInstance *ttmocks.MockQuery
+	qJob      *ttmocks.MockQuery
+	qAudit    *ttmocks.MockQuery
+	qUpdate   *ttmocks.MockQuery
+}
+
+func newOperatorEndpointTestDB() operatorEndpointTestDB {
+	db := ttmocks.NewMockExtendedDB()
+	qInstance := new(ttmocks.MockQuery)
+	qJob := new(ttmocks.MockQuery)
+	qAudit := new(ttmocks.MockQuery)
+	qUpdate := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInstance).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.ProvisionJob")).Return(qJob).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	for _, q := range []*ttmocks.MockQuery{qInstance, qJob, qAudit, qUpdate} {
+		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("Index", mock.Anything).Return(q).Maybe()
+		q.On("Limit", mock.Anything).Return(q).Maybe()
+		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("ConsistentRead").Return(q).Maybe()
+		q.On("Create").Return(nil).Maybe()
+		q.On("CreateOrUpdate").Return(nil).Maybe()
+		q.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Maybe()
+		q.On("First", mock.AnythingOfType("*models.ProvisionJob")).Return(nil).Maybe()
+		addStandardMockQueryStubs(q)
+	}
+
+	return operatorEndpointTestDB{db: db, qInstance: qInstance, qJob: qJob, qAudit: qAudit, qUpdate: qUpdate}
+}
+
+func operatorAuthenticatedCtx() *apptheory.Context {
+	ctx := &apptheory.Context{AuthIdentity: "alice", RequestID: "rid"}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+	return ctx
+}
+
+func portalUserCtx() *apptheory.Context {
+	return &apptheory.Context{AuthIdentity: "bob", RequestID: "rid"}
+}
+
+func unauthenticatedCtx() *apptheory.Context {
+	return &apptheory.Context{RequestID: "rid"}
+}
+
+func makeInstance(slug, lesserVer, bodyVer string, bodyUpdateAt, mcpWiredAt time.Time) *models.Instance {
+	return &models.Instance{
+		Slug:               slug,
+		Owner:              "alice",
+		Status:             models.InstanceStatusActive,
+		LesserVersion:      lesserVer,
+		LesserBodyVersion:  bodyVer,
+		LesserUpdateAt:     bodyUpdateAt,
+		LesserBodyUpdateAt: bodyUpdateAt,
+		McpWiredAt:         mcpWiredAt,
+		UpdatedAt:          bodyUpdateAt,
+	}
+}
+
+// --- #434: Operator releases endpoint ---
+
+func TestHandleOperatorReleases_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion:     "v1.4.2",
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("alpha", "v1.4.2", "v0.3.0", now, now),
+			makeInstance("beta", "v1.4.1", "v0.2.9", now.Add(-time.Hour), now.Add(-time.Hour)),
+			makeInstance("gamma", "v1.4.2", "v0.3.0", now, now),
+			makeInstance("delta", "v1.4.2", "v0.2.9", now, now.Add(-time.Hour)),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorReleases(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body operatorReleasesResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 4, body.FleetTotal)
+	require.Len(t, body.Channels, 2)
+
+	lesserCh := findChannel(body.Channels, "lesser")
+	require.NotNil(t, lesserCh)
+	require.Len(t, lesserCh.Versions, 2)
+	// v1.4.2 should be first (newest) and is_latest.
+	require.Equal(t, "v1.4.2", lesserCh.Versions[0].Version)
+	require.True(t, lesserCh.Versions[0].IsLatest)
+	require.Equal(t, 3, lesserCh.Versions[0].Adoption.Instances)
+	require.Equal(t, 75, lesserCh.Versions[0].Adoption.Percent)
+	require.Equal(t, "v1.4.1", lesserCh.Versions[1].Version)
+	require.False(t, lesserCh.Versions[1].IsLatest)
+	require.Equal(t, 1, lesserCh.Versions[1].Adoption.Instances)
+
+	bodyCh := findChannel(body.Channels, "lesser-body")
+	require.NotNil(t, bodyCh)
+	require.Len(t, bodyCh.Versions, 2)
+	require.Equal(t, "v0.3.0", bodyCh.Versions[0].Version)
+	require.True(t, bodyCh.Versions[0].IsLatest)
+	require.Equal(t, 2, bodyCh.Versions[0].Adoption.Instances)
+}
+
+func TestHandleOperatorReleases_NoInstances(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion:     "v1.4.2",
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorReleases(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body operatorReleasesResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 0, body.FleetTotal)
+	require.Len(t, body.Channels, 2)
+	for _, ch := range body.Channels {
+		require.Empty(t, ch.Versions)
+	}
+}
+
+func TestHandleOperatorReleases_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	// Portal user (no operator role).
+	ctx := portalUserCtx()
+	_, err := s.handleOperatorReleases(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok, "expected AppError, got %T: %v", err, err)
+	require.Equal(t, "app.forbidden", appErr.Code)
+
+	// Unauthenticated.
+	ctx2 := unauthenticatedCtx()
+	_, err = s.handleOperatorReleases(ctx2)
+	require.Error(t, err)
+}
+
+func TestHandleOperatorReleases_FiltersInactive(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion: "v1.4.2",
+	}}
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("active-a", "v1.4.2", "", time.Time{}, time.Time{}),
+			{Slug: "disabled-b", Status: models.InstanceStatusDisabled, LesserVersion: "v1.4.1"},
+			{Slug: "", Status: models.InstanceStatusActive}, // empty slug, filtered
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorReleases(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body operatorReleasesResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 1, body.FleetTotal)
+}
+
+func findChannel(channels []operatorReleaseChannel, id string) *operatorReleaseChannel {
+	for i := range channels {
+		if channels[i].ID == id {
+			return &channels[i]
+		}
+	}
+	return nil
+}
+
+// --- #435: Operator drift endpoint ---
+
+func TestHandleOperatorInstancesDrift_AllOK(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion:     "v1.4.2",
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("ok1", "v1.4.2", "v0.3.0", now, now),
+			makeInstance("ok2", "v1.4.2", "v0.3.0", now, now),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorInstancesDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body fleetDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 2, body.Summary.Total)
+	require.Equal(t, 0, body.Summary.LesserStale)
+	require.Equal(t, 0, body.Summary.BodyStale)
+	require.Equal(t, 0, body.Summary.MCPWireStale)
+}
+
+func TestHandleOperatorInstancesDrift_LesserStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion: "v1.4.2",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("old1", "v1.4.0", "", now, time.Time{}),
+			makeInstance("ok1", "v1.4.2", "", now, time.Time{}),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorInstancesDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body fleetDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 2, body.Summary.Total)
+	require.Equal(t, 1, body.Summary.LesserStale)
+	require.Equal(t, 0, body.Summary.MCPWireStale)
+}
+
+func TestHandleOperatorInstancesDrift_BodyStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("oldbody", "", "v0.2.5", now, time.Time{}),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorInstancesDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body fleetDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 1, body.Summary.BodyStale)
+}
+
+func TestHandleOperatorInstancesDrift_MCPWireStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	// MCP wired before body update → wire-stale.
+	mcpTime := now.Add(-24 * time.Hour)
+	bodyTime := now
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:               "wired-stale",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: bodyTime,
+				McpWiredAt:         mcpTime,
+				UpdatedAt:          bodyTime,
+			},
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorInstancesDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body fleetDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 1, body.Summary.MCPWireStale)
+}
+
+func TestHandleOperatorInstancesDrift_UnknownTargetVersion(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	// No config defaults → all drift is "unknown".
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("x", "v1.4.2", "v0.3.0", now, now),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorInstancesDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body fleetDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, stackDriftUnknown, body.Instances[0].Lesser.Drift)
+}
+
+func TestHandleOperatorInstancesDrift_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	// Portal user.
+	ctx := portalUserCtx()
+	_, err := s.handleOperatorInstancesDrift(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.forbidden", appErr.Code)
+
+	// Unauthenticated.
+	ctx2 := unauthenticatedCtx()
+	_, err = s.handleOperatorInstancesDrift(ctx2)
+	require.Error(t, err)
+}
+
+// --- #436: Operator MCP remediation endpoint ---
+
+func TestHandleOperatorRemediateMCPDrift_NoWireStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserDefaultVersion:     "v1.4.2",
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			makeInstance("ok1", "v1.4.2", "v0.3.0", now, now),
+		}
+	}).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Empty(t, body.CreatedJobIDs)
+	require.Equal(t, 0, body.Created)
+	require.Equal(t, 0, body.Skipped)
+}
+
+func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+
+	// Set up Instance scan + getInstance + no active MCP jobs (GSI2 empty).
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+		ManagedInstanceRoleName:         "ManagedInstanceRole",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	mcpTime := now.Add(-24 * time.Hour)
+	bodyTime := now
+
+	// Instance scan for drift.
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:               "wired-stale",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: bodyTime,
+				McpWiredAt:         mcpTime,
+				UpdatedAt:          bodyTime,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "wired-stale.greater.website",
+			},
+		}
+	}).Once()
+
+	// GSI2 active jobs: empty (no existing MCP-only jobs).
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Once()
+
+	// getInstance call for the wire-stale slug.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:                           "wired-stale",
+			Owner:                          "alice",
+			Status:                         models.InstanceStatusActive,
+			LesserBodyVersion:              "v0.3.0",
+			HostedAccountID:                "123456789012",
+			HostedRegion:                   "us-east-1",
+			HostedBaseDomain:               "wired-stale.greater.website",
+			LesserHostInstanceKeySecretARN: "",
+			LesserVersion:                  "v1.4.2",
+		}
+	}).Once()
+
+	// Audit.
+	tdb.qAudit.On("Create").Return(nil).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.CreatedJobIDs, 1)
+	require.Equal(t, 1, body.Created)
+	require.Equal(t, 0, body.Skipped)
+}
+
+func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+		ManagedInstanceRoleName:         "ManagedInstanceRole",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	mcpTime := now.Add(-24 * time.Hour)
+
+	// Instance scan: two wire-stale instances.
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = []*models.Instance{
+			{
+				Slug:               "ws-1",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         mcpTime,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "ws-1.greater.website",
+			},
+			{
+				Slug:               "ws-2",
+				Owner:              "alice",
+				Status:             models.InstanceStatusActive,
+				LesserBodyVersion:  "v0.3.0",
+				LesserBodyUpdateAt: now,
+				McpWiredAt:         mcpTime,
+				UpdatedAt:          now,
+				HostedAccountID:    "123456789012",
+				HostedRegion:       "us-east-1",
+				HostedBaseDomain:   "ws-2.greater.website",
+			},
+		}
+	}).Once()
+
+	// GSI2 active jobs: ws-1 already has an active MCP-only job.
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{
+				ID:           "existing-mcp-1",
+				InstanceSlug: "ws-1",
+				MCPOnly:      true,
+				Status:       models.UpdateJobStatusQueued,
+			},
+		}
+	}).Once()
+
+	// Only ws-2 should get a new job; ws-1 is skipped.
+	// getInstance for ws-2.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:                           "ws-2",
+			Owner:                          "alice",
+			Status:                         models.InstanceStatusActive,
+			LesserBodyVersion:              "v0.3.0",
+			HostedAccountID:                "123456789012",
+			HostedRegion:                   "us-east-1",
+			HostedBaseDomain:               "ws-2.greater.website",
+			LesserHostInstanceKeySecretARN: "",
+			LesserVersion:                  "v1.4.2",
+		}
+	}).Once()
+
+	// UpdateJob create for ws-2.
+	tdb.qUpdate.On("Create").Return(nil).Once()
+
+	// Audit.
+	tdb.qAudit.On("Create").Return(nil).Once()
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.CreatedJobIDs, 1)
+	require.Equal(t, 1, body.Created)
+	require.Equal(t, 1, body.Skipped)
+}
+
+func TestHandleOperatorRemediateMCPDrift_Unauthorized(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	ctx := portalUserCtx()
+	_, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.forbidden", appErr.Code)
+}
+
+// --- Drift computation unit tests ---
+
+func TestComputeComponentDrift(t *testing.T) {
+	t.Parallel()
+
+	if got := computeComponentDrift("v1.4.2", "v1.4.2"); got != stackDriftOK {
+		t.Fatalf("same version: got %q, want %q", got, stackDriftOK)
+	}
+	if got := computeComponentDrift("v1.4.0", "v1.4.2"); got != stackDriftStale {
+		t.Fatalf("older version: got %q, want %q", got, stackDriftStale)
+	}
+	if got := computeComponentDrift("v1.5.0", "v1.4.2"); got != stackDriftOK {
+		t.Fatalf("newer version: got %q, want %q", got, stackDriftOK)
+	}
+	if got := computeComponentDrift("", "v1.4.2"); got != stackDriftUnknown {
+		t.Fatalf("empty current: got %q, want %q", got, stackDriftUnknown)
+	}
+	if got := computeComponentDrift("v1.4.2", ""); got != stackDriftUnknown {
+		t.Fatalf("empty target: got %q, want %q", got, stackDriftUnknown)
+	}
+}
+
+func TestSortVersionStringsDesc(t *testing.T) {
+	t.Parallel()
+
+	versions := []string{"v1.4.0", "v1.4.2", "v1.3.9", "v2.0.0", "v1.10.0"}
+	sortVersionStringsDesc(versions)
+	expected := []string{"v2.0.0", "v1.10.0", "v1.4.2", "v1.4.0", "v1.3.9"}
+	for i, v := range versions {
+		if v != expected[i] {
+			t.Fatalf("position %d: got %q, want %q", i, v, expected[i])
+		}
+	}
+}
+
+func TestCompareVersions(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b string
+		want int
+	}{
+		{"v1.4.2", "v1.4.2", 0},
+		{"v1.4.2", "v1.4.1", 1},
+		{"v1.4.0", "v1.4.2", -1},
+		{"v2.0.0", "v1.9.9", 1},
+		{"v1.10.0", "v1.9.0", 1},
+		{"v0.3.0", "v0.2.9", 1},
+		{"1.4.2", "v1.4.2", 0}, // v prefix stripped
+	}
+	for _, tc := range cases {
+		got := compareVersions(tc.a, tc.b)
+		if got != tc.want {
+			t.Fatalf("compareVersions(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestComputeFleetDrift_EmptyInstances(t *testing.T) {
+	t.Parallel()
+
+	resp := computeFleetDrift([]*models.Instance{}, "v1.4.2", "v0.3.0")
+	require.Empty(t, resp.Instances)
+	require.Equal(t, 0, resp.Summary.Total)
+}
+
+func TestBuildOperatorReleasesResponse_EmptyStringVersionsIgnored(t *testing.T) {
+	t.Parallel()
+
+	// Instance with empty LesserVersion should be counted in fleet_total
+	// but not attributed to any version.
+	instances := []*models.Instance{
+		{Slug: "no-version", Owner: "alice", Status: models.InstanceStatusActive},
+	}
+
+	resp := buildOperatorReleasesResponse(instances, "v1.4.2", "v0.3.0")
+	require.Equal(t, 1, resp.FleetTotal)
+	require.Empty(t, resp.Channels[0].Versions)
+	require.Empty(t, resp.Channels[1].Versions)
+}

--- a/internal/controlplane/handlers_operator_endpoints_internal_test.go
+++ b/internal/controlplane/handlers_operator_endpoints_internal_test.go
@@ -161,22 +161,6 @@ func instanceWithProvisionJob(slug, lesserVer, provisionJobID string, updatedAt 
 	}
 }
 
-func instanceFull(slug, lesserVer, bodyVer, provisionJobID string, updatedAt time.Time) *models.Instance {
-	return &models.Instance{
-		Slug:               slug,
-		Owner:              "alice",
-		Status:             models.InstanceStatusActive,
-		LesserVersion:      lesserVer,
-		LesserBodyVersion:  bodyVer,
-		ProvisionJobID:     provisionJobID,
-		LesserBodyUpdateAt: updatedAt,
-		UpdatedAt:          updatedAt,
-		HostedAccountID:    "123456789012",
-		HostedRegion:       "us-east-1",
-		HostedBaseDomain:   slug + ".greater.website",
-	}
-}
-
 // --- #434: Operator releases endpoint ---
 
 func TestHandleOperatorReleases_HappyPath(t *testing.T) {
@@ -618,7 +602,7 @@ func TestHandleOperatorInstancesDrift_MCPWireStaleEvidence(t *testing.T) {
 	// MCP-only update job wired against v0.2.5.
 	// Evidence layer takes the latest per kind, so wire-stale shows.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID:                "upd-body-1",
@@ -776,7 +760,7 @@ func TestHandleOperatorRemediateMCPDrift_VersionFromDeployedBody(t *testing.T) {
 
 	// Evidence: body update job deployed v0.2.5, MCP job wired v0.2.4 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID:                "upd-body-1",
@@ -799,7 +783,7 @@ func TestHandleOperatorRemediateMCPDrift_VersionFromDeployedBody(t *testing.T) {
 
 	// GSI2 active jobs: empty (no existing MCP-only jobs).
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{}
 	}).Once()
 
@@ -900,7 +884,7 @@ func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
 
 	// Evidence for ws-audit-1: body v0.3.0 deployed, MCP v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID: "b1", InstanceSlug: "ws-audit-1", Status: models.UpdateJobStatusOK,
@@ -915,7 +899,7 @@ func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
 
 	// Evidence for ws-audit-2: body v0.3.0 deployed, MCP v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID: "b2", InstanceSlug: "ws-audit-2", Status: models.UpdateJobStatusOK,
@@ -930,7 +914,7 @@ func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
 
 	// GSI2 active jobs: empty.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{}
 	}).Once()
 
@@ -1020,7 +1004,7 @@ func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
 
 	// Evidence: body v0.3.0 deployed, MCP wired v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID: "b1", InstanceSlug: "wired-stale", Status: models.UpdateJobStatusOK,
@@ -1035,7 +1019,7 @@ func TestHandleOperatorRemediateMCPDrift_SingleWireStale(t *testing.T) {
 
 	// GSI2 active jobs: empty.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{}
 	}).Once()
 
@@ -1113,7 +1097,7 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 
 	// Evidence for ws-1: body v0.3.0, MCP v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID: "b1", InstanceSlug: "ws-1", Status: models.UpdateJobStatusOK,
@@ -1128,7 +1112,7 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 
 	// Evidence for ws-2: body v0.3.0, MCP v0.2.9 → wire-stale.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID: "b2", InstanceSlug: "ws-2", Status: models.UpdateJobStatusOK,
@@ -1143,7 +1127,7 @@ func TestHandleOperatorRemediateMCPDrift_IdempotentSkip(t *testing.T) {
 
 	// GSI2 active jobs: ws-1 already has an active MCP-only job.
 	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
-		dest := args.Get(0).(*[]*models.UpdateJob)
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
 		*dest = []*models.UpdateJob{
 			{
 				ID:           "existing-mcp-1",

--- a/internal/controlplane/handlers_operator_releases.go
+++ b/internal/controlplane/handlers_operator_releases.go
@@ -39,7 +39,8 @@ type operatorReleasesResponse struct {
 }
 
 // handleOperatorReleases returns per-channel release adoption telemetry
-// aggregated from host-side Instance state. Operator JWT required.
+// aggregated from UpdateJob + ProvisionJob + Instance evidence, per
+// Project 39 provisioning walk Change 5.2. Operator JWT required.
 func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Response, error) {
 	if err := requireOperator(ctx); err != nil {
 		return nil, err
@@ -53,10 +54,12 @@ func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Resp
 		return nil, appErr
 	}
 
+	evidence := gatherFleetEvidence(ctx, s, instances)
+
 	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
 	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
 
-	resp := buildOperatorReleasesResponse(instances, lesserTarget, bodyTarget)
+	resp := buildOperatorReleasesResponse(evidence, lesserTarget, bodyTarget)
 	return apptheory.JSON(http.StatusOK, resp)
 }
 
@@ -89,33 +92,46 @@ func (s *Server) listActiveInstances(ctx *apptheory.Context) ([]*models.Instance
 }
 
 // buildOperatorReleasesResponse aggregates per-channel version adoption from
-// active instance records. For each channel, versions are collected from
-// the Instance's current-version fields, counted, and sorted newest-first.
+// UpdateJob + ProvisionJob + Instance evidence. For each instance, the version
+// and released_at come from the best-available evidence source:
+//   - lesser channel: latest successful lesser update → provision job → instance
+//   - body channel:   latest successful body update   → instance state
+//
+// Without evidence, Instance fields alone can produce wrong version/adoption
+// when a successful update job exists but the Instance marker hasn't caught up,
+// or when a provision job records a deployment timestamp earlier than the
+// Instance's UpdatedAt.
 func buildOperatorReleasesResponse(
-	instances []*models.Instance,
+	evidence []*instanceJobsEvidence,
 	lesserDefault string,
 	bodyDefault string,
 ) operatorReleasesResponse {
-	fleetTotal := len(instances)
+	fleetTotal := len(evidence)
 
 	lesserVersions := map[string]*versionAdoption{}
 	bodyVersions := map[string]*versionAdoption{}
 
-	for _, inst := range instances {
-		slug := strings.TrimSpace(inst.Slug)
+	for _, ev := range evidence {
+		if ev == nil || ev.instance == nil {
+			continue
+		}
+		slug := strings.TrimSpace(ev.instance.Slug)
+		_ = slug // reserved for future per-slug drill-down
 
-		lesserVer := strings.TrimSpace(inst.LesserVersion)
+		// Lesser channel: prefer update job evidence for version and deployed-at.
+		lesserVer := lesserVersionFromEvidence(ev)
+		lesserAt := parseEvidenceTime(lesserDeployedAtFromEvidence(ev))
 		if lesserVer != "" {
-			va := ensureVersionAdoption(lesserVersions, lesserVer, inst.UpdatedAt)
+			va := ensureVersionAdoption(lesserVersions, lesserVer, lesserAt)
 			va.count++
-			va.slugs = append(va.slugs, slug)
 		}
 
-		bodyVer := strings.TrimSpace(inst.LesserBodyVersion)
+		// Body channel: prefer body update job evidence.
+		bodyVer := bodyVersionFromEvidence(ev)
+		bodyAt := parseEvidenceTime(bodyDeployedAtFromEvidence(ev))
 		if bodyVer != "" {
-			va := ensureVersionAdoption(bodyVersions, bodyVer, inst.LesserBodyUpdateAt)
+			va := ensureVersionAdoption(bodyVersions, bodyVer, bodyAt)
 			va.count++
-			va.slugs = append(va.slugs, slug)
 		}
 	}
 
@@ -128,9 +144,21 @@ func buildOperatorReleasesResponse(
 	}
 }
 
+// parseEvidenceTime parses an RFC3339 string back to time.Time for adoption
+// earliest-at tracking. Returns zero time on parse failure or empty string.
+func parseEvidenceTime(s string) time.Time {
+	if s == "" {
+		return time.Time{}
+	}
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return time.Time{}
+	}
+	return t
+}
+
 type versionAdoption struct {
 	count      int
-	slugs      []string
 	earliestAt time.Time
 }
 

--- a/internal/controlplane/handlers_operator_releases.go
+++ b/internal/controlplane/handlers_operator_releases.go
@@ -1,0 +1,249 @@
+package controlplane
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// operatorReleaseChannel represents a release channel (lesser or lesser-body)
+// with per-version adoption telemetry, per Project 39 provisioning walk
+// Change 5.2.
+type operatorReleaseChannel struct {
+	ID       string                   `json:"id"`
+	Versions []operatorReleaseVersion `json:"versions"`
+}
+
+type operatorReleaseVersion struct {
+	Version    string                  `json:"version"`
+	ReleasedAt string                  `json:"released_at"`
+	IsLatest   bool                    `json:"is_latest"`
+	IsBreaking bool                    `json:"is_breaking"`
+	Adoption   operatorReleaseAdoption `json:"adoption"`
+}
+
+type operatorReleaseAdoption struct {
+	Instances int `json:"instances"`
+	Of        int `json:"of"`
+	Percent   int `json:"percent"`
+}
+
+type operatorReleasesResponse struct {
+	Channels   []operatorReleaseChannel `json:"channels"`
+	FleetTotal int                      `json:"fleet_total"`
+}
+
+// handleOperatorReleases returns per-channel release adoption telemetry
+// aggregated from host-side Instance state. Operator JWT required.
+func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if err := requireOperator(ctx); err != nil {
+		return nil, err
+	}
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+
+	instances, appErr := s.listActiveInstances(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
+	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
+
+	resp := buildOperatorReleasesResponse(instances, lesserTarget, bodyTarget)
+	return apptheory.JSON(http.StatusOK, resp)
+}
+
+// listActiveInstances scans the Instance table for active instances.
+func (s *Server) listActiveInstances(ctx *apptheory.Context) ([]*models.Instance, *apptheory.AppError) {
+	var items []*models.Instance
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.Instance{}).
+		Where("SK", "=", models.SKMetadata).
+		Limit(500).
+		All(&items)
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list instances"}
+	}
+
+	active := make([]*models.Instance, 0, len(items))
+	for _, inst := range items {
+		if inst == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(inst.Status)) != models.InstanceStatusActive {
+			continue
+		}
+		if strings.TrimSpace(inst.Slug) == "" {
+			continue
+		}
+		active = append(active, inst)
+	}
+	return active, nil
+}
+
+// buildOperatorReleasesResponse aggregates per-channel version adoption from
+// active instance records. For each channel, versions are collected from
+// the Instance's current-version fields, counted, and sorted newest-first.
+func buildOperatorReleasesResponse(
+	instances []*models.Instance,
+	lesserDefault string,
+	bodyDefault string,
+) operatorReleasesResponse {
+	fleetTotal := len(instances)
+
+	lesserVersions := map[string]*versionAdoption{}
+	bodyVersions := map[string]*versionAdoption{}
+
+	for _, inst := range instances {
+		slug := strings.TrimSpace(inst.Slug)
+
+		lesserVer := strings.TrimSpace(inst.LesserVersion)
+		if lesserVer != "" {
+			va := ensureVersionAdoption(lesserVersions, lesserVer, inst.UpdatedAt)
+			va.count++
+			va.slugs = append(va.slugs, slug)
+		}
+
+		bodyVer := strings.TrimSpace(inst.LesserBodyVersion)
+		if bodyVer != "" {
+			va := ensureVersionAdoption(bodyVersions, bodyVer, inst.LesserBodyUpdateAt)
+			va.count++
+			va.slugs = append(va.slugs, slug)
+		}
+	}
+
+	lesserChannel := buildChannel("lesser", lesserVersions, fleetTotal, lesserDefault)
+	bodyChannel := buildChannel("lesser-body", bodyVersions, fleetTotal, bodyDefault)
+
+	return operatorReleasesResponse{
+		Channels:   []operatorReleaseChannel{lesserChannel, bodyChannel},
+		FleetTotal: fleetTotal,
+	}
+}
+
+type versionAdoption struct {
+	count      int
+	slugs      []string
+	earliestAt time.Time
+}
+
+func ensureVersionAdoption(m map[string]*versionAdoption, version string, t time.Time) *versionAdoption {
+	if va, ok := m[version]; ok {
+		if !t.IsZero() && (va.earliestAt.IsZero() || t.Before(va.earliestAt)) {
+			va.earliestAt = t
+		}
+		return va
+	}
+	va := &versionAdoption{earliestAt: t}
+	m[version] = va
+	return va
+}
+
+func buildChannel(
+	id string,
+	adoptions map[string]*versionAdoption,
+	fleetTotal int,
+	defaultVersion string,
+) operatorReleaseChannel {
+	versions := make([]string, 0, len(adoptions))
+	for v := range adoptions {
+		versions = append(versions, v)
+	}
+	sortVersionStringsDesc(versions)
+
+	out := make([]operatorReleaseVersion, 0, len(versions))
+	for _, v := range versions {
+		va := adoptions[v]
+		releasedAt := ""
+		if !va.earliestAt.IsZero() {
+			releasedAt = va.earliestAt.UTC().Format(time.RFC3339)
+		}
+		pct := 0
+		if fleetTotal > 0 {
+			pct = (va.count * 100) / fleetTotal
+		}
+		out = append(out, operatorReleaseVersion{
+			Version:    v,
+			ReleasedAt: releasedAt,
+			IsLatest:   strings.EqualFold(v, strings.TrimSpace(defaultVersion)),
+			IsBreaking: false,
+			Adoption: operatorReleaseAdoption{
+				Instances: va.count,
+				Of:        fleetTotal,
+				Percent:   pct,
+			},
+		})
+	}
+
+	return operatorReleaseChannel{ID: id, Versions: out}
+}
+
+// sortVersionStringsDesc sorts semver-like strings in descending order.
+// Falls back to simple string comparison for non-semver strings.
+func sortVersionStringsDesc(versions []string) {
+	sort.Slice(versions, func(i, j int) bool {
+		return compareVersions(versions[i], versions[j]) > 0
+	})
+}
+
+// compareVersions compares two version strings. Returns -1, 0, or 1.
+// Handles the "v" prefix and semver-style three-component versions.
+// Non-semver strings are compared lexicographically.
+func compareVersions(a, b string) int {
+	// Strip leading 'v' prefix if present.
+	sa := strings.TrimPrefix(strings.TrimSpace(a), "v")
+	sb := strings.TrimPrefix(strings.TrimSpace(b), "v")
+
+	// Try to split into numeric segments.
+	partsA := splitVersionNumeric(sa)
+	partsB := splitVersionNumeric(sb)
+
+	n := len(partsA)
+	if len(partsB) < n {
+		n = len(partsB)
+	}
+
+	for k := 0; k < n; k++ {
+		if partsA[k] < partsB[k] {
+			return -1
+		}
+		if partsA[k] > partsB[k] {
+			return 1
+		}
+	}
+
+	if len(partsA) < len(partsB) {
+		return -1
+	}
+	if len(partsA) > len(partsB) {
+		return 1
+	}
+	return 0
+}
+
+// splitVersionNumeric splits a semver-like string into numeric parts.
+// Non-numeric segments are treated as 0 for comparison purposes.
+func splitVersionNumeric(s string) []int {
+	segments := strings.Split(s, ".")
+	out := make([]int, 0, len(segments))
+	for _, seg := range segments {
+		n := 0
+		// Extract leading numeric portion.
+		for _, r := range seg {
+			if r >= '0' && r <= '9' {
+				n = n*10 + int(r-'0')
+			} else {
+				break
+			}
+		}
+		out = append(out, n)
+	}
+	return out
+}

--- a/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -1,0 +1,227 @@
+package controlplane
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/provisioning"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// remediateMCPDriftResponse is the response for POST /api/v1/operators/instances/remediate-mcp-drift.
+type remediateMCPDriftResponse struct {
+	CreatedJobIDs []string `json:"created_job_ids"`
+	Created       int      `json:"created"`
+	Skipped       int      `json:"skipped"`
+}
+
+// wireStaleEntry captures a wire-stale instance identified during fleet drift
+// computation for remediation.
+type wireStaleEntry struct {
+	slug           string
+	currentBodyVer string
+}
+
+// handleOperatorRemediateMCPDrift creates MCP-only UpdateJobs for instances
+// with wire-stale MCP wiring. Operator JWT required. Idempotent: skips slugs
+// that already have an active MCP-only UpdateJob.
+func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	if err := requireOperator(ctx); err != nil {
+		return nil, err
+	}
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+
+	instances, appErr := s.listActiveInstances(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	// Compute fleet drift to identify wire-stale instances.
+	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
+	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
+	driftResp := computeFleetDrift(instances, lesserTarget, bodyTarget)
+
+	// Collect wire-stale slugs with their current body versions.
+	var wireStale []wireStaleEntry
+	for _, entry := range driftResp.Instances {
+		if entry.MCP.Drift == stackDriftWireStale {
+			wireStale = append(wireStale, wireStaleEntry{
+				slug:           entry.Slug,
+				currentBodyVer: entry.Body.Current,
+			})
+		}
+	}
+
+	if len(wireStale) == 0 {
+		return apptheory.JSON(http.StatusOK, remediateMCPDriftResponse{
+			CreatedJobIDs: []string{},
+			Created:       0,
+			Skipped:       0,
+		})
+	}
+
+	// Check for existing active MCP-only jobs (idempotency).
+	activeJobs, listErr := s.store.ListActiveUpdateJobs(ctx.Context(), 500)
+	if listErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list active update jobs"}
+	}
+
+	activeMCPSlugs := map[string]bool{}
+	for _, job := range activeJobs {
+		if job != nil && job.MCPOnly {
+			activeMCPSlugs[strings.ToLower(strings.TrimSpace(job.InstanceSlug))] = true
+		}
+	}
+
+	// Resolve instance details and create jobs.
+	now := time.Now().UTC()
+	actor := strings.TrimSpace(ctx.AuthIdentity)
+	createdJobIDs, skipped := s.remediateWireStaleInstances(ctx, wireStale, activeMCPSlugs, bodyTarget, now)
+
+	// Emit operator audit event.
+	s.emitRemediationAudit(ctx, len(wireStale), now, actor)
+
+	return apptheory.JSON(http.StatusOK, remediateMCPDriftResponse{
+		CreatedJobIDs: createdJobIDs,
+		Created:       len(createdJobIDs),
+		Skipped:       skipped,
+	})
+}
+
+// remediateWireStaleInstances creates MCP-only UpdateJobs for wire-stale slugs,
+// skipping those that already have an active MCP-only job. Returns created
+// job IDs and the count of skipped slugs.
+func (s *Server) remediateWireStaleInstances(
+	ctx *apptheory.Context,
+	wireStale []wireStaleEntry,
+	activeMCPSlugs map[string]bool,
+	bodyTarget string,
+	now time.Time,
+) ([]string, int) {
+	var createdJobIDs []string
+	var skipped int
+
+	for _, entry := range wireStale {
+		if activeMCPSlugs[strings.ToLower(entry.slug)] {
+			skipped++
+			continue
+		}
+
+		inst, instErr := s.getInstance(ctx, entry.slug)
+		if instErr != nil || inst == nil {
+			skipped++
+			continue
+		}
+
+		job, jobErr := s.createRemediationMCPJob(ctx, inst, entry.currentBodyVer, bodyTarget, now)
+		if jobErr != nil {
+			skipped++
+			continue
+		}
+
+		if err := s.store.DB.WithContext(ctx.Context()).Model(job).Create(); err != nil {
+			skipped++
+			continue
+		}
+
+		_ = s.queues.enqueueProvisionJob(ctx.Context(), provisioning.JobMessage{
+			Kind:  "update_job",
+			JobID: job.ID,
+		})
+
+		createdJobIDs = append(createdJobIDs, strings.TrimSpace(job.ID))
+	}
+
+	return createdJobIDs, skipped
+}
+
+// createRemediationMCPJob builds an MCP-only UpdateJob for fleet remediation.
+// It sets LesserBodyVersion to the body target (config default) so the wire-mcp
+// deploy runner wires MCP against the target body version.
+func (s *Server) createRemediationMCPJob(
+	ctx *apptheory.Context,
+	inst *models.Instance,
+	currentBodyVer string,
+	bodyTarget string,
+	now time.Time,
+) (*models.UpdateJob, error) {
+	id, tokenErr := newToken(16)
+	if tokenErr != nil {
+		return nil, tokenErr
+	}
+
+	// Use target as the LesserBodyVersion for the MCP wiring step.
+	lesserBodyVersion := strings.TrimSpace(bodyTarget)
+	if lesserBodyVersion == "" {
+		lesserBodyVersion = strings.TrimSpace(currentBodyVer)
+	}
+	if lesserBodyVersion == "" {
+		return nil, fmt.Errorf("no body version available for MCP wiring")
+	}
+
+	baseURL := strings.TrimSpace(s.publicBaseURL())
+	attestationsURL := strings.TrimSpace(baseURL)
+
+	job := &models.UpdateJob{
+		ID:                             id,
+		InstanceSlug:                   strings.TrimSpace(inst.Slug),
+		Status:                         models.UpdateJobStatusQueued,
+		Step:                           "queued",
+		AccountID:                      strings.TrimSpace(inst.HostedAccountID),
+		AccountRoleName:                strings.TrimSpace(s.cfg.ManagedInstanceRoleName),
+		Region:                         strings.TrimSpace(inst.HostedRegion),
+		BaseDomain:                     strings.TrimSpace(inst.HostedBaseDomain),
+		LesserVersion:                  strings.TrimSpace(inst.LesserVersion),
+		LesserBodyVersion:              lesserBodyVersion,
+		MCPOnly:                        true,
+		LesserHostBaseURL:              baseURL,
+		LesserHostAttestationsURL:      attestationsURL,
+		LesserHostInstanceKeySecretARN: strings.TrimSpace(inst.LesserHostInstanceKeySecretARN),
+		TranslationEnabled:             effectiveUpdateTranslationEnabled(inst),
+		TipEnabled:                     effectiveTipEnabled(inst.TipEnabled),
+		TipChainID:                     effectiveTipChainID(inst.TipChainID),
+		TipContractAddress:             strings.TrimSpace(inst.TipContractAddress),
+		AIEnabled:                      effectiveLesserAIEnabled(inst.LesserAIEnabled),
+		AIModerationEnabled:            effectiveLesserAIModerationEnabled(inst.LesserAIModerationEnabled),
+		AINsfwDetectionEnabled:         effectiveLesserAINsfwDetectionEnabled(inst.LesserAINsfwDetectionEnabled),
+		AISpamDetectionEnabled:         effectiveLesserAISpamDetectionEnabled(inst.LesserAISpamDetectionEnabled),
+		AIPiiDetectionEnabled:          effectiveLesserAIPiiDetectionEnabled(inst.LesserAIPiiDetectionEnabled),
+		AIContentDetectionEnabled:      effectiveLesserAIContentDetectionEnabled(inst.LesserAIContentDetectionEnabled),
+		DeployStatus:                   updateJobPhaseStatusSkipped,
+		BodyStatus:                     updateJobPhaseStatusSkipped,
+		MCPStatus:                      updateJobPhaseStatusPending,
+		CreatedAt:                      now,
+		ExpiresAt:                      now.Add(30 * 24 * time.Hour),
+		RequestID:                      strings.TrimSpace(ctx.RequestID),
+	}
+	_ = job.UpdateKeys()
+	return job, nil
+}
+
+// emitRemediationAudit writes an operator audit event for MCP remediation.
+func (s *Server) emitRemediationAudit(
+	ctx *apptheory.Context,
+	numWireStale int,
+	now time.Time,
+	actor string,
+) {
+	if s == nil || s.store == nil || s.store.DB == nil {
+		return
+	}
+
+	audit := &models.AuditLogEntry{
+		Actor:     actor,
+		Action:    "operator.fleet.remediate_mcp_drift",
+		Target:    fmt.Sprintf("fleet:mcp-remediation:%d-slugs", numWireStale),
+		RequestID: strings.TrimSpace(ctx.RequestID),
+		CreatedAt: now,
+	}
+	_ = audit.UpdateKeys()
+	s.tryWriteAuditLog(ctx, audit)
+}

--- a/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -27,8 +27,13 @@ type wireStaleEntry struct {
 }
 
 // handleOperatorRemediateMCPDrift creates MCP-only UpdateJobs for instances
-// with wire-stale MCP wiring. Operator JWT required. Idempotent: skips slugs
-// that already have an active MCP-only UpdateJob.
+// with wire-stale MCP wiring, using evidence-based drift detection (from
+// Blocker 2). Operator JWT required. Idempotent: skips slugs that already
+// have an active MCP-only UpdateJob.
+//
+// Remediation wires MCP against the currently deployed body version (from
+// drift evidence), not the fleet config target, so MCP is consistent with
+// what's actually running on each instance.
 func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
 	if err := requireOperator(ctx); err != nil {
 		return nil, err
@@ -42,12 +47,13 @@ func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*appth
 		return nil, appErr
 	}
 
-	// Compute fleet drift to identify wire-stale instances.
+	// Compute evidence-based drift to identify wire-stale instances.
+	evidence := gatherFleetEvidence(ctx, s, instances)
 	lesserTarget := strings.TrimSpace(s.cfg.ManagedLesserDefaultVersion)
 	bodyTarget := strings.TrimSpace(s.cfg.ManagedLesserBodyDefaultVersion)
-	driftResp := computeFleetDrift(instances, lesserTarget, bodyTarget)
+	driftResp := computeFleetDrift(evidence, lesserTarget, bodyTarget)
 
-	// Collect wire-stale slugs with their current body versions.
+	// Collect wire-stale slugs with their current deployed body versions.
 	var wireStale []wireStaleEntry
 	for _, entry := range driftResp.Instances {
 		if entry.MCP.Drift == stackDriftWireStale {
@@ -66,7 +72,7 @@ func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*appth
 		})
 	}
 
-	// Check for existing active MCP-only jobs (idempotency).
+	// Check for existing active MCP-only jobs (idempotency via GSI2 UPDATE_ACTIVE).
 	activeJobs, listErr := s.store.ListActiveUpdateJobs(ctx.Context(), 500)
 	if listErr != nil {
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list active update jobs"}
@@ -82,10 +88,17 @@ func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*appth
 	// Resolve instance details and create jobs.
 	now := time.Now().UTC()
 	actor := strings.TrimSpace(ctx.AuthIdentity)
-	createdJobIDs, skipped := s.remediateWireStaleInstances(ctx, wireStale, activeMCPSlugs, bodyTarget, now)
 
-	// Emit operator audit event.
-	s.emitRemediationAudit(ctx, len(wireStale), now, actor)
+	// Remediation uses the drift entry's current_body (deployed body version),
+	// not the fleet config target. bodyTarget is only a fallback when the
+	// entry's current body version is empty.
+	createdJobIDs, remediatedSlugs, skipped := s.remediateWireStaleInstances(
+		ctx, wireStale, activeMCPSlugs, bodyTarget, now,
+	)
+
+	// Emit operator audit event AFTER remediation so we can include the
+	// affected slug list and created job IDs.
+	s.emitRemediationAudit(ctx, remediatedSlugs, createdJobIDs, now, actor)
 
 	return apptheory.JSON(http.StatusOK, remediateMCPDriftResponse{
 		CreatedJobIDs: createdJobIDs,
@@ -96,15 +109,16 @@ func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*appth
 
 // remediateWireStaleInstances creates MCP-only UpdateJobs for wire-stale slugs,
 // skipping those that already have an active MCP-only job. Returns created
-// job IDs and the count of skipped slugs.
+// job IDs, the list of successfully remediated slugs, and the count of skipped slugs.
 func (s *Server) remediateWireStaleInstances(
 	ctx *apptheory.Context,
 	wireStale []wireStaleEntry,
 	activeMCPSlugs map[string]bool,
 	bodyTarget string,
 	now time.Time,
-) ([]string, int) {
+) ([]string, []string, int) {
 	var createdJobIDs []string
+	var remediatedSlugs []string
 	var skipped int
 
 	for _, entry := range wireStale {
@@ -119,7 +133,15 @@ func (s *Server) remediateWireStaleInstances(
 			continue
 		}
 
-		job, jobErr := s.createRemediationMCPJob(ctx, inst, entry.currentBodyVer, bodyTarget, now)
+		// Use the drift entry's current_body (deployed body version) as the
+		// primary version source for MCP wiring. Fall back to bodyTarget only
+		// if currentBodyVer is empty.
+		wireVersion := strings.TrimSpace(entry.currentBodyVer)
+		if wireVersion == "" {
+			wireVersion = strings.TrimSpace(bodyTarget)
+		}
+
+		job, jobErr := s.createRemediationMCPJob(ctx, inst, wireVersion, now)
 		if jobErr != nil {
 			skipped++
 			continue
@@ -136,19 +158,20 @@ func (s *Server) remediateWireStaleInstances(
 		})
 
 		createdJobIDs = append(createdJobIDs, strings.TrimSpace(job.ID))
+		remediatedSlugs = append(remediatedSlugs, entry.slug)
 	}
 
-	return createdJobIDs, skipped
+	return createdJobIDs, remediatedSlugs, skipped
 }
 
 // createRemediationMCPJob builds an MCP-only UpdateJob for fleet remediation.
-// It sets LesserBodyVersion to the body target (config default) so the wire-mcp
-// deploy runner wires MCP against the target body version.
+// wireBodyVersion is the body version to wire MCP against — this should be
+// the currently deployed body version (from drift evidence), not the config
+// target, so MCP is wired against what's actually running on the instance.
 func (s *Server) createRemediationMCPJob(
 	ctx *apptheory.Context,
 	inst *models.Instance,
-	currentBodyVer string,
-	bodyTarget string,
+	wireBodyVersion string,
 	now time.Time,
 ) (*models.UpdateJob, error) {
 	id, tokenErr := newToken(16)
@@ -156,11 +179,7 @@ func (s *Server) createRemediationMCPJob(
 		return nil, tokenErr
 	}
 
-	// Use target as the LesserBodyVersion for the MCP wiring step.
-	lesserBodyVersion := strings.TrimSpace(bodyTarget)
-	if lesserBodyVersion == "" {
-		lesserBodyVersion = strings.TrimSpace(currentBodyVer)
-	}
+	lesserBodyVersion := strings.TrimSpace(wireBodyVersion)
 	if lesserBodyVersion == "" {
 		return nil, fmt.Errorf("no body version available for MCP wiring")
 	}
@@ -205,9 +224,12 @@ func (s *Server) createRemediationMCPJob(
 }
 
 // emitRemediationAudit writes an operator audit event for MCP remediation.
+// The audit record includes the affected slug list and created job IDs using
+// existing AuditLogEntry fields — no tenant content or secrets are logged.
 func (s *Server) emitRemediationAudit(
 	ctx *apptheory.Context,
-	numWireStale int,
+	slugs []string,
+	jobIDs []string,
 	now time.Time,
 	actor string,
 ) {
@@ -215,10 +237,18 @@ func (s *Server) emitRemediationAudit(
 		return
 	}
 
+	target := fmt.Sprintf("fleet:mcp-remediation:%d-slugs", len(slugs))
+	if len(slugs) > 0 {
+		target = fmt.Sprintf("fleet:mcp-remediation:slugs=%s", strings.Join(slugs, ","))
+	}
+	if len(jobIDs) > 0 {
+		target += fmt.Sprintf(";jobs=%s", strings.Join(jobIDs, ","))
+	}
+
 	audit := &models.AuditLogEntry{
 		Actor:     actor,
 		Action:    "operator.fleet.remediate_mcp_drift",
-		Target:    fmt.Sprintf("fleet:mcp-remediation:%d-slugs", numWireStale),
+		Target:    target,
 		RequestID: strings.TrimSpace(ctx.RequestID),
 		CreatedAt: now,
 	}

--- a/internal/controlplane/operator_jobs_evidence.go
+++ b/internal/controlplane/operator_jobs_evidence.go
@@ -173,20 +173,3 @@ func mcpWiredAgainstFromEvidence(ev *instanceJobsEvidence) string {
 func mcpCurrentBodyFromEvidence(ev *instanceJobsEvidence) string {
 	return bodyVersionFromEvidence(ev)
 }
-
-// mcpWiredAtFromEvidence returns the ISO8601 timestamp of the last MCP wiring.
-func mcpWiredAtFromEvidence(ev *instanceJobsEvidence) string {
-	if ev == nil {
-		return ""
-	}
-	if ev.latestMCPUpdate != nil {
-		return formatStackTime(ev.latestMCPUpdate.UpdatedAt)
-	}
-	if ev.provisionJob != nil && !ev.provisionJob.McpWiredAt.IsZero() {
-		return formatStackTime(ev.provisionJob.McpWiredAt)
-	}
-	if ev.instance != nil {
-		return formatStackTime(ev.instance.McpWiredAt)
-	}
-	return ""
-}

--- a/internal/controlplane/operator_jobs_evidence.go
+++ b/internal/controlplane/operator_jobs_evidence.go
@@ -1,0 +1,192 @@
+package controlplane
+
+import (
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// instanceJobsEvidence holds the latest successful update and provision job
+// evidence for a single instance. Used by operator fleet endpoints to source
+// version data from authoritative UpdateJob + ProvisionJob records rather than
+// relying on Instance fields alone.
+type instanceJobsEvidence struct {
+	latestLesserUpdate *models.UpdateJob
+	latestBodyUpdate   *models.UpdateJob
+	latestMCPUpdate    *models.UpdateJob
+	provisionJob       *models.ProvisionJob
+	instance           *models.Instance
+}
+
+// gatherInstanceJobsEvidence queries update jobs (via GSI1) and the initial
+// provision job for a single instance. Store.ListUpdateJobsByInstance returns
+// newest-first rows, so the first successful (status=ok) update job per kind is
+// the authoritative latest deployment evidence for operator fleet endpoints.
+func gatherInstanceJobsEvidence(ctx *apptheory.Context, s *Server, inst *models.Instance) *instanceJobsEvidence {
+	if inst == nil {
+		return nil
+	}
+
+	ev := &instanceJobsEvidence{instance: inst}
+
+	slug := strings.ToLower(strings.TrimSpace(inst.Slug))
+	if slug == "" {
+		return ev
+	}
+
+	// Query update job history and keep the first successful row per kind.
+	// ListUpdateJobsByInstance orders newest-first; overwriting while iterating
+	// would incorrectly select the oldest successful job in the returned page.
+	items, _ := s.store.ListUpdateJobsByInstance(ctx.Context(), slug, 20)
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		if strings.ToLower(strings.TrimSpace(item.Status)) != models.UpdateJobStatusOK {
+			continue
+		}
+		switch updateJobKind(item) {
+		case updateJobKindBody:
+			if ev.latestBodyUpdate == nil {
+				ev.latestBodyUpdate = item
+			}
+		case updateJobKindMCP:
+			if ev.latestMCPUpdate == nil {
+				ev.latestMCPUpdate = item
+			}
+		default:
+			if ev.latestLesserUpdate == nil {
+				ev.latestLesserUpdate = item
+			}
+		}
+	}
+
+	provJob := loadProvisionJobFallback(ctx, s, inst)
+	ev.provisionJob = provJob
+
+	return ev
+}
+
+// gatherFleetEvidence gathers jobs evidence for a list of active instances.
+func gatherFleetEvidence(ctx *apptheory.Context, s *Server, instances []*models.Instance) []*instanceJobsEvidence {
+	evidence := make([]*instanceJobsEvidence, 0, len(instances))
+	for _, inst := range instances {
+		ev := gatherInstanceJobsEvidence(ctx, s, inst)
+		if ev != nil {
+			evidence = append(evidence, ev)
+		}
+	}
+	return evidence
+}
+
+// lesserVersionFromEvidence returns the best-available lesser version from
+// evidence: latest successful lesser update → provision job → instance state.
+func lesserVersionFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil || ev.instance == nil {
+		return ""
+	}
+	if ev.latestLesserUpdate != nil {
+		if v := strings.TrimSpace(ev.latestLesserUpdate.LesserVersion); v != "" {
+			return v
+		}
+	}
+	if ev.provisionJob != nil {
+		if v := strings.TrimSpace(ev.provisionJob.LesserVersion); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(ev.instance.LesserVersion)
+}
+
+// lesserDeployedAtFromEvidence returns the best-available deployment timestamp
+// for the lesser component: latest successful lesser update → provision job →
+// instance update time.
+func lesserDeployedAtFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil {
+		return ""
+	}
+	if ev.latestLesserUpdate != nil {
+		return formatStackTime(ev.latestLesserUpdate.UpdatedAt)
+	}
+	if ev.provisionJob != nil {
+		return formatStackTime(ev.provisionJob.UpdatedAt)
+	}
+	if ev.instance != nil {
+		return formatStackTime(ev.instance.UpdatedAt)
+	}
+	return ""
+}
+
+// bodyVersionFromEvidence returns the best-available body version from
+// evidence: latest successful body update → instance state.
+func bodyVersionFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil || ev.instance == nil {
+		return ""
+	}
+	if ev.latestBodyUpdate != nil {
+		if v := strings.TrimSpace(ev.latestBodyUpdate.LesserBodyVersion); v != "" {
+			return v
+		}
+	}
+	return strings.TrimSpace(ev.instance.LesserBodyVersion)
+}
+
+// bodyDeployedAtFromEvidence returns the best-available deployment timestamp
+// for the body component: latest successful body update → provision job →
+// instance body update time.
+func bodyDeployedAtFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil {
+		return ""
+	}
+	if ev.latestBodyUpdate != nil {
+		return formatStackTime(ev.latestBodyUpdate.UpdatedAt)
+	}
+	if ev.provisionJob != nil && !ev.provisionJob.BodyProvisionedAt.IsZero() {
+		return formatStackTime(ev.provisionJob.BodyProvisionedAt)
+	}
+	if ev.instance != nil {
+		return formatStackTime(ev.instance.LesserBodyUpdateAt)
+	}
+	return ""
+}
+
+// mcpWiredAgainstFromEvidence returns the body version that MCP was last wired
+// against from the latest successful MCP-only update job. It intentionally does
+// not infer the version from Instance or ProvisionJob state: those records do
+// not preserve the body version MCP was wired against after later body updates.
+func mcpWiredAgainstFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil {
+		return ""
+	}
+	if ev.latestMCPUpdate != nil {
+		if v := strings.TrimSpace(ev.latestMCPUpdate.LesserBodyVersion); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// mcpCurrentBodyFromEvidence returns the currently deployed body version
+// that MCP should be wired against: same as bodyVersionFromEvidence.
+func mcpCurrentBodyFromEvidence(ev *instanceJobsEvidence) string {
+	return bodyVersionFromEvidence(ev)
+}
+
+// mcpWiredAtFromEvidence returns the ISO8601 timestamp of the last MCP wiring.
+func mcpWiredAtFromEvidence(ev *instanceJobsEvidence) string {
+	if ev == nil {
+		return ""
+	}
+	if ev.latestMCPUpdate != nil {
+		return formatStackTime(ev.latestMCPUpdate.UpdatedAt)
+	}
+	if ev.provisionJob != nil && !ev.provisionJob.McpWiredAt.IsZero() {
+		return formatStackTime(ev.provisionJob.McpWiredAt)
+	}
+	if ev.instance != nil {
+		return formatStackTime(ev.instance.McpWiredAt)
+	}
+	return ""
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -134,6 +134,9 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Post("/api/v1/operators/provisioning/jobs/{id}/adopt", s.handleAdoptOperatorProvisionJobAccount, apptheory.RequireAuth())
 	app.Post("/api/v1/operators/provisioning/jobs/{id}/note", s.handleAppendOperatorProvisionJobNote, apptheory.RequireAuth())
 	app.Get("/api/v1/operators/audit", s.handleListOperatorAuditLog, apptheory.RequireAuth())
+	app.Get("/api/v1/operators/releases", s.handleOperatorReleases, apptheory.RequireAuth())
+	app.Get("/api/v1/operators/instances/drift", s.handleOperatorInstancesDrift, apptheory.RequireAuth())
+	app.Post("/api/v1/operators/instances/remediate-mcp-drift", s.handleOperatorRemediateMCPDrift, apptheory.RequireAuth())
 
 	// Portal identity helpers.
 	app.Get("/api/v1/portal/me", s.handlePortalMe, apptheory.RequireAuth())


### PR DESCRIPTION
## Summary
- Adds three operator-only fleet management endpoints: `GET /api/v1/operators/releases`, `GET /api/v1/operators/instances/drift`, `POST /api/v1/operators/instances/remediate-mcp-drift`
- Implements M2.8 (#434), M2.9 (#435), and M2.10 (#436) of Project 39 / web UI rework
- All endpoints require operator JWT auth via existing `requireOperator` pattern
- Reusable fleet drift computation in `drift.go` shared between drift display and remediation

## Changes
- **New**: `internal/controlplane/handlers_operator_releases.go` — per-channel version adoption telemetry
- **New**: `internal/controlplane/handlers_operator_drift.go` — fleet drift endpoint handler
- **New**: `internal/controlplane/drift.go` — shared drift computation (lesser/body/MCP components)
- **New**: `internal/controlplane/handlers_operator_remediate_mcp.go` — MCP remediation with idempotency
- **New**: `internal/controlplane/handlers_operator_endpoints_internal_test.go` — 19 tests across all three endpoints
- **Modified**: `internal/controlplane/server.go` — 3 route registrations

## Validation
- `gofmt`: clean
- `go test ./...`: all pass (no regressions)
- `go vet ./...`: clean
- `gov-infra/verifiers/gov-verify-rubric.sh`: 37/0/0 PASS

## Test coverage
### #434 releases: 4 tests
- Happy path: multi-version aggregation with adoption percentages
- No instances: empty fleet
- Unauthorized: portal user + unauthenticated
- Filters inactive/disabled instances

### #435 drift: 6 tests
- All-OK fleet
- Lesser-stale detection
- Body-stale detection
- MCP wire-stale (timestamp heuristic)
- Unknown target version (no config defaults)
- Unauthorized

### #436 remediation: 4 tests
- No wire-stale instances → empty response
- Single wire-stale → creates 1 job
- Idempotent skip: active MCP-only job exists → skips
- Unauthorized

### Unit tests: 5 tests
- `computeComponentDrift`: same/older/newer/empty cases
- `compareVersions` / `sortVersionStringsDesc`: semver sorting
- `computeFleetDrift` empty instances
- `buildOperatorReleasesResponse` empty versions ignored

## Security invariants preserved
- Operator JWT required on all three endpoints
- Read-only host-side state aggregation (Instance + ProvisionJob + UpdateJob)
- No tenant-side reads, no release-verification bypass, no raw key logging
- No CSP changes, no web/ edits, no instance-auth contract changes
- No AppTheory/TableTheory/FaceTheory local patches

Closes #434
Closes #435
Closes #436

🤖 Generated with [Claude Code](https://claude.com/claude-code)