### PR TITLE
feat(cmd): scaffold cost-telemetry-worker Lambda (#451 / M3.7)

### DIFF
--- a/cdk/lib/cost-telemetry-worker-construct.ts
+++ b/cdk/lib/cost-telemetry-worker-construct.ts
@@ -1,0 +1,68 @@
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+/**
+ * Properties for CostTelemetryWorker.
+ *
+ * M3.7 scaffold: creates a scheduled Lambda for cost telemetry collection.
+ * No business logic yet — EventBridge entrypoint only.
+ * M3.8–M3.10 add CloudWatch / Cost Explorer / DynamoDB logic.
+ */
+export interface CostTelemetryWorkerProps {
+	/** Stack name prefix (e.g. "lesser-host-lab"). */
+	namePrefix: string;
+	/** Repository root directory for Go build. */
+	repoRoot: string;
+	/** Deployment stage. */
+	stage: string;
+}
+
+/**
+ * CostTelemetryWorker pairs a Lambda function with a scheduled EventBridge rule
+ * for periodic cost telemetry collection.
+ */
+export class CostTelemetryWorker extends Construct {
+	public readonly fn: lambda.Function;
+
+	constructor(scope: Construct, id: string, props: CostTelemetryWorkerProps) {
+		super(scope, id);
+
+		const buildDir = path.join(props.repoRoot, 'cdk', '.build', id);
+		fs.mkdirSync(buildDir, { recursive: true });
+		execFileSync('go', ['build', '-o', path.join(buildDir, 'bootstrap'), './cmd/cost-telemetry-worker'], {
+			cwd: props.repoRoot,
+			stdio: 'inherit',
+			env: {
+				...process.env,
+				CGO_ENABLED: '0',
+				GOOS: 'linux',
+				GOARCH: 'amd64',
+			},
+		});
+
+		this.fn = new lambda.Function(this, 'Fn', {
+			functionName: `${props.namePrefix}-cost-telemetry-worker`,
+			code: lambda.Code.fromAsset(buildDir),
+			handler: 'bootstrap',
+			runtime: lambda.Runtime.PROVIDED_AL2023,
+			memorySize: 256,
+			timeout: cdk.Duration.seconds(10),
+			environment: {
+				STAGE: props.stage,
+			},
+		});
+
+		const rule = new events.Rule(this, 'CollectRule', {
+			ruleName: `${props.namePrefix}-cost-telemetry-collect`,
+			schedule: events.Schedule.rate(cdk.Duration.hours(1)),
+		});
+		rule.addTarget(new targets.LambdaFunction(this.fn));
+	}
+}

--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -32,7 +32,7 @@ import * as apigwv2Integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations'
 import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
 
 import { renderProvisionRunnerBuildCommands, renderProvisionRunnerPreBuildCommands } from './provision-runner-buildspec';
-
+import { CostTelemetryWorker } from './cost-telemetry-worker-construct';
 export interface LesserHostStackProps extends cdk.StackProps {
 	stage: string;
 }
@@ -627,7 +627,7 @@ export class LesserHostStack extends cdk.Stack {
 			},
 			{ memorySize: 512, timeoutSeconds: 30 },
 		);
-
+		const costTelemetry = new CostTelemetryWorker(this, 'CostTelemetry', { namePrefix, repoRoot, stage });
 		stateTable.grantReadWriteData(controlPlaneFn);
 		stateTable.grantReadWriteData(trustFn);
 		stateTable.grantReadWriteData(renderWorkerFn);

--- a/cmd/cost-telemetry-worker/main.go
+++ b/cmd/cost-telemetry-worker/main.go
@@ -1,0 +1,18 @@
+// Command cost-telemetry-worker runs the cost telemetry collection worker Lambda.
+package main
+
+import (
+	"github.com/aws/aws-lambda-go/lambda"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+	"github.com/equaltoai/lesser-host/internal/observability"
+)
+
+func main() {
+	app := costtelemetry.New(
+		apptheory.WithObservability(observability.New(costtelemetry.ServiceName)),
+	)
+	lambda.Start(app.HandleLambda)
+}

--- a/internal/costtelemetry/app.go
+++ b/internal/costtelemetry/app.go
@@ -1,0 +1,32 @@
+package costtelemetry
+
+import (
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+)
+
+// ServiceName is the canonical service identifier for the cost telemetry worker.
+const ServiceName = "cost-telemetry-worker"
+
+// New constructs the cost telemetry worker app.
+func New(opts ...apptheory.Option) *apptheory.App {
+	cfg := config.Load()
+
+	srv := NewServer(cfg)
+
+	app := apptheory.New(opts...)
+	Register(app, srv)
+	return app
+}
+
+// Register registers cost telemetry worker handlers with an app.
+func Register(app *apptheory.App, srv *Server) *apptheory.App {
+	if app == nil {
+		return app
+	}
+	if srv != nil {
+		srv.Register(app)
+	}
+	return app
+}

--- a/internal/costtelemetry/server.go
+++ b/internal/costtelemetry/server.go
@@ -1,0 +1,72 @@
+package costtelemetry
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-lambda-go/events"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+)
+
+// Server processes scheduled cost telemetry collection events.
+// M3.7 scaffold: no business logic yet. M3.8–M3.10 implement
+// CloudWatch collection, Cost Explorer integration, and DynamoDB cache.
+type Server struct {
+	cfg config.Config
+}
+
+// NewServer constructs a cost telemetry worker Server.
+func NewServer(cfg config.Config) *Server {
+	return &Server{
+		cfg: cfg,
+	}
+}
+
+// Register registers scheduled events with the provided app.
+func (s *Server) Register(app *apptheory.App) {
+	if app == nil || s == nil {
+		return
+	}
+
+	ruleName := fmt.Sprintf("%s-%s-cost-telemetry-collect", s.cfg.AppName, s.cfg.Stage)
+	app.EventBridge(apptheory.EventBridgeRule(ruleName), s.handleScheduledTelemetry)
+}
+
+// handleScheduledTelemetry is the M3.7 scaffold scheduled handler.
+// It validates the EventContext, normalizes the scheduled workload,
+// and returns a small JSON-compatible summary. No AWS billing /
+// CloudWatch / Cost Explorer / DynamoDB business logic yet.
+//
+// M3.8–M3.10 wire the real collection pipeline here.
+func (s *Server) handleScheduledTelemetry(ctx *apptheory.EventContext, event events.EventBridgeEvent) (any, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("event context is nil")
+	}
+	if s == nil {
+		return nil, fmt.Errorf("server not initialized")
+	}
+
+	workload := apptheory.NormalizeEventBridgeScheduledWorkload(ctx, event)
+
+	return map[string]any{
+		"scaffold": "cost-telemetry-worker M3.7 scaffold — no business logic yet",
+		"workload": scheduledTelemetryWorkloadSummary(workload),
+	}, nil
+}
+
+func scheduledTelemetryWorkloadSummary(summary apptheory.EventBridgeScheduledWorkloadSummary) map[string]any {
+	return map[string]any{
+		"correlation_id":     summary.CorrelationID,
+		"correlation_source": summary.CorrelationSource,
+		"deadline_unix_ms":   summary.DeadlineUnixMS,
+		"detail_type":        summary.DetailType,
+		"event_id":           summary.EventID,
+		"idempotency_key":    summary.IdempotencyKey,
+		"kind":               summary.Kind,
+		"remaining_ms":       summary.RemainingMS,
+		"run_id":             summary.RunID,
+		"scheduled_time":     summary.ScheduledTime,
+		"source":             summary.Source,
+	}
+}

--- a/internal/costtelemetry/server_test.go
+++ b/internal/costtelemetry/server_test.go
@@ -1,0 +1,135 @@
+package costtelemetry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+)
+
+func TestHandleScheduledTelemetryReturnsWorkloadSummary(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.Config{
+		AppName: "lesser-host",
+		Stage:   "lab",
+	}
+	srv := NewServer(cfg)
+
+	scheduledAt := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	event := events.EventBridgeEvent{
+		ID:         "cost-telemetry-evt-1",
+		Source:     "aws.events",
+		DetailType: "Scheduled Event",
+		Resources: []string{
+			"arn:aws:events:us-east-1:123456789012:rule/lesser-host-lab-cost-telemetry-collect",
+		},
+		Time: scheduledAt,
+	}
+
+	out, err := srv.handleScheduledTelemetry(&apptheory.EventContext{
+		RequestID:   "req-cost-telemetry",
+		RemainingMS: 6000,
+	}, event)
+	if err != nil {
+		t.Fatalf("handleScheduledTelemetry: %v", err)
+	}
+
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map output, got %T", out)
+	}
+
+	scaffold, ok := m["scaffold"].(string)
+	if !ok {
+		t.Fatalf("expected scaffold string, got %T", m["scaffold"])
+	}
+	if scaffold == "" {
+		t.Fatalf("expected non-empty scaffold message")
+	}
+
+	workload, ok := m["workload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected workload summary map, got %T", m["workload"])
+	}
+
+	// Verify canonical workload summary fields are present.
+	wantFields := map[string]any{
+		"kind":           "scheduled",
+		"event_id":       "cost-telemetry-evt-1",
+		"source":         "aws.events",
+		"detail_type":    "Scheduled Event",
+		"remaining_ms":   6000,
+		"scheduled_time": scheduledAt.Format(time.RFC3339),
+	}
+	for k, want := range wantFields {
+		got, ok := workload[k]
+		if !ok {
+			t.Fatalf("workload missing field %q", k)
+		}
+		if got != want {
+			t.Fatalf("workload[%q] = %v, want %v", k, got, want)
+		}
+	}
+}
+
+func TestHandleScheduledTelemetryNilContext(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(config.Config{})
+	_, err := srv.handleScheduledTelemetry(nil, events.EventBridgeEvent{})
+	if err == nil {
+		t.Fatalf("expected error for nil context")
+	}
+}
+
+func TestHandleScheduledTelemetryNilServer(t *testing.T) {
+	t.Parallel()
+
+	var srv *Server
+	_, err := srv.handleScheduledTelemetry(&apptheory.EventContext{}, events.EventBridgeEvent{})
+	if err == nil {
+		t.Fatalf("expected error for nil server")
+	}
+}
+
+func TestHandleScheduledTelemetryEmptyEvents(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(config.Config{})
+	out, err := srv.handleScheduledTelemetry(&apptheory.EventContext{
+		RemainingMS: 6000,
+	}, events.EventBridgeEvent{})
+	if err != nil {
+		t.Fatalf("handleScheduledTelemetry with empty event: %v", err)
+	}
+
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected map output, got %T", out)
+	}
+
+	// Empty events are valid; workload summary fields should be present
+	// with zero-values where appropriate.
+	workload, ok := m["workload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected workload summary map for empty event")
+	}
+	if _, ok := workload["kind"]; !ok {
+		t.Fatalf("expected workload summary to have kind field")
+	}
+}
+
+func TestNew_ConstructsApp(t *testing.T) {
+	t.Setenv("AWS_REGION", "us-east-1")
+	t.Setenv("AWS_ACCESS_KEY_ID", "test")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "test")
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+
+	if got := New(); got == nil {
+		t.Fatalf("expected app, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Implements M3.7 from `docs/enumerated-changes-web-ui-rework-2026-05-24.md`: scaffold the cost-telemetry-worker Lambda with a scheduled EventBridge entrypoint
- No business logic yet (M3.8–M3.10 add CloudWatch collection, Cost Explorer integration, and DynamoDB cache)
- Safe no-op scaffold: validates EventContext, normalizes scheduled workload, returns JSON summary

## Files changed (6 files, +327/-2)

- `cmd/cost-telemetry-worker/main.go` — standard Lambda bootstrap (follows existing worker pattern)
- `internal/costtelemetry/server.go` — EventBridge handler + workload summary
- `internal/costtelemetry/app.go` — ServiceName, New, Register
- `internal/costtelemetry/server_test.go` — 5 tests (workload summary, nil-context, nil-server, empty-event, app construction)
- `cdk/lib/cost-telemetry-worker-construct.ts` — thin CDK construct (Lambda + hourly EventBridge schedule)
- `cdk/lib/lesser-host-stack.ts` — import + instantiate (+2/-2 lines)

## Acceptance checklist

- [x] New Lambda worker scaffolded (`cmd/cost-telemetry-worker/main.go`)
- [x] AppTheory scheduled-EventBridge entrypoint (`internal/costtelemetry/server.go`)
- [x] No business logic yet (M3.8–M3.10 implement collection/reconciliation/cache later)
- [x] Preserves multi-tenant-isolation posture (no customer-facing reads, no cross-tenant aggregation, no tenant content, no PII logging)
- [x] Does not implement #452/#453/#454/#455
- [x] No browser/web changes, CSP changes, instance-auth changes, Safe/on-chain changes, release-verification bypasses, or local AppTheory/TableTheory/FaceTheory patches
- [x] Follows existing AppTheory worker patterns (`internal/renderworker`, `internal/soulreputationworker`)

## Validation

| Check | Result |
|-------|--------|
| `go test ./...` | PASS (all packages) |
| `go vet ./...` | clean |
| `cd cdk && npm test && npm run synth` | 21/21 PASS |
| `bash gov-infra/verifiers/gov-verify-rubric.sh` | 39/39 PASS |
| `gofmt -l internal/costtelemetry/ cmd/cost-telemetry-worker/` | empty |

Closes #451.