### PR TITLE
feat(portal): add per-instance cost telemetry endpoint

### DIFF
--- a/internal/controlplane/handlers_portal_cost.go
+++ b/internal/controlplane/handlers_portal_cost.go
@@ -1,0 +1,151 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// portalCostResponse is the public DTO returned by
+// GET /api/v1/portal/instances/{slug}/cost (M3.11).
+//
+// Safety invariants:
+//   - Excludes PK, SK, TTL, account_id, raw EntriesJSON string, raw instance
+//     keys, secrets, request bodies, and tenant content.
+//   - Each day's entries are decoded from the store's cached JSON into
+//     ReconciledCostEntry structs, which carry no account_id or internal fields.
+type portalCostResponse struct {
+	InstanceSlug string               `json:"instance_slug"`
+	FromDate     string               `json:"from_date"`
+	ToDate       string               `json:"to_date"`
+	Days         []portalCostDayEntry `json:"days"`
+	Count        int                  `json:"count"`
+	TotalCost    float64              `json:"total_cost"`
+	Currency     string               `json:"currency"`
+}
+
+// portalCostDayEntry is one day of cost telemetry in the M3.11 response.
+type portalCostDayEntry struct {
+	Date     string                              `json:"date"`
+	DayCost  float64                             `json:"day_cost"`
+	Currency string                              `json:"currency"`
+	Entries  []costtelemetry.ReconciledCostEntry `json:"entries"`
+}
+
+// costQueryDefaultDays is the default lookback window when no query params
+// are supplied (past 30 days inclusive).
+const costQueryDefaultDays = 30
+
+// costQueryMaxLimit caps the number of records returned.
+const costQueryMaxLimit = 200
+
+// handlePortalGetInstanceCost implements GET /api/v1/portal/instances/{slug}/cost.
+//
+// Ownership is enforced via requireInstanceAccess before any cost telemetry
+// read. Optional query params from and to (YYYY-MM-DD) narrow the window;
+// the default is the past 30 days inclusive. Invalid dates fail closed.
+func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+	slug := strings.ToLower(strings.TrimSpace(inst.Slug))
+
+	from, to, parseErr := parseCostDateWindow(ctx)
+	if parseErr != nil {
+		return nil, parseErr
+	}
+
+	records, storeErr := s.store.ListCostTelemetryByInstance(ctx.Context(), slug, from, to, costQueryMaxLimit)
+	if storeErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list cost telemetry"}
+	}
+
+	resp := buildPortalCostResponse(slug, from, to, records)
+	return apptheory.JSON(http.StatusOK, resp)
+}
+
+// parseCostDateWindow extracts and validates the from/to date query params.
+// Defaults to the past 30 days inclusive when neither is supplied.
+func parseCostDateWindow(ctx *apptheory.Context) (from, to string, appErr *apptheory.AppError) {
+	from = strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "from"))
+	to = strings.TrimSpace(httpx.FirstQueryValue(ctx.Request.Query, "to"))
+
+	if from == "" && to == "" {
+		now := time.Now().UTC()
+		return now.AddDate(0, 0, -costQueryDefaultDays).Format("2006-01-02"),
+			now.Format("2006-01-02"),
+			nil
+	}
+	if from == "" || to == "" {
+		return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "from and to are required when either is supplied"}
+	}
+
+	fromTime, err := time.Parse("2006-01-02", from)
+	if err != nil {
+		return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "from must be YYYY-MM-DD"}
+	}
+	toTime, err := time.Parse("2006-01-02", to)
+	if err != nil {
+		return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "to must be YYYY-MM-DD"}
+	}
+	if fromTime.After(toTime) {
+		return "", "", &apptheory.AppError{Code: "app.bad_request", Message: "from must not be after to"}
+	}
+
+	return from, to, nil
+}
+
+// buildPortalCostResponse decodes EntriesJSON from each CostTelemetry record
+// and assembles the public response DTO. Internal fields (PK, SK, TTL,
+// account_id, raw JSON string) are excluded by construction.
+func buildPortalCostResponse(slug, from, to string, records []*models.CostTelemetry) portalCostResponse {
+	var total float64
+	days := make([]portalCostDayEntry, 0, len(records))
+	currency := "USD"
+
+	for _, rec := range records {
+		if rec == nil {
+			continue
+		}
+
+		var entries []costtelemetry.ReconciledCostEntry
+		if rec.EntriesJSON != "" {
+			if unmarshalErr := json.Unmarshal([]byte(rec.EntriesJSON), &entries); unmarshalErr != nil {
+				continue
+			}
+		}
+		if entries == nil {
+			entries = []costtelemetry.ReconciledCostEntry{}
+		}
+
+		total += rec.DayCost
+		if rec.Currency != "" {
+			currency = rec.Currency
+		}
+
+		days = append(days, portalCostDayEntry{
+			Date:     rec.Date,
+			DayCost:  rec.DayCost,
+			Currency: rec.Currency,
+			Entries:  entries,
+		})
+	}
+
+	return portalCostResponse{
+		InstanceSlug: slug,
+		FromDate:     from,
+		ToDate:       to,
+		Days:         days,
+		Count:        len(days),
+		TotalCost:    total,
+		Currency:     currency,
+	}
+}

--- a/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -1,0 +1,346 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/stretchr/testify/mock"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// ---------------------------------------------------------------------------
+// test constants
+// ---------------------------------------------------------------------------
+
+const (
+	testCostSlug1 = "demo"
+	testCostDate1 = "2026-05-25"
+	testCostDate2 = "2026-05-26"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// newCostTestDB creates a mock DB pre-wired for Instance and CostTelemetry
+// model queries.
+func newCostTestDB() (*ttmocks.MockExtendedDB, *ttmocks.MockQuery, *ttmocks.MockQuery) {
+	db, qs := newTestDBWithModelQueries("*models.Instance", "*models.CostTelemetry")
+	return db, qs[0], qs[1]
+}
+
+// stubCostInstanceFirst configures the Instance mock query's First to return
+// the given instance.
+func stubCostInstanceFirst(t *testing.T, q *ttmocks.MockQuery, inst models.Instance) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = inst
+	}).Maybe()
+}
+
+// stubCostRecords configures the CostTelemetry mock query's All to return
+// the given records.
+func stubCostRecords(t *testing.T, q *ttmocks.MockQuery, records []*models.CostTelemetry, err error) {
+	t.Helper()
+	q.On("All", mock.AnythingOfType("*[]*models.CostTelemetry")).Return(err).Run(func(args mock.Arguments) {
+		if err != nil {
+			return
+		}
+		dest := testutil.RequireMockArg[*[]*models.CostTelemetry](t, args, 0)
+		*dest = records
+	}).Once()
+}
+
+// costRecord builds a minimal CostTelemetry record with decoded entries in
+// EntriesJSON.
+func costRecord(slug, date string, dayCost float64, currency string, entries []costtelemetry.ReconciledCostEntry) *models.CostTelemetry {
+	entriesJSON, err := json.Marshal(entries)
+	if err != nil {
+		panic(err)
+	}
+	return &models.CostTelemetry{
+		InstanceSlug: slug,
+		Date:         date,
+		DayCost:      dayCost,
+		Currency:     currency,
+		EntriesJSON:  string(entriesJSON),
+	}
+}
+
+// newCostHandlerCtx builds a context with the given slug and optional query
+// params.
+func newCostHandlerCtx(slug string, query map[string][]string) *apptheory.Context {
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": slug},
+	}
+	if query != nil {
+		ctx.Request.Query = query
+	}
+	return ctx
+}
+
+// jsonContains asserts that the marshaled JSON of v does not contain any of
+// the forbidden strings.
+func jsonContains(t *testing.T, v any, forbidden ...string) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	for _, f := range forbidden {
+		if contains(s, f) {
+			t.Errorf("response contained forbidden field %q", f)
+		}
+	}
+}
+
+func contains(s, needle string) bool {
+	return len(s) >= len(needle) && searchSubstring(s, needle)
+}
+
+func searchSubstring(s, needle string) bool {
+	for i := 0; i <= len(s)-len(needle); i++ {
+		if s[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+func TestHandlePortalGetInstanceCost_Success(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst, qCost := newCostTestDB()
+	s := &Server{store: store.New(tdb)}
+
+	stubCostInstanceFirst(t, qInst, models.Instance{
+		Slug:  testCostSlug1,
+		Owner: "alice",
+	})
+
+	entries := []costtelemetry.ReconciledCostEntry{
+		{Date: testCostDate1, Service: "Lambda", Cost: 0.25, Currency: "USD"},
+		{Date: testCostDate1, Service: "DynamoDB", Cost: 0.10, Currency: "USD"},
+	}
+
+	stubCostRecords(t, qCost, []*models.CostTelemetry{
+		costRecord(testCostSlug1, testCostDate1, 0.35, "USD", entries),
+	}, nil)
+
+	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	})
+
+	resp, err := s.handlePortalGetInstanceCost(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("unexpected response: %#v err=%v", resp, err)
+	}
+
+	var body portalCostResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+
+	if body.InstanceSlug != testCostSlug1 {
+		t.Errorf("expected slug %q, got %q", testCostSlug1, body.InstanceSlug)
+	}
+	if body.Count != 1 {
+		t.Fatalf("expected 1 day, got %d", body.Count)
+	}
+	if body.TotalCost != 0.35 {
+		t.Errorf("expected total 0.35, got %f", body.TotalCost)
+	}
+	if body.Currency != "USD" {
+		t.Errorf("expected currency USD, got %q", body.Currency)
+	}
+
+	day := body.Days[0]
+	if day.Date != testCostDate1 {
+		t.Errorf("expected date %q, got %q", testCostDate1, day.Date)
+	}
+	if day.DayCost != 0.35 {
+		t.Errorf("expected day cost 0.35, got %f", day.DayCost)
+	}
+	if len(day.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(day.Entries))
+	}
+	if day.Entries[0].Service != "Lambda" || day.Entries[1].Service != "DynamoDB" {
+		t.Errorf("unexpected entries: %+v", day.Entries)
+	}
+
+	// Redaction: response must not contain internal fields.
+	jsonContains(t, body, "account_id", "PK", "SK", "ttl", "entries_json", "EntriesJSON")
+}
+
+func TestHandlePortalGetInstanceCost_WrongOwnerForbidden(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst, qCost := newCostTestDB()
+	s := &Server{store: store.New(tdb)}
+
+	// Instance is owned by "bob"; caller is "alice".
+	stubCostInstanceFirst(t, qInst, models.Instance{
+		Slug:  testCostSlug1,
+		Owner: "bob",
+	})
+
+	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	})
+
+	_, err := s.handlePortalGetInstanceCost(ctx)
+	if err == nil {
+		t.Fatal("expected forbidden error for wrong owner")
+	}
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != appErrCodeForbidden {
+		t.Fatalf("expected app.forbidden, got %#v", err)
+	}
+
+	// Prove cost telemetry was never read.
+	qCost.AssertNotCalled(t, "All", mock.Anything)
+}
+
+func TestHandlePortalGetInstanceCost_OperatorBypass(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst, qCost := newCostTestDB()
+	s := &Server{store: store.New(tdb)}
+
+	stubCostInstanceFirst(t, qInst, models.Instance{
+		Slug:  testCostSlug1,
+		Owner: "bob", // not the caller
+	})
+
+	stubCostRecords(t, qCost, []*models.CostTelemetry{
+		costRecord(testCostSlug1, testCostDate1, 1.50, "USD", nil),
+	}, nil)
+
+	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	})
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+
+	resp, err := s.handlePortalGetInstanceCost(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("operator should bypass ownership: resp=%#v err=%v", resp, err)
+	}
+}
+
+func TestHandlePortalGetInstanceCost_DefaultWindow(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst, qCost := newCostTestDB()
+	s := &Server{store: store.New(tdb)}
+
+	stubCostInstanceFirst(t, qInst, models.Instance{
+		Slug:  testCostSlug1,
+		Owner: "alice",
+	})
+
+	// When the handler has no query params, it defaults to past 30 days.
+	// We don't verify exact dates (they depend on time.Now()), but we verify
+	// the handler succeeds and the store is queried.
+	stubCostRecords(t, qCost, []*models.CostTelemetry{}, nil)
+
+	ctx := newCostHandlerCtx(testCostSlug1, nil)
+
+	resp, err := s.handlePortalGetInstanceCost(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("unexpected response: %#v err=%v", resp, err)
+	}
+
+	var body portalCostResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal response: %v", err)
+	}
+	if body.FromDate == "" || body.ToDate == "" {
+		t.Errorf("expected default date window, got from=%q to=%q", body.FromDate, body.ToDate)
+	}
+}
+
+func TestHandlePortalGetInstanceCost_InvalidDates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		code string
+	}{
+		{"from only", "2026-05-01", "", "app.bad_request"},
+		{"to only", "", "2026-05-26", "app.bad_request"},
+		{"bad from", "not-a-date", "2026-05-26", "app.bad_request"},
+		{"bad to", "2026-05-01", "nope", "app.bad_request"},
+		{"from after to", "2026-05-26", "2026-05-01", "app.bad_request"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tdb, qInst, _ := newCostTestDB()
+			s := &Server{store: store.New(tdb)}
+
+			stubCostInstanceFirst(t, qInst, models.Instance{
+				Slug:  testCostSlug1,
+				Owner: "alice",
+			})
+
+			ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+				"from": {tt.from},
+				"to":   {tt.to},
+			})
+
+			_, err := s.handlePortalGetInstanceCost(ctx)
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			appErr, ok := err.(*apptheory.AppError)
+			if !ok || appErr.Code != tt.code {
+				t.Fatalf("expected %s, got %#v", tt.code, err)
+			}
+		})
+	}
+}
+
+func TestHandlePortalGetInstanceCost_InstanceNotFound(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst, _ := newCostTestDB()
+	s := &Server{store: store.New(tdb)}
+
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	})
+
+	_, err := s.handlePortalGetInstanceCost(ctx)
+	if err == nil {
+		t.Fatal("expected not_found")
+	}
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != soulMintAppErrCodeNotFound {
+		t.Fatalf("expected app.not_found, got %#v", err)
+	}
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -157,6 +157,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Get("/api/v1/portal/instances/{slug}/stack", s.handlePortalGetInstanceStack, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/usage/{month}", s.handlePortalListInstanceUsage, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/usage/{month}/summary", s.handlePortalGetInstanceUsageSummary, apptheory.RequireAuth())
+	app.Get("/api/v1/portal/instances/{slug}/cost", s.handlePortalGetInstanceCost, apptheory.RequireAuth())
 
 	// Portal domains (owner-scoped).
 	app.Get("/api/v1/portal/instances/{slug}/domains", s.handlePortalListInstanceDomains, apptheory.RequireAuth())


### PR DESCRIPTION
## Summary

- Implements GET /api/v1/portal/instances/{slug}/cost (M3.11)
- Ownership enforced via `requireInstanceAccess` before any cost telemetry store read
- Default past-30-day inclusive window; optional from/to query params
- Invalid date bounds fail closed
- Response DTO excludes all internal fields (PK, SK, TTL, account_id, raw EntriesJSON)

## Files changed

- `internal/controlplane/handlers_portal_cost.go` (new) — handler, DTO, date window parser, response builder
- `internal/controlplane/handlers_portal_cost_internal_test.go` (new) — 6 tests
- `internal/controlplane/server.go` (+1 line) — route registration

## Test coverage

6 tests (all passing):
1. **Success** — own slug returns expected per-day rollup with decoded entries, total cost, and redaction proof (no account_id, PK, SK, TTL, entries_json in response)
2. **WrongOwnerForbidden** — other slug returns forbidden; proves CostTelemetry `All` was never called
3. **OperatorBypass** — operator role bypasses ownership check
4. **DefaultWindow** — no query params defaults to past 30 days
5. **InvalidDates** — 5 sub-cases: from-only, to-only, bad from, bad to, from-after-to (all fail closed)
6. **InstanceNotFound** — not_found when slug doesn't exist

## Validation

- `go test ./...` — all pass
- `go vet ./...` — clean
- `gofmt -l` — clean
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — 39/39 PASS

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)