### PR TITLE
[codex] Restore lab assets and Project 39 shell

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -1525,17 +1525,9 @@ export class LesserHostStack extends cdk.Stack {
 			autoDeleteObjects: stage !== 'live',
 		});
 
-		// AppTheorySsrSite (M0.12) — canonical AppTheory v1.9.0 composition.
+		// AppTheorySsrSite (M0.12) — canonical AppTheory v1.11.0 composition.
 		// Owns the single CloudFront distribution + OAC-signed SSR Lambda
-		// origin (AuthType.AWS_IAM fail-closed). Bearer-auth co-origins (HTTP
-		// API + SSE REST) attach via addBehavior() below; OAC does NOT
-		// propagate to them (M0.13 test asserts). CSP byte-string preserved
-		// via responseHeadersPolicy (M0.14 test). Mode SSR_ONLY matches host's
-		// per-request SSR architecture; SSG_ISR (S3 primary HTML) would be a
-		// larger shift not in scope. directS3PathPatterns NOT used because in
-		// SSR_ONLY it routes to assetsBucket; /_facetheory/data/* must hit
-		// htmlStoreBucket so SSR-Lambda sidecar writes and CloudFront reads
-		// land together without granting SSR write access to webBucket.
+		// origin and the direct S3 Vite asset behaviors.
 		const webSite = new AppTheorySsrSite(this, 'WebSite', {
 			ssrFunction: webSsrFn,
 			mode: AppTheorySsrSiteMode.SSR_ONLY,
@@ -1558,9 +1550,7 @@ export class LesserHostStack extends cdk.Stack {
 		// Preserve the legacy logical id so the existing CNAME owner updates in place.
 		(webSite.distribution.node.defaultChild as cloudfront.CfnDistribution).overrideLogicalId('WebDistribution59C46482');
 
-		// /_facetheory/data/* hand-wired to htmlStoreBucket. S3BucketOrigin
-		// .withOriginAccessControl keeps the bucket blockPublicAccess and
-		// signs CloudFront reads.
+		// /_facetheory/data/* hand-wired to htmlStoreBucket with OAC reads.
 		const sidecarOrigin = origins.S3BucketOrigin.withOriginAccessControl(htmlStoreBucket);
 		webSite.distribution.addBehavior('_facetheory/data/*', sidecarOrigin, {
 			viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -1568,7 +1558,6 @@ export class LesserHostStack extends cdk.Stack {
 			cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
 			responseHeadersPolicy: webSecurityHeaders,
 		});
-
 		// Bearer-auth co-origins (existing HTTP API + SSE REST; not Function
 		// URLs, so AppTheorySsrSite.bearerFunctionUrlOrigins[] doesn't apply).
 		// Attached via addBehavior(); OAC does NOT propagate (M0.13 test).

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.9.0/theory-cloud-apptheory-cdk-1.9.0.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.11.0/theory-cloud-apptheory-cdk-1.11.0.tgz",
         "aws-cdk-lib": "^2.256.1",
         "constructs": "^10.6.0"
       },
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.9.0",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.9.0/theory-cloud-apptheory-cdk-1.9.0.tgz",
-      "integrity": "sha512-JZnM/PHTO6xiL4aayjuho/68H4xx1qGjojULknS167TO/SqMfAqZ+wN9+qVc8v42xF5K0oz7hC+Yo1ELFP5vGw==",
+      "version": "1.11.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.11.0/theory-cloud-apptheory-cdk-1.11.0.tgz",
+      "integrity": "sha512-+iCyc1BSrFj5DGTr1Mo2gKI7UuSjpisrWD/IvJJSJuXRJ3bbdbQPZvXcZ8y+8BFBLjNtpIyr/YSfdyuDx4ZRVA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -14,7 +14,7 @@
     "destroy": "npm run build && cdk destroy --all"
   },
   "dependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.9.0/theory-cloud-apptheory-cdk-1.9.0.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.11.0/theory-cloud-apptheory-cdk-1.11.0.tgz",
     "aws-cdk-lib": "^2.256.1",
     "constructs": "^10.6.0"
   },

--- a/scripts/verify-facetheory-assets.sh
+++ b/scripts/verify-facetheory-assets.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: verify-facetheory-assets.sh <base-url>" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+  usage
+  exit 2
+fi
+
+base_url="${1%/}"
+case "$base_url" in
+  http://*|https://*) ;;
+  *)
+    echo "base-url must start with http:// or https://" >&2
+    exit 2
+    ;;
+esac
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+root_headers="$tmp_dir/root.headers"
+root_body="$tmp_dir/root.html"
+curl -fsS -D "$root_headers" -o "$root_body" "$base_url/"
+
+mapfile -t assets < <(python3 - "$root_body" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+html = Path(sys.argv[1]).read_text(encoding="utf-8")
+seen = set()
+for match in re.finditer(r'(?:href|src)="([^"]+)"', html):
+    url = match.group(1)
+    if not url.startswith("/assets/") or url in seen:
+        continue
+    seen.add(url)
+    print(url)
+PY
+)
+
+if [ "${#assets[@]}" -eq 0 ]; then
+  echo "no /assets/* references found in SSR shell" >&2
+  exit 1
+fi
+
+for asset_path in "${assets[@]}"; do
+  request_id="facetheory-asset-smoke-${RANDOM}-${RANDOM}"
+  headers="$tmp_dir/asset.headers"
+  body="$tmp_dir/asset.body"
+  curl -sS -H "x-request-id: ${request_id}" \
+    -D "$headers" \
+    -o "$body" \
+    "${base_url}${asset_path}?facetheory_asset_smoke=${RANDOM}${RANDOM}"
+
+  status="$(awk 'tolower($0) ~ /^http\// { code=$2 } END { print code }' "$headers")"
+  content_type="$(awk 'tolower($0) ~ /^content-type:/ { sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit }' "$headers")"
+  echoed_request_id="$(awk 'tolower($0) ~ /^x-request-id:/ { sub(/^[^:]+:[[:space:]]*/, ""); gsub(/\r/, ""); print; exit }' "$headers")"
+
+  case "$status" in
+    2*) ;;
+    *)
+      echo "${asset_path}: expected 2xx, got ${status:-missing}" >&2
+      sed -n '1,20p' "$headers" >&2
+      head -c 300 "$body" >&2 || true
+      echo >&2
+      exit 1
+      ;;
+  esac
+
+  case "$asset_path" in
+    *.css)
+      case "$content_type" in
+        text/css*) ;;
+        *)
+          echo "${asset_path}: expected text/css, got ${content_type:-missing}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    *.js|*.mjs)
+      case "$content_type" in
+        text/javascript*|application/javascript*) ;;
+        *)
+          echo "${asset_path}: expected JavaScript MIME, got ${content_type:-missing}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+  esac
+
+  if [ "$echoed_request_id" != "$request_id" ]; then
+    echo "${asset_path}: expected AppTheory asset behavior to echo x-request-id" >&2
+    echo "expected: $request_id" >&2
+    echo "observed: ${echoed_request_id:-missing}" >&2
+    exit 1
+  fi
+
+  if head -c 40 "$body" | grep -q '<?xml'; then
+    echo "${asset_path}: asset response is an XML error document" >&2
+    exit 1
+  fi
+
+  echo "${asset_path}: ok (${status}, ${content_type})"
+done

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
         "@graphql-typed-document-node/core": "^3.2.0",
         "@noble/hashes": "^2.0.1",
         "@safe-global/safe-apps-sdk": "^9.1.0",
-        "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.0/theory-cloud-facetheory-3.4.0.tgz",
+        "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.2/theory-cloud-facetheory-3.4.2.tgz",
         "focus-trap": "^8.0.0",
         "graphql": "^16.13.1",
         "graphql-ws": "^6.0.7",
@@ -1245,9 +1245,9 @@
       }
     },
     "node_modules/@theory-cloud/facetheory": {
-      "version": "3.4.0",
-      "resolved": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.0/theory-cloud-facetheory-3.4.0.tgz",
-      "integrity": "sha512-Sp5EPPEpwKoDE/kOkKHAlfnrUNPjfi/ii4p00U+ZHU4Tznn/ZYSdlxG6bdXZ9aPmcNG1YjQKYBEUsIITVuYioQ==",
+      "version": "3.4.2",
+      "resolved": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.2/theory-cloud-facetheory-3.4.2.tgz",
+      "integrity": "sha512-iuorGINr/SjG21hTiWDxY4udhkNKW8KyeoM5jRrtIZFZL4r10K4QWUDJTK34+2xV1Qq+fiBCp1TWOX9nQ+SL3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"

--- a/web/package.json
+++ b/web/package.json
@@ -41,7 +41,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "@noble/hashes": "^2.0.1",
     "@safe-global/safe-apps-sdk": "^9.1.0",
-    "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.0/theory-cloud-facetheory-3.4.0.tgz",
+    "@theory-cloud/facetheory": "https://github.com/theory-cloud/FaceTheory/releases/download/v3.4.2/theory-cloud-facetheory-3.4.2.tgz",
     "focus-trap": "^8.0.0",
     "graphql": "^16.13.1",
     "graphql-ws": "^6.0.7",

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -1,4 +1,15 @@
 <script lang="ts">
+	// FaceTheory emits CSS discovered from the rendered App surface into the
+	// SSR HTML. Keep Project 39 global styles on this graph (not only
+	// `main.ts`) so lab receives the Agent Genesis theme before hydration.
+	import 'src/lib/styles/greater/tokens.css';
+	import 'src/lib/tokens';
+	import 'src/lib/styles/greater/primitives.css';
+	import 'src/lib/styles/greater/shell.css';
+	import 'src/lib/styles/greater/host-platform.css';
+	import 'src/lib/tokens/operator-chrome.css';
+	import './app.css';
+
 	import { onMount } from 'svelte';
 	import { get } from 'svelte/store';
 
@@ -22,20 +33,23 @@
 	import Trust from 'src/pages/Trust.svelte';
 
 	let isOperatorRoute = $derived($currentPath === '/operator' || $currentPath.startsWith('/operator/'));
-	// M0.11 — /portal/fleet is the new shell-based fleet view; it renders
-	// inside PortalShell (greater-components Shell + Sidebar + Topbar +
-	// PageFrame + CommandPalette) rather than the legacy PortalLayout.
-	// Compatibility note: /portal and /portal/instances continue to use
-	// PortalLayout below — no legacy behavior is changed by this PR.
-	let isPortalFleetRoute = $derived(
-		$currentPath === '/portal/fleet' || $currentPath.startsWith('/portal/fleet/')
+	// Project 39 customer surfaces render inside the shell. /portal is the
+	// canonical fleet view; /portal/fleet remains a compatibility alias.
+	let isPortalShellRoute = $derived(
+		$currentPath === '/portal' ||
+			$currentPath === '/portal/fleet' ||
+			$currentPath.startsWith('/portal/fleet/') ||
+			$currentPath.startsWith('/portal/') ||
+			$currentPath === '/trust' ||
+			$currentPath.startsWith('/trust/') ||
+			$currentPath === '/account' ||
+			$currentPath === '/tip-registry' ||
+			$currentPath === '/tip-registry/register'
 	);
 	let isPortalRoute = $derived(
-		!isPortalFleetRoute && (
+		!isPortalShellRoute && (
 			$currentPath === '/' ||
-			$currentPath === '/portal' || $currentPath.startsWith('/portal/') ||
-			$currentPath === '/trust' || $currentPath.startsWith('/trust/') ||
-			$currentPath === '/tip-registry' || $currentPath === '/tip-registry/register' ||
+			$currentPath === '/trust' ||
 			$currentPath === '/account'
 		)
 	);
@@ -54,9 +68,19 @@
 		<OperatorLayout>
 			<Operator />
 		</OperatorLayout>
-	{:else if isPortalFleetRoute}
+	{:else if isPortalShellRoute}
 		<PortalShell>
-			<PortalFleet token={$session?.token ?? ''} />
+			{#if $currentPath === '/portal' || $currentPath === '/portal/fleet' || $currentPath.startsWith('/portal/fleet/')}
+				<PortalFleet token={$session?.token ?? ''} />
+			{:else if $currentPath.startsWith('/portal/')}
+				<Portal />
+			{:else if $currentPath === '/trust' || $currentPath.startsWith('/trust/')}
+				<Trust />
+			{:else if $currentPath === '/account'}
+				<Account />
+			{:else if $currentPath === '/tip-registry' || $currentPath === '/tip-registry/register'}
+				<TipRegistryRegister />
+			{/if}
 		</PortalShell>
 	{:else if isPortalRoute}
 		<PortalLayout>

--- a/web/src/app.css
+++ b/web/src/app.css
@@ -5,9 +5,14 @@ body {
 
 body {
 	margin: 0;
-	font-family: var(--gr-typography-fontFamily-sans, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif);
-	background: var(--gr-semantic-background-base, var(--gr-semantic-background-primary, #ffffff));
-	color: var(--gr-semantic-foreground-primary, #111827);
+	font-family: var(--ds-font-sans, var(--gr-typography-fontFamily-sans, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif));
+	background: var(--ds-bg-base, #f8f1e7);
+	background-image: var(--ds-page-gradient);
+	background-attachment: fixed;
+	color: var(--ds-fg-1, var(--gr-semantic-foreground-primary, #332116));
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
+	font-size: 15px;
 }
 
 a {
@@ -16,4 +21,82 @@ a {
 
 #app {
 	min-height: 100%;
+}
+
+:focus-visible {
+	outline: 2px solid var(--ds-border-focus, var(--gr-semantic-focus-ring, #8d64d1));
+	outline-offset: 2px;
+	border-radius: var(--ds-radius-sm, 0.375rem);
+}
+
+/*
+ * Project 39 — Agent Genesis runtime skin.
+ *
+ * The design-system tokens live in `src/lib/tokens`; these selectors make
+ * the vendored Greater shell/components visibly consume them. This is not a
+ * framework patch: it is host's app-level skin over Greater's stable class
+ * surface, loaded from the first-party bundle under the strict CSP.
+ */
+.gr-shell:not(.shell--operator) {
+	background: var(--ds-bg-base, #f8f1e7);
+	background-image: var(--ds-page-gradient);
+	background-attachment: fixed;
+	color: var(--ds-fg-1, #332116);
+}
+
+.gr-shell:not(.shell--operator) .gr-shell-sidebar,
+.gr-shell:not(.shell--operator) .gr-shell-topbar {
+	background: var(--ds-bg-glass, rgba(255, 251, 245, 0.82));
+	-webkit-backdrop-filter: blur(var(--ds-blur-nav, 24px));
+	backdrop-filter: blur(var(--ds-blur-nav, 24px));
+	border-color: var(--ds-border-default, rgba(107, 56, 16, 0.16));
+}
+
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__header,
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__footer {
+	border-color: var(--ds-border-subtle, rgba(107, 56, 16, 0.1));
+}
+
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > a,
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > button {
+	border-radius: var(--ds-radius-md, 0.75rem);
+	color: var(--ds-fg-2, rgba(51, 33, 22, 0.78));
+}
+
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > a:hover,
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > button:hover {
+	background: var(--ds-bg-raised, rgba(255, 255, 255, 0.72));
+	color: var(--ds-fg-1, #332116);
+}
+
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > a[aria-current='page'],
+.gr-shell:not(.shell--operator) .gr-shell-sidebar__body > button[aria-pressed='true'] {
+	background: color-mix(in srgb, var(--ds-secondary-500, #8d64d1) 14%, transparent);
+	color: var(--ds-fg-1, #332116);
+	font-weight: 700;
+}
+
+.gr-shell-panel,
+.gr-shell-statcard,
+.gr-card {
+	background: var(--ds-bg-surface, rgba(255, 251, 245, 0.92));
+	border-color: var(--ds-border-default, rgba(107, 56, 16, 0.16));
+	border-radius: var(--ds-radius-xl, 1.25rem);
+	box-shadow: var(--ds-shadow-sm, 0 4px 10px rgba(73, 34, 10, 0.05));
+}
+
+.gr-heading {
+	font-family: var(--ds-font-heading, var(--gr-typography-fontFamily-heading, Georgia, serif));
+	letter-spacing: -0.01em;
+}
+
+.gr-button--solid {
+	background: var(--ds-action-gradient, linear-gradient(135deg, #8d64d1, #e6a645));
+	box-shadow: var(--ds-shadow-button-primary, 0 18px 40px rgba(148, 74, 0, 0.18));
+	border: 0;
+}
+
+.gr-button--outline,
+.gr-button--ghost {
+	border-color: var(--ds-border-default, rgba(107, 56, 16, 0.16));
 }

--- a/web/src/lib/components/BrandLockup.svelte
+++ b/web/src/lib/components/BrandLockup.svelte
@@ -1,0 +1,76 @@
+<script lang="ts">
+	let {
+		edition,
+		size = 36,
+	}: {
+		edition: string;
+		size?: number;
+	} = $props();
+</script>
+
+<div class="brand-lockup" aria-label={`lesser.host — ${edition}`}>
+	<div
+		class="brand-lockup__mark"
+		style={`--brand-lockup-mark-size: ${size}px;`}
+		aria-hidden="true"
+	>
+		&lt;
+	</div>
+	<div class="brand-lockup__wordmark">
+		<span class="brand-lockup__main">&lt;esser.host</span>
+		<span class="brand-lockup__edition">{edition}</span>
+	</div>
+</div>
+
+<style>
+	.brand-lockup {
+		display: flex;
+		align-items: center;
+		gap: 0.65rem;
+		min-width: 0;
+	}
+
+	.brand-lockup__mark {
+		width: var(--brand-lockup-mark-size, 36px);
+		height: var(--brand-lockup-mark-size, 36px);
+		border-radius: 9px;
+		background: var(--ds-lesser-600, #9333ea);
+		display: grid;
+		place-items: center;
+		color: #fff;
+		font-family: var(--ds-font-heading, Georgia, serif);
+		font-size: calc(var(--brand-lockup-mark-size, 36px) * 0.6);
+		font-weight: 700;
+		line-height: 1;
+		box-shadow: 0 4px 12px rgba(147, 51, 234, 0.35);
+		flex: 0 0 auto;
+	}
+
+	.brand-lockup__wordmark {
+		display: flex;
+		flex-direction: column;
+		line-height: 1.1;
+		min-width: 0;
+	}
+
+	.brand-lockup__main {
+		font-family: var(--ds-font-heading, Georgia, serif);
+		font-size: 1.18rem;
+		font-weight: 700;
+		color: var(--ds-fg-1, #332116);
+		letter-spacing: -0.01em;
+		white-space: nowrap;
+	}
+
+	.brand-lockup__edition {
+		font-size: 0.66rem;
+		font-weight: 700;
+		letter-spacing: 0.14em;
+		text-transform: uppercase;
+		color: var(--ds-fg-3, rgba(51, 33, 22, 0.58));
+		margin-top: 2px;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+</style>

--- a/web/src/lib/components/InstanceDetailShell.svelte
+++ b/web/src/lib/components/InstanceDetailShell.svelte
@@ -134,7 +134,7 @@ Issue: equaltoai/lesser-host#414
 			description="Managed lesser.host instance — release state, configuration, domains, and access keys."
 		>
 			{#snippet actions()}
-				<Link {...linkProps('/portal/fleet')} variant="ghost">Fleet</Link>
+				<Link {...linkProps('/portal')} variant="ghost">Fleet</Link>
 				<Link {...linkProps('/portal')} variant="ghost">Back</Link>
 			{/snippet}
 		</PageTitle>

--- a/web/src/lib/components/OperatorLayout.svelte
+++ b/web/src/lib/components/OperatorLayout.svelte
@@ -3,7 +3,8 @@
 	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
 	import { logout } from 'src/lib/auth/logout';
-	import { Button, Heading, Link, Text } from 'src/lib/ui';
+	import { Button, Link, Text } from 'src/lib/ui';
+	import BrandLockup from './BrandLockup.svelte';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -28,7 +29,7 @@
 <div class="layout layout--operator shell--operator" data-shell="operator">
 	<nav class="layout__sidebar">
 		<div class="layout__brand">
-			<Heading level={2} size="xl">Operator Console</Heading>
+			<BrandLockup edition="Operator console" />
 			<Text size="sm" color="secondary">Managed-hosting control plane</Text>
 		</div>
 		<div class="layout__nav">
@@ -125,16 +126,41 @@
 	.layout {
 		display: flex;
 		min-height: 100vh;
-		background: var(--gr-color-background);
+		background: var(--ds-bg-base, #f8f1e7);
+		background-image: var(--ds-page-gradient);
+		background-attachment: fixed;
+	}
+	.layout--operator {
+		background: #1c1410;
+		background-image:
+			radial-gradient(circle at top right, rgba(178, 80, 24, 0.18), transparent 32rem),
+			radial-gradient(circle at top left, rgba(82, 50, 25, 0.18), transparent 28rem),
+			linear-gradient(180deg, #2a1f17 0%, #1c1410 100%);
+		background-attachment: fixed;
+		color: #faf4ea;
 	}
 	.layout__sidebar {
 		width: 260px;
 		display: flex;
 		flex-direction: column;
-		border-right: 1px solid var(--gr-color-border);
+		border-right: 1px solid var(--ds-border-default, var(--gr-semantic-border-default));
 		padding: var(--gr-spacing-scale-6) var(--gr-spacing-scale-4);
 		gap: var(--gr-spacing-scale-6);
-		background: var(--gr-color-background-surface);
+		background: var(--ds-bg-glass, var(--gr-semantic-background-surface));
+	}
+	.layout--operator .layout__sidebar {
+		border-right: 2px solid rgba(245, 158, 11, 0.55);
+		background: rgba(40, 30, 22, 0.78);
+		color: #faf4ea;
+	}
+	.layout--operator :global(.brand-lockup__main) {
+		color: #faf4ea;
+	}
+	.layout--operator :global(.brand-lockup__edition) {
+		color: rgba(250, 244, 234, 0.58);
+	}
+	.layout--operator :global(.gr-text--color-secondary) {
+		color: rgba(250, 244, 234, 0.68);
 	}
 	/*
 	 * The operator-specific sidebar seam is owned by operator-chrome.css so
@@ -161,6 +187,10 @@
 		gap: var(--gr-spacing-scale-3);
 		padding-top: var(--gr-spacing-scale-4);
 		border-top: 1px solid var(--gr-color-border);
+	}
+	.layout--operator .layout__footer {
+		border-top-color: rgba(255, 235, 200, 0.08);
+		color: rgba(250, 244, 234, 0.78);
 	}
 	.layout__footer :global(button) {
 		justify-content: flex-start;

--- a/web/src/lib/components/PortalLayout.svelte
+++ b/web/src/lib/components/PortalLayout.svelte
@@ -3,7 +3,8 @@
 	import { currentPath, linkProps, navigate } from 'src/lib/router';
 	import { session } from 'src/lib/session';
 	import { logout } from 'src/lib/auth/logout';
-	import { Button, Heading, Link, Text } from 'src/lib/ui';
+	import { Button, Link, Text } from 'src/lib/ui';
+	import BrandLockup from './BrandLockup.svelte';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -25,7 +26,7 @@
 <div class="layout">
 	<nav class="layout__sidebar">
 		<div class="layout__brand">
-			<Heading level={2} size="xl">lesser.host</Heading>
+			<BrandLockup edition="Control plane" />
 		</div>
 		<div class="layout__nav">
 			<Link
@@ -89,16 +90,20 @@
 	.layout {
 		display: flex;
 		min-height: 100vh;
-		background: var(--gr-color-background);
+		background: var(--ds-bg-base, #f8f1e7);
+		background-image: var(--ds-page-gradient);
+		background-attachment: fixed;
 	}
 	.layout__sidebar {
 		width: 260px;
 		display: flex;
 		flex-direction: column;
-		border-right: 1px solid var(--gr-color-border);
+		border-right: 1px solid var(--ds-border-default, var(--gr-semantic-border-default));
 		padding: var(--gr-spacing-scale-6) var(--gr-spacing-scale-4);
 		gap: var(--gr-spacing-scale-6);
-		background: var(--gr-color-background-surface);
+		background: var(--ds-bg-glass, var(--gr-semantic-background-surface));
+		-webkit-backdrop-filter: blur(var(--ds-blur-nav, 24px));
+		backdrop-filter: blur(var(--ds-blur-nav, 24px));
 	}
 	.layout__brand {
 		padding: 0 var(--gr-spacing-scale-2);
@@ -118,7 +123,7 @@
 		flex-direction: column;
 		gap: var(--gr-spacing-scale-3);
 		padding-top: var(--gr-spacing-scale-4);
-		border-top: 1px solid var(--gr-color-border);
+		border-top: 1px solid var(--ds-border-subtle, var(--gr-semantic-border-subtle));
 	}
 	.layout__user {
 		display: flex;

--- a/web/src/lib/components/PortalShell.svelte
+++ b/web/src/lib/components/PortalShell.svelte
@@ -1,15 +1,11 @@
 <!--
 @component
 PortalShell — greater-components Shell + Sidebar + Topbar + PageFrame
-composition for the customer portal's new fleet view.
+composition for the customer portal's fleet view.
 
-This is an ADDITIVE component for M0.11:
-  - It does NOT replace `PortalLayout.svelte` (kept untouched for the
-    legacy `/portal` / `/portal/instances` paths so byte-for-byte
-    compatibility is preserved).
-  - It is currently wired only by the new `/portal/fleet` route.
-  - Subsequent milestones may migrate additional portal sub-views into
-    this shell; this PR doesn't speculate.
+This shell is now the canonical `/portal` surface. The older
+`PortalLayout.svelte` remains only for legacy `/portal/instances` detail
+paths that have not yet been migrated into this shell.
 
 Behavior:
   - `Shell` provides the root grid with a `<main>` landmark
@@ -56,6 +52,7 @@ Issue: equaltoai/lesser-host#391
 	import { logout } from 'src/lib/auth/logout';
 	import { Button, Heading, Link, Text } from 'src/lib/ui';
 	import { portalFleetInstances, clearPortalFleetState } from 'src/lib/portalFleetState';
+	import BrandLockup from './BrandLockup.svelte';
 
 	interface Props {
 		/** Page content rendered inside the shell's PageFrame. */
@@ -108,18 +105,14 @@ Issue: equaltoai/lesser-host#391
 	}
 
 	function isPortalFleetActive(): boolean {
-		return isActive('/portal/fleet');
+		return $currentPath === '/portal' || isActive('/portal/fleet');
 	}
 
 	function isLegacyPortalActive(): boolean {
-		// Matches /portal and /portal/instances + nested paths, but NOT
-		// /portal/fleet, /portal/souls, or /portal/billing — which each
-		// get their own button state below.
+		// Matches only the legacy /portal/instances + nested paths.
 		return (
-			isActive('/portal') &&
-			!isActive('/portal/fleet') &&
-			!isActive('/portal/souls') &&
-			!isActive('/portal/billing')
+			isActive('/portal/instances') &&
+			!isActive('/portal/fleet')
 		);
 	}
 
@@ -138,15 +131,15 @@ Issue: equaltoai/lesser-host#391
 			{
 				id: 'nav.fleet',
 				label: 'Go to Fleet',
-				description: 'Customer fleet view (new shell)',
+				description: 'Customer fleet view',
 				keywords: ['portal', 'instances', 'overview'],
 				shortcut: 'F',
 			},
 			{
 				id: 'nav.legacy-instances',
-				label: 'Go to Instances (legacy)',
-				description: 'Existing /portal/instances list',
-				keywords: ['portal', 'list', 'old'],
+				label: 'Go to Instance list',
+				description: 'Detailed instance list',
+				keywords: ['portal', 'list', 'instances'],
 			},
 			{
 				id: 'nav.souls',
@@ -228,7 +221,7 @@ Issue: equaltoai/lesser-host#391
 		paletteQuery = '';
 		switch (item.id) {
 			case 'nav.fleet':
-				navigate('/portal/fleet');
+				navigate('/portal');
 				return;
 			case 'nav.legacy-instances':
 				navigate('/portal/instances');
@@ -285,11 +278,19 @@ Issue: equaltoai/lesser-host#391
 
 <Shell mainLabel="Customer portal" sidebarPlacement="left" sidebarWidth="md">
 	{#snippet topbar()}
-		<Topbar variant="default">
+		<Topbar variant="default" sticky>
 			{#snippet start()}
-				<div class="portal-shell__brand">
-					<Heading level={2} size="lg">lesser.host</Heading>
+				<div class="portal-shell__crumb">
+					<Heading level={2} size="lg">Portal</Heading>
+					<Text size="sm" color="secondary">Fleet, billing, trust, and soul operations</Text>
 				</div>
+			{/snippet}
+			{#snippet center()}
+				<button class="portal-shell__cmdk-trigger" type="button" onclick={() => (paletteOpen = true)}>
+					<span aria-hidden="true">⌕</span>
+					<span>Search instances, souls, jobs…</span>
+					<span class="portal-shell__kbd">⌘K</span>
+				</button>
 			{/snippet}
 			{#snippet end()}
 				<div class="portal-shell__topbar-end">
@@ -307,9 +308,12 @@ Issue: equaltoai/lesser-host#391
 
 	{#snippet sidebar()}
 		<Sidebar label="Primary navigation">
+			{#snippet header()}
+				<BrandLockup edition="Customer portal" />
+			{/snippet}
 			<div class="portal-shell__nav">
 				<Link
-					{...linkProps('/portal/fleet')}
+					{...linkProps('/portal')}
 					variant="ghost"
 					aria-current={isPortalFleetActive() ? 'page' : undefined}
 				>
@@ -320,7 +324,7 @@ Issue: equaltoai/lesser-host#391
 					variant="ghost"
 					aria-current={isLegacyPortalActive() ? 'page' : undefined}
 				>
-					Instances (legacy)
+					Instance list
 				</Link>
 				<Link
 					{...linkProps('/portal/souls')}
@@ -354,9 +358,24 @@ Issue: equaltoai/lesser-host#391
 					<Link {...linkProps('/operator')} variant="ghost">Operator Console</Link>
 				{/if}
 			</div>
-			<div class="portal-shell__sidebar-footer">
-				<Text size="sm" color="secondary">⌘K for command palette</Text>
-			</div>
+			{#snippet footer()}
+				<div class="portal-shell__sidebar-footer">
+					<Text size="sm" color="secondary">⌘K for command palette</Text>
+					{#if $session}
+						<div class="portal-shell__user-chip">
+							<span class="portal-shell__avatar" aria-hidden="true">
+								{$session.username.slice(0, 2).toUpperCase()}
+							</span>
+							<span class="portal-shell__user-copy">
+								<Text size="sm" weight="medium">@{$session.username}</Text>
+								<Text size="sm" color="secondary">{$session.role} · {$session.method ?? 'session'}</Text>
+							</span>
+						</div>
+					{:else}
+						<Link {...linkProps('/login')} variant="default">Sign in</Link>
+					{/if}
+				</div>
+			{/snippet}
 		</Sidebar>
 	{/snippet}
 
@@ -374,10 +393,11 @@ Issue: equaltoai/lesser-host#391
 />
 
 <style>
-	.portal-shell__brand {
+	.portal-shell__crumb {
 		display: flex;
-		align-items: center;
-		padding: 0 var(--gr-spacing-scale-3);
+		flex-direction: column;
+		justify-content: center;
+		min-width: 0;
 	}
 
 	.portal-shell__topbar-end {
@@ -385,6 +405,38 @@ Issue: equaltoai/lesser-host#391
 		gap: var(--gr-spacing-scale-3);
 		align-items: center;
 		padding: 0 var(--gr-spacing-scale-3);
+	}
+
+	.portal-shell__cmdk-trigger {
+		display: flex;
+		align-items: center;
+		gap: var(--ds-space-2, 0.5rem);
+		min-width: min(26rem, 42vw);
+		border: 1px solid var(--ds-border-subtle, rgba(107, 56, 16, 0.1));
+		border-radius: var(--ds-radius-pill, 999px);
+		padding: 0.42rem 0.75rem;
+		background: var(--ds-bg-raised, rgba(255, 255, 255, 0.72));
+		color: var(--ds-fg-2, rgba(51, 33, 22, 0.78));
+		font: inherit;
+		text-align: left;
+		cursor: pointer;
+		box-shadow: var(--ds-shadow-xs, 0 1px 2px rgba(73, 34, 10, 0.04));
+	}
+
+	.portal-shell__cmdk-trigger:hover {
+		color: var(--ds-fg-1, #332116);
+		border-color: var(--ds-border-default, rgba(107, 56, 16, 0.16));
+	}
+
+	.portal-shell__kbd {
+		margin-left: auto;
+		font-family: var(--ds-font-mono, ui-monospace, monospace);
+		font-size: 0.7rem;
+		background: var(--ds-bg-surface, rgba(255, 251, 245, 0.92));
+		border: 1px solid var(--ds-border-subtle, rgba(107, 56, 16, 0.1));
+		padding: 0.05rem 0.32rem;
+		border-radius: 5px;
+		color: var(--ds-fg-2, rgba(51, 33, 22, 0.78));
 	}
 
 	.portal-shell__nav {
@@ -400,7 +452,44 @@ Issue: equaltoai/lesser-host#391
 	}
 
 	.portal-shell__sidebar-footer {
-		padding: var(--gr-spacing-scale-3);
-		border-top: 1px solid var(--gr-semantic-border-default, var(--gr-color-gray-200));
+		display: flex;
+		flex-direction: column;
+		gap: var(--ds-space-3, 0.75rem);
+	}
+
+	.portal-shell__user-chip {
+		display: flex;
+		align-items: center;
+		gap: var(--ds-space-3, 0.75rem);
+		padding: var(--ds-space-2, 0.5rem);
+		border-radius: var(--ds-radius-lg, 1rem);
+		background: var(--ds-bg-raised, rgba(255, 255, 255, 0.72));
+		border: 1px solid var(--ds-border-subtle, rgba(107, 56, 16, 0.1));
+		min-width: 0;
+	}
+
+	.portal-shell__avatar {
+		width: 32px;
+		height: 32px;
+		border-radius: 999px;
+		background: linear-gradient(135deg, var(--ds-secondary-400, #aa84f2), var(--ds-primary-400, #e6a645));
+		color: white;
+		display: grid;
+		place-items: center;
+		font-weight: 700;
+		font-size: 0.82rem;
+		flex: 0 0 auto;
+	}
+
+	.portal-shell__user-copy {
+		display: flex;
+		flex-direction: column;
+		min-width: 0;
+	}
+
+	@media (max-width: 58rem) {
+		.portal-shell__cmdk-trigger {
+			display: none;
+		}
 	}
 </style>

--- a/web/src/lib/tokens/index.ts
+++ b/web/src/lib/tokens/index.ts
@@ -14,16 +14,14 @@
  *
  * Order matters: `ds.css` defines the `--ds-*` source-of-truth, then
  * `gr-bridge.css` reads those via `var(--ds-*)` to populate `--gr-*`. No
- * consumers are wired yet (M0.2 is scaffold-only); components adopt
- * incrementally as M0 progresses.
+ * The runtime entrypoint (`src/main.ts`) imports this barrel after Greater's
+ * default token CSS so Project 39's Agent Genesis palette overrides the
+ * default Greater scale for all host surfaces.
  *
- * NOTE — operator-chrome.css (M2.1, issue #427) is NOT loaded through this
- * barrel; it is imported directly from `src/main.ts` because (a) this
- * barrel is still scaffold-only and reaches no runtime import path, and
- * (b) the operator chrome must ship today even before the full DS bridge
- * is wired. See arch review 4363557132 on PR #512 for the bundle
- * regression this protects against; see gov-infra/verifiers/sec/operator-chrome-bundled.sh
- * for the CI guard.
+ * NOTE — operator-chrome.css (M2.1, issue #427) remains imported directly
+ * from `src/main.ts` because it is an operator-only skin layered after the
+ * default Agent Genesis bridge. See arch review 4363557132 on PR #512 and
+ * gov-infra/verifiers/sec/operator-chrome-bundled.sh for the bundle guard.
  *
  * Source: docs/design/web-ui-rework-2026-05-24/project/assets/tokens.css
  * Project 39: docs/enumerated-changes-web-ui-rework-2026-05-24.md M0.2

--- a/web/src/lib/tokens/operator-chrome.css
+++ b/web/src/lib/tokens/operator-chrome.css
@@ -10,12 +10,9 @@
  *   docs/design/web-ui-rework-2026-05-24/project/assets/app.css
  *
  * This file is intentionally SELF-CONTAINED — every colour resolves to a
- * literal value rather than to a `--ds-*` token. The `src/lib/tokens/ds.css`
- * + `gr-bridge.css` scaffolding is not yet wired into the runtime bundle
- * (see the M0.2 scaffold-only note in `src/lib/tokens/index.ts`), so this
- * file is consumed directly from `src/main.ts` instead of indirected
- * through the token barrel. That guarantees the operator chrome ships
- * regardless of when the broader DS bridge is plugged in.
+ * literal value rather than depending on token-import order. The global
+ * Agent Genesis DS bridge is imported from `src/main.ts`; operator chrome
+ * then layers on top as the operator-only dark warm-charcoal skin.
  *
  * Two scoping selectors are supported for back-compat:
  *

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,4 +1,7 @@
 import 'src/lib/styles/greater/tokens.css';
+// Project 39 runtime brand/theme bridge: Agent Genesis DS tokens override
+// the default Greater token scale before component CSS consumes them.
+import 'src/lib/tokens';
 import 'src/lib/styles/greater/primitives.css';
 import 'src/lib/styles/greater/shell.css';
 import 'src/lib/styles/greater/host-platform.css';


### PR DESCRIPTION
## Summary

- Consume the upstream AppTheory CDK / FaceTheory asset-serving fixes instead of keeping the lab-only OAI mitigation.
- Add `scripts/verify-facetheory-assets.sh` so deployed `/assets/*` CSS/JS are checked for 2xx, MIME shape, request-id echo, and non-S3-XML bodies.
- Restore the Project 39 branded web shell in lab: `BrandLockup`, customer `PortalShell` at `/portal`, and explicit operator dark chrome.

## Root cause / why

The lab UI recovery had two separate causes:

1. The FaceTheory/AppTheory `/assets/*` delivery path needed the upstream framework fix, not a host-local CloudFront workaround.
2. Project 39 branding/tokens were not on the SSR-discovered runtime import path, and `/portal` was still rendering the legacy Portal Dashboard instead of the Fleet shell.

## Host discipline notes

- **Governance / rubric:** no verifier or pack weakening. `gov-verify-rubric.sh` passes 40/0/0.
- **Multi-tenant isolation:** no tenant-data reads, shared credentials, or cross-tenant control-plane changes.
- **On-chain / soul registry:** no Solidity, mint-signer, Safe-ready, or on-chain-reaching changes.
- **Trust API / CSP:** no trust API auth changes. The web build retains strict-CSP posture and `verify-no-inline-html` passes.
- **Consumer release verification:** no provisioning release-verification bypass or managed-release contract change.
- **AGPL / dependencies:** framework dependency bumps consume published Theory Cloud release tarballs; no proprietary blobs introduced.

## Validation

Run locally on 2026-05-27 from `codex/fix-lab-assets-serving`:

- `git diff --check origin/main...HEAD`
- `go test ./...`
- `cd web && npm run lint`
- `cd web && npm run typecheck`
- `cd web && npm test` — 92 tests passed
- `cd cdk && npm run synth` — passed; emitted existing CDK deprecation/chunk-size warnings
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS, 40 pass / 0 fail / 0 blocked

Lab soak already completed from this branch: `AWS_PROFILE=Lesser theory app up --stage lab --execute` reached stack `UPDATE_COMPLETE`; asset smoke and CDP surface smokes passed for portal and operator shells.