### PR TITLE
feat(web): Operator Console M2.11–M2.13 (Stack Matrix wired + Wire-all CTA + provisioning timeline refinement)

### DIFF
--- a/web/src/lib/api/operatorProvisioning.ts
+++ b/web/src/lib/api/operatorProvisioning.ts
@@ -283,3 +283,41 @@ export function rowDriftLabel(entry: OperatorInstanceDriftEntry): RowDriftLabel 
 		(entry.mcp?.drift || '').toLowerCase() === 'ok';
 	return allOk ? 'ok' : 'unknown';
 }
+
+/* ──────────────────────────────────────────────────────────────────────────
+ * MCP-drift fleet remediation — M2.10 endpoint client.
+ *
+ * Shape matches the documented contract in
+ * `docs/provisioning-web-ui-rework-2026-05-24.md` Change 5.4 and the
+ * shipped backend (`internal/controlplane/handlers_operator_remediate_mcp.go`):
+ *
+ *   POST /api/v1/operators/instances/remediate-mcp-drift
+ *   {
+ *     "created_job_ids": ["uj-…", "uj-…"],
+ *     "created": 2,
+ *     "skipped": 1
+ *   }
+ *
+ * The backend reads fleet drift internally, then creates one MCP-only
+ * UpdateJob per slug whose `mcp.drift == "wire-stale"`. Idempotency is
+ * enforced via `GSI2 = UPDATE_ACTIVE` lookup — slugs that already have
+ * an active MCP-only job are surfaced in `skipped`, not `created`. The
+ * operator-JWT requirement matches the rest of the operator surface.
+ *
+ * No request body is required; the operator-JWT is the sole input.
+ * ────────────────────────────────────────────────────────────────────── */
+
+export interface RemediateMCPDriftResponse {
+	created_job_ids: string[];
+	created: number;
+	skipped: number;
+}
+
+export function remediateMCPDrift(token: string): Promise<RemediateMCPDriftResponse> {
+	return fetchJson<RemediateMCPDriftResponse>('/api/v1/operators/instances/remediate-mcp-drift', {
+		method: 'POST',
+		headers: {
+			authorization: `Bearer ${token}`,
+		},
+	});
+}

--- a/web/src/lib/components/ProvisioningTimeline.svelte
+++ b/web/src/lib/components/ProvisioningTimeline.svelte
@@ -2,9 +2,17 @@
 @component
 ProvisioningTimeline — vertical timeline of provisioning-job steps.
 
-Project 39 M2.4 (issue #430). Renders the kind-specific step list for
-the active job and marks the active step so operators can see which
-phase is currently running.
+Project 39 M2.4 (issue #430) shipped the base timeline; M2.13
+(issue #439) refines it per the four job kinds and adds an explicit
+auto-queued "Wire MCP in Lesser" gated step at the end of every
+update-body job timeline. The gated step is a UI affordance — it
+informs the operator that a body update intentionally leaves MCP in
+a wire-stale posture until either the fleet wire-all CTA or the
+per-instance wire-mcp flow remediates it. It is NOT a backend step
+inside the update-body job's state machine (BodyOnly jobs run
+body → verify → done; the MCP re-wire is a follow-up MCP-only
+UpdateJob), so it never carries an `active` or `failed` state — it
+only ever renders as `auto-queued`.
 
 Step vocabulary is sourced from the real provision-worker / update-job
 constants (NOT from a parallel UI-side enumeration). Aligned to source
@@ -22,7 +30,8 @@ after PR #512 arch review 4363557132 Blocker 3:
   update-* phases      — from `internal/provisionworker/update_jobs.go`
                           `updatePhase*` constants. Kind discriminates:
                           update-lesser: deploy → verify
-                          update-body  : body → verify
+                          update-body  : body → verify (+ auto-queued
+                                         wire-mcp gated step, UI-only)
                           wire-mcp     : mcp → verify
 
 A `failed` step is rendered if the job's status is 'error' and the
@@ -43,7 +52,9 @@ backend M2.4-companion work lands.
 The active-step indicator follows the WAI-ARIA "progressbar within a
 list" pattern: the timeline is a `<ol>`; the active step carries
 `aria-current="step"`; per-step state is exposed via `data-state` for
-analytics + gov-rubric checks.
+analytics + gov-rubric checks. The auto-queued gated step uses
+`data-state="auto-queued"` and never receives `aria-current` since it
+is a follow-up consequence rather than a current/completed work item.
 
 Posture preserved:
 - Strict-CSP-safe: no inline styles / scripts, no third-party origins.
@@ -51,10 +62,25 @@ Posture preserved:
   with the operator-JWT (host control-plane scope).
 - Trust-API instance-auth untouched; SEC-9 change-lock not engaged.
 
-Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4, M2.13
 -->
 <script lang="ts" module>
 	import type { JobKind } from './JobKindBadge.svelte';
+
+	/**
+	 * Sentinel step name for the auto-queued "Wire MCP in Lesser" gated
+	 * step appended to every update-body timeline. The colon-separated
+	 * form cannot collide with any real backend step constant (which use
+	 * dot-separated forms like `body.deploy.start`), so `findIndex` matches
+	 * against the active step never accidentally select it.
+	 */
+	export const AUTO_QUEUED_WIRE_MCP_STEP = 'wire-mcp-in-lesser:auto-queued';
+
+	/**
+	 * Human-readable label rendered for the gated step. Kept separate from
+	 * the sentinel so the sentinel can change without retranslating UI text.
+	 */
+	export const AUTO_QUEUED_WIRE_MCP_LABEL = 'Wire MCP in Lesser';
 
 	/**
 	 * Step lists per kind. Sourced verbatim from the real
@@ -89,10 +115,25 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 		// are not part of the visible step list; we render the major-phase
 		// sequence and let the per-step state reflect status.
 		'update-lesser': ['deploy', 'verify'],
-		'update-body': ['body', 'verify'],
+		// `body` and `verify` are the real BodyOnly state machine. The
+		// trailing AUTO_QUEUED_WIRE_MCP_STEP is a UI-only gated affordance:
+		// it cues the operator that a body update intentionally leaves the
+		// MCP component wire-stale until a follow-up MCP-only UpdateJob
+		// remediates. classifySteps() always marks it `auto-queued`.
+		'update-body': ['body', 'verify', AUTO_QUEUED_WIRE_MCP_STEP],
 		'wire-mcp': ['mcp', 'verify'],
 		'unknown': [],
 	};
+
+	/** Identify the auto-queued gated sentinel without leaking constants. */
+	export function isAutoQueuedStep(step: string): boolean {
+		return step === AUTO_QUEUED_WIRE_MCP_STEP;
+	}
+
+	/** Display label for a step — folds the auto-queued sentinel to its label. */
+	export function stepLabel(step: string): string {
+		return step === AUTO_QUEUED_WIRE_MCP_STEP ? AUTO_QUEUED_WIRE_MCP_LABEL : step;
+	}
 
 	/**
 	 * Build the step list for a given kind. For 'unknown' (or any kind
@@ -101,27 +142,38 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 	 * step. If the active step is not in the enumerated list (an unexpected
 	 * server-side step name — most likely a new phase added in
 	 * provision-worker before this component was updated), the active step
-	 * is appended at the end so it still surfaces somewhere.
+	 * is appended at the end so it still surfaces somewhere. The unknown
+	 * step is inserted BEFORE any trailing auto-queued sentinel so the
+	 * gated step remains visually terminal.
 	 */
 	export function stepsForKind(kind: JobKind, activeStep: string | undefined): string[] {
 		const enumerated = STEPS_BY_KIND[kind] ?? [];
 		if (enumerated.length === 0) return activeStep ? [activeStep] : [];
 		if (!activeStep) return enumerated;
 		const normalized = activeStep.toLowerCase();
-		const hit = enumerated.some((s) => s.toLowerCase() === normalized);
+		const hit = enumerated.some(
+			(s) => !isAutoQueuedStep(s) && s.toLowerCase() === normalized,
+		);
 		if (hit) return enumerated;
-		// Unknown step name — surface it so the operator at least sees it.
-		return [...enumerated, activeStep];
+		// Unknown step name — surface it so the operator at least sees it,
+		// but keep the auto-queued gated sentinel (if any) at the tail end.
+		const trailingAutoQueued = enumerated.filter(isAutoQueuedStep);
+		const realSteps = enumerated.filter((s) => !isAutoQueuedStep(s));
+		return [...realSteps, activeStep, ...trailingAutoQueued];
 	}
 
 	/**
-	 * Classify each step as 'completed', 'active', 'failed', or 'pending'
-	 * relative to the active step. The active step is matched
-	 * case-insensitively to tolerate backend-side variants. When the
-	 * active step is unknown (not in the enumerated list and not appended
-	 * by `stepsForKind`), all steps are marked pending.
+	 * Classify each step as 'completed', 'active', 'failed', 'pending',
+	 * or 'auto-queued' relative to the active step. The active step is
+	 * matched case-insensitively to tolerate backend-side variants. When
+	 * the active step is unknown (not in the enumerated list and not
+	 * appended by `stepsForKind`), all real steps are marked pending
+	 * (auto-queued sentinels keep their gated state). The auto-queued
+	 * sentinel is ALWAYS classified `auto-queued` regardless of job
+	 * status — it represents a downstream consequence (a follow-up
+	 * MCP-only UpdateJob) rather than progress within this job.
 	 */
-	export type StepState = 'completed' | 'active' | 'pending' | 'failed';
+	export type StepState = 'completed' | 'active' | 'pending' | 'failed' | 'auto-queued';
 	export function classifySteps(
 		steps: string[],
 		activeStep: string | undefined,
@@ -129,18 +181,28 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 	): StepState[] {
 		const status = (jobStatus || '').toLowerCase();
 		if (!activeStep) {
-			// No active step → mark all as pending (or completed if status is 'ok').
-			return steps.map(() => (status === 'ok' ? 'completed' : 'pending'));
+			// No active step → mark all real steps pending (or completed if
+			// status is 'ok'); gated steps stay auto-queued.
+			return steps.map((s) =>
+				isAutoQueuedStep(s) ? 'auto-queued' : status === 'ok' ? 'completed' : 'pending',
+			);
 		}
 		const normalized = activeStep.toLowerCase();
-		const activeIndex = steps.findIndex((s) => s.toLowerCase() === normalized);
-		if (activeIndex < 0) return steps.map(() => 'pending');
-		return steps.map((_, i) => {
+		// findIndex against real steps only — auto-queued sentinels are not
+		// candidates for the active position.
+		const activeIndex = steps.findIndex(
+			(s) => !isAutoQueuedStep(s) && s.toLowerCase() === normalized,
+		);
+		if (activeIndex < 0) {
+			return steps.map((s) => (isAutoQueuedStep(s) ? 'auto-queued' : 'pending'));
+		}
+		return steps.map((s, i) => {
+			if (isAutoQueuedStep(s)) return 'auto-queued';
 			if (i < activeIndex) return 'completed';
 			if (i === activeIndex) {
 				return status === 'error' || status === 'failed' ? 'failed' : 'active';
 			}
-			// If the whole job is done, every step is completed.
+			// If the whole job is done, every real step is completed.
 			if (status === 'ok' || status === 'done') return 'completed';
 			return 'pending';
 		});
@@ -186,6 +248,7 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 	<ol class="timeline" aria-label="Provisioning timeline">
 		{#each steps as step, i (step)}
 			{@const state = states[i]}
+			{@const autoQueued = isAutoQueuedStep(step)}
 			<li
 				class="timeline__step timeline__step--{state}"
 				aria-current={state === 'active' ? 'step' : undefined}
@@ -194,13 +257,15 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 				<span class="timeline__indicator" aria-hidden="true"></span>
 				<div class="timeline__content">
 					<div class="timeline__row">
-						<span class="timeline__step-name">{step}</span>
+						<span class="timeline__step-name">{stepLabel(step)}</span>
 						{#if state === 'active'}
 							<span class="timeline__pill timeline__pill--active">Active</span>
 						{:else if state === 'failed'}
 							<span class="timeline__pill timeline__pill--failed">Failed</span>
 						{:else if state === 'completed'}
 							<span class="timeline__pill timeline__pill--completed">Done</span>
+						{:else if state === 'auto-queued'}
+							<span class="timeline__pill timeline__pill--auto-queued">Auto-queued</span>
 						{/if}
 					</div>
 					{#if (state === 'active' || state === 'failed') && runUrl}
@@ -210,6 +275,21 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 					{/if}
 					{#if state === 'failed' && errorMessage}
 						<Text size="sm" color="secondary">{errorMessage}</Text>
+					{/if}
+					{#if autoQueued}
+						<!--
+							Explain the gated step's downstream contract so the
+							operator knows what to look for once this job lands. The
+							copy intentionally references the fleet wire-all CTA + the
+							per-instance manual remediation path; both are operator-
+							owned next steps.
+						-->
+						<Text size="sm" color="secondary">
+							Body updates leave MCP wire-stale until a follow-up MCP-only UpdateJob
+							re-wires it. Use the "Wire all" CTA on /operator/provisioning or
+							/operator/releases, or open the per-instance detail page for manual
+							control.
+						</Text>
 					{/if}
 				</div>
 			</li>
@@ -277,6 +357,24 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 		border-color: #ef4444;
 	}
 
+	/*
+	 * M2.13 auto-queued gated step visuals — distinct from active /
+	 * completed / failed so the operator reads it as a downstream
+	 * consequence rather than a real step in the current job. Dashed
+	 * border + transparent fill cue "queued elsewhere, not happening
+	 * here."
+	 */
+	.timeline__step--auto-queued .timeline__indicator {
+		background: transparent;
+		border-color: #6b7280;
+		border-style: dashed;
+	}
+
+	.timeline__step--auto-queued .timeline__step-name {
+		color: var(--ds-fg-2, inherit);
+		opacity: 0.85;
+	}
+
 	.timeline__content {
 		display: flex;
 		flex-direction: column;
@@ -320,6 +418,12 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.4
 	.timeline__pill--failed {
 		color: #ef4444;
 		background: rgba(239, 68, 68, 0.14);
+	}
+
+	.timeline__pill--auto-queued {
+		color: #6b7280;
+		background: rgba(107, 114, 128, 0.16);
+		border-style: dashed;
 	}
 
 	.timeline__log {

--- a/web/src/lib/components/ProvisioningTimeline.svelte.test.ts
+++ b/web/src/lib/components/ProvisioningTimeline.svelte.test.ts
@@ -1,0 +1,209 @@
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import type { JobKind } from './JobKindBadge.svelte';
+import {
+	AUTO_QUEUED_WIRE_MCP_LABEL,
+	AUTO_QUEUED_WIRE_MCP_STEP,
+	classifySteps,
+	isAutoQueuedStep,
+	stepLabel,
+	stepsForKind,
+} from './ProvisioningTimeline.svelte';
+
+/*
+ * M2.13 unit coverage for the ProvisioningTimeline helpers.
+ *
+ * Focused on three contracts:
+ *   1. stepsForKind enumerates the right step list per kind and only
+ *      appends the auto-queued gated sentinel to `update-body`.
+ *   2. classifySteps marks the gated step `auto-queued` regardless of
+ *      job state, never mistakes it for the active step, and preserves
+ *      pre-existing classification rules for real steps.
+ *   3. The sentinel is opaque from the outside: callers reach for it
+ *      via isAutoQueuedStep + stepLabel, never by matching the raw
+ *      string.
+ */
+
+describe('ProvisioningTimeline.stepsForKind', () => {
+	it('enumerates the provision step machine verbatim from provisionworker', () => {
+		const steps = stepsForKind('provision', undefined);
+		expect(steps).toEqual([
+			'queued',
+			'account.create',
+			'account.create.poll',
+			'account.move',
+			'account.assumeRole',
+			'dns.childZone',
+			'dns.parentDelegation',
+			'instance.config',
+			'deploy.start',
+			'deploy.wait',
+			'receipt.ingest',
+			'body.deploy.start',
+			'body.deploy.wait',
+			'deploy.mcp.start',
+			'deploy.mcp.wait',
+			'done',
+		]);
+	});
+
+	it('enumerates update-lesser as deploy → verify with no gated step', () => {
+		const steps = stepsForKind('update-lesser', undefined);
+		expect(steps).toEqual(['deploy', 'verify']);
+		expect(steps.some(isAutoQueuedStep)).toBe(false);
+	});
+
+	it('enumerates update-body as body → verify → auto-queued wire-mcp gated step', () => {
+		const steps = stepsForKind('update-body', undefined);
+		expect(steps).toEqual(['body', 'verify', AUTO_QUEUED_WIRE_MCP_STEP]);
+		expect(steps.filter(isAutoQueuedStep)).toHaveLength(1);
+		// The gated step is always terminal.
+		expect(steps[steps.length - 1]).toBe(AUTO_QUEUED_WIRE_MCP_STEP);
+	});
+
+	it('enumerates wire-mcp as mcp → verify with no gated step', () => {
+		const steps = stepsForKind('wire-mcp', undefined);
+		expect(steps).toEqual(['mcp', 'verify']);
+		expect(steps.some(isAutoQueuedStep)).toBe(false);
+	});
+
+	it('falls back to a single node for unknown kind when activeStep is set', () => {
+		const steps = stepsForKind('unknown', 'something.unmapped');
+		expect(steps).toEqual(['something.unmapped']);
+	});
+
+	it('returns an empty list for unknown kind without an active step', () => {
+		const steps = stepsForKind('unknown', undefined);
+		expect(steps).toEqual([]);
+	});
+
+	it('appends an unknown active step BEFORE the auto-queued gated step on update-body', () => {
+		// A future backend phase that this UI doesn't know about. The gated
+		// step must remain visually terminal so the operator still reads it
+		// as a downstream consequence.
+		const steps = stepsForKind('update-body', 'body.deploy.future-phase');
+		expect(steps).toEqual([
+			'body',
+			'verify',
+			'body.deploy.future-phase',
+			AUTO_QUEUED_WIRE_MCP_STEP,
+		]);
+	});
+
+	it('does not append a known active step (already in the enumerated list)', () => {
+		const steps = stepsForKind('update-body', 'body');
+		expect(steps).toEqual(['body', 'verify', AUTO_QUEUED_WIRE_MCP_STEP]);
+	});
+
+	it('matches the active step case-insensitively before deciding to append', () => {
+		const steps = stepsForKind('update-lesser', 'DEPLOY');
+		expect(steps).toEqual(['deploy', 'verify']);
+	});
+});
+
+describe('ProvisioningTimeline.classifySteps', () => {
+	it('marks all real update-body steps active/pending/auto-queued during body deploy', () => {
+		const steps = stepsForKind('update-body', 'body');
+		expect(classifySteps(steps, 'body', 'running')).toEqual([
+			'active',
+			'pending',
+			'auto-queued',
+		]);
+	});
+
+	it('keeps the gated step auto-queued even when the job has succeeded', () => {
+		const steps = stepsForKind('update-body', undefined);
+		// status='ok' would normally backfill every real step as completed.
+		expect(classifySteps(steps, undefined, 'ok')).toEqual([
+			'completed',
+			'completed',
+			'auto-queued',
+		]);
+	});
+
+	it('keeps the gated step auto-queued when the job has failed', () => {
+		const steps = stepsForKind('update-body', 'body');
+		expect(classifySteps(steps, 'body', 'error')).toEqual([
+			'failed',
+			'pending',
+			'auto-queued',
+		]);
+	});
+
+	it('never marks the gated sentinel as the active step', () => {
+		// Even if the backend somehow returned the sentinel as the active
+		// step (it would not — the sentinel is UI-only), classification
+		// refuses to elect it as active because the sentinel is filtered
+		// out of the findIndex pool.
+		const steps = stepsForKind('update-body', undefined);
+		const result = classifySteps(steps, AUTO_QUEUED_WIRE_MCP_STEP, 'running');
+		// activeIndex resolves to -1 → real steps go pending, gated stays auto-queued.
+		expect(result).toEqual(['pending', 'pending', 'auto-queued']);
+	});
+
+	it('matches active step case-insensitively', () => {
+		const steps = stepsForKind('update-lesser', 'DEPLOY');
+		expect(classifySteps(steps, 'DEPLOY', 'running')).toEqual(['active', 'pending']);
+	});
+
+	it('marks all steps pending when status is empty and no active step', () => {
+		const steps = stepsForKind('wire-mcp', undefined);
+		expect(classifySteps(steps, undefined, '')).toEqual(['pending', 'pending']);
+	});
+});
+
+describe('ProvisioningTimeline sentinel helpers', () => {
+	it('stepLabel folds the auto-queued sentinel to its human label', () => {
+		expect(stepLabel(AUTO_QUEUED_WIRE_MCP_STEP)).toBe(AUTO_QUEUED_WIRE_MCP_LABEL);
+	});
+
+	it('stepLabel passes through real step names unchanged', () => {
+		expect(stepLabel('body')).toBe('body');
+		expect(stepLabel('deploy.wait')).toBe('deploy.wait');
+	});
+
+	it('isAutoQueuedStep distinguishes the sentinel from real step names', () => {
+		expect(isAutoQueuedStep(AUTO_QUEUED_WIRE_MCP_STEP)).toBe(true);
+		expect(isAutoQueuedStep('body')).toBe(false);
+		expect(isAutoQueuedStep('verify')).toBe(false);
+		expect(isAutoQueuedStep('mcp')).toBe(false);
+	});
+
+	it('sentinel string cannot collide with real backend step constants', () => {
+		// The colon separator distinguishes the UI sentinel from the
+		// dotted backend constants (e.g. body.deploy.start, deploy.mcp.wait).
+		// Guard against accidental sentinel rename to a dotted form.
+		expect(AUTO_QUEUED_WIRE_MCP_STEP).toContain(':');
+		expect(AUTO_QUEUED_WIRE_MCP_STEP).not.toContain('.');
+	});
+});
+
+describe('ProvisioningTimeline.svelte source — M2.13 acceptance', () => {
+	// Source-level assertions guard the component's visible contract:
+	// the auto-queued pill, the gated indicator styling, and the
+	// `data-state="auto-queued"` analytics hook.
+	const source = readFileSync(
+		join(process.cwd(), 'src/lib/components/ProvisioningTimeline.svelte'),
+		'utf8',
+	);
+	const kinds: JobKind[] = ['provision', 'update-lesser', 'update-body', 'wire-mcp', 'unknown'];
+
+	it('enumerates a STEPS_BY_KIND entry for every JobKind', () => {
+		for (const kind of kinds) {
+			expect(source).toContain(`'${kind}':`);
+		}
+	});
+
+	it('renders an "Auto-queued" pill for the gated step', () => {
+		expect(source).toContain("timeline__pill--auto-queued");
+		expect(source).toContain('>Auto-queued<');
+	});
+
+	it('declares the auto-queued indicator style block', () => {
+		expect(source).toContain('.timeline__step--auto-queued .timeline__indicator');
+	});
+});

--- a/web/src/pages/operator/ProvisioningJobs.svelte
+++ b/web/src/pages/operator/ProvisioningJobs.svelte
@@ -27,11 +27,13 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 		OperatorInstancesDriftResult,
 		OperatorProvisionJobListItem,
 		OperatorUpdateJobListItem,
+		RemediateMCPDriftResponse,
 	} from 'src/lib/api/operatorProvisioning';
 	import {
 		listOperatorInstancesDrift,
 		listOperatorProvisionJobs,
 		listOperatorUpdateJobs,
+		remediateMCPDrift,
 		retryOperatorProvisionJob,
 	} from 'src/lib/api/operatorProvisioning';
 	import JobKindBadge from 'src/lib/components/JobKindBadge.svelte';
@@ -57,6 +59,14 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 	// is not yet present; `data` once telemetry is available.
 	let drift = $state<OperatorInstancesDriftResult | null>(null);
 	let driftError = $state<string | null>(null);
+
+	// M2.12 wire-all state mirrors /operator/releases: the same fleet
+	// remediation endpoint, the same idempotency contract, the same
+	// post-action drift refresh. Both pages render the alert + CTA so an
+	// operator finding wire-stale drift on either page can act in place.
+	let wireAllPending = $state(false);
+	let wireAllResult = $state<RemediateMCPDriftResponse | null>(null);
+	let wireAllError = $state<string | null>(null);
 
 	/**
 	 * Unified feed: ProvisionJob rows + UpdateJob rows merged by
@@ -95,6 +105,11 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 		driftError = null;
 		provisionJobs = [];
 		updateJobsResult = null;
+		// Drop a stale wire-all result on a manual refresh so the toast
+		// doesn't outlive its data lineage; the per-attempt error similarly
+		// resets.
+		wireAllResult = null;
+		wireAllError = null;
 		// Keep `drift` across reloads so the banner doesn't flicker on filter
 		// changes; only clear if a fresh load fails or the endpoint flips
 		// from `data` → `endpoint-pending` (which is a meaningful change).
@@ -138,6 +153,38 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 			errorMessage = formatError(err);
 		} finally {
 			loading = false;
+		}
+	}
+
+	/**
+	 * M2.12 wire-all CTA. Calls the M2.10 fleet remediation endpoint and
+	 * stores the per-attempt result so the toast wording can reflect
+	 * created vs. skipped (idempotent re-clicks land 0 created /
+	 * non-zero skipped). After remediation we reload the page list so
+	 * any newly-queued MCP-only UpdateJobs surface in the rows feed —
+	 * the rows themselves come from the UpdateJob aggregation, but a
+	 * full `load()` also re-fetches drift so the alert reflects the
+	 * post-action posture.
+	 */
+	async function wireAll() {
+		wireAllError = null;
+		wireAllResult = null;
+		wireAllPending = true;
+		try {
+			wireAllResult = await remediateMCPDrift(token);
+			// Re-fetch drift only; the rows feed already includes UpdateJobs
+			// once they materialize and the operator can refresh manually
+			// for the row-level view.
+			drift = await listOperatorInstancesDrift(token).catch(() => drift);
+		} catch (err) {
+			if ((err as Partial<ApiError>).status === 401) {
+				await logout();
+				navigate('/login');
+				return;
+			}
+			wireAllError = formatError(err);
+		} finally {
+			wireAllPending = false;
 		}
 	}
 
@@ -188,12 +235,32 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 		{@const count = drift.data.summary?.mcp_wire_stale ?? 0}
 		{#if count > 0}
 			<Alert variant="warning" title="MCP wire drift detected">
-				<Text size="sm">
-					{count} managed {count === 1 ? 'instance is' : 'instances are'} on a wire-stale MCP
-					revision. Use the Stack Matrix or Wire-all CTA on
-					<Link {...linkProps('/operator/releases')} variant="default">/operator/releases</Link>
-					to remediate.
-				</Text>
+				<!--
+					M2.12: top-of-page wire-all CTA. The alert frames the problem
+					(N wire-stale instances) and the button calls the M2.10
+					fleet-remediation endpoint directly so an operator landing on
+					/operator/provisioning doesn't need to bounce through the
+					releases page to act. Idempotent by backend contract; the
+					toast below reflects created + skipped.
+				-->
+				<div class="op-provisioning__wireall">
+					<Text size="sm">
+						{count} managed {count === 1 ? 'instance is' : 'instances are'} on a wire-stale
+						MCP revision. The "Wire all" CTA queues one MCP-only UpdateJob per affected slug;
+						idempotent on re-click. The Stack Matrix on
+						<Link {...linkProps('/operator/releases')} variant="default">/operator/releases</Link>
+						shows per-row drift detail.
+					</Text>
+					<div class="op-provisioning__wireall-actions">
+						<Button
+							variant="solid"
+							onclick={() => void wireAll()}
+							disabled={wireAllPending}
+						>
+							{wireAllPending ? 'Wiring…' : `Wire all (${count})`}
+						</Button>
+					</div>
+				</div>
 			</Alert>
 		{:else}
 			<Alert variant="info" title="Fleet wire-aligned">
@@ -203,15 +270,56 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 	{:else if drift?.kind === 'endpoint-pending'}
 		<Alert variant="info" title="MCP drift telemetry pending">
 			<Text size="sm">
-				Awaiting the operator drift-aggregation endpoint
-				(<span class="op-provisioning__mono">/api/v1/operators/instances/drift</span>, M2.9).
-				The provisioning list still renders normally while the backend ships.
+				The operator drift aggregation endpoint
+				(<span class="op-provisioning__mono">/api/v1/operators/instances/drift</span>) did not
+				respond with drift data for the current request. The provisioning list still renders
+				normally; use Refresh to retry.
 			</Text>
 		</Alert>
 	{:else if driftError}
 		<Alert variant="warning" title="MCP drift load failed">
 			<Text size="sm">{driftError}</Text>
 		</Alert>
+	{/if}
+
+	<!--
+		M2.12 wire-all result + error toasts (shared shape with
+		/operator/releases). Created → success toast with link to view the
+		queued jobs (which surface inline in the rows feed below as
+		updateJobsResult ships, but the explicit toast confirms the action
+		regardless). Skipped-only → info-toast explicitly noting the
+		idempotency guard fired; surfaces the active-jobs count.
+	-->
+	{#if wireAllError}
+		<Alert variant="error" title="Wire all failed">
+			<Text size="sm">{wireAllError}</Text>
+		</Alert>
+	{:else if wireAllResult}
+		{#if wireAllResult.created > 0}
+			<Alert variant="success" title="MCP wire-all queued">
+				<Text size="sm">
+					Queued {wireAllResult.created}
+					MCP-only {wireAllResult.created === 1 ? 'job' : 'jobs'}{wireAllResult.skipped > 0
+						? `; skipped ${wireAllResult.skipped} already-active`
+						: ''}. The new {wireAllResult.created === 1 ? 'row appears' : 'rows appear'} in the
+					list below once the worker picks them up.
+				</Text>
+			</Alert>
+		{:else if wireAllResult.skipped > 0}
+			<Alert variant="info" title="MCP wire-all idempotent">
+				<Text size="sm">
+					No new jobs created — {wireAllResult.skipped}
+					{wireAllResult.skipped === 1 ? 'slug already has' : 'slugs already have'} an active
+					MCP-only UpdateJob in flight. Re-check once those jobs land.
+				</Text>
+			</Alert>
+		{:else}
+			<Alert variant="info" title="MCP wire-all no-op">
+				<Text size="sm">
+					Nothing to do — no instances reported wire-stale at request time.
+				</Text>
+			</Alert>
+		{/if}
 	{/if}
 
 	<Card variant="outlined" padding="lg">
@@ -432,5 +540,22 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.3
 	.op-provisioning__mono {
 		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
 			monospace;
+	}
+
+	/*
+	 * M2.12 wire-all alert layout — stack body + action vertically so the
+	 * button reads as a clear next-step rather than fighting the title
+	 * baseline. Matches the equivalent block on /operator/releases.
+	 */
+	.op-provisioning__wireall {
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-2);
+	}
+
+	.op-provisioning__wireall-actions {
+		display: flex;
+		gap: var(--gr-spacing-scale-2);
+		flex-wrap: wrap;
 	}
 </style>

--- a/web/src/pages/operator/Releases.svelte
+++ b/web/src/pages/operator/Releases.svelte
@@ -25,15 +25,18 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 	import { onMount } from 'svelte';
 
 	import type { ApiError } from 'src/lib/api/http';
-	import type { OperatorInstancesDriftResult } from 'src/lib/api/operatorProvisioning';
-	import { listOperatorInstancesDrift } from 'src/lib/api/operatorProvisioning';
+	import type {
+		OperatorInstancesDriftResult,
+		RemediateMCPDriftResponse,
+	} from 'src/lib/api/operatorProvisioning';
+	import { listOperatorInstancesDrift, remediateMCPDrift } from 'src/lib/api/operatorProvisioning';
 	import type { ListOperatorReleasesResult } from 'src/lib/api/operatorReleases';
 	import { channelVersions, listOperatorReleases } from 'src/lib/api/operatorReleases';
 	import ReleaseTimeline from 'src/lib/components/ReleaseTimeline.svelte';
 	import StackMatrix from 'src/lib/components/StackMatrix.svelte';
 	import { logout } from 'src/lib/auth/logout';
-	import { navigate } from 'src/lib/router';
-	import { Alert, Button, Card, Heading, Spinner, Text } from 'src/lib/ui';
+	import { linkProps, navigate } from 'src/lib/router';
+	import { Alert, Button, Card, Heading, Link, Spinner, Text } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
 
@@ -42,6 +45,15 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 	let releases = $state<ListOperatorReleasesResult | null>(null);
 	let drift = $state<OperatorInstancesDriftResult | null>(null);
 	let wireActionInfo = $state<string | null>(null);
+
+	// M2.12 wire-all state: in-flight flag, last result (kept so idempotent
+	// re-clicks reflect 0-created and a non-zero skipped count), and a
+	// per-attempt error string. We don't store the job IDs in this scope
+	// because the per-job UI lives at /operator/provisioning — the toast
+	// links there for follow-up.
+	let wireAllPending = $state(false);
+	let wireAllResult = $state<RemediateMCPDriftResponse | null>(null);
+	let wireAllError = $state<string | null>(null);
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -58,6 +70,10 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 		wireActionInfo = null;
 		releases = null;
 		drift = null;
+		// Drop a stale wire-all result so the toast doesn't persist across
+		// a manual refresh; the per-attempt error similarly resets.
+		wireAllResult = null;
+		wireAllError = null;
 
 		loading = true;
 		try {
@@ -82,17 +98,54 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 	}
 
 	/**
-	 * Per-row "Wire MCP" handler emitted by the Stack Matrix. The actual
-	 * remediation endpoint is M2.10; until that ships we surface an
-	 * info banner explaining the action, the slug, and the next-step
-	 * link so the operator can take manual action from the per-slug
-	 * detail page.
+	 * Per-row "Wire MCP" handler emitted by the Stack Matrix. The fleet
+	 * remediation endpoint (M2.10) operates fleet-wide via the "Wire all"
+	 * CTA above; per-row remediation is delegated to the per-instance
+	 * detail page where the operator owns the call site. Inform the
+	 * operator instead of silently doing nothing.
 	 */
 	function handleStackAction(slug: string, action: 'wire-mcp') {
 		if (action === 'wire-mcp') {
-			wireActionInfo = `Wire MCP requested for "${slug}". The fleet remediation endpoint (M2.10) ships in a follow-on commit; use the per-instance detail page for manual remediation in the meantime.`;
+			wireActionInfo = `Wire MCP requested for "${slug}". Use the "Wire all" button above to remediate every wire-stale instance, or open /operator/instances/${slug} for per-instance control.`;
 		}
 	}
+
+	/**
+	 * M2.12 wire-all CTA. Calls POST /api/v1/operators/instances/remediate-mcp-drift
+	 * (M2.10 backend) and stores the per-attempt result so the toast can
+	 * reflect both created and skipped counts. The endpoint is idempotent
+	 * via GSI2 UPDATE_ACTIVE on the backend — re-clicks land 0-created /
+	 * non-zero-skipped, which the toast wording captures explicitly.
+	 *
+	 * After a successful remediation, we re-fetch drift so the summary
+	 * strip + matrix reflect the post-remediation state. (The wire-mcp
+	 * UpdateJobs are async; drift recomputation here shows the *queued*
+	 * MCP-only jobs are in flight, not their eventual completion.)
+	 */
+	async function wireAll() {
+		wireAllError = null;
+		wireAllResult = null;
+		wireAllPending = true;
+		try {
+			wireAllResult = await remediateMCPDrift(token);
+			// Re-fetch drift only — releases telemetry is independent of
+			// the wire-all action.
+			drift = await listOperatorInstancesDrift(token).catch(() => drift);
+		} catch (err) {
+			if ((err as Partial<ApiError>).status === 401) {
+				await logout();
+				navigate('/login');
+				return;
+			}
+			wireAllError = formatError(err);
+		} finally {
+			wireAllPending = false;
+		}
+	}
+
+	const wireStaleCount = $derived(
+		drift?.kind === 'data' ? drift.data.summary?.mcp_wire_stale ?? 0 : 0,
+	);
 
 	onMount(() => {
 		void load();
@@ -121,6 +174,79 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<!--
+		M2.12 top-of-page MCP-drift alert + "Wire all" CTA. Mirrors the
+		alert on /operator/provisioning, but adds the fleet remediation
+		button inline since this page is the canonical home for the
+		matrix view that surfaces wire-stale rows. The button is enabled
+		only when drift has loaded AND `summary.mcp_wire_stale > 0`.
+	-->
+	{#if drift?.kind === 'data'}
+		{#if wireStaleCount > 0}
+			<Alert variant="warning" title="MCP wire drift detected">
+				<div class="op-releases__wireall">
+					<Text size="sm">
+						{wireStaleCount}
+						managed {wireStaleCount === 1 ? 'instance is' : 'instances are'} on a wire-stale
+						MCP revision. The "Wire all" CTA queues one MCP-only UpdateJob per affected
+						slug; idempotent on re-click via the active-jobs guard.
+					</Text>
+					<div class="op-releases__wireall-actions">
+						<Button
+							variant="solid"
+							onclick={() => void wireAll()}
+							disabled={wireAllPending}
+						>
+							{wireAllPending ? 'Wiring…' : `Wire all (${wireStaleCount})`}
+						</Button>
+					</div>
+				</div>
+			</Alert>
+		{:else}
+			<Alert variant="info" title="Fleet wire-aligned">
+				<Text size="sm">All managed instances are wire-aligned with their target MCP revision.</Text>
+			</Alert>
+		{/if}
+	{/if}
+
+	<!--
+		Wire-all result + error toasts. We surface both `created` and
+		`skipped` so the operator can distinguish first-click remediation
+		from a no-op idempotent re-click. The "View jobs" link routes
+		to /operator/provisioning where the per-job rows render.
+	-->
+	{#if wireAllError}
+		<Alert variant="error" title="Wire all failed">
+			<Text size="sm">{wireAllError}</Text>
+		</Alert>
+	{:else if wireAllResult}
+		{#if wireAllResult.created > 0}
+			<Alert variant="success" title="MCP wire-all queued">
+				<Text size="sm">
+					Queued {wireAllResult.created}
+					MCP-only {wireAllResult.created === 1 ? 'job' : 'jobs'}{wireAllResult.skipped > 0
+						? `; skipped ${wireAllResult.skipped} already-active`
+						: ''}.
+					<Link {...linkProps('/operator/provisioning')} variant="default">View jobs ↗</Link>
+				</Text>
+			</Alert>
+		{:else if wireAllResult.skipped > 0}
+			<Alert variant="info" title="MCP wire-all idempotent">
+				<Text size="sm">
+					No new jobs created — {wireAllResult.skipped}
+					{wireAllResult.skipped === 1 ? 'slug already has' : 'slugs already have'} an active
+					MCP-only UpdateJob in flight. Re-check once those jobs land.
+				</Text>
+			</Alert>
+		{:else}
+			<Alert variant="info" title="MCP wire-all no-op">
+				<Text size="sm">
+					Nothing to do — no instances reported wire-stale at request time.
+				</Text>
+			</Alert>
+		{/if}
+	{/if}
 
 	{#if loading}
 		<div class="op-releases__loading">
@@ -297,6 +423,24 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 
 	.op-releases__summary-value[data-tone='ok'] {
 		color: #22c55e;
+	}
+
+	/*
+	 * M2.12 wire-all CTA layout — stack body text + action buttons
+	 * vertically with a small gap so the button has visual room and
+	 * doesn't fight the alert title for the same baseline. CSP-safe
+	 * (no inline styles).
+	 */
+	.op-releases__wireall {
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-2);
+	}
+
+	.op-releases__wireall-actions {
+		display: flex;
+		gap: var(--gr-spacing-scale-2);
+		flex-wrap: wrap;
 	}
 
 	@media (max-width: 880px) {

--- a/web/src/pages/operator/Releases.svelte
+++ b/web/src/pages/operator/Releases.svelte
@@ -1,23 +1,25 @@
 <!--
 @component
-Operator Releases — two-channel release timeline (lesser + lesser-body).
+Operator Releases — two-channel release timeline (lesser + lesser-body)
+plus the fleet Stack Matrix.
 
-Project 39 M2.5 (issue #431). Renders two side-by-side columns sourcing
-adoption-aware release history from the M2.8 endpoint
-`/api/v1/operators/releases`. When the endpoint is not yet present,
-falls back to a "telemetry pending" placeholder so the page is
-navigable from day one (same pattern as the M2.3 drift banner and the
-M1.6 stack endpoint).
+Project 39 M2.5 (issue #431) shipped the two-channel timeline scaffold
+plus a forward-compat Stack Matrix card whose narrative pointed at the
+then-pending M2.9 drift endpoint. PR #513 landed the M2.8 / M2.9 / M2.10
+operator backends, so the Stack Matrix is now first-class: M2.11
+(issue #437) wires it through to the live `/api/v1/operators/instances/drift`
+aggregation and surfaces a per-summary drift strip above the matrix so
+the operator can read fleet posture at a glance.
 
-The page is operator-only: the calling endpoint is operator-JWT gated;
-no tenant content is read.
+The page is operator-only: every endpoint it consumes is operator-JWT
+gated; no tenant content is read.
 
 Posture preserved:
 - Strict-CSP-safe: no inline scripts / styles / third-party origins.
 - Multi-tenant isolation: aggregation is fleet-level metadata only.
 - Trust-API instance-auth untouched; SEC-9 change-lock not engaged.
 
-Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5, M2.11
 -->
 <script lang="ts">
 	import { onMount } from 'svelte';
@@ -130,9 +132,10 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5
 	{:else if releases?.kind === 'endpoint-pending'}
 		<Alert variant="info" title="Release telemetry pending">
 			<Text size="sm">
-				Awaiting the operator releases aggregation endpoint
-				(<span class="op-releases__mono">/api/v1/operators/releases</span>, M2.8). The page
-				layout ships now so the M2.6 Stack Matrix + M2.11 Wire-all CTA have a stable home.
+				The operator releases aggregation endpoint
+				(<span class="op-releases__mono">/api/v1/operators/releases</span>, M2.8) did not
+				respond with adoption data for the current request. The Stack Matrix below still
+				reads from the M2.9 drift endpoint and renders independently.
 			</Text>
 		</Alert>
 	{:else if releases?.kind === 'data'}
@@ -157,12 +160,43 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5
 			<Heading level={3} size="lg">Stack matrix</Heading>
 		{/snippet}
 		{#if drift?.kind === 'data'}
+			{@const summary = drift.data.summary}
+			<dl
+				class="op-releases__summary"
+				aria-label="Fleet drift summary"
+			>
+				<div class="op-releases__summary-cell">
+					<dt><Text size="xs" color="secondary">Total</Text></dt>
+					<dd class="op-releases__summary-value">{summary?.total ?? drift.data.instances.length}</dd>
+				</div>
+				<div class="op-releases__summary-cell">
+					<dt><Text size="xs" color="secondary">Lesser stale</Text></dt>
+					<dd
+						class="op-releases__summary-value"
+						data-tone={(summary?.lesser_stale ?? 0) > 0 ? 'warn' : 'ok'}
+					>{summary?.lesser_stale ?? 0}</dd>
+				</div>
+				<div class="op-releases__summary-cell">
+					<dt><Text size="xs" color="secondary">Body stale</Text></dt>
+					<dd
+						class="op-releases__summary-value"
+						data-tone={(summary?.body_stale ?? 0) > 0 ? 'warn' : 'ok'}
+					>{summary?.body_stale ?? 0}</dd>
+				</div>
+				<div class="op-releases__summary-cell">
+					<dt><Text size="xs" color="secondary">MCP wire-stale</Text></dt>
+					<dd
+						class="op-releases__summary-value"
+						data-tone={(summary?.mcp_wire_stale ?? 0) > 0 ? 'warn' : 'ok'}
+					>{summary?.mcp_wire_stale ?? 0}</dd>
+				</div>
+			</dl>
 			<StackMatrix entries={drift.data.instances} onAction={handleStackAction} />
 		{:else if drift?.kind === 'endpoint-pending'}
 			<Text size="sm" color="secondary">
-				Stack matrix telemetry is pending the M2.9
-				<span class="op-releases__mono">/api/v1/operators/instances/drift</span> endpoint.
-				The matrix component lights up the moment the backend ships.
+				The operator drift aggregation endpoint
+				(<span class="op-releases__mono">/api/v1/operators/instances/drift</span>) did not
+				respond with drift data for the current request. Use Refresh to retry.
 			</Text>
 		{:else}
 			<Text size="sm" color="secondary">No fleet drift data loaded.</Text>
@@ -212,6 +246,57 @@ Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.5
 
 	.op-releases__mono {
 		font-family: var(--gr-typography-fontFamily-mono, ui-monospace, monospace);
+	}
+
+	/*
+	 * M2.11 drift summary strip. Reads directly from
+	 * `drift.data.summary` (total / lesser_stale / body_stale / mcp_wire_stale)
+	 * so the operator can read fleet posture before scanning the matrix.
+	 * `data-tone="warn"` is the single dynamic state; rendered as a static
+	 * attribute (not an inline `style:` directive) to keep the strict
+	 * `style-src 'self'` CSP intact — same pattern as PR #512 M2.7
+	 * (SVG adoption bar) but with even less moving parts since it's a
+	 * count, not a width.
+	 */
+	.op-releases__summary {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+		gap: var(--gr-spacing-scale-3);
+		margin: 0 0 var(--gr-spacing-scale-4) 0;
+		padding: var(--gr-spacing-scale-3);
+		border: 1px solid var(--gr-color-border, currentColor);
+		border-radius: 6px;
+		background: rgba(255, 255, 255, 0.02);
+	}
+
+	.op-releases__summary-cell {
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-1);
+		min-width: 0;
+	}
+
+	.op-releases__summary-cell dt {
+		margin: 0;
+	}
+
+	.op-releases__summary-cell dd {
+		margin: 0;
+	}
+
+	.op-releases__summary-value {
+		font-family: var(--gr-typography-fontFamily-mono, ui-monospace, monospace);
+		font-size: 1.1rem;
+		font-weight: 600;
+		color: var(--ds-fg-1, inherit);
+	}
+
+	.op-releases__summary-value[data-tone='warn'] {
+		color: #f59e0b;
+	}
+
+	.op-releases__summary-value[data-tone='ok'] {
+		color: #22c55e;
 	}
 
 	@media (max-width: 880px) {


### PR DESCRIPTION
## Summary

Project 39 M2.11–M2.13 — three M2 web-only changes that follow the M2.8/M2.9/M2.10 operator-backend landings (PR #513) and complete the operator-facing wire-all flow.

- **M2.11 — `feat(web): wire Stack Matrix to fleet drift endpoint` (#437)** — M2.5 shipped the `/operator/releases` scaffold + a forward-compat Stack Matrix card pointing at the then-pending M2.9 drift endpoint. The card now reads live `/api/v1/operators/instances/drift` data and surfaces a per-summary drift strip (total / lesser-stale / body-stale / mcp-wire-stale) above the matrix so an operator can read fleet posture at a glance. Stale "endpoint pending" narratives are rewritten as honest "didn't respond for this request" guidance now that the backend has shipped.

- **M2.12 — `feat(web): wire "Wire all" CTA to MCP-drift remediation` (#438)** — New `remediateMCPDrift(token)` client + top-of-page "Wire all" CTAs on both `/operator/provisioning` and `/operator/releases`. Both pages share the same idempotent flow: POST to `/api/v1/operators/instances/remediate-mcp-drift` (M2.10), render an Alert toast distinguishing created / skipped / no-op outcomes, then re-fetch drift so the post-action posture appears in the alert + summary strip. Idempotent re-clicks land `0-created / N-skipped` and the toast wording reflects that explicitly.

- **M2.13 — `feat(web): refine provisioning timeline for four job kinds` (#439)** — `ProvisioningTimeline.svelte` gains an explicit auto-queued "Wire MCP in Lesser" gated step at the end of every `update-body` timeline. The gated step is UI-only — `BodyOnly` jobs run `body → verify → done` in the real state machine; the MCP re-wire is a separate follow-up MCP-only `UpdateJob` (the wire-stale condition the M2.10 fleet remediation endpoint resolves). Surfacing the gated step as a visually terminal node with a dashed "Auto-queued" pill educates operators that body updates intentionally leave MCP wire-stale until a follow-up action (fleet wire-all or per-instance manual control) runs. 22 unit tests cover the four kinds, the auto-queued classification rules, the sentinel-opacity contract, and the source-level acceptance.

Each subissue ships as one signed commit (GPG key 72D6153132D52023, all `Good signature`).

| Commit | Subject | Issue |
|---|---|---|
| `06cd620` | feat(web): wire Stack Matrix to fleet drift endpoint | #437 |
| `321cec2` | feat(web): wire "Wire all" CTA to MCP-drift remediation | #438 |
| `39a4798` | feat(web): refine provisioning timeline for four job kinds | #439 |

## Posture

- **Strict CSP preserved.** All dynamic tone uses static `data-tone` / `data-state` attributes (consumed by per-component CSS) — no inline `style:` directives that would violate `style-src 'self'`. Cross-references the PR #512 M2.7 SVG-bar lesson; the gate from PR #512 follow-up (`operator-chrome-bundled.sh`, `web-css-no-svelte-global.sh`) both still PASS on the built bundle.
- **Multi-tenant isolation preserved.** Both M2.11 and M2.12 read only operator-JWT-gated fleet aggregation surfaces; the remediation endpoint creates one MCP-only `UpdateJob` per affected slug and emits an operator audit event with the slug list (no cross-tenant data in the response). M2.13 is render-only.
- **Trust-API instance-auth untouched.** SEC-9 / SEC-10 change-locks not engaged on any change.
- **Consumer release verification untouched.** No provisioning-worker code paths touched.

## Validation

- `cd web && npm run lint` → clean
- `cd web && npm run typecheck` → 0/0/0 (3,197 files)
- `cd web && npm test` → 87/87 pass (15 test files, includes the new 22-test `ProvisioningTimeline.svelte.test.ts`)
- `cd web && npm run build` → PASS (SEC-6 `verify-no-inline-html` + SEC-7 `verify-oac-form-integrity`)
- `bash gov-infra/verifiers/sec/operator-chrome-bundled.sh` → PASS
- `bash gov-infra/verifiers/sec/web-css-no-svelte-global.sh` → PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → **37/0/0 PASS**
- `go vet ./...` → clean
- `go test ./internal/controlplane -run 'TestHandleOperatorInstancesDrift|TestHandleOperatorRemediateMCPDrift|TestHandleOperatorReleases|TestComputeFleet'` → ok

## Test plan

- [ ] CI green (gov-infra rubric verifiers + web lint/typecheck/test/build + Go test + CDK synth)
- [ ] Deploy to lab via `theory app up --stage lab` (held — handled by the post-merge stage rollout per the M2.18 pack-bump milestone)
- [ ] Manual smoke in lab:
  - [ ] `/operator/releases` shows the drift summary strip + Stack Matrix with live drift data
  - [ ] `/operator/provisioning` shows the top-of-page MCP-drift alert with embedded "Wire all" CTA when fleet contains wire-stale instances
  - [ ] "Wire all" CTA triggers MCP-only `UpdateJob` per affected slug; success toast shows created/skipped counts
  - [ ] Re-click of "Wire all" lands `0-created / N-skipped`; toast reflects idempotency
  - [ ] `update-body` job detail page shows the auto-queued "Wire MCP in Lesser" gated step with the "Auto-queued" pill + downstream-contract copy
  - [ ] No CSP violations in browser console
- [ ] M2.14–M2.18 (SEC-12 + MAI-5 verifiers + threat-model + controls-matrix + `2026.05.24-web.2` pack bump + lab soak) — separate PRs, out of scope here

Closes #437, #438, #439. Parent #374 remains open through M2.14–M2.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)