### PR TITLE
feat(web): wire Cost & usage tab to real-time telemetry + SEC-13 verifier

### DIFF
--- a/gov-infra/pack.json
+++ b/gov-infra/pack.json
@@ -2,6 +2,7 @@
   "$schema": "https://gov.pai.dev/schemas/pack.schema.json",
   "schemaVersion": 1,
   "packVersion": "2026.05.24-web.3",
+  "packDigest": "27bbbb8d0e045ff31c3662dccc3ff3e855fd363d92ca5bd24923c0a8b23a38b7",
   "domain": "custom",
   "projectSlug": "lesser-host",
   "generatedAt": "2026-05-26T22:38:16Z",
@@ -56,6 +57,5 @@
       "gov-infra/evidence/MAI-5-output.log",
       "gov-infra/evidence/SEC-13-output.log"
     ]
-  },
-  "packDigest": "91222d2785f12f91b746fd4d71ea8d2e8053b8cda7e9f383bb7a63a4c3766ce3"
+  }
 }

--- a/gov-infra/pack.json
+++ b/gov-infra/pack.json
@@ -1,14 +1,13 @@
 {
   "$schema": "https://gov.pai.dev/schemas/pack.schema.json",
   "schemaVersion": 1,
-  "packVersion": "2026.05.24-web.2",
-  "packDigest": "2e63904cdd37fba5efb4f3c215b12d468f3fcf56c3a4419a11205eb1b543a404",
+  "packVersion": "2026.05.24-web.3",
   "domain": "custom",
   "projectSlug": "lesser-host",
-  "generatedAt": "2026-05-26T16:12:07Z",
+  "generatedAt": "2026-05-26T22:38:16Z",
   "source": {
-    "commitSha": "78c40e4a09e6d1980d8cbd0dc70c6fb1b9caa0c7",
-    "branch": "theorymcp/equaltoai/host/project-39-m2.14-m2.18-gov-pack"
+    "commitSha": "71287a7bf1a01fbce7dc6df3b07dacbb96821128",
+    "branch": "aron/project39-m3.12-m3.14-cost-telemetry-web"
   },
   "artifacts": {
     "planning": [
@@ -39,7 +38,8 @@
       "gov-infra/verifiers/con/wire-mcp-route-ownership.sh",
       "gov-infra/verifiers/sec/portal-stack-state-tenant-scoping.sh",
       "gov-infra/verifiers/sec/operator-drift-auth-gate.sh",
-      "gov-infra/verifiers/mai/wire-all-idempotency.sh"
+      "gov-infra/verifiers/mai/wire-all-idempotency.sh",
+      "gov-infra/verifiers/sec/cost-telemetry-redaction.sh"
     ],
     "evidence": [
       "gov-infra/evidence/gov-rubric-report.json",
@@ -53,7 +53,9 @@
       "gov-infra/evidence/CON-4-output.log",
       "gov-infra/evidence/SEC-11-output.log",
       "gov-infra/evidence/SEC-12-output.log",
-      "gov-infra/evidence/MAI-5-output.log"
+      "gov-infra/evidence/MAI-5-output.log",
+      "gov-infra/evidence/SEC-13-output.log"
     ]
-  }
+  },
+  "packDigest": "91222d2785f12f91b746fd4d71ea8d2e8053b8cda7e9f383bb7a63a4c3766ce3"
 }

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -73,6 +73,7 @@ rm -f \
   "${EVIDENCE_DIR}/SEC-10-output.log" \
   "${EVIDENCE_DIR}/SEC-11-output.log" \
   "${EVIDENCE_DIR}/SEC-12-output.log" \
+  "${EVIDENCE_DIR}/SEC-13-output.log" \
   "${EVIDENCE_DIR}/MAI-5-output.log" \
   "${EVIDENCE_DIR}/CON-4-output.log"
 
@@ -2254,6 +2255,7 @@ run_check "SEC-9" "Security" "bash ${GOV_INFRA}/verifiers/sec/trust-auth-preserv
 run_check "SEC-10" "Security" "bash ${GOV_INFRA}/verifiers/sec/release-verification-preservation.sh"
 run_check "SEC-11" "Security" "bash ${GOV_INFRA}/verifiers/sec/portal-stack-state-tenant-scoping.sh"
 run_check "SEC-12" "Security" "bash ${GOV_INFRA}/verifiers/sec/operator-drift-auth-gate.sh"
+run_check "SEC-13" "Security" "bash ${GOV_INFRA}/verifiers/sec/cost-telemetry-redaction.sh"
 
 # === Compliance Readiness (CMP) ===
 check_file_exists "CMP-1" "Compliance" "${PLANNING_DIR}/lesser-host-controls-matrix.md"

--- a/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
+++ b/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# SEC-13: Cost-telemetry redaction + multi-tenant read ordering.
+#
+# Verifies that the portal cost-telemetry endpoint handler:
+#   1. Enforces tenant-scoped ownership via requireInstanceAccess before any
+#      cost telemetry database read.
+#   2. Does not expose PII, cross-tenant fields, tenant content, raw instance
+#      keys, account IDs, table keys (PK/SK), TTL, or raw EntriesJSON storage
+#      payloads in the customer-facing response DTO.
+#
+# Multi-tenant read ordering (Dimension 1):
+#   requireInstanceAccess must appear inside handlePortalGetInstanceCost at a
+#   line number strictly before ListCostTelemetryByInstance. This ensures the
+#   ownership check gates all cost telemetry store reads.
+#
+# Redaction (Dimension 2):
+#   The portalCostResponse, portalCostDayEntry, and ReconciledCostEntry types
+#   must exclude account_id, PK, SK, ttl, entries_json, EntriesJSON, raw
+#   instance keys, secrets, request bodies, actor/object/content URIs, and
+#   tenant content. The Go handler source and test file are both checked.
+#
+# Full points: requireInstanceAccess before ListCostTelemetryByInstance, and
+#   the source + tests prove forbidden fields are excluded.
+# Zero points: any violation — wrong ordering, forbidden field present in DTO,
+#   or redaction test missing.
+#
+# No partial credit.
+#
+# Source: Issue equaltoai/lesser-host#457
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${REPO_ROOT}"
+
+HANDLER_FILE="internal/controlplane/handlers_portal_cost.go"
+TEST_FILE="internal/controlplane/handlers_portal_cost_internal_test.go"
+
+echo "SEC-13: Cost-telemetry redaction + multi-tenant read ordering"
+echo "Handler file: ${HANDLER_FILE}"
+echo "Test file:    ${TEST_FILE}"
+echo ""
+
+# ── Step 1: Files must exist ──────────────────────────────────────────────
+FAIL=0
+
+if [[ ! -f "${HANDLER_FILE}" ]]; then
+  echo "FAIL: handler file missing: ${HANDLER_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${TEST_FILE}" ]]; then
+  echo "FAIL: test file missing: ${TEST_FILE}" >&2
+  exit 1
+fi
+
+# ── Dimension 1: Multi-tenant read ordering ───────────────────────────────
+# requireInstanceAccess must be called before ListCostTelemetryByInstance.
+
+if ! grep -q 'requireInstanceAccess' "${HANDLER_FILE}"; then
+  echo "FAIL: requireInstanceAccess call not found in handler" >&2
+  FAIL=1
+fi
+
+# Exclude comment lines (//...) to avoid matching doc comments.
+AUTH_LINE="$(grep -n 'requireInstanceAccess' "${HANDLER_FILE}" | grep -v '^\s*[0-9]*:\s*//' | head -1 | cut -d: -f1 || true)"
+if [[ -z "${AUTH_LINE}" ]]; then
+  echo "FAIL: requireInstanceAccess call not found (non-comment)" >&2
+  FAIL=1
+else
+  echo "Ownership check: requireInstanceAccess at line ${AUTH_LINE}"
+fi
+
+# Find ListCostTelemetryByInstance call site (not definition, not comments).
+STORE_LINE="$(grep -n 'ListCostTelemetryByInstance' "${HANDLER_FILE}" | grep -v '^\s*[0-9]*:\s*//' | grep -v 'func ' | head -1 | cut -d: -f1 || true)"
+if [[ -z "${STORE_LINE}" ]]; then
+  echo "FAIL: ListCostTelemetryByInstance call not found in handler" >&2
+  FAIL=1
+else
+  echo "Cost telemetry read: ListCostTelemetryByInstance at line ${STORE_LINE}"
+fi
+
+if [[ -n "${AUTH_LINE}" ]] && [[ -n "${STORE_LINE}" ]]; then
+  if [[ "${STORE_LINE}" -le "${AUTH_LINE}" ]]; then
+    echo "FAIL: ListCostTelemetryByInstance (line ${STORE_LINE}) precedes requireInstanceAccess (line ${AUTH_LINE})" >&2
+    FAIL=1
+  else
+    echo "PASS: ownership check precedes cost telemetry read (${AUTH_LINE} < ${STORE_LINE})"
+  fi
+fi
+
+echo ""
+
+# ── Dimension 2: DTO redaction — handler source ────────────────────────────
+# The portalCostResponse, portalCostDayEntry, and ReconciledCostEntry types
+# (plus buildPortalCostResponse) must not reference forbidden fields on
+# non-comment lines. Doc comments describing excluded fields are legitimate.
+
+HANDLER_CONTENT="$(cat "${HANDLER_FILE}")"
+
+# Extract non-comment source lines (exclude // and block-comment lines).
+NON_COMMENT="$(echo "${HANDLER_CONTENT}" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*/\*')"
+
+echo "Dimension 2a: DTO redaction in handler source"
+
+# EntriesJSON is expected in buildPortalCostResponse for unmarshaling,
+# but must not appear in the DTO struct field tags or response fields.
+# Allow EntriesJSON only in the unmarshal line (rec.EntriesJSON).
+if echo "${NON_COMMENT}" | grep -qF 'EntriesJSON' && ! echo "${NON_COMMENT}" | grep -qF 'rec.EntriesJSON'; then
+  echo "FAIL: EntriesJSON found on non-comment line outside rec.EntriesJSON unmarshal" >&2
+  FAIL=1
+elif echo "${NON_COMMENT}" | grep -qF 'EntriesJSON'; then
+  echo "PASS: EntriesJSON only in rec.EntriesJSON unmarshal (expected)"
+fi
+
+if echo "${NON_COMMENT}" | grep -qF 'entries_json'; then
+  echo "FAIL: entries_json found on non-comment line" >&2
+  FAIL=1
+fi
+
+# Verify the forbidden tokens are explicitly absent from the DTO struct definitions.
+# portalCostResponse and portalCostDayEntry are defined in this file.
+DTO_REGION="$(echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostResponse struct/,/^}/p'; echo; echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostDayEntry struct/,/^}/p')"
+
+# The DTO region must NOT contain json:"account_id", json:"pk", json:"sk", json:"ttl", etc.
+DTO_FORBIDDEN=(
+  '"account_id"'
+  '"pk"'
+  '"sk"'
+  '"ttl"'
+  '"entries_json"'
+  '"EntriesJSON"'
+  '"instance_key"'
+  '"raw_key"'
+)
+
+for forbidden in "${DTO_FORBIDDEN[@]}"; do
+  if echo "${DTO_REGION}" | grep -qF "${forbidden}"; then
+    echo "FAIL: DTO struct contains forbidden json tag ${forbidden}" >&2
+    FAIL=1
+  fi
+done
+
+echo "PASS: DTO struct json tags are clean of forbidden fields"
+
+echo ""
+
+# ── Dimension 2b: Redaction proof in tests ─────────────────────────────────
+# The test file must contain a redaction assertion that proves the response
+# JSON does not contain account_id, PK, SK, ttl, entries_json, or EntriesJSON.
+
+TEST_CONTENT="$(cat "${TEST_FILE}")"
+
+echo "Dimension 2b: Redaction proof in test file"
+
+# Verify the test calls jsonContains with forbidden field names.
+if echo "${TEST_CONTENT}" | grep -q 'jsonContains.*account_id.*PK.*SK.*ttl.*entries_json.*EntriesJSON'; then
+  echo "PASS: test redaction assertion found (jsonContains with forbidden fields)"
+else
+  echo "FAIL: no jsonContains redaction assertion covering account_id, PK, SK, ttl, entries_json, EntriesJSON" >&2
+  FAIL=1
+fi
+
+# Verify the WrongOwnerForbidden test proves cost store was never read.
+if echo "${TEST_CONTENT}" | grep -q 'AssertNotCalled.*All'; then
+  echo "PASS: test proves cost telemetry not read on forbidden (AssertNotCalled)"
+else
+  echo "FAIL: no AssertNotCalled proof that cost telemetry is skipped on forbidden" >&2
+  FAIL=1
+fi
+
+echo ""
+
+if [[ "${FAIL}" -ne 0 ]]; then
+  echo "FAIL: SEC-13 cost-telemetry redaction check failed" >&2
+  exit 1
+fi
+
+echo "PASS: SEC-13 cost-telemetry redaction + multi-tenant read ordering verified"

--- a/web/src/lib/api/portalUsage.ts
+++ b/web/src/lib/api/portalUsage.ts
@@ -115,3 +115,63 @@ export function portalGetUsageSummary(token: string, slug: string, month: string
 	});
 }
 
+// ---------------------------------------------------------------------------
+// Cost telemetry (M3.11+) — GET /api/v1/portal/instances/{slug}/cost
+// ---------------------------------------------------------------------------
+
+export interface CostAttributionMetric {
+	service: string;
+	metric_name: string;
+	stat: string;
+	unit: string;
+	value: number;
+}
+
+export interface CostServiceEntry {
+	date: string;
+	service: string;
+	cost: number;
+	currency: string;
+	metrics?: CostAttributionMetric[];
+}
+
+export interface CostDayEntry {
+	date: string;
+	day_cost: number;
+	currency: string;
+	entries: CostServiceEntry[];
+}
+
+export interface PortalCostResponse {
+	instance_slug: string;
+	from_date: string;
+	to_date: string;
+	days: CostDayEntry[];
+	count: number;
+	total_cost: number;
+	currency: string;
+}
+
+/**
+ * Fetch per-instance real-time cost telemetry for the given date window.
+ * Defaults to the past 30 days when from/to are omitted.
+ */
+export function portalGetInstanceCost(
+	token: string,
+	slug: string,
+	from?: string,
+	to?: string,
+): Promise<PortalCostResponse> {
+	const params = new URLSearchParams();
+	if (from) params.set('from', from);
+	if (to) params.set('to', to);
+	const qs = params.toString();
+	return fetchJson<PortalCostResponse>(
+		`/api/v1/portal/instances/${encodeURIComponent(slug)}/cost${qs ? `?${qs}` : ''}`,
+		{
+			headers: {
+				authorization: `Bearer ${token}`,
+			},
+		},
+	);
+}

--- a/web/src/pages/portal/InstanceCost.svelte
+++ b/web/src/pages/portal/InstanceCost.svelte
@@ -2,35 +2,32 @@
 @component
 InstanceCost — Instance Detail Cost & usage tab.
 
-M1.13 — Project 39 web UI rework. Replaces the coming-soon placeholder on
-the Cost & usage tab with real data: current-month budget (included, used,
-remaining credits) and cache hit rate, both sourced from the existing
-portal budget + usage-summary endpoints.
+M3.12 — Project 39 cost telemetry wiring. Replaces the "coming soon" empty state
+and TODO(M3) static breakdown with real-time cost telemetry from
+GET /api/v1/portal/instances/{slug}/cost. Aggregates response entries by service
+and renders category totals plus daily/entry details.
 
-Per-Lambda/Dynamo/egress real-time cost telemetry is deferred to M3; this
-tab surfaces a "Real-time cost telemetry coming soon" empty state for that
-breakdown. Legacy `/portal/instances/{slug}/budgets` and `/usage` pages
-remain functional for drill-down.
+Budget + usage summary from M1.13 is preserved. Cost data loads separately so
+budget/summary still display even when cost telemetry is not yet available.
 
 Posture invariants preserved:
   - Strict-no-inline-CSP safe.
-  - Multi-tenant isolation: budget/usage endpoints enforce per-slug
-    ownership server-side via `requireInstanceAccess`.
-  - Trust-API instance-auth untouched; SEC-9 change-lock not engaged.
+  - Multi-tenant isolation: cost endpoint enforces per-slug ownership server-side
+    via requireInstanceAccess.
+  - Trust-API instance-auth untouched.
   - No on-chain code path changed.
   - No framework local patches; consumes existing API client modules,
     UI primitives, and shell components through released surfaces.
 
-Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M1.13
-Issue: equaltoai/lesser-host#422
+Source: Issue equaltoai/lesser-host#456
 -->
 
 <script lang="ts">
 	import { onMount } from 'svelte';
 
 	import type { ApiError } from 'src/lib/api/http';
-	import type { BudgetMonthResponse, UsageSummaryResponse } from 'src/lib/api/portalUsage';
-	import { portalGetBudgetMonth, portalGetUsageSummary } from 'src/lib/api/portalUsage';
+	import type { BudgetMonthResponse, UsageSummaryResponse, PortalCostResponse, CostDayEntry } from 'src/lib/api/portalUsage';
+	import { portalGetBudgetMonth, portalGetUsageSummary, portalGetInstanceCost } from 'src/lib/api/portalUsage';
 	import { logout } from 'src/lib/auth/logout';
 	import { linkProps, navigate } from 'src/lib/router';
 	import { Alert, Button, Card, DefinitionItem, DefinitionList, Heading, Link, Spinner, Text } from 'src/lib/ui';
@@ -78,11 +75,50 @@ Issue: equaltoai/lesser-host#422
 		return Math.max(0, included - used);
 	}
 
+	interface ServiceAggregate {
+		service: string;
+		total: number;
+		count: number;
+		currency: string;
+	}
+
+	/**
+	 * Aggregate cost entries across all days by service name.
+	 * Returns an array of service aggregates sorted by total cost descending.
+	 */
+	function aggregateByService(days: CostDayEntry[]): ServiceAggregate[] {
+		const byService: Record<string, ServiceAggregate> = {};
+		for (const day of days) {
+			for (const entry of day.entries) {
+				const existing = byService[entry.service];
+				if (existing) {
+					existing.total += entry.cost;
+					existing.count++;
+				} else {
+					byService[entry.service] = { service: entry.service, total: entry.cost, count: 1, currency: entry.currency };
+				}
+			}
+		}
+		return Object.values(byService).sort((a, b) => b.total - a.total);
+	}
+
+	/**
+	 * Format a cost value for display. Uses fixed precision for sub-dollar
+	 * values and 2 decimal places for larger amounts.
+	 */
+	function formatCost(n: number): string {
+		if (n < 0.01) return `$${n.toFixed(6)}`;
+		return `$${n.toFixed(2)}`;
+	}
+
 	let loading = $state(false);
+	let costLoading = $state(false);
 	let errorMessage = $state<string | null>(null);
+	let costError = $state<string | null>(null);
 
 	let budget = $state<BudgetMonthResponse | null>(null);
 	let summary = $state<UsageSummaryResponse | null>(null);
+	let cost = $state<PortalCostResponse | null>(null);
 
 	/**
 	 * Month label pinned at the start of each `loadAll()` so the header,
@@ -107,6 +143,7 @@ Issue: equaltoai/lesser-host#422
 		// `{:else if errorMessage}` arm; on 401 we navigate to /login
 		// before the state matters.
 		errorMessage = null;
+		costError = null;
 
 		const month = currentMonthUTC();
 		displayMonth = month;
@@ -127,6 +164,22 @@ Issue: equaltoai/lesser-host#422
 			errorMessage = formatError(err);
 		} finally {
 			loading = false;
+		}
+
+		// Cost telemetry loads separately so budget/summary still display
+		// when cost data is not yet available. On 401, redirect.
+		costLoading = true;
+		try {
+			cost = await portalGetInstanceCost(token, slug);
+		} catch (err) {
+			if ((err as Partial<ApiError>).status === 401) {
+				await logout();
+				navigate('/login');
+				return;
+			}
+			costError = formatError(err);
+		} finally {
+			costLoading = false;
 		}
 	}
 
@@ -199,39 +252,73 @@ Issue: equaltoai/lesser-host#422
 				<Heading level={3} size="lg">Real-time cost telemetry</Heading>
 			{/snippet}
 
-			<Alert variant="info" title="Real-time cost telemetry coming soon">
-				<Text size="sm">
-					Per-Lambda, per-Dynamo-table, and per-egress cost breakdown with
-					real-time telemetry is scheduled for M3 alongside the cost-telemetry
-					firehose. The current tab surfaces budget and aggregate usage through
-					the existing portal budget and usage-summary endpoints.
+			{#if costLoading && !cost}
+				<div class="instance-cost__loading">
+					<Spinner size="sm" />
+					<Text size="sm">Loading cost telemetry…</Text>
+				</div>
+			{:else if costError && !cost}
+				<Alert variant="warning" title="Cost telemetry unavailable">{costError}</Alert>
+			{:else if cost}
+				<Text size="sm" color="secondary">
+					{cost.from_date} – {cost.to_date} · {cost.count} day(s) · Total: {formatCost(cost.total_cost)} {cost.currency}
 				</Text>
-			</Alert>
 
-			<!-- TODO(M3): replace this static breakdown with live per-Lambda /
-			     per-Dynamo / per-egress telemetry once the cost-telemetry firehose
-			     lands. Tracking: M3 cost-telemetry milestone. -->
-			<div class="instance-cost__coming-soon-grid">
-				<div class="instance-cost__coming-soon-item">
-					<Text size="sm" weight="medium">Lambda</Text>
-					<Text size="sm" color="secondary">Invocation count / duration / cost per function — pending M3 telemetry pipeline.</Text>
-				</div>
-				<div class="instance-cost__coming-soon-item">
-					<Text size="sm" weight="medium">DynamoDB</Text>
-					<Text size="sm" color="secondary">RCU/WCU consumption / storage per table — pending M3 telemetry pipeline.</Text>
-				</div>
-				<div class="instance-cost__coming-soon-item">
-					<Text size="sm" weight="medium">Egress</Text>
-					<Text size="sm" color="secondary">Data transfer by destination / protocol — pending M3 telemetry pipeline.</Text>
-				</div>
-			</div>
+				{@const byService = aggregateByService(cost.days)}
+				{#if byService.length > 0}
+					<div class="instance-cost__service-grid">
+						{#each byService as agg (agg.service)}
+							<div class="instance-cost__service-item">
+								<Text size="sm" weight="medium">{agg.service}</Text>
+								<div class="instance-cost__service-cost">
+									<Text size="sm"><span class="instance-cost__mono">{formatCost(agg.total)}</span></Text>
+									<Text size="xs" color="secondary">{agg.count} entry(s)</Text>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{/if}
+
+				{#if cost.days.length > 0}
+					<div class="instance-cost__daily-section">
+						<Text size="sm" weight="medium">Daily breakdown</Text>
+						<div class="instance-cost__daily-list">
+							{#each [...cost.days].reverse() as day (day.date)}
+								<div class="instance-cost__daily-row">
+									<div class="instance-cost__daily-header">
+										<Text size="sm" weight="medium">{day.date}</Text>
+										<Text size="sm"><span class="instance-cost__mono">{formatCost(day.day_cost)} {day.currency}</span></Text>
+									</div>
+									{#if day.entries.length > 0}
+										<div class="instance-cost__daily-entries">
+											{#each day.entries as entry (entry.service + "-" + entry.date)}
+												<div class="instance-cost__daily-entry">
+													<Text size="xs" color="secondary">{entry.service}</Text>
+													<Text size="xs"><span class="instance-cost__mono">{formatCost(entry.cost)}</span></Text>
+												</div>
+											{/each}
+										</div>
+									{/if}
+								</div>
+							{/each}
+						</div>
+					</div>
+				{/if}
+			{:else}
+				<Alert variant="info" title="No cost telemetry available">
+					<Text size="sm">
+						Cost telemetry data for this instance is not yet available.
+						Data typically appears within 24–48 hours of instance activity.
+					</Text>
+				</Alert>
+			{/if}
 		</Card>
 
 		<div class="instance-cost__actions">
 			<Button
 				variant="outline"
 				onclick={() => void loadAll()}
-				loading={loading}
+				loading={loading || costLoading}
 				loadingBehavior="prepend"
 			>
 				Refresh
@@ -255,14 +342,14 @@ Issue: equaltoai/lesser-host#422
 		align-items: center;
 	}
 
-	.instance-cost__coming-soon-grid {
+	.instance-cost__service-grid {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-		gap: var(--gr-spacing-scale-4);
+		grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+		gap: var(--gr-spacing-scale-3);
 		margin-top: var(--gr-spacing-scale-4);
 	}
 
-	.instance-cost__coming-soon-item {
+	.instance-cost__service-item {
 		display: flex;
 		flex-direction: column;
 		gap: var(--gr-spacing-scale-1);
@@ -272,10 +359,60 @@ Issue: equaltoai/lesser-host#422
 		background: var(--gr-color-surface);
 	}
 
+	.instance-cost__service-cost {
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-0);
+	}
+
+	.instance-cost__daily-section {
+		margin-top: var(--gr-spacing-scale-4);
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-3);
+	}
+
+	.instance-cost__daily-list {
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-2);
+	}
+
+	.instance-cost__daily-row {
+		padding: var(--gr-spacing-scale-2);
+		border: 1px solid var(--gr-color-border-subtle, #d9d9d9);
+		border-radius: var(--gr-radius-sm, 8px);
+	}
+
+	.instance-cost__daily-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.instance-cost__daily-entries {
+		margin-top: var(--gr-spacing-scale-1);
+		padding-top: var(--gr-spacing-scale-1);
+		border-top: 1px solid var(--gr-color-border-subtle, #d9d9d9);
+		display: flex;
+		flex-direction: column;
+		gap: var(--gr-spacing-scale-0);
+	}
+
+	.instance-cost__daily-entry {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
 	.instance-cost__actions {
 		display: flex;
 		gap: var(--gr-spacing-scale-2);
 		align-items: center;
 		flex-wrap: wrap;
+	}
+
+	.instance-cost__mono {
+		font-family: var(--gr-typography-fontFamily-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
 	}
 </style>

--- a/web/src/pages/portal/InstanceCost.svelte
+++ b/web/src/pages/portal/InstanceCost.svelte
@@ -77,29 +77,58 @@ Source: Issue equaltoai/lesser-host#456
 
 	interface ServiceAggregate {
 		service: string;
+		category: string;
 		total: number;
 		count: number;
 		currency: string;
 	}
 
 	/**
-	 * Aggregate cost entries across all days by service name.
-	 * Returns an array of service aggregates sorted by total cost descending.
+	 * Aggregate cost entries across all days by category.
+	 * Returns an array of category aggregates sorted by total cost descending.
 	 */
-	function aggregateByService(days: CostDayEntry[]): ServiceAggregate[] {
-		const byService: Record<string, ServiceAggregate> = {};
+	function aggregateByCategory(days: CostDayEntry[]): ServiceAggregate[] {
+		const byCategory: Record<string, ServiceAggregate> = {};
 		for (const day of days) {
 			for (const entry of day.entries) {
-				const existing = byService[entry.service];
+				const cat = categoryForService(entry.service);
+				const existing = byCategory[cat];
 				if (existing) {
 					existing.total += entry.cost;
 					existing.count++;
 				} else {
-					byService[entry.service] = { service: entry.service, total: entry.cost, count: 1, currency: entry.currency };
+					byCategory[cat] = { service: entry.service, category: cat, total: entry.cost, count: 1, currency: entry.currency };
 				}
 			}
 		}
-		return Object.values(byService).sort((a, b) => b.total - a.total);
+		return Object.values(byCategory).sort((a, b) => b.total - a.total);
+	}
+
+	/**
+	 * Categorize a normalized service name into a user-facing category label.
+	 *
+	 * Maps Lambda → "Lambda", DynamoDB → "DynamoDB", and
+	 * DataTransfer / CloudFront / any data-transfer-like service → "Egress".
+	 * All other services pass through unchanged.
+	 *
+	 * The mapping is case-insensitive on input and returns stable labels
+	 * regardless of upstream service-name drift.
+	 */
+	function categoryForService(service: string): string {
+		const s = (service ?? '').trim();
+		const lower = s.toLowerCase();
+		if (lower === 'lambda') return 'Lambda';
+		if (lower === 'dynamodb') return 'DynamoDB';
+		if (
+			lower === 'datatransfer' ||
+			lower === 'cloudfront' ||
+			lower.includes('data transfer') ||
+			lower.includes('egress') ||
+			lower.includes('datatransfer')
+		) {
+			return 'Egress';
+		}
+		return s || 'Unknown';
 	}
 
 	/**
@@ -264,12 +293,12 @@ Source: Issue equaltoai/lesser-host#456
 					{cost.from_date} – {cost.to_date} · {cost.count} day(s) · Total: {formatCost(cost.total_cost)} {cost.currency}
 				</Text>
 
-				{@const byService = aggregateByService(cost.days)}
-				{#if byService.length > 0}
+				{@const byCategory = aggregateByCategory(cost.days)}
+				{#if byCategory.length > 0}
 					<div class="instance-cost__service-grid">
-						{#each byService as agg (agg.service)}
+						{#each byCategory as agg (agg.category)}
 							<div class="instance-cost__service-item">
-								<Text size="sm" weight="medium">{agg.service}</Text>
+								<Text size="sm" weight="medium">{agg.category}</Text>
 								<div class="instance-cost__service-cost">
 									<Text size="sm"><span class="instance-cost__mono">{formatCost(agg.total)}</span></Text>
 									<Text size="xs" color="secondary">{agg.count} entry(s)</Text>

--- a/web/src/pages/portal/InstanceCost.svelte.test.ts
+++ b/web/src/pages/portal/InstanceCost.svelte.test.ts
@@ -130,11 +130,30 @@ describe('InstanceCost cost & usage tab', () => {
 		expect(template).not.toContain('cost__coming-soon-item');
 	});
 
-	it('renders per-service cost breakdown grid from live data', () => {
-		// M3.12: the service grid must exist, aggregating entries by service.
-		expect(source).toContain('aggregateByService(cost.days)');
+	it('renders per-category cost breakdown grid from live data', () => {
+		// M3.12: the service grid must exist, aggregating entries by category
+		// via the categorization layer (categoryForService).
+		expect(source).toContain('aggregateByCategory(cost.days)');
 		expect(source).toContain('instance-cost__service-grid');
 		expect(source).toContain('instance-cost__service-item');
+	});
+
+	it('categorizes Lambda, DynamoDB, and Egress services with explicit labels', () => {
+		// M3.12 #456: the categorization layer must map services to
+		// user-facing category labels. Removing the categoryForService
+		// function or its Egress mapping must fail this test.
+		expect(source).toContain('function categoryForService(');
+		expect(source).toContain("return 'Lambda'");
+		expect(source).toContain("return 'DynamoDB'");
+		expect(source).toContain("return 'Egress'");
+
+		// DataTransfer and CloudFront must both map to Egress.
+		expect(source).toContain("lower === 'datatransfer'");
+		expect(source).toContain("lower === 'cloudfront'");
+
+		// Egress-like patterns must be caught.
+		expect(source).toContain("lower.includes('data transfer')");
+		expect(source).toContain("lower.includes('egress')");
 	});
 
 	it('renders daily cost breakdown from live data', () => {

--- a/web/src/pages/portal/InstanceCost.svelte.test.ts
+++ b/web/src/pages/portal/InstanceCost.svelte.test.ts
@@ -55,12 +55,6 @@ describe('InstanceCost cost & usage tab', () => {
 		expect(source).toContain("navigate('/login');");
 	});
 
-	it('marks the per-Lambda / Dynamo / egress breakdown for M3 replacement', () => {
-		// Anchor the deferral to the M3 milestone so the static placeholder
-		// is not left as a visual artifact once live telemetry lands.
-		expect(source).toContain('TODO(M3)');
-	});
-
 	it('surfaces inflight-refresh state via Button loading prop', () => {
 		// The Refresh button must convey inflight state during a refresh after
 		// initial load — when data is already present, the page-level spinner
@@ -70,7 +64,7 @@ describe('InstanceCost cost & usage tab', () => {
 		const scriptEnd = source.indexOf('</script>');
 		expect(scriptEnd).toBeGreaterThan(0);
 		const template = source.slice(scriptEnd);
-		expect(template).toContain('loading={loading}');
+		expect(template).toContain('loading={loading || costLoading}');
 		expect(template).toContain('loadingBehavior="prepend"');
 	});
 
@@ -112,5 +106,54 @@ describe('InstanceCost cost & usage tab', () => {
 		// branch (containing the Refresh button with its inline loading
 		// affordance) keeps the user oriented.
 		expect(source).toContain('{#if loading && !budget && !summary}');
+	});
+
+	// ── M3 cost telemetry wiring tests (#456) ────────────────────────────
+
+	it('imports and calls portalGetInstanceCost for real-time cost telemetry', () => {
+		// M3.12: the page must request the cost endpoint.
+		expect(source).toContain('import { portalGetBudgetMonth, portalGetUsageSummary, portalGetInstanceCost }');
+		expect(source).toContain('portalGetInstanceCost(token, slug)');
+	});
+
+	it('does not render the old TODO(M3) placeholder or coming-soon empty state', () => {
+		// M3.12: the "coming soon" empty state and TODO(M3) static breakdown
+		// must be replaced with live cost data. The doc comment may reference
+		// TODO(M3) historically, but the template must not contain any TODO(M3)
+		// directives or coming-soon placeholder text.
+		const scriptEnd = source.indexOf('</script>');
+		expect(scriptEnd).toBeGreaterThan(0);
+		const template = source.slice(scriptEnd);
+		expect(template).not.toContain('TODO(M3)');
+		expect(template).not.toContain('Real-time cost telemetry coming soon');
+		expect(template).not.toContain('cost__coming-soon-grid');
+		expect(template).not.toContain('cost__coming-soon-item');
+	});
+
+	it('renders per-service cost breakdown grid from live data', () => {
+		// M3.12: the service grid must exist, aggregating entries by service.
+		expect(source).toContain('aggregateByService(cost.days)');
+		expect(source).toContain('instance-cost__service-grid');
+		expect(source).toContain('instance-cost__service-item');
+	});
+
+	it('renders daily cost breakdown from live data', () => {
+		// M3.12: daily breakdown section must exist.
+		expect(source).toContain('Daily breakdown');
+		expect(source).toContain('instance-cost__daily-list');
+		expect(source).toContain('instance-cost__daily-row');
+	});
+
+	it('handles 401 on cost endpoint', () => {
+		// M3.12: 401 from the cost endpoint must also trigger logout + redirect.
+		// The cost-specific catch block must contain the 401 check.
+		expect(source).toContain('portalGetInstanceCost(token, slug)');
+
+		// Verify there's a second 401 check in the cost catch block
+		// (the first is in the budget/summary catch).
+		const first401 = source.indexOf(').status === 401');
+		expect(first401).toBeGreaterThan(0);
+		const second401 = source.indexOf(').status === 401', first401 + 1);
+		expect(second401).toBeGreaterThan(first401);
 	});
 });


### PR DESCRIPTION
## Summary
- Wire Cost & usage tab to live cost telemetry from `GET /api/v1/portal/instances/{slug}/cost` (#456)
- Add SEC-13 cost-telemetry redaction verifier with multi-tenant read ordering (#457)
- Bump gov-infra pack to 2026.05.24-web.3 (#458)

## Changes

### feat(web): wire Cost & usage tab to real-time telemetry (#456)
- Add `portalGetInstanceCost` API client + TypeScript types to `web/src/lib/api/portalUsage.ts`
- Rewrite `InstanceCost.svelte` to fetch and display live cost data:
  - Per-service aggregate breakdown (sorted by total cost)
  - Daily breakdown with per-entry service/cost details
  - Handles loading, error, and no-data states
  - Preserves budget/usage summary from M1.13
  - Preserves 401 logout redirect on both budget/summary and cost endpoints
- Update tests: remove TODO(M3) placeholder check, add cost endpoint tests
  (import, call site, 401 handling, service grid, daily breakdown, no old placeholder)

### feat(gov-infra): add SEC-13 cost-telemetry redaction verifier (#457)
- New verifier at `gov-infra/verifiers/sec/cost-telemetry-redaction.sh`:
  - **Dimension 1**: Verifies `requireInstanceAccess` line < `ListCostTelemetryByInstance` line
  - **Dimension 2a**: Verifies DTO struct json tags exclude forbidden fields
    (`account_id`, `pk`, `sk`, `ttl`, `entries_json`, `instance_key`, `raw_key`)
  - **Dimension 2b**: Verifies Go tests contain redaction assertions
    (`jsonContains` with forbidden fields; `AssertNotCalled` on forbidden)
- Wired as SEC-13 into `gov-verify-rubric.sh` with evidence cleanup

### chore(gov-infra): bump pack to 2026.05.24-web.3 (#458)
- Bump packVersion from `2026.05.24-web.2` to `2026.05.24-web.3`
- Add SEC-13 verifier and evidence to pack artifacts
- Recompute packDigest

## Validation
- `go test ./...` — all pass
- `go vet ./...` — clean
- `cd web && npm run lint` — pass
- `cd web && npm run typecheck` — pass (0 errors, 0 warnings)
- `cd web && npm test` — 91/91 pass
- `cd web && npm run build` — pass (including verify-no-inline-html, verify-oac-form-integrity)
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — **40 PASS / 0 FAIL / 0 BLOCKED**

Closes #456
Closes #457
Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)