### PR TITLE
fix(cdk): preserve web distribution during FaceTheory cutover

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -1490,8 +1490,8 @@ export class LesserHostStack extends cdk.Stack {
 		this.ensureWebBuild();
 		const webSsrFn = new lambda.Function(this, 'WebSsrFn', {
 			functionName: `${namePrefix}-web-ssr`,
-			code: lambda.Code.fromAsset(path.join(this.repoRoot(), 'web', 'dist', 'server')),
-			handler: 'face-app.handler',
+			code: lambda.Code.fromAsset(path.join(this.repoRoot(), 'web', 'dist')),
+			handler: 'server/face-app.handler',
 			runtime: lambda.Runtime.NODEJS_22_X,
 			memorySize: 512,
 			timeout: cdk.Duration.seconds(15),
@@ -1555,6 +1555,8 @@ export class LesserHostStack extends cdk.Stack {
 			removalPolicy,
 			autoDeleteObjects: stage !== 'live',
 		});
+		// Preserve the legacy logical id so the existing CNAME owner updates in place.
+		(webSite.distribution.node.defaultChild as cloudfront.CfnDistribution).overrideLogicalId('WebDistribution59C46482');
 
 		// /_facetheory/data/* hand-wired to htmlStoreBucket. S3BucketOrigin
 		// .withOriginAccessControl keeps the bucket blockPublicAccess and

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -41,6 +41,13 @@ function findResources(template: SynthesizedTemplate, type: string): Array<Recor
 		.map((resource) => resource?.Properties ?? {});
 }
 
+function findResourceEntries(
+	template: SynthesizedTemplate,
+	type: string,
+): Array<[string, { Type?: string; Properties?: Record<string, unknown> }]> {
+	return Object.entries(template.Resources ?? {}).filter(([, resource]) => resource?.Type === type);
+}
+
 function parseAccessLogFormat(stage: Record<string, unknown>): Record<string, unknown> {
 	const accessLogSettings = stage.AccessLogSettings;
 	assert.ok(accessLogSettings && typeof accessLogSettings === 'object', 'expected stage access log settings');
@@ -228,6 +235,16 @@ test('web asset bundling does not execute npm locally in CI', () => {
 	assert.equal(shouldUseLocalWebBundling({}), true);
 });
 
+test('web SSR Lambda packages the Vite manifest beside the server bundle', () => {
+	const template = synthTemplate();
+	const fn = findLambdaByFunctionName(template, '-web-ssr');
+	assert.equal(
+		fn?.Handler,
+		'server/face-app.handler',
+		'WebSsrFn must package web/dist so face-app can read ../.vite/manifest.json and emit client assets',
+	);
+});
+
 // ────────────────────────────────────────────────────────────────────
 // M0.13 — CloudFront composition tests (SEC-8 verifier input).
 //
@@ -270,6 +287,20 @@ function distributionConfig(template: SynthesizedTemplate): DistributionConfig {
 	assert.ok(config && typeof config === 'object', 'distribution missing DistributionConfig');
 	return config as DistributionConfig;
 }
+
+test('M0.13 distribution: preserves legacy logical id for in-place alias migration', () => {
+	const distributions = findResourceEntries(synthTemplate(), 'AWS::CloudFront::Distribution');
+	assert.equal(
+		distributions.length,
+		1,
+		`expected exactly one CloudFront distribution, got ${distributions.length}`,
+	);
+	assert.equal(
+		distributions[0]?.[0],
+		'WebDistribution59C46482',
+		'CloudFront distribution logical id must remain the legacy WebDistribution id so lab/live aliases update in place instead of colliding on create-before-delete',
+	);
+});
 
 function originById(config: DistributionConfig, id: unknown): CloudFrontOrigin {
 	const origin = (config.Origins ?? []).find((entry) => entry.Id === id);


### PR DESCRIPTION
## Summary

- Preserve the legacy CloudFront distribution logical id (`WebDistribution59C46482`) when adopting `AppTheorySsrSite`, so CloudFormation updates the existing `lab.lesser.host` / `lesser.host` distribution in place instead of trying to create a second distribution with the same CNAME.
- Package `web/dist` for the SSR Lambda and use `server/face-app.handler`, so `face-app.mjs` can read `../.vite/manifest.json` and emit FaceTheory client bootstrap assets.
- Add CDK regression tests for both migration hazards.

## Steward notes

This fixes the lab deploy failure observed on 2026-05-26:

- Failed deploy from `origin/main @ 279c9ae` rolled back with CloudFront 409 duplicate CNAME for `lab.lesser.host`.
- Existing alias owner is distribution `E1L099GJ786HXN` (`d3cua9wqe14jkh.cloudfront.net`).
- After preserving the legacy logical id, lab updated that same distribution in place.
- A post-deploy smoke then caught missing SSR client assets because the Lambda bundle omitted the Vite manifest; this PR fixes that packaging path too.

## Governance / security impact

- Multi-tenant isolation: preserved; no tenant-account/IAM data path changes.
- On-chain/soul registry: unaffected.
- Trust API / instance auth: preserved; bearer-auth API and trust origins remain non-OAC as locked by existing SEC-8 tests.
- CSP: preserved; existing CSP byte-string tests remain green.
- Consumer release verification: unaffected.
- AGPL/dependency impact: no dependency changes.

## Validation

- `cd cdk && npm test` — PASS (23 tests)
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (40 pass / 0 fail / 0 blocked)
- `AWS_PROFILE=Lesser theory app up --stage lab --execute` — PASS

## Lab smoke after deploy

- Stack `lesser-host-lab`: `UPDATE_COMPLETE`
- CloudFront distribution `E1L099GJ786HXN`: `Deployed`, alias `lab.lesser.host`
- `GET https://lab.lesser.host/` returns FaceTheory SSR shell with modulepreload, CSS, hydration sidecar link, and `face-client` script.
- `GET https://lab.lesser.host/_facetheory/probe` returns FaceTheory probe with client asset tags.
- `GET https://lab.lesser.host/_facetheory/data/home.json` returns `{"routeId":"home","route":"/"}`.
- `GET https://lab.lesser.host/api/v1/portal/me` returns `401`, confirming API behavior still reaches the control-plane API.
- `GET https://lab.lesser.host/.well-known/jwks.json` returns `200`, confirming trust behavior still reaches the trust API.

## Provenance

Local git/gh fallback used because the routed commit API is a poor fit for the 2,000-line CDK stack file; validation and deployment were performed from the same branch content before opening this PR.
