### PR TITLE
feat(costtelemetry): Cost Explorer integration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/cloudwatch v1.57.0
 	github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12
 	github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20
+	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.9
 	github.com/aws/aws-sdk-go-v2/service/kms v1.50.3

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12 h1:lQTVEv/YAk8Rw1Yf4XZS/
 github.com/aws/aws-sdk-go-v2/service/codebuild v1.68.12/go.mod h1:yoa0R6Xku788EmJYkFiARzJBxt4A3hgFjQPRmMAttr0=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20 h1:AFxiBqfeAwybIkTFP2cVYjPpEeo9jvYR5qaJ+664mLI=
 github.com/aws/aws-sdk-go-v2/service/comprehend v1.40.20/go.mod h1:0ZcEjoeeMH4Mji0ZrwiKgTnQiv7uoNG9DoQS2crnhX8=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8 h1:rUg81vwoGgCmnQxsVl+B65QF8Qh+zYCluhyAcxsk79o=
+github.com/aws/aws-sdk-go-v2/service/costexplorer v1.63.8/go.mod h1:V+bKJ05kIC6K0LH8TB3D5boy7F8BhrZeecoXLz1NlB4=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2 h1:xi/ECwajy2mixviBD7bKAlGGSwzEaFKX2wIhrZt9NGw=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.56.2/go.mod h1:dLREOeW66eVaaGIOi2ZlLHDgkR3nuJ02rd00j0YSlBE=
 github.com/aws/aws-sdk-go-v2/service/iam v1.53.9 h1:slEs4iUvSt/YOiQQajtXkYBZTMrsEeplSnaB928p4l0=

--- a/internal/costtelemetry/cost_explorer.go
+++ b/internal/costtelemetry/cost_explorer.go
@@ -1,0 +1,437 @@
+package costtelemetry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+// costExplorerAPI is the subset of the AWS Cost Explorer SDK used by
+// the collector. Kept unexported: only the factory creates instances;
+// tests implement against this interface.
+type costExplorerAPI interface {
+	GetCostAndUsage(ctx context.Context, params *costexplorer.GetCostAndUsageInput, optFns ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error)
+}
+
+// CostExplorerClientFactory creates Cost Explorer API clients scoped
+// to a given account and region.
+//
+// Cost Explorer is typically queried from the management / payer account
+// with a LINKED_ACCOUNT filter rather than directly from the linked
+// account. Production implementations must translate the accountID
+// parameter into the appropriate Cost Explorer filter when the worker
+// runs from the host (payer) account. The interface does not prescribe
+// the implementation — the accountID and region parameters carry tenant
+// dimensions, and the factory's Client method is the seam for test
+// injection.
+//
+// M3.8 watchpoint: CloudWatch no-dimension queries are treated as
+// per-tenant-account aggregates because the tenant account is the
+// isolation boundary. Cost Explorer similarly treats all queries as
+// per-tenant-account, with the factory / filter translation absorbing
+// the payer-account-vs-linked-account wiring difference. Do not
+// introduce cross-tenant aggregation.
+type CostExplorerClientFactory interface {
+	// Client returns a Cost Explorer API client for the given account
+	// and region. Production wiring must apply tenant scoping (e.g.,
+	// LINKED_ACCOUNT filter) when the worker runs from the host account.
+	Client(ctx context.Context, accountID, region string) (costExplorerAPI, error)
+}
+
+// CostExplorerCollector queries AWS Cost Explorer for billing-grain
+// cost data and reconciles it with CloudWatch metric attributions.
+// This is the M3.9 test seam: tests inject mocks; production injects
+// the AWS SDK-backed implementation.
+type CostExplorerCollector interface {
+	// CollectCosts queries Cost Explorer for billing-grain cost data
+	// for the given tenant scope over the specified time window.
+	// The returned CostExplorerResult carries explicit tenant dimensions
+	// (Slug, AccountID) so downstream steps cannot accidentally merge
+	// data across tenant accounts.
+	CollectCosts(ctx context.Context, scope TenantScope, windowStart, windowEnd time.Time) (*CostExplorerResult, error)
+
+	// Reconcile merges Cost Explorer billing data with CloudWatch metric
+	// attributions into a per-instance per-day reconciled report.
+	//
+	// This is a pure function — it makes no AWS calls. Call CollectCosts
+	// first, then pass the result here along with the CloudWatch report.
+	//
+	// The report preserves tenant scoping and contains no PII, tenant
+	// content, raw instance keys, secrets, or request bodies.
+	Reconcile(ceResult *CostExplorerResult, cwReport *InstanceCostReport) (*ReconciledCostReport, error)
+}
+
+// costBreakdownMetric is the Cost Explorer metric name used for
+// billing-grain cost queries.
+const costBreakdownMetric = "UnblendedCost"
+
+// CostBreakdown represents a single AWS service's cost from Cost Explorer.
+type CostBreakdown struct {
+	Service  string  `json:"service"`  // e.g., "Amazon Lambda"
+	Amount   float64 `json:"amount"`   // cost in USD (or the queried currency)
+	Currency string  `json:"currency"` // e.g., "USD"
+}
+
+// CostExplorerResult is the raw billing-grain cost data from Cost Explorer
+// for a tenant. Contains no PII, tenant content, raw instance keys, secrets,
+// or request bodies.
+type CostExplorerResult struct {
+	Slug        string          `json:"slug"`
+	AccountID   string          `json:"account_id"`
+	WindowStart time.Time       `json:"window_start"`
+	WindowEnd   time.Time       `json:"window_end"`
+	Costs       []CostBreakdown `json:"costs"`
+	TotalCost   float64         `json:"total_cost"`
+	Currency    string          `json:"currency"`
+}
+
+// ReconciledCostEntry combines Cost Explorer billing data with CloudWatch
+// metric attributions for a single service dimension on a single day.
+// Safe for future customer exposure.
+type ReconciledCostEntry struct {
+	Date     string               `json:"date"`    // YYYY-MM-DD
+	Service  string               `json:"service"` // normalized (CW-style), e.g., "Lambda"
+	Cost     float64              `json:"cost"`    // from Cost Explorer (USD)
+	Currency string               `json:"currency"`
+	Metrics  []ServiceAttribution `json:"metrics,omitempty"` // CloudWatch attributions
+}
+
+// ReconciledCostReport is the M3.9 output: aggregate per-instance per-day
+// cost data that reconciles Cost Explorer billing with CloudWatch metrics.
+// Safe for caching (M3.10) and customer exposure (M3.11+).
+type ReconciledCostReport struct {
+	Slug        string                `json:"slug"`
+	AccountID   string                `json:"account_id"`
+	WindowStart time.Time             `json:"window_start"`
+	WindowEnd   time.Time             `json:"window_end"`
+	Entries     []ReconciledCostEntry `json:"entries"`
+	TotalCost   float64               `json:"total_cost"`
+	Currency    string                `json:"currency"`
+}
+
+// costExplorerCollectorImpl is the AWS SDK-backed CostExplorerCollector.
+type costExplorerCollectorImpl struct {
+	factory CostExplorerClientFactory
+}
+
+// NewCostExplorerCollector constructs an AWS SDK-backed CostExplorerCollector.
+// The factory is used to create per-account clients, which in production
+// may apply a LINKED_ACCOUNT filter when the worker runs from the host
+// (payer) account.
+func NewCostExplorerCollector(factory CostExplorerClientFactory) CostExplorerCollector {
+	return &costExplorerCollectorImpl{factory: factory}
+}
+
+// CollectCosts implements CostExplorerCollector.
+func (c *costExplorerCollectorImpl) CollectCosts(ctx context.Context, scope TenantScope, windowStart, windowEnd time.Time) (*CostExplorerResult, error) {
+	if err := validateScope(scope); err != nil {
+		return nil, err
+	}
+	if err := validateWindow(windowStart, windowEnd); err != nil {
+		return nil, err
+	}
+
+	client, err := c.factory.Client(ctx, scope.AccountID, scope.Region)
+	if err != nil {
+		return nil, fmt.Errorf("costtelemetry: creating Cost Explorer client for account %s region %s: %w",
+			scope.AccountID, scope.Region, err)
+	}
+
+	// Normalize the window to full-day boundaries. Cost Explorer uses
+	// YYYY-MM-DD strings with exclusive end, so we anchor at midnight.
+	startDate := windowStart.UTC().Truncate(24 * time.Hour)
+	endDate := ceilingDay(windowEnd.UTC())
+
+	results, err := c.queryCostExplorer(ctx, client, startDate, endDate)
+	if err != nil {
+		return nil, fmt.Errorf("costtelemetry: querying Cost Explorer for %s (account %s): %w",
+			scope.Slug, scope.AccountID, err)
+	}
+
+	return buildCostExplorerResult(scope, windowStart, windowEnd, results)
+}
+
+// queryCostExplorer calls GetCostAndUsage with DAILY granularity grouped
+// by SERVICE, paginating when the response carries a continuation token.
+func (c *costExplorerCollectorImpl) queryCostExplorer(
+	ctx context.Context,
+	client costExplorerAPI,
+	startDate, endDate time.Time,
+) ([]cetypes.ResultByTime, error) {
+	input := &costexplorer.GetCostAndUsageInput{
+		Granularity: cetypes.GranularityDaily,
+		Metrics:     []string{costBreakdownMetric},
+		TimePeriod: &cetypes.DateInterval{
+			Start: aws.String(startDate.Format("2006-01-02")),
+			End:   aws.String(endDate.Format("2006-01-02")),
+		},
+		GroupBy: []cetypes.GroupDefinition{
+			{
+				Type: cetypes.GroupDefinitionTypeDimension,
+				Key:  aws.String(string(cetypes.DimensionService)),
+			},
+		},
+	}
+
+	var allResults []cetypes.ResultByTime
+	for {
+		output, err := client.GetCostAndUsage(ctx, input)
+		if err != nil {
+			return nil, fmt.Errorf("GetCostAndUsage: %w", err)
+		}
+		allResults = append(allResults, output.ResultsByTime...)
+		if output.NextPageToken == nil {
+			break
+		}
+		input.NextPageToken = output.NextPageToken
+	}
+	return allResults, nil
+}
+
+// buildCostExplorerResult converts paginated Cost Explorer results into
+// a CostExplorerResult carrying a flat list of per-service cost breakdowns
+// across the full window.
+func buildCostExplorerResult(
+	scope TenantScope,
+	windowStart, windowEnd time.Time,
+	results []cetypes.ResultByTime,
+) (*CostExplorerResult, error) {
+	costMap := make(map[string]*CostBreakdown) // keyed by CE service name
+	var totalCost float64
+	currency := "USD"
+
+	for _, rbt := range results {
+		// Aggregate per-period totals (groups may or may not sum to
+		// the period total due to rounding / ungrouped line items).
+		for _, group := range rbt.Groups {
+			ceService := ""
+			if len(group.Keys) > 0 {
+				ceService = group.Keys[0]
+			}
+			if ceService == "" {
+				continue
+			}
+			am, cur := extractMetricValueCE(group.Metrics[costBreakdownMetric])
+			if cur != "" {
+				currency = cur
+			}
+			entry, ok := costMap[ceService]
+			if !ok {
+				entry = &CostBreakdown{
+					Service:  ceService,
+					Currency: currency,
+				}
+				costMap[ceService] = entry
+			}
+			entry.Amount += am
+			totalCost += am
+		}
+	}
+
+	costs := make([]CostBreakdown, 0, len(costMap))
+	for _, cb := range costMap {
+		// Round to meaningful precision (6 decimal places for
+		// sub-cent fractional costs common in AWS billing).
+		cb.Amount = math.Round(cb.Amount*1e6) / 1e6
+		// Omit zero-cost entries — they represent nil/unparseable
+		// amounts or services with no meaningful cost, and add noise.
+		if cb.Amount == 0 {
+			continue
+		}
+		costs = append(costs, *cb)
+	}
+	totalCost = math.Round(totalCost*1e6) / 1e6
+
+	// Sort for deterministic output.
+	sort.Slice(costs, func(i, j int) bool {
+		return costs[i].Service < costs[j].Service
+	})
+
+	return &CostExplorerResult{
+		Slug:        scope.Slug,
+		AccountID:   scope.AccountID,
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
+		Costs:       costs,
+		TotalCost:   totalCost,
+		Currency:    currency,
+	}, nil
+}
+
+// Reconcile implements CostExplorerCollector.
+func (c *costExplorerCollectorImpl) Reconcile(ceResult *CostExplorerResult, cwReport *InstanceCostReport) (*ReconciledCostReport, error) {
+	if ceResult == nil {
+		return nil, fmt.Errorf("costtelemetry: ceResult is nil")
+	}
+	if cwReport == nil {
+		return nil, fmt.Errorf("costtelemetry: cwReport is nil")
+	}
+	if ceResult.Slug != cwReport.Slug {
+		return nil, fmt.Errorf("costtelemetry: slug mismatch between CE (%q) and CW (%q)",
+			ceResult.Slug, cwReport.Slug)
+	}
+	if ceResult.AccountID != cwReport.AccountID {
+		return nil, fmt.Errorf("costtelemetry: account mismatch between CE (%q) and CW (%q)",
+			ceResult.AccountID, cwReport.AccountID)
+	}
+
+	// Build a lookup of CW attributions by normalized service name.
+	cwByService := buildCWAttributionLookup(cwReport.Attributions)
+
+	entries := make([]ReconciledCostEntry, 0, len(ceResult.Costs))
+
+	// For the reconciliation, CE data is per-day (DAILY granularity)
+	// but CW data is a single window aggregate. Each daily entry
+	// carries the full window's CW metric attributions as context.
+	// Future M3.11 can split CW metrics per-day if needed.
+	for _, cb := range ceResult.Costs {
+		normService := mapCEToCWService(cb.Service)
+
+		var metrics []ServiceAttribution
+		if attrs, ok := cwByService[normService]; ok {
+			metrics = attrs
+		}
+
+		entries = append(entries, ReconciledCostEntry{
+			Service:  normService,
+			Cost:     cb.Amount,
+			Currency: cb.Currency,
+			Metrics:  metrics,
+		})
+	}
+
+	// Sort entries for deterministic output.
+	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Service != entries[j].Service {
+			return entries[i].Service < entries[j].Service
+		}
+		return entries[i].Cost < entries[j].Cost
+	})
+
+	// Use the tighter of the two windows.
+	windowStart := ceResult.WindowStart
+	if cwReport.WindowStart.After(windowStart) {
+		windowStart = cwReport.WindowStart
+	}
+	windowEnd := ceResult.WindowEnd
+	if cwReport.WindowEnd.Before(windowEnd) {
+		windowEnd = cwReport.WindowEnd
+	}
+
+	return &ReconciledCostReport{
+		Slug:        ceResult.Slug,
+		AccountID:   ceResult.AccountID,
+		WindowStart: windowStart,
+		WindowEnd:   windowEnd,
+		Entries:     entries,
+		TotalCost:   ceResult.TotalCost,
+		Currency:    ceResult.Currency,
+	}, nil
+}
+
+// buildCWAttributionLookup indexes CloudWatch attributions by normalized
+// service name for O(1) reconciliation lookups.
+func buildCWAttributionLookup(attributions []ServiceAttribution) map[string][]ServiceAttribution {
+	if len(attributions) == 0 {
+		return nil
+	}
+	out := make(map[string][]ServiceAttribution)
+	for _, a := range attributions {
+		out[a.Service] = append(out[a.Service], a)
+	}
+	return out
+}
+
+// validateWindow validates the time window for Cost Explorer queries.
+func validateWindow(windowStart, windowEnd time.Time) error {
+	if !windowStart.Before(windowEnd) {
+		return fmt.Errorf("costtelemetry: windowStart must be before windowEnd (start=%s, end=%s)",
+			windowStart.Format(time.RFC3339), windowEnd.Format(time.RFC3339))
+	}
+	return nil
+}
+
+// ceilingDay returns the start of the next UTC day after t.
+// Used to normalize Cost Explorer end-dates which are exclusive.
+func ceilingDay(t time.Time) time.Time {
+	dayStart := t.Truncate(24 * time.Hour)
+	if t.Equal(dayStart) {
+		// Already at midnight — return the same value (empty range
+		// is caught by validateWindow).
+		return t
+	}
+	return dayStart.Add(24 * time.Hour)
+}
+
+// extractMetricValueCE extracts a float64 amount and currency string
+// from a Cost Explorer MetricValue. Returns (0, "") when the Amount
+// is nil or unparseable.
+func extractMetricValueCE(mv cetypes.MetricValue) (float64, string) {
+	currency := ""
+	if mv.Unit != nil {
+		currency = *mv.Unit
+	}
+	if mv.Amount == nil {
+		return 0, currency
+	}
+	val, err := strconv.ParseFloat(*mv.Amount, 64)
+	if err != nil {
+		return 0, currency
+	}
+	return val, currency
+}
+
+// mapCEToCWService maps a Cost Explorer service name (e.g., "Amazon Lambda")
+// to the normalized service name used by CloudWatch attributions
+// (e.g., "Lambda"). Returns the original input when no mapping exists.
+//
+// The mapping is the reconciliation bridge: CE returns display names
+// while CW uses short identifiers. This is a best-effort mapping;
+// AWS may add or rename service display names over time. Unknown
+// services pass through unchanged.
+func mapCEToCWService(ceService string) string {
+	if normalized, ok := ceToCWService[ceService]; ok {
+		return normalized
+	}
+	return ceService
+}
+
+// ceToCWService maps Cost Explorer service display names to CloudWatch
+// normalized service names. This is the reconciliation bridge between
+// the two AWS APIs.
+//
+// NOTE: AWS may add service names or change display labels. This table
+// is the maintained set for costtelemetry. Missing entries cause the CE
+// service name to pass through unchanged.
+var ceToCWService = map[string]string{
+	"Amazon API Gateway":                 "APIGateway",
+	"Amazon CloudFront":                  "CloudFront",
+	"Amazon CloudWatch":                  "CloudWatch",
+	"Amazon Cognito":                     "Cognito",
+	"Amazon DynamoDB":                    "DynamoDB",
+	"Amazon EC2":                         "EC2",
+	"Amazon Elastic Compute Cloud":       "EC2",
+	"Amazon Kinesis":                     "Kinesis",
+	"Amazon Route 53":                    "Route53",
+	"Amazon Simple Notification Service": "SNS",
+	"Amazon Simple Queue Service":        "SQS",
+	"Amazon Simple Storage Service":      "S3",
+	"AWS Certificate Manager":            "ACM",
+	"AWS CloudFront":                     "CloudFront",
+	"AWS CodeBuild":                      "CodeBuild",
+	"AWS Data Transfer":                  "DataTransfer",
+	"AWS Elastic Load Balancing":         "ELB",
+	"AWS Key Management Service":         "KMS",
+	"AWS Lambda":                         "Lambda",
+	"AWS Route 53":                       "Route53",
+	"AWS Secrets Manager":                "SecretsManager",
+	"AWS Step Functions":                 "StepFunctions",
+	"EC2 - Other":                        "EC2",
+}

--- a/internal/costtelemetry/cost_explorer.go
+++ b/internal/costtelemetry/cost_explorer.go
@@ -72,8 +72,11 @@ type CostExplorerCollector interface {
 // billing-grain cost queries.
 const costBreakdownMetric = "UnblendedCost"
 
-// CostBreakdown represents a single AWS service's cost from Cost Explorer.
+// CostBreakdown represents a single AWS service's cost from Cost Explorer
+// on a single day. The Date field carries the YYYY-MM-DD value from
+// ResultByTime.TimePeriod.Start.
 type CostBreakdown struct {
+	Date     string  `json:"date"`     // YYYY-MM-DD
 	Service  string  `json:"service"`  // e.g., "Amazon Lambda"
 	Amount   float64 `json:"amount"`   // cost in USD (or the queried currency)
 	Currency string  `json:"currency"` // e.g., "USD"
@@ -195,21 +198,27 @@ func (c *costExplorerCollectorImpl) queryCostExplorer(
 	return allResults, nil
 }
 
-// buildCostExplorerResult converts paginated Cost Explorer results into
-// a CostExplorerResult carrying a flat list of per-service cost breakdowns
-// across the full window.
-func buildCostExplorerResult(
-	scope TenantScope,
-	windowStart, windowEnd time.Time,
-	results []cetypes.ResultByTime,
-) (*CostExplorerResult, error) {
-	costMap := make(map[string]*CostBreakdown) // keyed by CE service name
+// costBreakdownKey is the composite key for CostExplorer cost entries,
+// scoping a CostBreakdown to a single day and a single service.
+type costBreakdownKey struct {
+	date    string
+	service string
+}
+
+// aggregateCostBreakdowns walks paginated Cost Explorer results and
+// accumulates per-day per-service cost breakdowns. Returns the populated
+// map (keyed by date+service), the running total, and the prevailing
+// currency string observed from metric units.
+func aggregateCostBreakdowns(results []cetypes.ResultByTime) (map[costBreakdownKey]*CostBreakdown, float64, string) {
+	costMap := make(map[costBreakdownKey]*CostBreakdown)
 	var totalCost float64
 	currency := "USD"
 
 	for _, rbt := range results {
-		// Aggregate per-period totals (groups may or may not sum to
-		// the period total due to rounding / ungrouped line items).
+		date := ""
+		if rbt.TimePeriod != nil && rbt.TimePeriod.Start != nil {
+			date = *rbt.TimePeriod.Start
+		}
 		for _, group := range rbt.Groups {
 			ceService := ""
 			if len(group.Keys) > 0 {
@@ -222,26 +231,38 @@ func buildCostExplorerResult(
 			if cur != "" {
 				currency = cur
 			}
-			entry, ok := costMap[ceService]
+			ck := costBreakdownKey{date: date, service: ceService}
+			entry, ok := costMap[ck]
 			if !ok {
 				entry = &CostBreakdown{
+					Date:     date,
 					Service:  ceService,
 					Currency: currency,
 				}
-				costMap[ceService] = entry
+				costMap[ck] = entry
 			}
 			entry.Amount += am
 			totalCost += am
 		}
 	}
+	return costMap, totalCost, currency
+}
+
+// buildCostExplorerResult converts paginated Cost Explorer results into
+// a CostExplorerResult carrying a flat list of per-day per-service cost
+// breakdowns across the full window. Each entry carries the CE daily
+// date (ResultByTime.TimePeriod.Start) so downstream reconciliation
+// preserves the day dimension required by M3.9.
+func buildCostExplorerResult(
+	scope TenantScope,
+	windowStart, windowEnd time.Time,
+	results []cetypes.ResultByTime,
+) (*CostExplorerResult, error) {
+	costMap, totalCost, currency := aggregateCostBreakdowns(results)
 
 	costs := make([]CostBreakdown, 0, len(costMap))
 	for _, cb := range costMap {
-		// Round to meaningful precision (6 decimal places for
-		// sub-cent fractional costs common in AWS billing).
 		cb.Amount = math.Round(cb.Amount*1e6) / 1e6
-		// Omit zero-cost entries — they represent nil/unparseable
-		// amounts or services with no meaningful cost, and add noise.
 		if cb.Amount == 0 {
 			continue
 		}
@@ -249,8 +270,10 @@ func buildCostExplorerResult(
 	}
 	totalCost = math.Round(totalCost*1e6) / 1e6
 
-	// Sort for deterministic output.
 	sort.Slice(costs, func(i, j int) bool {
+		if costs[i].Date != costs[j].Date {
+			return costs[i].Date < costs[j].Date
+		}
 		return costs[i].Service < costs[j].Service
 	})
 
@@ -294,12 +317,21 @@ func (c *costExplorerCollectorImpl) Reconcile(ceResult *CostExplorerResult, cwRe
 	for _, cb := range ceResult.Costs {
 		normService := mapCEToCWService(cb.Service)
 
+		// M3.9: every reconciled entry must carry a date. If the
+		// upstream CostBreakdown has an empty Date, the CE collection
+		// step did not preserve TimePeriod.Start and the report is
+		// unusable for per-day attribution.
+		if cb.Date == "" {
+			return nil, fmt.Errorf("costtelemetry: CE cost entry for service %q has empty date — CE collection must preserve TimePeriod.Start", cb.Service)
+		}
+
 		var metrics []ServiceAttribution
 		if attrs, ok := cwByService[normService]; ok {
 			metrics = attrs
 		}
 
 		entries = append(entries, ReconciledCostEntry{
+			Date:     cb.Date,
 			Service:  normService,
 			Cost:     cb.Amount,
 			Currency: cb.Currency,
@@ -307,8 +339,11 @@ func (c *costExplorerCollectorImpl) Reconcile(ceResult *CostExplorerResult, cwRe
 		})
 	}
 
-	// Sort entries for deterministic output.
+	// Sort entries for deterministic output: date, service, cost.
 	sort.Slice(entries, func(i, j int) bool {
+		if entries[i].Date != entries[j].Date {
+			return entries[i].Date < entries[j].Date
+		}
 		if entries[i].Service != entries[j].Service {
 			return entries[i].Service < entries[j].Service
 		}

--- a/internal/costtelemetry/cost_explorer_test.go
+++ b/internal/costtelemetry/cost_explorer_test.go
@@ -268,6 +268,13 @@ func TestCECollectCosts_HappyPath(t *testing.T) {
 		t.Fatalf("expected 2 costs, got %d: %s", len(result.Costs), costKeys(result.Costs))
 	}
 
+	// Verify each entry carries the daily date from TimePeriod.Start.
+	for _, c := range result.Costs {
+		if c.Date != testCEDate1 {
+			t.Fatalf("expected date %q, got %q for service %q", testCEDate1, c.Date, c.Service)
+		}
+	}
+
 	// Verify rounding: 0.0532947123 → 0.053295 after rounding to 1e6.
 	lambdaCost, ok := findCostBreakdown(result.Costs, testCEServiceLambda)
 	if !ok {
@@ -322,18 +329,43 @@ func TestCECollectCosts_MultipleDays(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Same service across two days should be aggregated into a single
-	// CostBreakdown entry with the summed amount.
-	if len(result.Costs) != 1 {
-		t.Fatalf("expected 1 cost entry (aggregated across days), got %d: %s",
+	// M3.9: same service across two days must NOT collapse into one entry.
+	// Each day must produce its own CostBreakdown with the correct date
+	// and per-day amount.
+	if len(result.Costs) != 2 {
+		t.Fatalf("expected 2 cost entries (one per day), got %d: %s",
 			len(result.Costs), costKeys(result.Costs))
 	}
-	lambdaCost, ok := findCostBreakdown(result.Costs, testCEServiceLambda)
-	if !ok {
-		t.Fatalf("missing cost for %s", testCEServiceLambda)
+
+	// Find entries by date.
+	var day1Cost, day2Cost float64
+	var day1Found, day2Found bool
+	for _, c := range result.Costs {
+		if c.Service != testCEServiceLambda {
+			t.Fatalf("unexpected service %q", c.Service)
+		}
+		switch c.Date {
+		case testCEDate1:
+			day1Cost = c.Amount
+			day1Found = true
+		case testCEDate2:
+			day2Cost = c.Amount
+			day2Found = true
+		default:
+			t.Fatalf("unexpected date %q in cost entry", c.Date)
+		}
 	}
-	if lambdaCost.Amount != 0.08 {
-		t.Fatalf("Lambda cost = %v, want 0.08 (0.05 + 0.03)", lambdaCost.Amount)
+	if !day1Found {
+		t.Fatal("missing cost entry for date 2026-05-25")
+	}
+	if !day2Found {
+		t.Fatal("missing cost entry for date 2026-05-26")
+	}
+	if day1Cost != 0.05 {
+		t.Fatalf("2026-05-25 Lambda cost = %v, want 0.05", day1Cost)
+	}
+	if day2Cost != 0.03 {
+		t.Fatalf("2026-05-26 Lambda cost = %v, want 0.03", day2Cost)
 	}
 	if result.TotalCost != 0.08 {
 		t.Fatalf("TotalCost = %v, want 0.08", result.TotalCost)
@@ -371,7 +403,16 @@ func TestCECollectCosts_MultipleServices(t *testing.T) {
 		t.Fatalf("TotalCost = %v, want 2.05", result.TotalCost)
 	}
 
-	// Verify deterministic sort order (lexicographic by CE service name).
+	// M3.9: every entry must carry the date from TimePeriod.Start.
+	for _, c := range result.Costs {
+		if c.Date != testCEDate1 {
+			t.Fatalf("expected date %q, got %q for service %q", testCEDate1, c.Date, c.Service)
+		}
+	}
+
+	// Verify deterministic sort order (date, then lexicographic by CE
+	// service name). With a single date the primary key is the same for
+	// all entries, so the secondary service-name sort dominates.
 	// "AWS" < "Amazon" because 'W' (87) < 'm' (109) in ASCII.
 	expectedOrder := []string{
 		testCEServiceLambda,   // "AWS Lambda"
@@ -510,9 +551,6 @@ func TestCECollectCosts_NilAmount(t *testing.T) {
 	if len(result.Costs) != 0 {
 		t.Fatalf("expected 0 costs (nil amount treated as 0, zero-cost entry may be omitted), got %d", len(result.Costs))
 	}
-	// Actually with amount=0, the CostBreakdown is created but with Amount=0.
-	// Let me check: buildCostExplorerResult appends every group with non-empty
-	// key even if the amount is 0. So it should have 1 entry.
 	if result.TotalCost != 0 {
 		t.Fatalf("TotalCost = %v, want 0", result.TotalCost)
 	}
@@ -589,8 +627,8 @@ func TestReconcile_HappyPath(t *testing.T) {
 		TotalCost:   0.08,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceLambda, Amount: 0.053295, Currency: testCECurrencyUSD},
-			{Service: testCEServiceDynamoDB, Amount: 0.004219, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.053295, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceDynamoDB, Amount: 0.004219, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -618,8 +656,25 @@ func TestReconcile_HappyPath(t *testing.T) {
 		t.Fatalf("expected 2 entries, got %d: %s", len(report.Entries), entryKeys(report.Entries))
 	}
 
-	// Lambda entry should have 2 CW metrics attached.
-	for _, entry := range report.Entries {
+	assertReconciledEntryDates(t, report.Entries)
+	assertReconciledServiceEntries(t, report.Entries)
+}
+
+// assertReconciledEntryDates fails if any reconciled entry has an empty Date.
+func assertReconciledEntryDates(t *testing.T, entries []ReconciledCostEntry) {
+	t.Helper()
+	for _, entry := range entries {
+		if entry.Date == "" {
+			t.Fatalf("reconciled entry for service %q has empty date", entry.Service)
+		}
+	}
+}
+
+// assertReconciledServiceEntries validates the HappyPath fixture's per-service
+// cost and metric counts for Lambda and DynamoDB entries.
+func assertReconciledServiceEntries(t *testing.T, entries []ReconciledCostEntry) {
+	t.Helper()
+	for _, entry := range entries {
 		switch entry.Service {
 		case testCENormLambda:
 			if entry.Cost != 0.053295 {
@@ -715,7 +770,7 @@ func TestReconcile_EmptyCWAttributions(t *testing.T) {
 		TotalCost:   0.05,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -732,6 +787,9 @@ func TestReconcile_EmptyCWAttributions(t *testing.T) {
 	if len(report.Entries[0].Metrics) != 0 {
 		t.Fatalf("expected 0 metrics (empty CW), got %d", len(report.Entries[0].Metrics))
 	}
+	if report.Entries[0].Date == "" {
+		t.Fatal("reconciled entry has empty date")
+	}
 }
 
 func TestReconcile_ServiceMappingApplied(t *testing.T) {
@@ -746,7 +804,7 @@ func TestReconcile_ServiceMappingApplied(t *testing.T) {
 		TotalCost:   0.10,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceAPIGW, Amount: 0.10, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceAPIGW, Amount: 0.10, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -784,7 +842,7 @@ func TestReconcile_UnknownServicePassthrough(t *testing.T) {
 		TotalCost:   0.01,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: "AWS NoSuchService", Amount: 0.01, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: "AWS NoSuchService", Amount: 0.01, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -816,8 +874,8 @@ func TestReconcile_DeterministicOutput(t *testing.T) {
 		TotalCost:   0.15,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceS3, Amount: 0.05, Currency: testCECurrencyUSD},
-			{Service: testCEServiceLambda, Amount: 0.10, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceS3, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.10, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -856,7 +914,7 @@ func TestReconcile_WindowIntersection(t *testing.T) {
 		TotalCost:   0.05,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -1165,7 +1223,7 @@ func TestReconcile_MultipleMetricsSameService(t *testing.T) {
 		TotalCost:   0.05,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -1200,7 +1258,7 @@ func TestReconcile_CWServiceNotInCE(t *testing.T) {
 		TotalCost:   0.05,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -1237,9 +1295,9 @@ func TestReconcile_SortOrder(t *testing.T) {
 		TotalCost:   0.35,
 		Currency:    testCECurrencyUSD,
 		Costs: []CostBreakdown{
-			{Service: testCEServiceS3, Amount: 0.10, Currency: testCECurrencyUSD},
-			{Service: testCEServiceSQS, Amount: 0.05, Currency: testCECurrencyUSD},
-			{Service: testCEServiceLambda, Amount: 0.20, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceS3, Amount: 0.10, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceSQS, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.20, Currency: testCECurrencyUSD},
 		},
 	}
 
@@ -1256,5 +1314,36 @@ func TestReconcile_SortOrder(t *testing.T) {
 		if report.Entries[i].Service != exp {
 			t.Fatalf("entries[%d] = %q, want %q (deterministic sort)", i, report.Entries[i].Service, exp)
 		}
+	}
+}
+
+// TestReconcile_EmptyDate verifies that Reconcile returns an error when
+// any CostBreakdown has an empty Date. M3.9 acceptance requires per-day
+// attribution; entries without dates are unusable.
+func TestReconcile_EmptyDate(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.10,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Date: testCEDate1, Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Date: "", Service: testCEServiceDynamoDB, Amount: 0.05, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+
+	_, err := cc.Reconcile(ceResult, cwReport)
+	if err == nil {
+		t.Fatal("expected error for empty Date in CostBreakdown")
+	}
+	if !strings.Contains(err.Error(), "empty date") {
+		t.Fatalf("error should mention empty date: %v", err)
 	}
 }

--- a/internal/costtelemetry/cost_explorer_test.go
+++ b/internal/costtelemetry/cost_explorer_test.go
@@ -1,0 +1,1260 @@
+package costtelemetry
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
+	cetypes "github.com/aws/aws-sdk-go-v2/service/costexplorer/types"
+)
+
+// ---------------------------------------------------------------------------
+// test constants for Cost Explorer tests
+// ---------------------------------------------------------------------------
+
+const (
+	testCEServiceLambda   = "AWS Lambda"
+	testCEServiceDynamoDB = "Amazon DynamoDB"
+	testCEServiceAPIGW    = "Amazon API Gateway"
+	testCEServiceS3       = "Amazon Simple Storage Service"
+	testCEServiceSQS      = "Amazon Simple Queue Service"
+	testCEServiceCloudF   = "Amazon CloudFront"
+	testCECurrencyUSD     = "USD"
+	testCEDate1           = "2026-05-25"
+	testCEDate2           = "2026-05-26"
+	testCENormLambda      = "Lambda"
+	testCENormDynamoDB    = "DynamoDB"
+	testCENormAPIGW       = "APIGateway"
+)
+
+// ---------------------------------------------------------------------------
+// fake Cost Explorer implementations for tests
+// ---------------------------------------------------------------------------
+
+// fakeCostExplorerAPI implements costExplorerAPI for tests.
+type fakeCostExplorerAPI struct {
+	results []cetypes.ResultByTime
+	err     error
+}
+
+func (f *fakeCostExplorerAPI) GetCostAndUsage(_ context.Context, _ *costexplorer.GetCostAndUsageInput, _ ...func(*costexplorer.Options)) (*costexplorer.GetCostAndUsageOutput, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &costexplorer.GetCostAndUsageOutput{
+		ResultsByTime: f.results,
+	}, nil
+}
+
+// fakeCostExplorerClientFactory implements CostExplorerClientFactory for tests.
+type fakeCostExplorerClientFactory struct {
+	api costExplorerAPI
+}
+
+func (f *fakeCostExplorerClientFactory) Client(_ context.Context, _, _ string) (costExplorerAPI, error) {
+	if f.api == nil {
+		return nil, fmt.Errorf("no Cost Explorer client configured for test")
+	}
+	return f.api, nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func makeCECollector(api costExplorerAPI) CostExplorerCollector {
+	factory := &fakeCostExplorerClientFactory{api: api}
+	return NewCostExplorerCollector(factory)
+}
+
+// ceServiceGroup creates a single Group with the given service name and cost.
+func ceServiceGroup(service string, amount string) cetypes.Group {
+	return cetypes.Group{
+		Keys: []string{service},
+		Metrics: map[string]cetypes.MetricValue{
+			costBreakdownMetric: {
+				Amount: aws.String(amount),
+				Unit:   aws.String(testCECurrencyUSD),
+			},
+		},
+	}
+}
+
+// ceResultByTime creates a ResultByTime for the given date with the provided groups.
+func ceResultByTime(startDate string, groups ...cetypes.Group) cetypes.ResultByTime {
+	return cetypes.ResultByTime{
+		TimePeriod: &cetypes.DateInterval{
+			Start: aws.String(startDate),
+			End:   aws.String(nextDate(startDate)),
+		},
+		Groups: groups,
+	}
+}
+
+// nextDate returns the next day as YYYY-MM-DD given a YYYY-MM-DD input.
+func nextDate(date string) string {
+	t, _ := time.Parse("2006-01-02", date)
+	return t.Add(24 * time.Hour).Format("2006-01-02")
+}
+
+// cwReportWithAttributions creates an InstanceCostReport for a given slug
+// with the specified attributions.
+func cwReportWithAttributions(slug, accountID string, attributions ...ServiceAttribution) *InstanceCostReport {
+	start := time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC)
+	end := start.Add(48 * time.Hour)
+	return &InstanceCostReport{
+		Slug:         slug,
+		AccountID:    accountID,
+		WindowStart:  start,
+		WindowEnd:    end,
+		Attributions: attributions,
+	}
+}
+
+// costKeys returns sorted keys for assertion diagnostics.
+func costKeys(costs []CostBreakdown) string {
+	keys := make([]string, len(costs))
+	for i, c := range costs {
+		keys[i] = c.Service
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+// entryKeys returns sorted service keys from reconciled entries for diagnostics.
+func entryKeys(entries []ReconciledCostEntry) string {
+	keys := make([]string, len(entries))
+	for i, e := range entries {
+		keys[i] = e.Service
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ", ")
+}
+
+// findCostBreakdown locates a CostBreakdown by service name.
+func findCostBreakdown(costs []CostBreakdown, service string) (CostBreakdown, bool) {
+	for _, c := range costs {
+		if c.Service == service {
+			return c, true
+		}
+	}
+	return CostBreakdown{}, false
+}
+
+// ---------------------------------------------------------------------------
+// validation tests
+// ---------------------------------------------------------------------------
+
+func TestCECollectCosts_BlankSlug(t *testing.T) {
+	t.Parallel()
+	cc := makeCECollector(&fakeCostExplorerAPI{})
+	scope := validScope()
+	scope.Slug = ""
+	start, end := validWindow()
+
+	_, err := cc.CollectCosts(context.Background(), scope, start, end)
+	if err == nil {
+		t.Fatal("expected error for blank slug")
+	}
+	if !strings.Contains(err.Error(), "Slug") {
+		t.Fatalf("error should mention Slug: %v", err)
+	}
+}
+
+func TestCECollectCosts_BlankAccountID(t *testing.T) {
+	t.Parallel()
+	cc := makeCECollector(&fakeCostExplorerAPI{})
+	scope := validScope()
+	scope.AccountID = ""
+	start, end := validWindow()
+
+	_, err := cc.CollectCosts(context.Background(), scope, start, end)
+	if err == nil {
+		t.Fatal("expected error for blank AccountID")
+	}
+	if !strings.Contains(err.Error(), "AccountID") {
+		t.Fatalf("error should mention AccountID: %v", err)
+	}
+}
+
+func TestCECollectCosts_BlankRegion(t *testing.T) {
+	t.Parallel()
+	cc := makeCECollector(&fakeCostExplorerAPI{})
+	scope := validScope()
+	scope.Region = ""
+	start, end := validWindow()
+
+	_, err := cc.CollectCosts(context.Background(), scope, start, end)
+	if err == nil {
+		t.Fatal("expected error for blank Region")
+	}
+	if !strings.Contains(err.Error(), "Region") {
+		t.Fatalf("error should mention Region: %v", err)
+	}
+}
+
+func TestCECollectCosts_InvertedWindow(t *testing.T) {
+	t.Parallel()
+	cc := makeCECollector(&fakeCostExplorerAPI{})
+	start := time.Date(2026, 5, 27, 12, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 26, 0, 0, 0, 0, time.UTC)
+
+	_, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err == nil {
+		t.Fatal("expected error for inverted window")
+	}
+	if !strings.Contains(err.Error(), "windowStart must be before windowEnd") {
+		t.Fatalf("error should mention window ordering: %v", err)
+	}
+}
+
+func TestCECollectCosts_EqualWindow(t *testing.T) {
+	t.Parallel()
+	cc := makeCECollector(&fakeCostExplorerAPI{})
+	ts := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+
+	_, err := cc.CollectCosts(context.Background(), validScope(), ts, ts)
+	if err == nil {
+		t.Fatal("expected error for equal start/end")
+	}
+}
+
+func TestCECollectCosts_FactoryError(t *testing.T) {
+	t.Parallel()
+	collector := NewCostExplorerCollector(&fakeCostExplorerClientFactory{api: nil})
+	start, end := validWindow()
+
+	_, err := collector.CollectCosts(context.Background(), validScope(), start, end)
+	if err == nil {
+		t.Fatal("expected error from factory")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CollectCosts happy-path tests
+// ---------------------------------------------------------------------------
+
+func TestCECollectCosts_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			ceResultByTime(testCEDate1,
+				ceServiceGroup(testCEServiceLambda, "0.0532947123"),
+				ceServiceGroup(testCEServiceDynamoDB, "0.0042189000"),
+			),
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Slug != testSlug {
+		t.Fatalf("expected slug 'demo', got %q", result.Slug)
+	}
+	if result.AccountID != testAccountID {
+		t.Fatalf("expected AccountID %q, got %q", testAccountID, result.AccountID)
+	}
+	if len(result.Costs) != 2 {
+		t.Fatalf("expected 2 costs, got %d: %s", len(result.Costs), costKeys(result.Costs))
+	}
+
+	// Verify rounding: 0.0532947123 → 0.053295 after rounding to 1e6.
+	lambdaCost, ok := findCostBreakdown(result.Costs, testCEServiceLambda)
+	if !ok {
+		t.Fatalf("missing cost for %s", testCEServiceLambda)
+	}
+	expected := 0.053295
+	if lambdaCost.Amount != expected {
+		t.Fatalf("Lambda cost = %v, want %v (rounded to 6 decimal places)", lambdaCost.Amount, expected)
+	}
+	if lambdaCost.Currency != testCECurrencyUSD {
+		t.Fatalf("currency = %q, want USD", lambdaCost.Currency)
+	}
+
+	dynamoCost, ok := findCostBreakdown(result.Costs, testCEServiceDynamoDB)
+	if !ok {
+		t.Fatalf("missing cost for %s", testCEServiceDynamoDB)
+	}
+	expected = 0.004219
+	if dynamoCost.Amount != expected {
+		t.Fatalf("DynamoDB cost = %v, want %v", dynamoCost.Amount, expected)
+	}
+
+	// Total should be sum of both.
+	expectedTotal := 0.057514 // 0.053295 + 0.004219
+	if result.TotalCost != expectedTotal {
+		t.Fatalf("TotalCost = %v, want %v", result.TotalCost, expectedTotal)
+	}
+	if result.Currency != testCECurrencyUSD {
+		t.Fatalf("result currency = %q, want USD", result.Currency)
+	}
+}
+
+func TestCECollectCosts_MultipleDays(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			ceResultByTime(testCEDate1,
+				ceServiceGroup(testCEServiceLambda, "0.05"),
+			),
+			ceResultByTime(testCEDate2,
+				ceServiceGroup(testCEServiceLambda, "0.03"),
+			),
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Same service across two days should be aggregated into a single
+	// CostBreakdown entry with the summed amount.
+	if len(result.Costs) != 1 {
+		t.Fatalf("expected 1 cost entry (aggregated across days), got %d: %s",
+			len(result.Costs), costKeys(result.Costs))
+	}
+	lambdaCost, ok := findCostBreakdown(result.Costs, testCEServiceLambda)
+	if !ok {
+		t.Fatalf("missing cost for %s", testCEServiceLambda)
+	}
+	if lambdaCost.Amount != 0.08 {
+		t.Fatalf("Lambda cost = %v, want 0.08 (0.05 + 0.03)", lambdaCost.Amount)
+	}
+	if result.TotalCost != 0.08 {
+		t.Fatalf("TotalCost = %v, want 0.08", result.TotalCost)
+	}
+}
+
+func TestCECollectCosts_MultipleServices(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			ceResultByTime(testCEDate1,
+				ceServiceGroup(testCEServiceLambda, "1.00"),
+				ceServiceGroup(testCEServiceDynamoDB, "0.50"),
+				ceServiceGroup(testCEServiceAPIGW, "0.25"),
+				ceServiceGroup(testCEServiceS3, "0.10"),
+				ceServiceGroup(testCEServiceSQS, "0.05"),
+				ceServiceGroup(testCEServiceCloudF, "0.15"),
+			),
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Costs) != 6 {
+		t.Fatalf("expected 6 costs, got %d: %s", len(result.Costs), costKeys(result.Costs))
+	}
+	// Total should be 1.00 + 0.50 + 0.25 + 0.10 + 0.05 + 0.15 = 2.05
+	if result.TotalCost != 2.05 {
+		t.Fatalf("TotalCost = %v, want 2.05", result.TotalCost)
+	}
+
+	// Verify deterministic sort order (lexicographic by CE service name).
+	// "AWS" < "Amazon" because 'W' (87) < 'm' (109) in ASCII.
+	expectedOrder := []string{
+		testCEServiceLambda,   // "AWS Lambda"
+		testCEServiceAPIGW,    // "Amazon API Gateway"
+		testCEServiceCloudF,   // "Amazon CloudFront"
+		testCEServiceDynamoDB, // "Amazon DynamoDB"
+		testCEServiceSQS,      // "Amazon Simple Queue Service"
+		testCEServiceS3,       // "Amazon Simple Storage Service"
+	}
+	for i, exp := range expectedOrder {
+		if result.Costs[i].Service != exp {
+			t.Fatalf("costs[%d] = %q, want %q (deterministic sort)", i, result.Costs[i].Service, exp)
+		}
+	}
+}
+
+func TestCECollectCosts_EmptyResults(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: nil,
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Slug != testSlug {
+		t.Fatalf("expected slug in report even with empty results")
+	}
+	if len(result.Costs) != 0 {
+		t.Fatalf("expected 0 costs, got %d", len(result.Costs))
+	}
+	if result.TotalCost != 0 {
+		t.Fatalf("TotalCost should be 0 for empty results, got %v", result.TotalCost)
+	}
+}
+
+func TestCECollectCosts_EmptyGroups(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			{
+				TimePeriod: &cetypes.DateInterval{
+					Start: aws.String(testCEDate1),
+					End:   aws.String(nextDate(testCEDate1)),
+				},
+				Groups: nil,
+			},
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Costs) != 0 {
+		t.Fatalf("expected 0 costs for empty groups, got %d", len(result.Costs))
+	}
+}
+
+func TestCECollectCosts_GroupWithEmptyKeys(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			ceResultByTime(testCEDate1,
+				cetypes.Group{
+					Keys: []string{}, // empty key — should be skipped
+					Metrics: map[string]cetypes.MetricValue{
+						costBreakdownMetric: {
+							Amount: aws.String("1.00"),
+							Unit:   aws.String(testCECurrencyUSD),
+						},
+					},
+				},
+				ceServiceGroup(testCEServiceLambda, "0.50"),
+			),
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Costs) != 1 {
+		t.Fatalf("expected 1 cost (empty-key group skipped), got %d", len(result.Costs))
+	}
+	if result.TotalCost != 0.5 {
+		t.Fatalf("TotalCost = %v, want 0.5 (empty-key group excluded)", result.TotalCost)
+	}
+}
+
+func TestCECollectCosts_NilAmount(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			{
+				TimePeriod: &cetypes.DateInterval{
+					Start: aws.String(testCEDate1),
+					End:   aws.String(nextDate(testCEDate1)),
+				},
+				Groups: []cetypes.Group{
+					{
+						Keys: []string{testCEServiceLambda},
+						Metrics: map[string]cetypes.MetricValue{
+							costBreakdownMetric: {
+								Amount: nil, // nil amount → treated as 0
+								Unit:   aws.String(testCECurrencyUSD),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	cc := makeCECollector(api)
+	result, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Costs) != 0 {
+		t.Fatalf("expected 0 costs (nil amount treated as 0, zero-cost entry may be omitted), got %d", len(result.Costs))
+	}
+	// Actually with amount=0, the CostBreakdown is created but with Amount=0.
+	// Let me check: buildCostExplorerResult appends every group with non-empty
+	// key even if the amount is 0. So it should have 1 entry.
+	if result.TotalCost != 0 {
+		t.Fatalf("TotalCost = %v, want 0", result.TotalCost)
+	}
+}
+
+func TestCECollectCosts_APIError(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	api := &fakeCostExplorerAPI{err: fmt.Errorf("access denied")}
+	cc := makeCECollector(api)
+
+	_, err := cc.CollectCosts(context.Background(), validScope(), start, end)
+	if err == nil {
+		t.Fatal("expected error from GetCostAndUsage")
+	}
+	if !strings.Contains(err.Error(), "access denied") {
+		t.Fatalf("error should propagate: %v", err)
+	}
+}
+
+func TestCECollectCosts_OutputIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	start, end := validWindow()
+	makeAPI := func() *fakeCostExplorerAPI {
+		return &fakeCostExplorerAPI{
+			results: []cetypes.ResultByTime{
+				ceResultByTime(testCEDate1,
+					ceServiceGroup(testCEServiceAPIGW, "0.25"),
+					ceServiceGroup(testCEServiceLambda, "1.00"),
+				),
+			},
+		}
+	}
+
+	cc1 := makeCECollector(makeAPI())
+	result1, err := cc1.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cc2 := makeCECollector(makeAPI())
+	result2, err := cc2.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result1.Costs) != len(result2.Costs) {
+		t.Fatalf("cost count differs: %d vs %d", len(result1.Costs), len(result2.Costs))
+	}
+	for i := range result1.Costs {
+		if result1.Costs[i].Service != result2.Costs[i].Service ||
+			result1.Costs[i].Amount != result2.Costs[i].Amount ||
+			result1.Costs[i].Currency != result2.Costs[i].Currency {
+			t.Fatalf("mismatch at index %d: %+v vs %+v", i, result1.Costs[i], result2.Costs[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reconcile tests
+// ---------------------------------------------------------------------------
+
+func TestReconcile_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.08,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceLambda, Amount: 0.053295, Currency: testCECurrencyUSD},
+			{Service: testCEServiceDynamoDB, Amount: 0.004219, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID,
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 42},
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Duration", Stat: "Average", Unit: "Milliseconds", Value: 150.5},
+		ServiceAttribution{Service: testCENormDynamoDB, MetricName: "ConsumedReadCapacityUnits", Stat: "Sum", Unit: "Count", Value: 1000},
+	)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.Slug != testSlug {
+		t.Fatalf("Slug = %q, want %q", report.Slug, testSlug)
+	}
+	if report.AccountID != testAccountID {
+		t.Fatalf("AccountID = %q, want %q", report.AccountID, testAccountID)
+	}
+	if report.TotalCost != 0.08 {
+		t.Fatalf("TotalCost = %v, want 0.08", report.TotalCost)
+	}
+	if len(report.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %s", len(report.Entries), entryKeys(report.Entries))
+	}
+
+	// Lambda entry should have 2 CW metrics attached.
+	for _, entry := range report.Entries {
+		switch entry.Service {
+		case testCENormLambda:
+			if entry.Cost != 0.053295 {
+				t.Fatalf("Lambda cost = %v, want 0.053295", entry.Cost)
+			}
+			if len(entry.Metrics) != 2 {
+				t.Fatalf("Lambda should have 2 metrics, got %d", len(entry.Metrics))
+			}
+		case testCENormDynamoDB:
+			if entry.Cost != 0.004219 {
+				t.Fatalf("DynamoDB cost = %v, want 0.004219", entry.Cost)
+			}
+			if len(entry.Metrics) != 1 {
+				t.Fatalf("DynamoDB should have 1 metric, got %d", len(entry.Metrics))
+			}
+		default:
+			t.Fatalf("unexpected service %q", entry.Service)
+		}
+	}
+}
+
+func TestReconcile_NilCEResult(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+
+	_, err := cc.Reconcile(nil, cwReport)
+	if err == nil {
+		t.Fatal("expected error for nil CE result")
+	}
+	if !strings.Contains(err.Error(), "ceResult is nil") {
+		t.Fatalf("error should mention nil ceResult: %v", err)
+	}
+}
+
+func TestReconcile_NilCWReport(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{Slug: testSlug, AccountID: testAccountID}
+
+	_, err := cc.Reconcile(ceResult, nil)
+	if err == nil {
+		t.Fatal("expected error for nil CW report")
+	}
+	if !strings.Contains(err.Error(), "cwReport is nil") {
+		t.Fatalf("error should mention nil cwReport: %v", err)
+	}
+}
+
+func TestReconcile_SlugMismatch(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{Slug: "slug-a", AccountID: testAccountID}
+	cwReport := cwReportWithAttributions("slug-b", testAccountID)
+
+	_, err := cc.Reconcile(ceResult, cwReport)
+	if err == nil {
+		t.Fatal("expected error for slug mismatch")
+	}
+	if !strings.Contains(err.Error(), "slug mismatch") {
+		t.Fatalf("error should mention slug mismatch: %v", err)
+	}
+}
+
+func TestReconcile_AccountMismatch(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{Slug: testSlug, AccountID: "111111111111"}
+	cwReport := cwReportWithAttributions(testSlug, "999999999999")
+
+	_, err := cc.Reconcile(ceResult, cwReport)
+	if err == nil {
+		t.Fatal("expected error for account mismatch")
+	}
+	if !strings.Contains(err.Error(), "account mismatch") {
+		t.Fatalf("error should mention account mismatch: %v", err)
+	}
+}
+
+func TestReconcile_EmptyCWAttributions(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.05,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID) // empty attributions
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	if len(report.Entries[0].Metrics) != 0 {
+		t.Fatalf("expected 0 metrics (empty CW), got %d", len(report.Entries[0].Metrics))
+	}
+}
+
+func TestReconcile_ServiceMappingApplied(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.10,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceAPIGW, Amount: 0.10, Currency: testCECurrencyUSD},
+		},
+	}
+
+	// CW attribution uses the normalized name "APIGateway".
+	cwReport := cwReportWithAttributions(testSlug, testAccountID,
+		ServiceAttribution{Service: testCENormAPIGW, MetricName: "Count", Stat: "Sum", Unit: "Count", Value: 5000},
+	)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	entry := report.Entries[0]
+	if entry.Service != testCENormAPIGW {
+		t.Fatalf("expected normalized service %q, got %q", testCENormAPIGW, entry.Service)
+	}
+	if len(entry.Metrics) != 1 {
+		t.Fatalf("expected 1 metric (mapped via CE→CW), got %d", len(entry.Metrics))
+	}
+}
+
+func TestReconcile_UnknownServicePassthrough(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.01,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: "AWS NoSuchService", Amount: 0.01, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	// Unknown service should pass through unchanged.
+	if report.Entries[0].Service != "AWS NoSuchService" {
+		t.Fatalf("unknown service should pass through: got %q", report.Entries[0].Service)
+	}
+}
+
+func TestReconcile_DeterministicOutput(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.15,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceS3, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Service: testCEServiceLambda, Amount: 0.10, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+
+	report1, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	report2, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report1.Entries) != len(report2.Entries) {
+		t.Fatalf("entry count differs: %d vs %d", len(report1.Entries), len(report2.Entries))
+	}
+	for i := range report1.Entries {
+		e1 := report1.Entries[i]
+		e2 := report2.Entries[i]
+		if e1.Service != e2.Service || e1.Cost != e2.Cost {
+			t.Fatalf("mismatch at index %d: %+v vs %+v", i, e1, e2)
+		}
+	}
+}
+
+func TestReconcile_WindowIntersection(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.05,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+		},
+	}
+
+	// CW window is tighter — starts later, ends earlier.
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+	cwReport.WindowStart = time.Date(2026, 5, 25, 12, 0, 0, 0, time.UTC)
+	cwReport.WindowEnd = time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !report.WindowStart.Equal(cwReport.WindowStart) {
+		t.Fatalf("WindowStart = %v, want %v (tighter CW start)", report.WindowStart, cwReport.WindowStart)
+	}
+	if !report.WindowEnd.Equal(cwReport.WindowEnd) {
+		t.Fatalf("WindowEnd = %v, want %v (tighter CW end)", report.WindowEnd, cwReport.WindowEnd)
+	}
+}
+
+func TestReconcile_NoCosts(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0,
+		Currency:    testCECurrencyUSD,
+		Costs:       nil,
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID,
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 42},
+	)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Entries) != 0 {
+		t.Fatalf("expected 0 entries for no costs, got %d", len(report.Entries))
+	}
+	if report.TotalCost != 0 {
+		t.Fatalf("TotalCost = %v, want 0", report.TotalCost)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// unit tests for helpers
+// ---------------------------------------------------------------------------
+
+func TestCeilingDay_AfterMidnight(t *testing.T) {
+	t.Parallel()
+
+	// 2026-05-26 12:00:00 UTC → should return 2026-05-27 00:00:00 UTC.
+	input := time.Date(2026, 5, 26, 12, 0, 0, 0, time.UTC)
+	got := ceilingDay(input)
+	expected := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Fatalf("ceilingDay(%v) = %v, want %v", input, got, expected)
+	}
+}
+
+func TestCeilingDay_AtMidnight(t *testing.T) {
+	t.Parallel()
+
+	// Already at midnight — should stay at midnight.
+	input := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+	got := ceilingDay(input)
+	if !got.Equal(input) {
+		t.Fatalf("ceilingDay at midnight should return same time; got %v, want %v", got, input)
+	}
+}
+
+func TestCeilingDay_EndOfDay(t *testing.T) {
+	t.Parallel()
+
+	// 2026-05-26 23:59:59 UTC → should return 2026-05-27 00:00:00 UTC.
+	input := time.Date(2026, 5, 26, 23, 59, 59, 0, time.UTC)
+	got := ceilingDay(input)
+	expected := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Fatalf("ceilingDay(%v) = %v, want %v", input, got, expected)
+	}
+}
+
+func TestCeilingDay_StartOfDay(t *testing.T) {
+	t.Parallel()
+
+	// 2026-05-26 00:00:01 UTC → should return 2026-05-27 00:00:00 UTC.
+	input := time.Date(2026, 5, 26, 0, 0, 1, 0, time.UTC)
+	got := ceilingDay(input)
+	expected := time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC)
+	if !got.Equal(expected) {
+		t.Fatalf("ceilingDay(%v) = %v, want %v", input, got, expected)
+	}
+}
+
+func TestExtractMetricValueCE_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	mv := cetypes.MetricValue{
+		Amount: aws.String("0.0532947123"),
+		Unit:   aws.String(testCECurrencyUSD),
+	}
+	amount, currency := extractMetricValueCE(mv)
+	if amount != 0.0532947123 {
+		t.Fatalf("amount = %v, want 0.0532947123", amount)
+	}
+	if currency != testCECurrencyUSD {
+		t.Fatalf("currency = %q, want USD", currency)
+	}
+}
+
+func TestExtractMetricValueCE_NilAmount(t *testing.T) {
+	t.Parallel()
+
+	mv := cetypes.MetricValue{
+		Amount: nil,
+		Unit:   aws.String(testCECurrencyUSD),
+	}
+	amount, currency := extractMetricValueCE(mv)
+	if amount != 0 {
+		t.Fatalf("amount = %v, want 0", amount)
+	}
+	if currency != testCECurrencyUSD {
+		t.Fatalf("currency = %q, want USD", currency)
+	}
+}
+
+func TestExtractMetricValueCE_NilUnit(t *testing.T) {
+	t.Parallel()
+
+	mv := cetypes.MetricValue{
+		Amount: aws.String("1.50"),
+		Unit:   nil,
+	}
+	amount, currency := extractMetricValueCE(mv)
+	if amount != 1.50 {
+		t.Fatalf("amount = %v, want 1.50", amount)
+	}
+	if currency != "" {
+		t.Fatalf("currency = %q, want empty string", currency)
+	}
+}
+
+func TestExtractMetricValueCE_BadFormat(t *testing.T) {
+	t.Parallel()
+
+	mv := cetypes.MetricValue{
+		Amount: aws.String("not-a-number"),
+		Unit:   aws.String(testCECurrencyUSD),
+	}
+	amount, currency := extractMetricValueCE(mv)
+	if amount != 0 {
+		t.Fatalf("amount = %v, want 0 for unparseable value", amount)
+	}
+	if currency != testCECurrencyUSD {
+		t.Fatalf("currency = %q, want USD", currency)
+	}
+}
+
+func TestMapCEToCWService_KnownMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ceName string
+		want   string
+	}{
+		{"AWS Lambda", testCENormLambda},
+		{"Amazon DynamoDB", testCENormDynamoDB},
+		{"Amazon API Gateway", testCENormAPIGW},
+		{"Amazon Simple Storage Service", "S3"},
+		{"Amazon Simple Queue Service", "SQS"},
+		{"Amazon CloudFront", "CloudFront"},
+		{"AWS CloudFront", "CloudFront"},
+		{"Amazon Route 53", "Route53"},
+		{"AWS Route 53", "Route53"},
+		{"AWS Key Management Service", "KMS"},
+		{"AWS CodeBuild", "CodeBuild"},
+		{"AWS Secrets Manager", "SecretsManager"},
+		{"AWS Step Functions", "StepFunctions"},
+		{"Amazon CloudWatch", "CloudWatch"},
+		{"Amazon Cognito", "Cognito"},
+		{"Amazon EC2", "EC2"},
+		{"Amazon Elastic Compute Cloud", "EC2"},
+		{"EC2 - Other", "EC2"},
+		{"AWS Certificate Manager", "ACM"},
+		{"AWS Data Transfer", "DataTransfer"},
+		{"AWS Elastic Load Balancing", "ELB"},
+	}
+
+	for _, tt := range tests {
+		got := mapCEToCWService(tt.ceName)
+		if got != tt.want {
+			t.Fatalf("mapCEToCWService(%q) = %q, want %q", tt.ceName, got, tt.want)
+		}
+	}
+}
+
+func TestMapCEToCWService_UnknownPassthrough(t *testing.T) {
+	t.Parallel()
+
+	inputs := []string{
+		"AWS NoSuchService",
+		"",
+		"Amazon SomethingUnknown",
+		"Tax",
+		"AWS Support",
+	}
+	for _, in := range inputs {
+		got := mapCEToCWService(in)
+		if got != in {
+			t.Fatalf("mapCEToCWService(%q) = %q, want %q (passthrough)", in, got, in)
+		}
+	}
+}
+
+func TestBuildCWAttributionLookup_Empty(t *testing.T) {
+	t.Parallel()
+
+	got := buildCWAttributionLookup(nil)
+	if got != nil {
+		t.Fatalf("expected nil for nil input, got %v", got)
+	}
+
+	got = buildCWAttributionLookup([]ServiceAttribution{})
+	if got != nil {
+		t.Fatalf("expected nil for empty slice, got %v", got)
+	}
+}
+
+func TestBuildCWAttributionLookup_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	attrs := []ServiceAttribution{
+		{Service: testCENormLambda, MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 42},
+		{Service: testCENormLambda, MetricName: "Duration", Stat: "Average", Unit: "Milliseconds", Value: 150.5},
+		{Service: testCENormDynamoDB, MetricName: "ConsumedReadCapacityUnits", Stat: "Sum", Unit: "Count", Value: 1000},
+	}
+
+	lookup := buildCWAttributionLookup(attrs)
+	if len(lookup) != 2 {
+		t.Fatalf("expected 2 service keys, got %d", len(lookup))
+	}
+	if len(lookup[testCENormLambda]) != 2 {
+		t.Fatalf("Lambda should have 2 attributions, got %d", len(lookup[testCENormLambda]))
+	}
+	if len(lookup[testCENormDynamoDB]) != 1 {
+		t.Fatalf("DynamoDB should have 1 attribution, got %d", len(lookup[testCENormDynamoDB]))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// integration-style: NewCostExplorerCollector returns a usable interface
+// ---------------------------------------------------------------------------
+
+func TestNewCostExplorerCollector_ReturnsInterface(t *testing.T) {
+	api := &fakeCostExplorerAPI{
+		results: []cetypes.ResultByTime{
+			ceResultByTime(testCEDate1,
+				ceServiceGroup(testCEServiceLambda, "1.00"),
+			),
+		},
+	}
+
+	collector := NewCostExplorerCollector(&fakeCostExplorerClientFactory{api: api})
+	if collector == nil {
+		t.Fatal("NewCostExplorerCollector returned nil")
+	}
+
+	start, end := validWindow()
+	result, err := collector.CollectCosts(context.Background(), validScope(), start, end)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if result.Slug != testSlug {
+		t.Fatalf("expected slug 'demo', got %q", result.Slug)
+	}
+	if len(result.Costs) != 1 {
+		t.Fatalf("expected 1 cost, got %d", len(result.Costs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// reconciliation edge cases
+// ---------------------------------------------------------------------------
+
+func TestReconcile_MultipleMetricsSameService(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.05,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID,
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 42},
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Duration", Stat: "Average", Unit: "Milliseconds", Value: 150.5},
+		ServiceAttribution{Service: testCENormLambda, MetricName: "Errors", Stat: "Sum", Unit: "Count", Value: 0},
+	)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	if len(report.Entries[0].Metrics) != 3 {
+		t.Fatalf("expected 3 metrics for Lambda, got %d", len(report.Entries[0].Metrics))
+	}
+}
+
+func TestReconcile_CWServiceNotInCE(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.05,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceLambda, Amount: 0.05, Currency: testCECurrencyUSD},
+		},
+	}
+
+	// CW has metrics for DynamoDB but CE has no DynamoDB cost — that's fine.
+	// The DynamoDB metrics simply don't attach to any CE entry.
+	cwReport := cwReportWithAttributions(testSlug, testAccountID,
+		ServiceAttribution{Service: testCENormDynamoDB, MetricName: "ConsumedReadCapacityUnits", Stat: "Sum", Unit: "Count", Value: 500},
+	)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Lambda entry should have no metrics (CW has no Lambda data).
+	if len(report.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(report.Entries))
+	}
+	if len(report.Entries[0].Metrics) != 0 {
+		t.Fatalf("Lambda entry should have 0 metrics (CW has DynamoDB only), got %d",
+			len(report.Entries[0].Metrics))
+	}
+}
+
+func TestReconcile_SortOrder(t *testing.T) {
+	t.Parallel()
+
+	cc := makeCECollector(nil)
+	ceResult := &CostExplorerResult{
+		Slug:        testSlug,
+		AccountID:   testAccountID,
+		WindowStart: time.Date(2026, 5, 25, 0, 0, 0, 0, time.UTC),
+		WindowEnd:   time.Date(2026, 5, 27, 0, 0, 0, 0, time.UTC),
+		TotalCost:   0.35,
+		Currency:    testCECurrencyUSD,
+		Costs: []CostBreakdown{
+			{Service: testCEServiceS3, Amount: 0.10, Currency: testCECurrencyUSD},
+			{Service: testCEServiceSQS, Amount: 0.05, Currency: testCECurrencyUSD},
+			{Service: testCEServiceLambda, Amount: 0.20, Currency: testCECurrencyUSD},
+		},
+	}
+
+	cwReport := cwReportWithAttributions(testSlug, testAccountID)
+
+	report, err := cc.Reconcile(ceResult, cwReport)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should be sorted by service, then by cost.
+	expectedOrder := []string{testCENormLambda, "S3", "SQS"}
+	for i, exp := range expectedOrder {
+		if report.Entries[i].Service != exp {
+			t.Fatalf("entries[%d] = %q, want %q (deterministic sort)", i, report.Entries[i].Service, exp)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Implements M3.9 Cost Explorer billing integration (`go test ./...` PASS, `go vet ./...` clean, gov-rubric 39/0/0 PASS)
- New `CostExplorerCollector` interface with `CollectCosts` (queries CE with DAILY/SERVICE granularity) and `Reconcile` (pure function combining CE + CW data)
- 42 tests with fake implementations of `costExplorerAPI` and `CostExplorerClientFactory`
- CE→CW service name mapping table bridges AWS API naming conventions

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean (non-web non-cdk non-contracts)
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — 39 PASS / 0 FAIL / 0 BLOCKED
- [x] No CDK changes (npm test + synth not needed)
- [x] No web/ changes (lint + typecheck + test + build not needed)

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)