### PR TITLE
feat(costtelemetry): DynamoDB cache model

### DIFF
--- a/internal/costtelemetry/cache.go
+++ b/internal/costtelemetry/cache.go
@@ -1,0 +1,120 @@
+package costtelemetry
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// CostTelemetryStore is the minimal store seam for persisting cost
+// telemetry cache records. Tests implement this interface with a
+// fake; production satisfies it with the real store.Store.
+//
+// Only the write path is exposed here; M3.11 adds query methods
+// through the same store interface.
+type CostTelemetryStore interface {
+	PutCostTelemetry(ctx context.Context, record *models.CostTelemetry) error
+}
+
+// CostTelemetryCache persists reconciled cost data as per-instance
+// per-day CostTelemetry records.
+//
+// The cache is the M3.10 interface seam: tests inject a fake store;
+// production injects the real store.Store.
+type CostTelemetryCache interface {
+	// Write persists a ReconciledCostReport as per-day CostTelemetry
+	// records. The report's entries are grouped by date, and each
+	// group is written as a single upsertable record keyed by
+	// (COST_TELEMETRY#<slug>, <date>).
+	//
+	// Re-running Write for the same slug and date range is idempotent:
+	// each (slug, date) record is upserted, so subsequent runs replace
+	// rather than duplicate.
+	//
+	// Returns the number of records written.
+	Write(ctx context.Context, report *ReconciledCostReport) (int, error)
+}
+
+// NewCostTelemetryCache constructs a CostTelemetryCache backed by the
+// given store.
+func NewCostTelemetryCache(store CostTelemetryStore) CostTelemetryCache {
+	return &costTelemetryCacheImpl{store: store}
+}
+
+type costTelemetryCacheImpl struct {
+	store CostTelemetryStore
+}
+
+// Write implements CostTelemetryCache.
+func (c *costTelemetryCacheImpl) Write(ctx context.Context, report *ReconciledCostReport) (int, error) {
+	if report == nil {
+		return 0, fmt.Errorf("costtelemetry: report is nil")
+	}
+	if report.Slug == "" {
+		return 0, fmt.Errorf("costtelemetry: report slug is empty")
+	}
+
+	// Group entries by date. Each date becomes one CostTelemetry record.
+	byDate := groupEntriesByDate(report.Entries)
+
+	// Build and persist one record per date.
+	written := 0
+	for _, date := range sortedDates(byDate) {
+		entries := byDate[date]
+
+		// Compute per-day total from the entries.
+		var dayCost float64
+		for _, e := range entries {
+			dayCost += e.Cost
+		}
+
+		entriesJSON, err := json.Marshal(entries)
+		if err != nil {
+			return written, fmt.Errorf("costtelemetry: marshaling entries for slug %s date %s: %w",
+				report.Slug, date, err)
+		}
+
+		record := &models.CostTelemetry{
+			InstanceSlug: report.Slug,
+			Date:         date,
+			EntriesJSON:  string(entriesJSON),
+			DayCost:      dayCost,
+			Currency:     report.Currency,
+		}
+
+		if err := c.store.PutCostTelemetry(ctx, record); err != nil {
+			return written, fmt.Errorf("costtelemetry: writing cache record for slug %s date %s: %w",
+				report.Slug, date, err)
+		}
+		written++
+	}
+
+	return written, nil
+}
+
+// groupEntriesByDate splits a flat list of reconciled entries into a map
+// keyed by date string (YYYY-MM-DD). Each date bucket preserves the
+// original entry order.
+func groupEntriesByDate(entries []ReconciledCostEntry) map[string][]ReconciledCostEntry {
+	byDate := make(map[string][]ReconciledCostEntry)
+	for _, e := range entries {
+		if e.Date == "" {
+			continue
+		}
+		byDate[e.Date] = append(byDate[e.Date], e)
+	}
+	return byDate
+}
+
+// sortedDates returns the keys of a date→entries map in ascending order.
+func sortedDates(byDate map[string][]ReconciledCostEntry) []string {
+	dates := make([]string, 0, len(byDate))
+	for d := range byDate {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+	return dates
+}

--- a/internal/costtelemetry/cache_test.go
+++ b/internal/costtelemetry/cache_test.go
@@ -1,0 +1,683 @@
+package costtelemetry
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// ---------------------------------------------------------------------------
+// test constants
+// ---------------------------------------------------------------------------
+
+const (
+	testCacheSlug     = "demo"
+	testCacheDate1    = "2026-05-25"
+	testCacheDate2    = "2026-05-26"
+	testCacheCurrency = "USD"
+)
+
+// ---------------------------------------------------------------------------
+// fake CostTelemetryStore for tests
+// ---------------------------------------------------------------------------
+
+// fakeCostTelemetryStore records PutCostTelemetry calls in memory.
+// It simulates TableTheory's CreateOrUpdate lifecycle by calling
+// BeforeCreate on each record, which populates PK, SK, TTL, and
+// timestamps as the production store would.
+//
+// Error injection: failOnCall controls which call number (1-indexed)
+// should return an error. Zero means never fail.
+type fakeCostTelemetryStore struct {
+	records    []*models.CostTelemetry
+	failOnCall int // call number that should fail; 0 = never fail
+	callCount  int
+	err        error // error to return when failing; uses sentinel if nil
+	lastRecord *models.CostTelemetry
+}
+
+func (s *fakeCostTelemetryStore) PutCostTelemetry(ctx context.Context, record *models.CostTelemetry) error {
+	s.callCount++
+
+	// Check for injected failure before recording — this simulates
+	// a store that rejects the write (e.g. DynamoDB throttle).
+	if s.failOnCall > 0 && s.callCount >= s.failOnCall {
+		if s.err != nil {
+			return s.err
+		}
+		return errors.New("fake store error")
+	}
+
+	// Simulate TableTheory's CreateOrUpdate lifecycle: run BeforeCreate
+	// so PK, SK, TTL, and timestamps are populated as they would be
+	// in production. This lets tests assert on key shape, TTL, etc.
+	if record != nil {
+		if err := record.BeforeCreate(); err != nil {
+			return err
+		}
+		// Shallow copy is safe: all fields are value types or immutable strings.
+		cp := *record
+		s.records = append(s.records, &cp)
+	}
+	s.lastRecord = record
+	return nil
+}
+
+// recordCount returns the number of records written to the store.
+func (s *fakeCostTelemetryStore) recordCount() int { return len(s.records) }
+
+// recordByDate returns the first record with the given date, or nil.
+func (s *fakeCostTelemetryStore) recordByDate(date string) *models.CostTelemetry {
+	for _, r := range s.records {
+		if r != nil && r.Date == date {
+			return r
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// newTestReport builds a ReconciledCostReport for tests.
+func newTestReport(slug string, entries ...ReconciledCostEntry) *ReconciledCostReport {
+	if len(entries) == 0 {
+		return &ReconciledCostReport{
+			Slug:      slug,
+			Currency:  testCacheCurrency,
+			Entries:   nil,
+			TotalCost: 0,
+		}
+	}
+	var total float64
+	for _, e := range entries {
+		total += e.Cost
+	}
+	return &ReconciledCostReport{
+		Slug:      slug,
+		Currency:  testCacheCurrency,
+		Entries:   entries,
+		TotalCost: total,
+	}
+}
+
+// entry builds a ReconciledCostEntry.
+func entry(date, service string, cost float64) ReconciledCostEntry {
+	return ReconciledCostEntry{
+		Date:     date,
+		Service:  service,
+		Cost:     cost,
+		Currency: testCacheCurrency,
+	}
+}
+
+// entryWithMetrics builds a ReconciledCostEntry with CloudWatch metrics.
+func entryWithMetrics(date, service string, cost float64, metrics ...ServiceAttribution) ReconciledCostEntry {
+	return ReconciledCostEntry{
+		Date:     date,
+		Service:  service,
+		Cost:     cost,
+		Currency: testCacheCurrency,
+		Metrics:  metrics,
+	}
+}
+
+// decodeEntries parses EntriesJSON from a CostTelemetry record.
+func decodeEntries(t *testing.T, record *models.CostTelemetry) []ReconciledCostEntry {
+	t.Helper()
+	if record == nil {
+		t.Fatal("record is nil")
+	}
+	var entries []ReconciledCostEntry
+	if err := json.Unmarshal([]byte(record.EntriesJSON), &entries); err != nil {
+		t.Fatalf("decode entries: %v", err)
+	}
+	return entries
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestCacheWriteSingleDaySingleService(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.25),
+	)
+
+	written, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != 1 {
+		t.Fatalf("expected 1 record written, got %d", written)
+	}
+	if store.recordCount() != 1 {
+		t.Fatalf("expected 1 store record, got %d", store.recordCount())
+	}
+
+	rec := store.records[0]
+	if rec.InstanceSlug != testCacheSlug {
+		t.Errorf("InstanceSlug = %q, want %q", rec.InstanceSlug, testCacheSlug)
+	}
+	if rec.Date != testCacheDate1 {
+		t.Errorf("Date = %q, want %q", rec.Date, testCacheDate1)
+	}
+	if rec.DayCost != 1.25 {
+		t.Errorf("DayCost = %f, want 1.25", rec.DayCost)
+	}
+	if rec.Currency != testCacheCurrency {
+		t.Errorf("Currency = %q, want %q", rec.Currency, testCacheCurrency)
+	}
+
+	entries := decodeEntries(t, rec)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Service != "Lambda" {
+		t.Errorf("Service = %q, want Lambda", entries[0].Service)
+	}
+}
+
+func TestCacheWriteMultiDaySplit(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+		entry(testCacheDate1, "DynamoDB", 2.00),
+		entry(testCacheDate2, "Lambda", 3.00),
+		entry(testCacheDate2, "S3", 0.50),
+	)
+
+	written, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != 2 {
+		t.Fatalf("expected 2 records written, got %d", written)
+	}
+	if store.recordCount() != 2 {
+		t.Fatalf("expected 2 store records, got %d", store.recordCount())
+	}
+
+	// Day 1: 2 entries, cost = 3.00
+	d1 := store.recordByDate(testCacheDate1)
+	if d1 == nil {
+		t.Fatalf("no record for date %q", testCacheDate1)
+	}
+	if d1.DayCost != 3.00 {
+		t.Errorf("Day1 DayCost = %f, want 3.00", d1.DayCost)
+	}
+	d1Entries := decodeEntries(t, d1)
+	if len(d1Entries) != 2 {
+		t.Fatalf("Day1: expected 2 entries, got %d", len(d1Entries))
+	}
+
+	// Day 2: 2 entries, cost = 3.50
+	d2 := store.recordByDate(testCacheDate2)
+	if d2 == nil {
+		t.Fatalf("no record for date %q", testCacheDate2)
+	}
+	if d2.DayCost != 3.50 {
+		t.Errorf("Day2 DayCost = %f, want 3.50", d2.DayCost)
+	}
+	d2Entries := decodeEntries(t, d2)
+	if len(d2Entries) != 2 {
+		t.Fatalf("Day2: expected 2 entries, got %d", len(d2Entries))
+	}
+}
+
+func TestCacheWritePreservesMetrics(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	metrics := []ServiceAttribution{
+		{Service: "Lambda", MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 100},
+	}
+	report := newTestReport(testCacheSlug,
+		entryWithMetrics(testCacheDate1, "Lambda", 1.25, metrics...),
+	)
+
+	_, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	rec := store.recordByDate(testCacheDate1)
+	entries := decodeEntries(t, rec)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if len(entries[0].Metrics) != 1 {
+		t.Fatalf("expected 1 metric, got %d", len(entries[0].Metrics))
+	}
+	if entries[0].Metrics[0].MetricName != "Invocations" {
+		t.Errorf("MetricName = %q, want Invocations", entries[0].Metrics[0].MetricName)
+	}
+}
+
+func TestCacheWriteIdempotent(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+		entry(testCacheDate2, "S3", 0.50),
+	)
+
+	// First write.
+	written1, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if written1 != 2 {
+		t.Fatalf("first Write: expected 2 records, got %d", written1)
+	}
+
+	// Second write with same data. The fake store accumulates records,
+	// so the count should double. In production, CreateOrUpdate upserts
+	// the same PK+SK, so the record count stays at 2. Here we verify
+	// that the cache writer produces the same number of records and
+	// the keys (slug+date) are identical — meaning the production
+	// store would upsert rather than insert duplicates.
+	written2, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+	if written2 != 2 {
+		t.Fatalf("second Write: expected 2 records, got %d", written2)
+	}
+	if store.recordCount() != 4 {
+		t.Fatalf("fake store accumulated 4 records (expected for test double); "+
+			"production CreateOrUpdate would keep 2 (got %d)", store.recordCount())
+	}
+
+	// Verify that the second write's records have the same PK+SK as the first.
+	for i := 0; i < 2; i++ {
+		first := store.records[i]
+		second := store.records[i+2]
+		if first.PK != second.PK {
+			t.Errorf("record %d: PK mismatch across writes: %q vs %q", i, first.PK, second.PK)
+		}
+		if first.SK != second.SK {
+			t.Errorf("record %d: SK mismatch across writes: %q vs %q", i, first.SK, second.SK)
+		}
+		if first.InstanceSlug != second.InstanceSlug {
+			t.Errorf("record %d: InstanceSlug mismatch: %q vs %q", i, first.InstanceSlug, second.InstanceSlug)
+		}
+		if first.Date != second.Date {
+			t.Errorf("record %d: Date mismatch: %q vs %q", i, first.Date, second.Date)
+		}
+	}
+}
+
+func TestCacheWriteIdempotentSameSlugSameDatesNoDuplicates(t *testing.T) {
+	t.Parallel()
+
+	// This test verifies that when writing the same slug+date twice,
+	// only one PK+SK pair is produced per date. The fake store lets
+	// us inspect what keys the cache writer would send to the real
+	// store, confirming that CreateOrUpdate would upsert rather than
+	// insert duplicates.
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+	)
+
+	// Write twice.
+	if _, err := cache.Write(ctx, report); err != nil {
+		t.Fatalf("first Write: %v", err)
+	}
+	if _, err := cache.Write(ctx, report); err != nil {
+		t.Fatalf("second Write: %v", err)
+	}
+
+	// Both writes should produce records with the same PK+SK for the same date.
+	// Verify there are exactly 2 records (one per write) and they have the same key.
+	if store.recordCount() != 2 {
+		t.Fatalf("expected 2 records total, got %d", store.recordCount())
+	}
+
+	r1 := store.records[0]
+	r2 := store.records[1]
+	if r1.PK != r2.PK || r1.SK != r2.SK {
+		t.Errorf("PK/SK differ across writes: (%q, %q) vs (%q, %q)",
+			r1.PK, r1.SK, r2.PK, r2.SK)
+	}
+}
+
+func TestCacheWriteTenantScoping(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	slugA := "tenant-alpha"
+	slugB := "tenant-beta"
+
+	reportA := newTestReport(slugA, entry(testCacheDate1, "Lambda", 1.00))
+	reportB := newTestReport(slugB, entry(testCacheDate1, "Lambda", 2.00))
+
+	if _, err := cache.Write(ctx, reportA); err != nil {
+		t.Fatalf("Write A: %v", err)
+	}
+	if _, err := cache.Write(ctx, reportB); err != nil {
+		t.Fatalf("Write B: %v", err)
+	}
+
+	if store.recordCount() != 2 {
+		t.Fatalf("expected 2 records, got %d", store.recordCount())
+	}
+
+	for _, rec := range store.records {
+		if !strings.Contains(rec.PK, rec.InstanceSlug) {
+			t.Errorf("PK %q does not contain InstanceSlug %q", rec.PK, rec.InstanceSlug)
+		}
+
+		// Verify tenant A and tenant B records are in different partitions.
+		otherSlug := slugA
+		if rec.InstanceSlug == slugA {
+			otherSlug = slugB
+		}
+		if strings.Contains(rec.PK, otherSlug) {
+			t.Errorf("PK %q contains other tenant slug %q", rec.PK, otherSlug)
+		}
+	}
+}
+
+func TestCacheWriteTTLSet(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+	)
+
+	before := time.Now().UTC()
+	_, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	after := time.Now().UTC()
+
+	rec := store.recordByDate(testCacheDate1)
+	if rec == nil {
+		t.Fatalf("no record written")
+	}
+
+	// TTL must be non-zero.
+	if rec.TTL == 0 {
+		t.Fatalf("TTL is zero; must be set to a retention-policy value")
+	}
+
+	// ExpiresAt must be set.
+	if rec.ExpiresAt.IsZero() {
+		t.Fatalf("ExpiresAt is zero; must be set")
+	}
+
+	// ExpiresAt should be ~90 days from now.
+	expectedMin := before.Add(models.CostTelemetryRetentionDays * 24 * time.Hour)
+	expectedMax := after.Add(models.CostTelemetryRetentionDays * 24 * time.Hour)
+	if rec.ExpiresAt.Before(expectedMin) || rec.ExpiresAt.After(expectedMax) {
+		t.Errorf("ExpiresAt = %s, want between %s and %s",
+			rec.ExpiresAt.Format(time.RFC3339),
+			expectedMin.Format(time.RFC3339),
+			expectedMax.Format(time.RFC3339))
+	}
+
+	// TTL should equal ExpiresAt.Unix().
+	if rec.TTL != rec.ExpiresAt.Unix() {
+		t.Errorf("TTL = %d, want ExpiresAt.Unix() = %d", rec.TTL, rec.ExpiresAt.Unix())
+	}
+
+	// Verify TTL matches the retention constant: ExpiresAt should be
+	// CreatedAt + retention days. TTL is a Unix timestamp, not a duration.
+	expectedExpiresAt := rec.CreatedAt.Add(models.CostTelemetryRetentionDays * 24 * time.Hour)
+	diff := rec.ExpiresAt.Sub(expectedExpiresAt)
+	if diff < 0 {
+		diff = -diff
+	}
+	if diff > 2*time.Second {
+		t.Errorf("ExpiresAt = %s, want ~%s (CreatedAt + %d days); diff = %s",
+			rec.ExpiresAt.Format(time.RFC3339),
+			expectedExpiresAt.Format(time.RFC3339),
+			models.CostTelemetryRetentionDays,
+			diff)
+	}
+}
+
+func TestCacheWriteEmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug) // no entries
+
+	written, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != 0 {
+		t.Errorf("expected 0 records written for empty report, got %d", written)
+	}
+	if store.recordCount() != 0 {
+		t.Errorf("expected 0 store records, got %d", store.recordCount())
+	}
+}
+
+func TestCacheWriteNilReport(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCostTelemetryCache(&fakeCostTelemetryStore{})
+	ctx := context.Background()
+
+	_, err := cache.Write(ctx, nil)
+	if err == nil {
+		t.Fatalf("expected error for nil report")
+	}
+}
+
+func TestCacheWriteEmptySlug(t *testing.T) {
+	t.Parallel()
+
+	cache := NewCostTelemetryCache(&fakeCostTelemetryStore{})
+	ctx := context.Background()
+
+	report := newTestReport("", entry(testCacheDate1, "Lambda", 1.00))
+
+	_, err := cache.Write(ctx, report)
+	if err == nil {
+		t.Fatalf("expected error for empty slug")
+	}
+}
+
+func TestCacheWriteStoreError(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{
+		failOnCall: 1, // fail on first write
+		err:        fmt.Errorf("simulated store error"),
+	}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+	)
+
+	written, err := cache.Write(ctx, report)
+	if err == nil {
+		t.Fatalf("expected error from failing store, got nil")
+	}
+	if written != 0 {
+		t.Errorf("expected 0 records written on store error, got %d", written)
+	}
+}
+
+func TestCacheWritePartialStoreError(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{
+		failOnCall: 2, // succeed once, then fail on second
+		err:        fmt.Errorf("simulated store error after first write"),
+	}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+		entry(testCacheDate2, "DynamoDB", 2.00),
+	)
+
+	written, err := cache.Write(ctx, report)
+	if err == nil {
+		t.Fatalf("expected error after partial write, got nil")
+	}
+	if written != 1 {
+		t.Errorf("expected 1 record written before error, got %d", written)
+	}
+}
+
+func TestCacheWritePKShape(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.00),
+	)
+
+	_, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	rec := store.recordByDate(testCacheDate1)
+	if rec == nil {
+		t.Fatalf("no record written")
+	}
+
+	// PK must be COST_TELEMETRY#<slug>.
+	wantPK := fmt.Sprintf("COST_TELEMETRY#%s", testCacheSlug)
+	if rec.PK != wantPK {
+		t.Errorf("PK = %q, want %q", rec.PK, wantPK)
+	}
+
+	// SK must be the date.
+	if rec.SK != testCacheDate1 {
+		t.Errorf("SK = %q, want %q", rec.SK, testCacheDate1)
+	}
+}
+
+func TestCacheWriteSkipsEmptyDateEntry(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry("", "Lambda", 1.00),               // empty date — should be skipped
+		entry(testCacheDate1, "DynamoDB", 2.00), // valid date
+	)
+
+	written, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if written != 1 {
+		t.Fatalf("expected 1 record (empty-date entry skipped), got %d", written)
+	}
+
+	rec := store.recordByDate(testCacheDate1)
+	if rec == nil {
+		t.Fatalf("no record for date %q", testCacheDate1)
+	}
+	entries := decodeEntries(t, rec)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Service != "DynamoDB" {
+		t.Errorf("Service = %q, want DynamoDB", entries[0].Service)
+	}
+}
+
+func TestCacheWriteDayCostAggregation(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeCostTelemetryStore{}
+	cache := NewCostTelemetryCache(store)
+	ctx := context.Background()
+
+	report := newTestReport(testCacheSlug,
+		entry(testCacheDate1, "Lambda", 1.11),
+		entry(testCacheDate1, "DynamoDB", 2.22),
+		entry(testCacheDate1, "S3", 3.33),
+	)
+
+	_, err := cache.Write(ctx, report)
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	rec := store.recordByDate(testCacheDate1)
+	wantCost := 1.11 + 2.22 + 3.33
+	if rec.DayCost != wantCost {
+		t.Errorf("DayCost = %f, want %f", rec.DayCost, wantCost)
+	}
+}
+
+func TestNewCostTelemetryCache_ReturnsInterface(t *testing.T) {
+	t.Parallel()
+
+	// Verify the constructor returns a non-nil interface value.
+	cache := NewCostTelemetryCache(&fakeCostTelemetryStore{})
+	if cache == nil {
+		t.Fatalf("NewCostTelemetryCache returned nil")
+	}
+}
+
+func TestCostTelemetryRetentionDaysIsPositive(t *testing.T) {
+	t.Parallel()
+
+	if models.CostTelemetryRetentionDays <= 0 {
+		t.Errorf("CostTelemetryRetentionDays = %d, must be positive", models.CostTelemetryRetentionDays)
+	}
+	if models.CostTelemetryRetentionDays < 30 {
+		t.Errorf("CostTelemetryRetentionDays = %d, must be >= 30 to support M3.11 past-30-day queries",
+			models.CostTelemetryRetentionDays)
+	}
+}

--- a/internal/store/cost_telemetry.go
+++ b/internal/store/cost_telemetry.go
@@ -1,0 +1,67 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// PutCostTelemetry creates or updates a CostTelemetry record.
+// Because the primary key is (COST_TELEMETRY#<slug>, <date>), re-running
+// the worker for the same slug and date upserts the same record — the
+// write path is naturally idempotent.
+func (s *Store) PutCostTelemetry(ctx context.Context, record *models.CostTelemetry) error {
+	if err := s.requireDB(); err != nil {
+		return err
+	}
+	if record == nil {
+		return fmt.Errorf("cost telemetry record is required")
+	}
+	return s.putModel(ctx, record)
+}
+
+// ListCostTelemetryByInstance returns cost telemetry records for the given
+// instance slug over the specified date range (inclusive). Records are
+// ordered by date descending (most recent first).
+//
+// The date range uses the SK field which is the date in YYYY-MM-DD format.
+// Both dateFrom and dateTo are inclusive bounds.
+func (s *Store) ListCostTelemetryByInstance(ctx context.Context, slug string, dateFrom, dateTo string, limit int) ([]*models.CostTelemetry, error) {
+	if err := s.requireDB(); err != nil {
+		return nil, err
+	}
+
+	slug = strings.ToLower(strings.TrimSpace(slug))
+	if slug == "" {
+		return nil, fmt.Errorf("instance slug is required")
+	}
+	dateFrom = strings.TrimSpace(dateFrom)
+	dateTo = strings.TrimSpace(dateTo)
+	if dateFrom == "" || dateTo == "" {
+		return nil, fmt.Errorf("dateFrom and dateTo are required")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 200 {
+		limit = 200
+	}
+
+	pk := fmt.Sprintf("COST_TELEMETRY#%s", slug)
+
+	var items []*models.CostTelemetry
+	err := s.DB.WithContext(ctx).
+		Model(&models.CostTelemetry{}).
+		Where("PK", "=", pk).
+		Where("SK", ">=", dateFrom).
+		Where("SK", "<=", dateTo).
+		OrderBy("SK", "DESC").
+		Limit(limit).
+		All(&items)
+	if err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -22,6 +22,7 @@ func LambdaInit() (DB, error) {
 		&models.BillingPaymentMethod{},
 		&models.BillingProfile{},
 		&models.ControlPlaneConfig{},
+		&models.CostTelemetry{},
 		&models.CreditPurchase{},
 		&models.Domain{},
 		&models.ExternalInstanceRegistration{},

--- a/internal/store/models/cost_telemetry.go
+++ b/internal/store/models/cost_telemetry.go
@@ -1,0 +1,120 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// CostTelemetryRetentionDays is the number of days cost telemetry records are
+// retained before DynamoDB TTL expiry.
+//
+// The 90-day window supports M3.11's past-30-day default query window with
+// ample buffer for Cost Explorer latency (up to 48 hours for current-day
+// billing data to finalize), operator review of historical billing data, and
+// the reconciliation window between CloudWatch metrics and Cost Explorer
+// billing-grain data.
+//
+// This is a conservative bounded retention: no cost telemetry record lives
+// indefinitely in the table. TTL is never zero or unbounded.
+const CostTelemetryRetentionDays = 90
+
+// CostTelemetry caches per-instance per-day reconciled cost data produced
+// by the cost-telemetry worker (M3.10). Each record represents one day of
+// billing data for a single managed instance.
+//
+// # Key design
+//
+// Primary key (PK = "COST_TELEMETRY#<slug>", SK = "<date>"):
+//
+//   - The PK embeds the instance slug, scoping all reads and writes to a
+//     single tenant. This shape makes cross-tenant reads difficult to
+//     perform accidentally.
+//   - The SK is the date in YYYY-MM-DD format. Querying for a date range
+//     uses SK >= "2026-01-01" AND SK <= "2026-01-31" on the main table.
+//   - Rerunning the worker for the same slug and date upserts the same
+//     record via CreateOrUpdate, making the write path naturally idempotent.
+//
+// # Data safety
+//
+// Contains no PII, tenant content, raw instance keys, secrets, or request
+// bodies. All fields are derived from AWS billing and metric APIs and are
+// safe for future customer exposure (M3.11+). The EntriesJSON field holds
+// only ReconciledCostEntry values whose constituent types (ReconciledCostEntry,
+// ServiceAttribution) are explicitly documented as safe for caching and
+// customer exposure.
+//
+// # TTL
+//
+// Every record carries a DynamoDB TTL attribute set to ExpiresAt.Unix().
+// The default TTL is CostTelemetryRetentionDays (90 days) from CreatedAt.
+// Explicit ExpiresAt values are preserved to support per-record retention
+// overrides if needed.
+type CostTelemetry struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	InstanceSlug string  `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	Date         string  `theorydb:"attr:date" json:"date"` // YYYY-MM-DD
+	EntriesJSON  string  `theorydb:"attr:entriesJson" json:"entries,omitempty"`
+	DayCost      float64 `theorydb:"attr:dayCost" json:"day_cost"`
+	Currency     string  `theorydb:"attr:currency" json:"currency"`
+
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at"`
+	ExpiresAt time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
+}
+
+// TableName returns the database table name for CostTelemetry.
+func (CostTelemetry) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating CostTelemetry.
+func (c *CostTelemetry) BeforeCreate() error {
+	if err := c.UpdateKeys(); err != nil {
+		return err
+	}
+	now := time.Now().UTC()
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	c.UpdatedAt = now
+	if c.ExpiresAt.IsZero() {
+		c.ExpiresAt = c.CreatedAt.Add(CostTelemetryRetentionDays * 24 * time.Hour)
+	}
+	c.TTL = c.ExpiresAt.Unix()
+	return nil
+}
+
+// BeforeUpdate updates timestamps and TTL before updating CostTelemetry.
+func (c *CostTelemetry) BeforeUpdate() error {
+	c.UpdatedAt = time.Now().UTC()
+	c.TTL = c.ExpiresAt.Unix()
+	return nil
+}
+
+// UpdateKeys updates the database keys for CostTelemetry.
+func (c *CostTelemetry) UpdateKeys() error {
+	c.InstanceSlug = strings.ToLower(strings.TrimSpace(c.InstanceSlug))
+	c.Date = strings.TrimSpace(c.Date)
+	c.Currency = strings.TrimSpace(c.Currency)
+
+	if c.InstanceSlug == "" {
+		return fmt.Errorf("CostTelemetry: InstanceSlug is required")
+	}
+	if c.Date == "" {
+		return fmt.Errorf("CostTelemetry: Date is required")
+	}
+
+	c.PK = fmt.Sprintf("COST_TELEMETRY#%s", c.InstanceSlug)
+	c.SK = c.Date
+	return nil
+}
+
+// GetPK returns the partition key for CostTelemetry.
+func (c *CostTelemetry) GetPK() string { return c.PK }
+
+// GetSK returns the sort key for CostTelemetry.
+func (c *CostTelemetry) GetSK() string { return c.SK }


### PR DESCRIPTION
## Summary

Implements M3.10: DynamoDB cache model for cost telemetry data, producing per-instance per-day CostTelemetry records from reconciled cost reports.

- **CostTelemetry model** (`internal/store/models/cost_telemetry.go`): TableTheory model with tenant-scoped key shape (`COST_TELEMETRY#<slug>`, `<date>`), 90-day TTL retention policy, standard lifecycle hooks
- **Cache writer** (`internal/costtelemetry/cache.go`): `CostTelemetryCache` interface + store-backed implementation that splits `ReconciledCostReport` entries by date and persists one record per day
- **Store methods** (`internal/store/cost_telemetry.go`): `PutCostTelemetry` (idempotent upsert) + `ListCostTelemetryByInstance` (date-range query, ready for M3.11)
- **Model registration** (`internal/store/db.go`): added to `LambdaInit`
- **Tests** (`internal/costtelemetry/cache_test.go`): 17 tests covering single/multi-day writes, metric preservation, idempotence, tenant scoping, TTL, PK/SK shape, empty-date skip, error propagation, nil/empty rejection

## Design Decisions

| Concern | Decision |
|---|---|
| Key shape | `PK = COST_TELEMETRY#<slug>`, `SK = <date>` — scoped to tenant, prevents accidental cross-tenant reads |
| Idempotence | `CreateOrUpdate` upserts by PK+SK; re-running worker for same slug+date replaces, never duplicates |
| TTL | `CostTelemetryRetentionDays = 90` — supports M3.11's past-30-day queries + Cost Explorer latency |
| Data safety | No PII, tenant content, raw keys, or secrets in any field |
| Test seam | `CostTelemetryStore` interface; fake simulates TableTheory `BeforeCreate` lifecycle |

## Validation

- `go test ./...` — all pass (incl. 17 new cache tests + all existing)
- `go vet ./...` — clean
- `gofmt -l` new files — clean
- `gov-infra/verifiers/gov-verify-rubric.sh` — 39/39 PASS
- No CDK, web/, contracts, or governance paths changed

## Deferred

- M3.11: `GET /api/v1/portal/instances/{slug}/cost` customer-facing endpoint
- M3.13: cost-telemetry redaction verifier (SEC-13)

Closes #454

🤖 Generated with [Claude Code](https://claude.com/claude-code)