### PR TITLE
feat(web): M3.1–M3.6 — Operator Console balance + public attestation re-skin on dark chrome

### DIFF
--- a/web/src/pages/operator/AuditLog.svelte
+++ b/web/src/pages/operator/AuditLog.svelte
@@ -1,3 +1,27 @@
+<!--
+@component
+Operator Audit explorer — re-skinned for the M2.1 dark warm-charcoal chrome.
+
+Project 39 M3.2 (issue #446). Surfaces the operator-audit log search behind
+a dark-chrome shell: search filters live in a single Filters card; results
+land in a per-row card list under a Results card; the result count surfaces
+as a top-of-page `SummaryStrip` + `StatCard` so an operator scanning the
+audit feed sees the post-filter sample size before scrolling.
+
+Behavior preserved:
+- Same `listOperatorAuditLog` endpoint, same operator-JWT requirement, same
+  RFC3339 filter contract (actor / action / target / request_id / since /
+  until), same 100-row paging, same 401 → logout / login navigation guard.
+- No new operator-JWT routes; no audit-row mutation (audit is append-only
+  per host's audit-event discipline).
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins.
+- Multi-tenant isolation: operator-scope read; no tenant content.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not engaged.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.2
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -6,6 +30,8 @@
 	import { listOperatorAuditLog } from 'src/lib/api/operatorAudit';
 	import { logout } from 'src/lib/auth/logout';
 	import { navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Button, Card, CopyButton, Heading, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
@@ -20,6 +46,17 @@
 	let requestId = $state('');
 	let since = $state('');
 	let until = $state('');
+
+	/**
+	 * Audit-result tone: zero rows reads as neutral (no signal), >0 reads as
+	 * informational (results present). The audit feed is operator-read-only,
+	 * so non-zero is not "needs attention" — `default` keeps the dark chrome
+	 * calm.
+	 */
+	function resultStatus(count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		return 'default';
+	}
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -58,6 +95,8 @@
 		}
 	}
 
+	const resultCount = $derived<number | null>(data ? data.entries.length : null);
+
 	onMount(() => {
 		void load();
 	});
@@ -73,6 +112,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="Audit window" columns={1} gap="md">
+		<StatCard
+			label="Results in current view"
+			value={String(resultCount ?? 0)}
+			status={resultStatus(resultCount)}
+		/>
+	</SummaryStrip>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -218,9 +265,17 @@
 		align-items: center;
 	}
 
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-audit__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>
-

--- a/web/src/pages/operator/ExternalInstanceRegistrations.svelte
+++ b/web/src/pages/operator/ExternalInstanceRegistrations.svelte
@@ -1,3 +1,28 @@
+<!--
+@component
+Operator external instance registrations — re-skinned for the M2.1 dark
+warm-charcoal chrome.
+
+Project 39 M3.1 (issue #445). Tab 3 of 3 in the Approvals surface (alongside
+portal users and vanity domains). Carries the same SummaryStrip queue-count
+header so an operator landing on the Approvals navigation sees the per-tab
+backlog before scrolling.
+
+Behavior preserved:
+- Same `listExternalInstanceRegistrations` + `approveExternalInstanceRegistration`
+  + `rejectExternalInstanceRegistration` endpoints; same 401 → logout /
+  login navigation guard; same Open-instance link to the read-only support
+  view.
+- No new operator-JWT routes; no new write endpoints.
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins.
+- Multi-tenant isolation: pending registrations are operator-scope only;
+  no tenant content read.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not engaged.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.1
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -10,6 +35,8 @@
 	} from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
 	import { linkProps, navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Badge, Button, Card, CopyButton, Heading, Link, Spinner, Text } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
@@ -20,6 +47,16 @@
 
 	let actingId = $state<string | null>(null);
 	let actionError = $state<string | null>(null);
+
+	/**
+	 * Mirror M2.2 Dashboard.queueStatus(): non-zero queue → amber on dark
+	 * chrome; zero → success-green; null (unloaded) → neutral default.
+	 */
+	function queueStatus(count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		if (count > 0) return 'warning';
+		return 'success';
+	}
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -73,6 +110,8 @@
 		}
 	}
 
+	const queueCount = $derived<number | null>(data ? data.registrations.length : null);
+
 	onMount(() => {
 		void load();
 	});
@@ -88,6 +127,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="External registrations queue" columns={1} gap="md">
+		<StatCard
+			label="Pending external registrations"
+			value={String(queueCount ?? 0)}
+			status={queueStatus(queueCount)}
+		/>
+	</SummaryStrip>
 
 	{#if loading}
 		<div class="op-external__loading">
@@ -244,9 +291,17 @@
 		align-items: center;
 	}
 
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-external__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>
-

--- a/web/src/pages/operator/InstanceSupport.svelte
+++ b/web/src/pages/operator/InstanceSupport.svelte
@@ -1,3 +1,42 @@
+<!--
+@component
+Operator Instances — read-only support view re-skinned for the M2.1 dark
+warm-charcoal chrome.
+
+Project 39 M3.3 (issue #447). One page covers both routes the issue
+identifies (`/operator/instances` slug search and
+`/operator/instances/{slug}` slug detail); the routing dispatch in
+`web/src/pages/Operator.svelte` maps `instances` + `instanceDetail` to this
+component (with the slug prop set on the detail route).
+
+Behavior preserved:
+- Read-mostly support surface: Overview / Config / Domains / Budgets /
+  Provisioning / Updates cards.
+- Managed-only mutations (Apply configuration / Rotate instance key /
+  Start version update / Update lesser-body / Update MCP) remain gated
+  behind `managed()` and the existing operator-JWT portal endpoints.
+- Same `portalGetInstance` / `portalListInstanceDomains` /
+  `portalListBudgets` / `portalGetProvisioning` /
+  `portalListUpdateJobs` / `portalCreateUpdateJob` endpoints; same
+  401 → logout / login navigation guard; same `pollUntil` UpdateJob
+  polling contract with abort-on-slug-change semantics; same
+  `validateManagedReleaseTag` input validation.
+- No operator-only routes added; this surface re-uses the customer
+  portal endpoints intentionally (operator support view re-uses the
+  same data shape so support and customer self-serve diverge minimally).
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins;
+  `safeHref` continues to gate external run-log URLs.
+- Multi-tenant isolation: scoped per slug; no cross-slug aggregation;
+  the slug navigation guard in `$effect` re-loads on slug change.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not
+  engaged.
+- Release-verification untouched: managed-update jobs flow through the
+  existing checksum-gated worker contract.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.3
+-->
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 
@@ -16,6 +55,8 @@
 	import { pollUntil } from 'src/lib/polling';
 	import { navigate } from 'src/lib/router';
 	import { validateManagedReleaseTag } from 'src/lib/utils/versionTags';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token, slug } = $props<{ token: string; slug?: string }>();
@@ -90,6 +131,20 @@
 	function isUpdateTerminal(job: UpdateJobResponse | null): boolean {
 		if (!job) return true;
 		return job.status === 'ok' || job.status === 'error';
+	}
+
+	/**
+	 * Map a string status to a `StatCard` tone so the top-of-page
+	 * SummaryStrip reads as "ok" / "needs attention" / "error" on the
+	 * dark chrome. Empty / unknown statuses fall through to neutral.
+	 */
+	function statusTone(value: string | undefined | null): StatCardStatus {
+		const v = (value || '').toLowerCase().trim();
+		if (!v) return 'default';
+		if (v === 'ok' || v === 'active' || v === 'success' || v === 'ready') return 'success';
+		if (v === 'error' || v === 'failed') return 'danger';
+		if (v === 'running' || v === 'queued' || v === 'pending' || v === 'in_progress' || v === 'updating') return 'warning';
+		return 'default';
 	}
 
 	function jobKind(job?: UpdateJobResponse | null): string {
@@ -413,6 +468,20 @@
 			<Text size="sm">Enter a slug and click Open.</Text>
 		</Alert>
 	{:else if instance}
+		<SummaryStrip label="Instance state" columns={3} gap="md">
+			<StatCard label="Status" value={instance.status || '—'} status={statusTone(instance.status)} />
+			<StatCard
+				label="Provision"
+				value={instance.provision_status || '—'}
+				status={statusTone(instance.provision_status)}
+			/>
+			<StatCard
+				label="Lesser update"
+				value={instance.lesser_update_status || '—'}
+				status={statusTone(instance.lesser_update_status)}
+			/>
+		</SummaryStrip>
+
 		<Card variant="outlined" padding="lg">
 			{#snippet header()}
 				<div class="op-support__row">
@@ -926,8 +995,17 @@
 		background: var(--gr-color-surface);
 	}
 
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-support__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 

--- a/web/src/pages/operator/SoulRegistry.svelte
+++ b/web/src/pages/operator/SoulRegistry.svelte
@@ -1,3 +1,45 @@
+<!--
+@component
+Operator Soul registry — re-skinned for the M2.1 dark warm-charcoal chrome.
+
+Project 39 M3.5 (issue #449). Re-skins the Safe-mediated soul-registry
+governance surface at `/operator/soul-registry`. Publishes (reputation root
+/ validation root) and lists open governance operations by status. Adds a
+top-of-page `SummaryStrip` with the active status-filter bucket count and
+per-field `CopyButton` on the Safe-payload preview so an operator handing
+off to Safe for signing can paste each field individually.
+
+Posture preserved (and elevated because soul-registry mutations touch
+the soul-registry namespace contract that lesser-soul publishes — every
+mutation here is, by host's discipline, a Safe-ready governance event):
+- Strict-CSP-safe: no inline scripts / styles / third-party origins; the
+  Safe-app `frame-ancestors` exception lives in `safeAppCsp` and is
+  unchanged.
+- Safe-ready governance preserved: Open-in-Safe handoff continues to
+  stage a short-lived operator session via `stageSafeAppSessionHandoff`
+  and to build the Safe-app launch URL via `buildSafeWalletAppUrl` —
+  no signer-bypass paths added, no new Safe contract calls introduced.
+- On-chain integrity untouched: no contract changes, no mint-signer
+  surface, no off-chain reconciliation contract change.
+- Multi-tenant isolation: operator-scope only; soul-registry mutations
+  govern the registry namespace, not per-tenant data.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not
+  engaged.
+
+Behavior preserved:
+- Same `listSoulOperations` + `publishSoulReputationRoot` +
+  `publishSoulValidationRoot` + `soulPublicGetConfig` endpoints.
+- Same Safe-launch handoff with `stageSafeAppSessionHandoff` +
+  `buildSafeWalletAppUrl`, same chain-id resolution, same clipboard
+  fallback when popup blockers fire.
+- Same operator-JWT requirement; same 401 → logout / login navigation
+  guard; same status-filter contract (pending / proposed / executed /
+  failed).
+- No new operator-JWT routes; no new write endpoints; no new Safe
+  contract calls.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.5
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
@@ -8,6 +50,8 @@
 	import { logout } from 'src/lib/auth/logout';
 	import { linkProps, navigate, safeAppRootUrl, stageSafeAppTarget } from 'src/lib/router';
 	import { session, stageSafeAppSessionHandoff } from 'src/lib/session';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text } from 'src/lib/ui';
 	import { buildSafeWalletAppUrl } from 'src/lib/wallet/safeApp';
 
@@ -41,6 +85,18 @@
 		if (s === 'proposed' || s === 'pending') return { variant: 'outlined', color: 'warning' };
 		if (s === 'failed') return { variant: 'filled', color: 'error' };
 		return { variant: 'outlined', color: 'gray' };
+	}
+
+	/**
+	 * Mirror TipRegistry.bucketStatus(): pending-bucket non-zero → amber
+	 * (operator attention for sign-off); failed-bucket non-zero → danger;
+	 * proposed / executed are informational.
+	 */
+	function bucketStatus(filter: string, count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		if (filter === 'pending' && count > 0) return 'warning';
+		if (filter === 'failed' && count > 0) return 'danger';
+		return 'default';
 	}
 
 	function parseSafePayload(op: SoulOperation): { safe_address: string; to: string; value: string; data: string } | null {
@@ -169,6 +225,8 @@
 		}
 	}
 
+	const bucketCount = $derived<number | null>(ops ? ops.operations.length : null);
+
 	onMount(() => {
 		void loadConfig();
 		void load();
@@ -185,6 +243,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="Operations in current bucket" columns={1} gap="md">
+		<StatCard
+			label={`Operations · status ${statusFilter}`}
+			value={String(bucketCount ?? 0)}
+			status={bucketStatus(statusFilter, bucketCount)}
+		/>
+	</SummaryStrip>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -246,11 +312,38 @@
 			</div>
 
 			{#if res.safe_tx}
+				<!--
+					Safe-payload preview keeps each field's copy-to-clipboard
+					adjacent to its value so an operator handing off to Safe
+					for signing can paste each field individually. Mirrors the
+					M3.4 Tip-registry preview. tx-hash reconciliation lives on
+					the per-operation detail surface.
+				-->
 				<DefinitionList>
-					<DefinitionItem label="Safe" monospace>{res.safe_tx.safe_address}</DefinitionItem>
-					<DefinitionItem label="To" monospace>{res.safe_tx.to}</DefinitionItem>
-					<DefinitionItem label="Value" monospace>{res.safe_tx.value}</DefinitionItem>
-					<DefinitionItem label="Data" monospace>{res.safe_tx.data}</DefinitionItem>
+					<DefinitionItem label="Safe" monospace>
+						<span class="op-soul__safe-row">
+							<span>{res.safe_tx.safe_address}</span>
+							<CopyButton size="sm" text={res.safe_tx.safe_address} />
+						</span>
+					</DefinitionItem>
+					<DefinitionItem label="To" monospace>
+						<span class="op-soul__safe-row">
+							<span>{res.safe_tx.to}</span>
+							<CopyButton size="sm" text={res.safe_tx.to} />
+						</span>
+					</DefinitionItem>
+					<DefinitionItem label="Value" monospace>
+						<span class="op-soul__safe-row">
+							<span>{res.safe_tx.value}</span>
+							<CopyButton size="sm" text={res.safe_tx.value} />
+						</span>
+					</DefinitionItem>
+					<DefinitionItem label="Data" monospace>
+						<span class="op-soul__safe-row">
+							<span>{res.safe_tx.data}</span>
+							<CopyButton size="sm" text={res.safe_tx.data} />
+						</span>
+					</DefinitionItem>
 				</DefinitionList>
 			{/if}
 		</Card>
@@ -419,8 +512,26 @@
 		flex-wrap: wrap;
 	}
 
+	/* Inline Safe-payload row — see TipRegistry.svelte (M3.4) for rationale. */
+	.op-soul__safe-row {
+		display: inline-flex;
+		gap: var(--gr-spacing-scale-2);
+		align-items: center;
+		flex-wrap: wrap;
+		word-break: break-all;
+	}
+
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-soul__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>

--- a/web/src/pages/operator/TipRegistry.svelte
+++ b/web/src/pages/operator/TipRegistry.svelte
@@ -1,3 +1,42 @@
+<!--
+@component
+Operator Tip registry — re-skinned for the M2.1 dark warm-charcoal chrome.
+
+Project 39 M3.4 (issue #448). The index surface at `/operator/tip-registry`
+that gathers Safe-mediated tip-registry mutations (host ensure / set host
+active / token allowlist) and lists open operations by status. The dark
+chrome treats Safe-payload preview material as first-class evidence: per-row
+CopyButton on each Safe payload field so the safe-launch flow round-trips
+unbroken from this surface (the Open-operation detail page —
+`TipRegistryOperationDetail.svelte` — handles tx-hash reconciliation on
+its own re-skin track via operator-detail wiring).
+
+Behavior preserved:
+- Same `ensureTipRegistryHost` / `setTipRegistryHostActive` /
+  `setTipRegistryTokenAllowed` / `listTipRegistryOperations` endpoints.
+- Same Safe-payload data shape — `safe_address` / `to` / `value` / `data`
+  copy-to-clipboard is preserved (now per-field for the Safe-payload
+  audit-trail; the per-operation `View operation` link still navigates to
+  the detail page where tx-hash reconciliation lives).
+- Same operator-JWT requirement; same 401 → logout / login navigation
+  guard; same idempotent ensure-host no-op surface; same TipSplitter Safe
+  contract interaction (this page is presentational; no Safe contract or
+  Safe-ready governance mutation is introduced).
+- No new operator-JWT routes; no new write endpoints.
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins; the
+  Safe-app `frame-ancestors` exception lives in `safeAppCsp` and is
+  unchanged.
+- Multi-tenant isolation: operator-scope only; tip-registry mutations
+  govern the platform-wide allowlist, not per-tenant data.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not
+  engaged.
+- On-chain integrity untouched: Safe-ready payloads continue to flow
+  through the existing tip-registry operations contract.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.4
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -11,6 +50,8 @@
 	} from 'src/lib/api/tipRegistry';
 	import { logout } from 'src/lib/auth/logout';
 	import { linkProps, navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Badge, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Select, Spinner, Text, TextField } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
@@ -46,6 +87,20 @@
 		if (s === 'proposed' || s === 'pending') return { variant: 'outlined', color: 'warning' };
 		if (s === 'failed') return { variant: 'filled', color: 'error' };
 		return { variant: 'outlined', color: 'gray' };
+	}
+
+	/**
+	 * Map the active status-filter result count to a `StatCardStatus` tone
+	 * so the top-of-page SummaryStrip telegraphs whether there's a backlog.
+	 * Pending-bucket non-zero → amber (operator attention); other buckets
+	 * (proposed / executed / failed) stay neutral — they're informational
+	 * not actionable from this surface.
+	 */
+	function bucketStatus(filter: string, count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		if (filter === 'pending' && count > 0) return 'warning';
+		if (filter === 'failed' && count > 0) return 'danger';
+		return 'default';
 	}
 
 	async function load() {
@@ -139,6 +194,8 @@
 		}
 	}
 
+	const bucketCount = $derived<number | null>(ops ? ops.operations.length : null);
+
 	onMount(() => {
 		void load();
 	});
@@ -154,6 +211,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="Operations in current bucket" columns={1} gap="md">
+		<StatCard
+			label={`Operations · status ${statusFilter}`}
+			value={String(bucketCount ?? 0)}
+			status={bucketStatus(statusFilter, bucketCount)}
+		/>
+	</SummaryStrip>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -235,11 +300,40 @@
 					</div>
 
 					{#if res.safe_tx}
+						<!--
+							Safe-payload preview keeps each field's copy-to-clipboard
+							adjacent to its value so an operator handing off to Safe
+							for signing can paste each field individually without
+							hunting through a JSON blob. This preserves the M3.4
+							"Safe payload copy-to-clipboard preserved" acceptance
+							criterion. tx-hash reconciliation continues to live on
+							the per-operation detail page.
+						-->
 						<DefinitionList>
-							<DefinitionItem label="Safe" monospace>{res.safe_tx.safe_address}</DefinitionItem>
-							<DefinitionItem label="To" monospace>{res.safe_tx.to}</DefinitionItem>
-							<DefinitionItem label="Value" monospace>{res.safe_tx.value}</DefinitionItem>
-							<DefinitionItem label="Data" monospace>{res.safe_tx.data}</DefinitionItem>
+							<DefinitionItem label="Safe" monospace>
+								<span class="op-tip__safe-row">
+									<span>{res.safe_tx.safe_address}</span>
+									<CopyButton size="sm" text={res.safe_tx.safe_address} />
+								</span>
+							</DefinitionItem>
+							<DefinitionItem label="To" monospace>
+								<span class="op-tip__safe-row">
+									<span>{res.safe_tx.to}</span>
+									<CopyButton size="sm" text={res.safe_tx.to} />
+								</span>
+							</DefinitionItem>
+							<DefinitionItem label="Value" monospace>
+								<span class="op-tip__safe-row">
+									<span>{res.safe_tx.value}</span>
+									<CopyButton size="sm" text={res.safe_tx.value} />
+								</span>
+							</DefinitionItem>
+							<DefinitionItem label="Data" monospace>
+								<span class="op-tip__safe-row">
+									<span>{res.safe_tx.data}</span>
+									<CopyButton size="sm" text={res.safe_tx.data} />
+								</span>
+							</DefinitionItem>
 						</DefinitionList>
 					{/if}
 				{/if}
@@ -417,8 +511,28 @@
 		align-items: center;
 	}
 
+	/* Inline Safe-payload row: value + CopyButton sit on the same line so the
+	 * field is paste-ready without scrolling. The hash string wraps if the
+	 * viewport narrows. */
+	.op-tip__safe-row {
+		display: inline-flex;
+		gap: var(--gr-spacing-scale-2);
+		align-items: center;
+		flex-wrap: wrap;
+		word-break: break-all;
+	}
+
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-tip__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>

--- a/web/src/pages/operator/UserApprovals.svelte
+++ b/web/src/pages/operator/UserApprovals.svelte
@@ -1,3 +1,27 @@
+<!--
+@component
+Operator portal user approvals — re-skinned for the M2.1 dark warm-charcoal chrome.
+
+Project 39 M3.1 (issue #445). One of three Approvals tabs (alongside vanity
+domains and external instance registrations); each tab carries a SummaryStrip
+queue-count card at the top so an operator landing on the page sees the
+backlog before scrolling. Mirrors the M2.2 Dashboard pattern (issue #428):
+non-zero queue → amber warning, zero queue → success.
+
+Behavior preserved:
+- Same `listPortalUserApprovals` + `approvePortalUser` + `rejectPortalUser`
+  endpoints; same 401 → logout / login navigation guard; same review-note
+  capture.
+- No new operator-JWT routes; no new write endpoints.
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins.
+- Multi-tenant isolation: pending portal users are operator-scope only; no
+  tenant content read.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not engaged.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.1
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -6,6 +30,8 @@
 	import { approvePortalUser, listPortalUserApprovals, rejectPortalUser } from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
 	import { navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Badge, Button, Card, CopyButton, Heading, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
@@ -17,6 +43,16 @@
 	let reviewNote = $state('');
 	let actingUser = $state<string | null>(null);
 	let actionError = $state<string | null>(null);
+
+	/**
+	 * Mirror M2.2 Dashboard.queueStatus(): non-zero queue → amber so the
+	 * SummaryStrip card reads as "needs attention" on the dark chrome.
+	 */
+	function queueStatus(count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		if (count > 0) return 'warning';
+		return 'success';
+	}
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -71,6 +107,8 @@
 		}
 	}
 
+	const queueCount = $derived<number | null>(data ? data.users.length : null);
+
 	onMount(() => {
 		void load();
 	});
@@ -86,6 +124,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="Portal user queue" columns={1} gap="md">
+		<StatCard
+			label="Pending portal users"
+			value={String(queueCount ?? 0)}
+			status={queueStatus(queueCount)}
+		/>
+	</SummaryStrip>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -258,7 +304,23 @@
 		align-items: center;
 	}
 
+	/*
+	 * Token chain mirrors operator-chrome.css: prefer the canonical
+	 * greater-components typography token, fall back to the system mono
+	 * stack. The previous `--gr-font-family-mono` reference was a typo
+	 * (the bridged token is `--gr-typography-fontFamily-mono` — confirmed
+	 * in `src/lib/styles/greater/tokens.css` and `src/lib/tokens/gr-bridge.css`).
+	 */
 	.op-users__mono {
-		font-family: var(--gr-font-family-mono);
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
+			monospace;
 	}
 </style>

--- a/web/src/pages/operator/VanityDomainRequests.svelte
+++ b/web/src/pages/operator/VanityDomainRequests.svelte
@@ -1,3 +1,27 @@
+<!--
+@component
+Operator vanity domain requests — re-skinned for the M2.1 dark warm-charcoal
+chrome.
+
+Project 39 M3.1 (issue #445). Tab 2 of 3 in the Approvals surface (alongside
+portal users and external instance registrations). Carries the same
+SummaryStrip queue-count header so an operator landing on the Approvals
+navigation sees the per-tab backlog before scrolling.
+
+Behavior preserved:
+- Same `listVanityDomainRequests` + `approveVanityDomainRequest` +
+  `rejectVanityDomainRequest` endpoints; same 401 → logout / login
+  navigation guard; same review-note capture; same Open-instance link.
+- No new operator-JWT routes; no new write endpoints.
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins.
+- Multi-tenant isolation: pending vanity domain requests are operator-scope
+  only; no tenant content read.
+- Trust-API instance-auth untouched; SEC-9 / SEC-12 change-locks not engaged.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.1
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -6,6 +30,8 @@
 	import { approveVanityDomainRequest, listVanityDomainRequests, rejectVanityDomainRequest } from 'src/lib/api/operators';
 	import { logout } from 'src/lib/auth/logout';
 	import { linkProps, navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Badge, Button, Card, CopyButton, Heading, Link, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { token } = $props<{ token: string }>();
@@ -17,6 +43,16 @@
 	let reviewNote = $state('');
 	let actingDomain = $state<string | null>(null);
 	let actionError = $state<string | null>(null);
+
+	/**
+	 * Mirror M2.2 Dashboard.queueStatus(): non-zero queue → amber on dark
+	 * chrome; zero → success-green; null (unloaded) → neutral default.
+	 */
+	function queueStatus(count: number | null): StatCardStatus {
+		if (count == null) return 'default';
+		if (count > 0) return 'warning';
+		return 'success';
+	}
 
 	function formatError(err: unknown): string {
 		if (!err) return 'unknown error';
@@ -71,6 +107,8 @@
 		}
 	}
 
+	const queueCount = $derived<number | null>(data ? data.requests.length : null);
+
 	onMount(() => {
 		void load();
 	});
@@ -86,6 +124,14 @@
 			<Button variant="outline" onclick={() => void load()} disabled={loading}>Refresh</Button>
 		</div>
 	</header>
+
+	<SummaryStrip label="Vanity domain queue" columns={1} gap="md">
+		<StatCard
+			label="Pending vanity domains"
+			value={String(queueCount ?? 0)}
+			status={queueStatus(queueCount)}
+		/>
+	</SummaryStrip>
 
 	<Card variant="outlined" padding="lg">
 		{#snippet header()}
@@ -258,8 +304,17 @@
 		align-items: center;
 	}
 
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.op-requests__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>

--- a/web/src/pages/trust/AttestationInspector.svelte
+++ b/web/src/pages/trust/AttestationInspector.svelte
@@ -1,3 +1,37 @@
+<!--
+@component
+Public attestation inspector — re-skinned for the M2.1 design-token surface.
+
+Project 39 M3.6 (issue #450). The publicly-reachable attestation viewer at
+`/attestations/{id}`. Re-skin is presentational only per the trust-and-safety
+walk (24dcd86) — Dimension 1 (no auth change), Dimension 2 (no JWS decode
+path change), Dimension 3 (client-rendered; ISR deferred), Dimension 4
+(MarkdownRenderer mandatory-sanitization path preserved by intentional
+absence — no markdown surface is introduced; `pretty()` JSON-stringifies
+the header / payload into `TextArea readonly`, which Svelte escapes safely).
+
+Posture preserved:
+- Strict-CSP-safe: no inline scripts / styles / third-party origins; the
+  `webCsp` byte-string remains unchanged; the inspector renders entirely
+  via host's own bundle.
+- Trust-API instance-auth untouched: this is the public read surface; no
+  instance-key path; no internal-only fields surfaced (the response shape
+  from `/attestations/{id}` already redacts; nothing read here that wasn't
+  already in the public response).
+- No client-side caching beyond browser HTTP cache: same fetch on every
+  load; no IndexedDB / localStorage / SW caching layer added.
+- Multi-tenant isolation: attestations are public artifacts; no tenant
+  data is accessed.
+
+Behavior preserved:
+- Same `getAttestation(id)` + `getJWKS()` endpoints; same JWS decode +
+  header-kid + JWKS-kid surface; same Refresh button; same `Back` link;
+  same TextArea-readonly render of header + payload JSON.
+- No new endpoints; no new fields surfaced.
+
+Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M3.6
+Trust walk: docs/trust-and-safety-web-ui-rework-2026-05-24.md (24dcd86)
+-->
 <script lang="ts">
 	import { onMount } from 'svelte';
 
@@ -5,6 +39,8 @@
 	import type { AttestationResponse, JWKS } from 'src/lib/api/trust';
 	import { getAttestation, getJWKS } from 'src/lib/api/trust';
 	import { linkProps, navigate } from 'src/lib/router';
+	import { StatCard, SummaryStrip } from 'src/lib/shell';
+	import type { StatCardStatus } from 'src/lib/shell';
 	import { Alert, Button, Card, CopyButton, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text, TextArea } from 'src/lib/ui';
 
 	let { id } = $props<{ id: string }>();
@@ -43,6 +79,31 @@
 		const keys = jwks?.keys ?? [];
 		const kids = keys.map((k) => (typeof k.kid === 'string' ? k.kid : '')).filter(Boolean);
 		return Array.from(new Set(kids));
+	}
+
+	/**
+	 * Surface whether the header's kid is present in the JWKS the inspector
+	 * loaded alongside the attestation. A `success` tone tells the reader
+	 * "this attestation's signing key is in the published JWKS"; a `warning`
+	 * tone (kid present, JWKS missing) tells them the JWKS read failed but
+	 * the attestation itself loaded; `default` for the loading / no-data
+	 * state. Verification is the operator's responsibility; this card is a
+	 * fast visual signal, not a verifier.
+	 */
+	function kidPresenceStatus(): StatCardStatus {
+		if (!attestation) return 'default';
+		const headerK = headerKid();
+		if (!headerK) return 'default';
+		if (!jwks) return 'warning';
+		return jwksKids().includes(headerK) ? 'success' : 'warning';
+	}
+
+	function kidPresenceLabel(): string {
+		if (!attestation) return '—';
+		const headerK = headerKid();
+		if (!headerK) return 'no kid';
+		if (!jwks) return 'JWKS unavailable';
+		return jwksKids().includes(headerK) ? 'kid in JWKS' : 'kid not in JWKS';
 	}
 
 	async function load() {
@@ -87,6 +148,18 @@
 	{:else if errorMessage}
 		<Alert variant="error" title="Attestation">{errorMessage}</Alert>
 	{:else if attestation}
+		<!--
+			Fast visual signal: does the attestation's header kid appear in
+			the public JWKS the inspector loaded alongside it? This is a
+			lookup, not a verification — the reader still runs the JWS
+			verification per the instructions below. `warning` covers both
+			"kid not found in JWKS" and "JWKS unavailable" so the inspector
+			never silently implies a verified posture it can't claim.
+		-->
+		<SummaryStrip label="Inspector state" columns={1} gap="md">
+			<StatCard label="Header kid presence" value={kidPresenceLabel()} status={kidPresenceStatus()} />
+		</SummaryStrip>
+
 		<Card variant="outlined" padding="lg">
 			{#snippet header()}
 				<div class="trust-att__row">
@@ -118,6 +191,13 @@
 			{#snippet header()}
 				<Heading level={3} size="lg">Header</Heading>
 			{/snippet}
+			<!--
+				JSON content is rendered through TextArea readonly. Svelte
+				escapes the string body; no Markdown or HTML interpretation
+				path is introduced here, which preserves the mandatory-
+				sanitization invariant the trust-and-safety walk asserts
+				for the inspector (Dimension 4).
+			-->
 			<TextArea value={pretty(attestation.header)} readonly rows={10} />
 		</Card>
 
@@ -177,8 +257,17 @@
 		margin-top: var(--gr-spacing-scale-3);
 	}
 
+	/* Canonical mono token chain — see UserApprovals.svelte (M3.1) for rationale. */
 	.trust-att__mono {
-		font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
+		font-family:
+			var(--gr-typography-fontFamily-mono),
+			ui-monospace,
+			SFMono-Regular,
+			Menlo,
+			Monaco,
+			Consolas,
+			'Liberation Mono',
+			'Courier New',
 			monospace;
 	}
 </style>


### PR DESCRIPTION
## Summary

- M3.1 (#445): Re-skin Operator Approvals — 3 tabs (portal users, vanity domains, external instance registrations) on dark chrome with per-tab `SummaryStrip` queue-count cards and canonical mono token.
- M3.2 (#446): Re-skin Operator Audit explorer with a result-count `SummaryStrip` (neutral tone for the read-only investigation surface) and canonical mono token.
- M3.3 (#447): Re-skin Operator Instances read-only support view (`/operator/instances` + `/operator/instances/{slug}`) with a three-card `SummaryStrip` (status, provision, latest Lesser update).
- M3.4 (#448): Re-skin Operator Tip registry with per-field `CopyButton` on the Safe-payload preview (`safe_address` / `to` / `value` / `data`) so the M3.4 "Safe payload copy-to-clipboard preserved" acceptance is met and strengthened.
- M3.5 (#449): Re-skin Operator Soul registry with the same per-field Safe-payload preview pattern; Safe-launch handoff (`stageSafeAppSessionHandoff` + `buildSafeWalletAppUrl`) preserved unchanged.
- M3.6 (#450): Re-skin public attestation inspector with a "header kid presence" indicator (lookup, not verification — `warning` tone covers "kid not found" and "JWKS unavailable" so the inspector never silently implies a verified posture).

Implements enumerated changes M3.1–M3.6 from `docs/enumerated-changes-web-ui-rework-2026-05-24.md`; parent issue #375. M3.7–M3.13 (cost-telemetry firehose) and M3.14 (pack bump) are out of scope per the issue's "deferrable" gating.

## Stewardship posture

- **Presentational only.** No data-layer change, no auth contract change, no Safe contract change, no on-chain mutation, no new operator-JWT routes.
- **Trust API / CSP preserved.** No inline scripts / styles / third-party origins; CSP byte-string unchanged; `safeAppCsp` `frame-ancestors` exception unchanged. Attestation inspector preserves the mandatory-sanitization invariant by absence (no Markdown surface introduced; header / payload render through `TextArea readonly` with Svelte's default string-escaping).
- **Instance-auth preserved.** `sha256(raw_key)` contract untouched.
- **Multi-tenant isolation preserved.** All re-skinned operator surfaces remain operator-scope reads + the existing portal endpoints; Instance support view continues to scope per slug.
- **Consumer release verification untouched.** Managed-update jobs continue to flow through the checksum-gated worker.
- **AGPL discipline.** No proprietary blobs; no AGPL-incompatible dependencies introduced.
- **Framework consumption idiomatic.** Continued use of `@equaltoai/greater-components` shell primitives (`SummaryStrip`, `StatCard`) re-exported via `src/lib/shell`; no local FaceTheory / greater-components patches.
- **Token hygiene.** Replaces the stale `--gr-font-family-mono` reference (typo — never resolved) and hardcoded mono stacks with the canonical `--gr-typography-fontFamily-mono` token chain (resolved through `web/src/lib/styles/greater/tokens.css` and `web/src/lib/tokens/gr-bridge.css`).

## Validation run locally

- `cd web && npm run lint` — PASS
- `cd web && npm run typecheck` — PASS (svelte-check 0 errors / 0 warnings; tsc node-config clean)
- `cd web && npm test` — PASS (15 test files / 87 tests)
- `cd web && npm run build` — PASS (vite SPA + SSR; `verify-no-inline-html` PASS; `verify-oac-form-integrity` PASS; build-sidecars wrote 10 static sidecars)
- `go vet ./...` — clean
- `go test ./...` — PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — **PASS 39 / Fail 0 / Blocked 0**

CDK synth was skipped because no CDK paths are touched in this PR; the `cd cdk && npm test && npm run synth` gate runs from a fresh `npm ci` in CI.

## Stage rollout

- [x] Merged to main *(this PR)*
- [ ] Deployed to lab via `theory app up --stage lab`
- [ ] Lab soak (3–5 days per the M3 stage-rollout checkpoint on #375)
- [ ] Sim canary readiness gate (Phase R.1)

Closes M3.1–M3.6 commit set on #375; remaining M3 checkpoints (lab soak, sim canary) progress on the parent issue.

## Commits

All six commits are GPG-signed (RSA 72D6153132D52023, `Aron Price <aron23@gmail.com>`, ultimate trust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)