### PR TITLE
fix(portal): M0 correctness and immediate chrome hygiene

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -691,12 +691,15 @@ export class LesserHostStack extends cdk.Stack {
 		});
 		inboundEmailRule.node.addDependency(inboundEmailIdentity);
 
-		provisionRunnerProject.addToRolePolicy(
-			new iam.PolicyStatement({
-				actions: ['sts:AssumeRole'],
-				resources: [`arn:aws:iam::*:role/${managedInstanceRoleName.trim() || defaultManagedInstanceRoleName}`],
-			}),
-		);
+		const managedInstanceRoleArn = `arn:aws:iam::*:role/${managedInstanceRoleName.trim() || defaultManagedInstanceRoleName}`;
+		for (const principal of [provisionRunnerProject, provisionWorkerFn, controlPlaneFn, commWorkerFn]) {
+			principal.addToRolePolicy(
+				new iam.PolicyStatement({
+					actions: ['sts:AssumeRole'],
+					resources: [managedInstanceRoleArn],
+				}),
+			);
+		}
 		provisionWorkerFn.addToRolePolicy(
 			new iam.PolicyStatement({
 				actions: [
@@ -710,34 +713,15 @@ export class LesserHostStack extends cdk.Stack {
 			}),
 		);
 
-		provisionWorkerFn.addToRolePolicy(
-			new iam.PolicyStatement({
-				actions: ['sts:AssumeRole'],
-				resources: [`arn:aws:iam::*:role/${managedInstanceRoleName.trim() || defaultManagedInstanceRoleName}`],
-			}),
-		);
 		if (managedOrgVendingRoleArn.trim()) {
-			provisionWorkerFn.addToRolePolicy(
-				new iam.PolicyStatement({
-					actions: ['sts:AssumeRole'],
-					resources: [managedOrgVendingRoleArn.trim()],
-				}),
-			);
-		}
-
-		commWorkerFn.addToRolePolicy(
-			new iam.PolicyStatement({
-				actions: ['sts:AssumeRole'],
-				resources: [`arn:aws:iam::*:role/${managedInstanceRoleName.trim() || defaultManagedInstanceRoleName}`],
-			}),
-		);
-		if (managedOrgVendingRoleArn.trim()) {
-			commWorkerFn.addToRolePolicy(
-				new iam.PolicyStatement({
-					actions: ['sts:AssumeRole'],
-					resources: [managedOrgVendingRoleArn.trim()],
-				}),
-			);
+			for (const fn of [provisionWorkerFn, controlPlaneFn, commWorkerFn]) {
+				fn.addToRolePolicy(
+					new iam.PolicyStatement({
+						actions: ['sts:AssumeRole'],
+						resources: [managedOrgVendingRoleArn.trim()],
+					}),
+				);
+			}
 		}
 
 		if (managedParentHostedZoneId.trim()) {

--- a/docs/project-42-portal-redesign/README.md
+++ b/docs/project-42-portal-redesign/README.md
@@ -132,6 +132,9 @@ of whether the board is up.
   `audit-mapping.md` in this directory.
 - Prior planning bundle (superseded): `docs/project-39-web-ui-rework-2026-05-24.md`
 - Already-shipped foundation work that this bundle assumes complete:
-  PRs #520, #521, #522 (cost telemetry endpoint, web wiring, SEC-13
-  verifier); #523 (FaceTheory CDN cutover); #524 (Project 39 branded
-  shell + FaceTheory v3.4.2 asset fix).
+  PRs #520, #521, #522 for host-local billing/telemetry scaffolding and SEC-13
+  verifier coverage; #523 (FaceTheory CDN cutover); #524 (Project 39 branded
+  shell + FaceTheory v3.4.2 asset fix). Important caveat: PR #522 does **not**
+  satisfy Project 42 M0.4 by itself. Portal instance cost/usage must read the
+  managed Lesser instance metrics contract, not host-local or synthetic
+  telemetry.

--- a/docs/project-42-portal-redesign/README.md
+++ b/docs/project-42-portal-redesign/README.md
@@ -1,0 +1,137 @@
+# Project 42 — Portal Redesign — planning bundle
+
+This directory supersedes the 2026-05-24 Project 39 planning bundle
+(`docs/project-39-web-ui-rework-2026-05-24.md`,
+`docs/roadmap-web-ui-rework-2026-05-24.md`,
+`docs/enumerated-changes-web-ui-rework-2026-05-24.md`,
+`docs/governance-rubric-web-ui-rework-2026-05-24.md`).
+
+Arch-driven board (created 2026-05-27): https://github.com/orgs/equaltoai/projects/42
+Parent issue: https://github.com/equaltoai/lesser-host/issues/525
+Older board (Project 39, superseded but still public):
+https://github.com/orgs/equaltoai/projects/39
+
+The earlier bundle landed the FaceTheory adoption, the AppTheory CDK upgrade,
+the strict-CSP / OAC asset transport, the cost-telemetry endpoint + web
+wiring, the SEC-13 verifier, and the Project 39 design tokens + branded
+shell on lab. It did **not** deliver the per-surface content redesign
+specified in the design fixture, and an automated browser audit on
+2026-05-27 confirmed the gap is substantial (6 P0 correctness bugs and a
+long list of P1/P2 design absences across Fleet, Instance Detail, Billing,
+Souls, Trust, Account, and the shell).
+
+This bundle is the corrected plan for **closing that gap**, organised under
+explicit rules that the previous bundle violated.
+
+## The design source of truth
+
+The canonical design is the Claude Design handoff bundle at:
+
+> https://api.anthropic.com/v1/design/h/sNM_e6zaXsWRLX9VetdC4w
+
+The bundle is a tarball; the readable assets are at
+`lesser-host/project/src/*.jsx`, `lesser-host/project/assets/*.css`,
+`lesser-host/chats/chat1.md`, and `lesser-host/README.md`. A working
+extraction lives at `/tmp/design-sNM/lesser-host/` on the steward's host.
+
+Per the bundle README, the design medium is HTML/CSS/JS prototypes — the
+job is to **recreate them pixel-perfectly** in the target codebase
+(Svelte 5 + greater-components). Match the visual output; do **not** copy
+the prototype's internal structure unless it happens to fit.
+
+`design-spec-summary.md` in this directory captures the design intent
+per surface with file:line references back into the bundle.
+
+## What the previous plan got wrong
+
+Three structural failings, documented so the new plan does not repeat
+them:
+
+1. **Macro-milestones bundled too much.** Prior M0 contained 29 enumerated
+   sub-tasks across FaceTheory adoption (framework), CDK plumbing,
+   design tokens, route porting, web build tests, shell adoption,
+   `CommandPalette`, `FleetCard`, `CostGauge`, and `ActivitySparkline`.
+   That is six separable concerns. The bundle's macro-milestone never
+   produced a single coherent PR.
+2. **UI and backend rode together.** Cost-telemetry endpoint, web wiring,
+   verifier, and pack bump were all under one "M3" header even though
+   each is a distinct PR with distinct review needs.
+3. **No per-surface design-fidelity gate.** Each slice was self-graded
+   against tests and the gov rubric, neither of which catches "the
+   surface does not look like the design." Surfaces drifted while
+   plumbing landed green.
+
+## The rules this bundle enforces
+
+These rules are non-negotiable for the work the bundle scopes. The
+steward refuses milestones that violate them.
+
+1. **One milestone, one branch, one PR, ≤ 8 tasks, single concern.**
+   No mixing primitives with shell with content. No mixing UI with
+   backend. Each PR is reviewable in ≤ 20 minutes.
+2. **Backend and UI ship in separate milestones.** If a surface needs a
+   new endpoint, the endpoint ships in milestone N (handler + DTO +
+   redaction proof + unit test). The UI consuming it ships in milestone
+   N+1. Never both in one PR.
+3. **Per-surface UI milestones consume already-shipped primitives.**
+   Primitives are added in foundation milestones, not invented inline
+   on a content milestone.
+4. **P0 correctness is its own slice.** Bug fixes do not ride alongside
+   design milestones. M0 of this bundle is a bug-fix-only PR.
+5. **Foundation precedes per-surface work.** Primitives (M1), shell (M2),
+   and the command palette (M3) land before any per-surface UI milestone.
+6. **Each design-milestone PR ships a side-by-side fidelity artifact.**
+   A pair of screenshots — design fixture and live surface — at the same
+   viewport, committed under
+   `gov-infra/evidence/design-fidelity/<milestone>/<surface>.{png,md}`.
+   The PR cannot merge if the comparison is visually wrong, even if all
+   tests pass and the gov rubric is green. This is the gate the previous
+   bundle did not have.
+7. **One surface at a time.** Avoids merge conflicts in the shell and
+   keeps each PR independently reviewable.
+
+## Layered structure
+
+| Layer | Purpose | Milestones |
+|---|---|---|
+| 0 — Correctness | Fix the 6 P0 bugs from the audit. No design work. | M0 |
+| 1 — Foundation | Primitives, shell redesign, ⌘K palette. | M1, M2, M3 |
+| 2 — Customer portal surfaces | One UI milestone per surface; data milestone only if endpoint is missing. | M4..M17 |
+| 3 — Operator console | Dark warm-charcoal chrome + per-surface. Planned only after Layer 2 lands. | placeholder |
+
+## Where the docs live
+
+- `README.md` (this file) — rules, layering, design source of truth.
+- `design-spec-summary.md` — per-surface design intent with file:line
+  references back into the bundle.
+- `audit-mapping.md` — every audit row (P0/P1/P2/P3) cross-referenced
+  to the milestone that owns it.
+- `milestones/00-index.md` — milestone index with one-line summaries.
+- `milestones/01-m0-p0-correctness.md` — M0 detail.
+- `milestones/02-m1-primitives.md` — M1 detail.
+- `milestones/03-m2-shell.md` — M2 detail.
+- `milestones/04-m3-cmdk.md` — M3 detail.
+- `milestones/05-m4-fleet-ui.md` through `18-m17-account-ui.md` —
+  outline only; detail is filled in only when the predecessor merges.
+- `milestones/operator-console-layer.md` — Layer 3 placeholder.
+
+## Tracking
+
+Project tracking (Projects v2 board, GitHub issues, sub-issue
+relationships) is driven by **arch.equaltoai@theorymcp.ai**. This
+bundle is the host steward's proposed input to that planning step;
+arch may adjust milestone ordering, names, or labels before issues are
+filed. Until arch's board exists, M0 may still begin work locally on
+its dedicated branch — the rules above govern the PR shape regardless
+of whether the board is up.
+
+## Cross-references
+
+- Design bundle: https://api.anthropic.com/v1/design/h/sNM_e6zaXsWRLX9VetdC4w
+- Audit (2026-05-27): in conversation transcript; rows mapped under
+  `audit-mapping.md` in this directory.
+- Prior planning bundle (superseded): `docs/project-39-web-ui-rework-2026-05-24.md`
+- Already-shipped foundation work that this bundle assumes complete:
+  PRs #520, #521, #522 (cost telemetry endpoint, web wiring, SEC-13
+  verifier); #523 (FaceTheory CDN cutover); #524 (Project 39 branded
+  shell + FaceTheory v3.4.2 asset fix).

--- a/docs/project-42-portal-redesign/audit-mapping.md
+++ b/docs/project-42-portal-redesign/audit-mapping.md
@@ -1,0 +1,95 @@
+# Audit → milestone mapping
+
+Every row from the 2026-05-27 portal audit, cross-referenced to the
+milestone that owns it. Surfaces anything the milestone list missed
+and lets reviewers verify completeness as milestones land.
+
+Audit source: in-conversation transcript, 2026-05-27. Priorities are
+the audit's own (P0/P1/P2/P3); ownership column points to the new
+milestone bundle in this directory.
+
+## P0 — correctness
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 1 | Souls tab shows empty state despite bound souls (data fetch bug) | Instance → Souls | **M0** — task 5 |
+| 2 | Trust and Account nav use wrong base path (`/trust`, `/account` outside `/portal/*`) | Nav | **M0** — task 1 |
+| 3 | Trust page breaks out of portal chrome | Trust | **M0** — task 1 (route fix restores chrome) |
+| 4 | Billing page h1 shows "Portal Dashboard" | Billing | **M0** — task 2 |
+| 5 | Cost telemetry HTTP 500 error | Instance → Cost | **M0** — task 4 |
+| 6 | Provisioning form shown on active/healthy instances | Instance → Overview | **M0** — task 3 |
+
+## P1 — design absences (Fleet + Instance Detail)
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 1 | Fleet dashboard missing greeting, summary, stat cards, right column | Fleet | **M4** — Fleet UI |
+| 2 | Fleet cards show no activity data (users, posts, sparklines) | Fleet | **M4** UI + **M5** data |
+| 3 | Fleet missing Provision-instance CTA + Cards/Table toggle | Fleet | **M4** |
+| 4 | `{slug}` template variable unrendered in Instances description | Instance list | **M0** — task 6 |
+| 5 | Instance Overview missing stat cards, activity charts, souls preview | Instance Overview | **M6** — Overview UI |
+| 6 | Instance Overview missing right rail (Snapshot / Operate / Owners) | Instance Overview | **M6** |
+| 7 | Stack section missing icons + per-component Manage / Re-wire actions | Instance Overview | **M6** |
+| 8 | Two unlabeled Refresh buttons on Instance Overview | Instance Overview | **M6** |
+
+## P1 — design absences (Cost & Config)
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 9 | Wrong metrics on Cost tab (credits vs. dollars/GB-sec) | Instance → Cost | **M8** — Cost & usage UI (post-M0 fix) |
+| 10 | No compute / egress breakdown | Instance → Cost | **M8** |
+| 11 | Configuration tab missing identity + federation sections | Instance → Config | **M9** — Configuration UI |
+| 12 | Inconsistent toggle sizing in Config | Instance → Config | **M9** |
+| 13 | Tab named "Config" not "Configuration" | Instance → Config | **M9** |
+
+## P1 — design absences (Souls)
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 14 | Instance Souls tab missing table format + "Request soul" CTA | Instance → Souls | **M10** — Souls tab UI |
+| 15 | Souls top-level is legacy-framed card list; no roster table | Souls | **M13** — Souls top-level UI |
+| 16 | Souls page missing Roster Status summary + Minting guidance | Souls | **M13** |
+| 17 | Souls page missing "Request a soul" CTA | Souls | **M13** |
+
+## P1 — design absences (Billing + Trust)
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 18 | Billing missing spend analytics (4 metric cards, MAU, post denom) | Billing | **M11** — Billing UI |
+| 19 | Billing missing weekly stacked bar chart | Billing | **M11** |
+| 20 | Billing missing invoice history | Billing | **M12** — Billing data (invoices) |
+| 21 | Billing missing payment-method display | Billing | **M12** |
+| 22 | Trust is API explorer, not federation health dashboard | Trust | **M15** UI + **M16** data |
+| 23 | Trust missing federation health stats (peers, warnings, severed, sig fails) | Trust | **M15** + **M16** |
+| 24 | Trust missing peer constellation visualisation | Trust | **M15** |
+| 25 | Trust missing Trust-score gauge panel | Trust | **M15** |
+| 26 | Trust missing Vouches from peers panel | Trust | **M15** + **M16** |
+
+## P2 — shell + chrome
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 1 | Sidebar missing grouped sections (Overview / Instances / Agents / Settings) | Nav | **M2** — shell |
+| 2 | Sidebar missing per-instance entries with status dots + alert badges | Nav | **M2** |
+| 3 | No notification bell in topbar | Nav | **M2** |
+| 4 | No Operator console button at sidebar footer | Nav | **M2** |
+| 5 | Sidebar footer shows raw wallet hash instead of display name | Nav | **M0** — task 7 (immediate fix), retained by **M2** |
+| 6 | No ⌘K command palette | Nav | **M3** — ⌘K |
+
+## P3 — polish
+
+| # | Audit row | Surface | Owner |
+|---|---|---|---|
+| 1 | Timestamps as raw ISO 8601 strings (not human dates / relatives) | Instance → Overview | **M6** |
+| 2 | Key IDs unformatted, no truncation or copy buttons | Instance → Keys | **M9** (Keys tab UI) |
+| 3 | "No budget set" message has no action path | Fleet | **M4** |
+
+## Cross-surface concerns
+
+| Concern | Owner |
+|---|---|
+| Each new milestone PR commits a side-by-side `gov-infra/evidence/design-fidelity/<milestone>/<surface>.{png,md}` artifact | Every milestone (per Rule 6) |
+| Token bridge: any design `--ds-*` token unmapped to host's existing token set is added in M1 | **M1** — primitives |
+| No new external script origins; CSP single-origin preserved | Every milestone (per stewardship rules) |
+| Instance API-key hashes remain `sha256(raw)`; raw keys never returned on re-read | Out of scope for this bundle; existing rule |
+| AGPL header presence on new Svelte files | Every milestone; gov rubric CMP |

--- a/docs/project-42-portal-redesign/design-spec-summary.md
+++ b/docs/project-42-portal-redesign/design-spec-summary.md
@@ -1,0 +1,327 @@
+# Project 42 — Portal Redesign — design spec summary
+
+Per-surface summary of the design fixture
+(`https://api.anthropic.com/v1/design/h/sNM_e6zaXsWRLX9VetdC4w`,
+extracted to `/tmp/design-sNM/lesser-host/` on the steward's host).
+
+Each section lists:
+
+- **Intent** — one paragraph of what the design wants the surface to do.
+- **Reference** — file:line into the design fixture.
+- **Primitives consumed** — the design's component vocabulary the
+  surface depends on (drives the Foundation milestones).
+- **Data shown** — what data needs to be on the wire to render this
+  fully (drives whether the surface needs a backend milestone).
+
+When a surface lists data that the existing host endpoints already
+provide, the surface's milestone is UI-only. When data is missing,
+a backend milestone precedes the UI milestone.
+
+---
+
+## Chrome — PortalShell (3-column app chassis)
+
+**Intent.** A persistent 3-column layout: grouped sidebar (Overview /
+Instances / Agents / Settings) + main content + optional contextual
+right rail. Sidebar shows per-instance entries with status dots and
+alert badges. Topbar carries breadcrumbs, the ⌘K search trigger, and
+a notifications bell. Sidebar footer carries the user chip (display
+name, role · auth method, sign-out) and — for admins — an "Operator
+console" button.
+
+**Reference.** `project/src/shell.jsx:18–186` (Sidebar, Topbar,
+ContentWithRail, PageHeader, PortalShell).
+
+**Primitives consumed.** `BrandMark`, `Avatar`, `Eyebrow`, `Badge`,
+status `dot` element, `IcSearch`, `IcBell`, `IcLogout`, `IcShield`,
+crumb separator.
+
+**Data shown.** Session display name, role, auth method; instance
+list (slug, status, alert flag) — already on the wire.
+
+---
+
+## Chrome — Command Palette (⌘K)
+
+**Intent.** A global ⌘K (and Ctrl-K) keybinding opens a centered
+overlay with a search input and four groups: Navigate, Actions,
+Instances, Souls. Items fuzzy-filter against label and hint. Enter
+navigates; Escape closes.
+
+**Reference.** `project/src/shell.jsx:249–329` (CommandPalette),
+`project/src/data.jsx:179–192` (COMMAND_PALETTE seed groups).
+
+**Primitives consumed.** Modal backdrop, search input, group label,
+item row, `kbd` chip, `IcSearch`, `IcArrowRight`.
+
+**Data shown.** Static action seed + dynamic instance + soul lists —
+all client-side, no new endpoint.
+
+---
+
+## Portal — Fleet (`/portal`)
+
+**Intent.** Personalised landing. Greeting + one-sentence smart
+summary at the top. Four metric cards (Live instances, Souls, MTD
+spend, Federation). A "Fleet" panel with one card per instance:
+status dot, CostGauge donut, 7-day activity sparkline, four metric
+chips (Souls, Active users, Posts 24h, Federation). Right rail:
+Cost pulse (live), Right-now/Provisioning, Heads-up/Alerts.
+
+**Reference.** `project/src/portal-pages.jsx:3–165` (PortalHome,
+InstanceCard).
+
+**Primitives consumed.** `PageHeader`, `Panel`, `Metric`,
+`InstanceCard`, `CostGauge`, `Sparkline`, `ProgressBar`,
+`Badge`, `Tabs` (Cards/Table toggle), `Button`, `Alert`,
+`Eyebrow`, live-dot indicator.
+
+**Data shown.** Per-instance: slug, domain, stage, status, region,
+spend, budget, projected, souls, peers, severed, sparkActivity,
+sparkCost, activeUsers, posts24h, sigFails, provisioning state.
+The existing `portalListInstances` + `portalBilling` endpoints cover
+most fields; **activeUsers, posts24h, sigFails, sparkActivity,
+sparkCost, severed** are missing from the host-side portal endpoints
+and require a backend milestone (M5).
+
+---
+
+## Portal — Instance Detail (`/portal/instances/{slug}`)
+
+**Intent.** Tabbed instance shell with six tabs: Overview, Cost &
+usage, Configuration, Domains, Keys, Souls. Persistent right rail
+with three panels: Snapshot (Instance ID, Region, Created, Domain,
+Anchor freshness), Operate (Refresh anchor, Export config, Open
+config…), Owners (avatar, handle, role).
+
+**Reference.** `project/src/portal-pages.jsx:167–250` (InstanceDetail,
+Tabs wiring, right rail).
+
+**Primitives consumed.** `PageHeader` (with embedded badge + mono
+domain), `Tabs` (with badges), `Panel`, `DL`, `DLItem`, `Avatar`,
+`Button`.
+
+**Data shown.** Instance metadata (already on the wire), souls
+filtered by instance (already on the wire), owner list (needs
+backend if not already exposed).
+
+### Tab: Overview
+
+**Intent.** Four metric cards (MTD spend, Active users 30d, Posts
+24h, Sig failures). A **Stack card** (Lesser version, Body version
+or "Add agentic", MCP wiring state, drift warning). A 7-day Activity
+panel with two sparklines (Posts federated+local, Daily spend). A
+Souls preview panel listing the souls bound to this instance.
+
+**Reference.** `project/src/portal-pages.jsx:252–301` (InstanceOverview);
+Stack card lives in `project/src/releases.jsx` (StackCard).
+
+**Primitives consumed.** `Metric`, `StackCard`, `Panel`, `Sparkline`,
+`Avatar`, `SoulStageBadge`, `Button`.
+
+**Data shown.** activeUsers, posts24h, sigFails, sparkActivity,
+sparkCost — same data the Fleet card needs; same backend gap.
+Stack card needs Lesser version, Body version, MCP-wiring state —
+**these are already plumbed** through host's instance state model.
+
+### Tab: Cost & usage
+
+**Intent.** Three header cards (MTD vs budget with progress, Compute
+GB-sec sparkline, Egress GB), a "Where the dollars go" service-level
+breakdown table with progress bars, and a Budget alarms panel with
+configurable thresholds.
+
+**Reference.** `project/src/portal-pages.jsx:303–378`
+(InstanceCostUsage, BudgetRow).
+
+**Primitives consumed.** `Panel`, `Sparkline`, `Badge`, `ProgressBar`,
+`Switch`, `Button`, `gtable` (data table).
+
+**Data shown.** Real-time cost telemetry **already shipped** in PR
+#522. The layout / breakdown table / budget alarm rows need UI work
+only; no new backend.
+
+### Tab: Configuration
+
+**Intent.** Three sections (Instance identity, Federation policy with
+toggle rows, Rate limits).
+
+**Reference.** `project/src/portal-pages.jsx:380–423`.
+
+**Primitives consumed.** `Panel`, `DL`, `DLItem`, `Switch`,
+`ConfigToggle` row primitive.
+
+**Data shown.** Instance config — already on the wire via existing
+config endpoints.
+
+### Tab: Domains
+
+**Intent.** Table of attached domains (name, role, state, TLS, issued
+date) with an "Add domain" CTA.
+
+**Reference.** `project/src/portal-pages.jsx:425–449`.
+
+**Primitives consumed.** `Panel`, `gtable`, `Badge`, `Button`.
+
+**Data shown.** Domain list — already on the wire.
+
+### Tab: Keys
+
+**Intent.** Table of API keys (label, masked token, scopes, created,
+last used) with revoke and issue actions.
+
+**Reference.** `project/src/portal-pages.jsx:451–476`.
+
+**Primitives consumed.** `Panel`, `gtable`, `CopyChip`, `Button`.
+
+**Data shown.** Key metadata — already on the wire.
+
+### Tab: Souls
+
+**Intent.** Table of souls bound to this instance (avatar + handle,
+stage, model, anchor freshness, tips MTD) with a "Request soul" CTA.
+
+**Reference.** `project/src/portal-pages.jsx:478–510` (InstanceSouls,
+SoulStageBadge).
+
+**Primitives consumed.** `Panel`, `gtable`, `Avatar`, `SoulStageBadge`,
+`Badge`, `Button`.
+
+**Data shown.** Soul list — already on the wire. Audit P0 bug: the
+existing fetch returns empty for instances with bound souls. M0
+investigates and fixes the fetch, not the layout.
+
+---
+
+## Portal — Billing (`/portal/billing`)
+
+**Intent.** Spend analytics. Four metric cards (MTD, Projected EOM,
+Per-active-user cost, Per-federated-post cost). Stacked weekly bar
+chart (5 weeks, stacks by instance). Per-instance breakdown table
+with burn progress. Right rail: This month (with sparkline),
+Payment method, Recent invoices.
+
+**Reference.** `project/src/portal-pages-2.jsx:3–169` (PortalBilling).
+
+**Primitives consumed.** `PageHeader`, `Metric`, `Panel`,
+`ProgressBar`, stacked-bar primitive (per-week aggregation),
+`gtable`, `Badge`, `Button`.
+
+**Data shown.** Per-instance MTD spend, budget, projected, accent
+colour. Weekly aggregate of spend stacked by instance. MAU + per-
+post denominators (computed). Invoice history. Payment method
+(masked card + expiry).
+
+Backend gaps: **invoice history** and **payment-method display**
+likely need new control-plane handlers (or new fields on an existing
+one). The weekly stacked aggregate may need a new aggregation
+endpoint or can be computed in the SPA from existing daily data.
+
+---
+
+## Portal — Souls top-level (`/portal/souls`)
+
+**Intent.** Roster of soul-bound agents tied to the customer's
+instances. Filterable table (All / Graduated / In review tabs) with
+columns: Soul, Instance, Stage, Anchor, Model, Tips · May. Right
+rail: Roster status (totals by stage), Soul minting guidance.
+
+**Reference.** `project/src/portal-pages-2.jsx:171–249` (PortalSouls).
+
+**Primitives consumed.** `PageHeader`, `Panel`, `Tabs`, `gtable`,
+`Avatar`, `SoulStageBadge`, `Badge`, `DL`, `DLItem`, `Button`.
+
+**Data shown.** Soul roster — already on the wire.
+
+---
+
+## Portal — Soul Detail (`/portal/souls/{handle}`)
+
+**Intent.** Per-soul detail. Manifest (handle, stage, model,
+instance, requested, graduated, reviewer). Anchor gauge. Tip
+earnings (this month + last + split). Three metric cards (Posts 30d,
+Followers, Avg tip). Continuity-loop 7-day bar chart. Activity
+timeline.
+
+**Reference.** `project/src/portal-pages-2.jsx:251–369` (SoulDetail).
+
+**Primitives consumed.** `PageHeader` (with avatar + handle layout),
+`Panel`, `DL`, `DLItem`, `Avatar`, `CostGauge`, `Metric`, bar-chart
+primitive, activity timeline row, `Alert`, `Badge`, `Button`.
+
+**Data shown.** Soul manifest, anchor state, tip split, 7-day
+continuity signals, activity events. The bar-chart + continuity
+signal feed may need a backend milestone if not already exposed.
+
+---
+
+## Portal — Trust (`/portal/trust`)
+
+**Intent.** Federation health dashboard. Four metric cards (Reachable
+peers, Warnings, Severed last-30d, Sig failures 24h). Peer
+constellation grid (each square = one peer with status dot, last
+fetch time, follower count). Two sparkline panels (HTTP-sig
+failures, Inbound queue depth). Right rail: Trust score gauge,
+Vouches from peers (ranked bars), Severed alert.
+
+**Reference.** `project/src/portal-pages-2.jsx:371–469` (PortalTrust).
+
+**Primitives consumed.** `PageHeader`, `Metric`, `Panel`, `Sparkline`,
+`Alert`, `ProgressBar`, `CostGauge` (re-used as trust gauge),
+`peer` constellation grid primitive, dot indicator, `Badge`,
+`Button`.
+
+**Data shown.** Federation peer roll-up (reachable, warning,
+severed), sig-failure counters, inbound queue depth, trust score,
+vouches. **Most of this is not on the wire today** — Trust UI today
+is an attestation API explorer. A trust-data milestone precedes the
+trust-UI milestone.
+
+The existing trust attestation endpoints stay; this is a new
+operator-facing data surface, not a replacement of the attestation
+API.
+
+---
+
+## Portal — Account (`/portal/account`)
+
+**Intent.** Slim identity + session view. Identity DL (username,
+display name, email, role). Session DL (method, wallet, token
+expiry, IP) with Rotate-token + Sign-out-all actions.
+
+**Reference.** `project/src/portal-pages-2.jsx:471–500` (PortalAccount).
+
+**Primitives consumed.** `PageHeader`, `Panel`, `DL`, `DLItem`,
+`Button`.
+
+**Data shown.** Session metadata — already on the wire.
+
+---
+
+## Operator console (Layer 3, deferred)
+
+The design also includes a complete Operator console with distinct
+dark warm-charcoal chrome (`project/src/operator-pages.jsx`,
+`project/src/releases.jsx`). Layer 3 of this bundle plans those
+surfaces (Dashboard, Provisioning list + job detail, Approvals tabs,
+Audit, Releases timelines + Stack Matrix, Instances, Tip registry,
+Soul registry). Detailed planning happens after Layer 2 lands.
+
+See `milestones/operator-console-layer.md` for the placeholder.
+
+---
+
+## Tokens and CSS
+
+The design provides:
+
+- `assets/tokens.css` — the `--ds-*` design-token surface (typography,
+  colour, spacing, radius, shadow).
+- `assets/app.css` — component-level CSS bound to those tokens.
+
+Host's Project 39 design tokens (Agent Genesis + Greater defaults +
+host bridge) are already on the runtime path per PR #524. The
+design's `--ds-*` names should map onto the existing host token set;
+where they don't, the **Foundation primitives milestone (M1)** adds
+the missing mappings. Token additions are a foundation concern, not
+a per-surface one.

--- a/docs/project-42-portal-redesign/design-spec-summary.md
+++ b/docs/project-42-portal-redesign/design-spec-summary.md
@@ -137,9 +137,11 @@ configurable thresholds.
 **Primitives consumed.** `Panel`, `Sparkline`, `Badge`, `ProgressBar`,
 `Switch`, `Button`, `gtable` (data table).
 
-**Data shown.** Real-time cost telemetry **already shipped** in PR
-#522. The layout / breakdown table / budget alarm rows need UI work
-only; no new backend.
+**Data shown.** Real managed Lesser instance usage/cost metrics. PR
+#522 shipped host-local telemetry scaffolding, but it does **not** satisfy the
+portal instance data source by itself. M0.4 wires the existing portal cost route
+to the managed Lesser metrics contract; M8 is UI/layout work on top of that
+route, not permission to fall back to host-local or synthetic telemetry.
 
 ### Tab: Configuration
 

--- a/docs/project-42-portal-redesign/milestones/00-index.md
+++ b/docs/project-42-portal-redesign/milestones/00-index.md
@@ -1,0 +1,74 @@
+# Milestones — index
+
+One-line summary for every milestone in the bundle. Each milestone is
+its own branch, one PR, ≤ 8 tasks, single concern. Detail docs are
+filled in only when the predecessor merges (except the first four,
+which are detailed up front).
+
+## Layer 0 — correctness
+
+| ID | Title | Branch | Detail |
+|---|---|---|---|
+| M0 | P0 correctness bundle (6 tasks, no design changes) | `aron/portal-m0-p0-correctness` | [01-m0-p0-correctness.md](01-m0-p0-correctness.md) |
+
+## Layer 1 — foundation
+
+| ID | Title | Branch | Detail |
+|---|---|---|---|
+| M1 | Foundation primitives — CostGauge, Sparkline, Metric, Eyebrow, gauge variants | `aron/portal-m1-primitives` | [02-m1-primitives.md](02-m1-primitives.md) |
+| M2 | PortalShell redesign — grouped sidebar, per-instance entries, identity chip, bell, ⌘K trigger | `aron/portal-m2-shell` | [03-m2-shell.md](03-m2-shell.md) |
+| M3 | ⌘K command palette | `aron/portal-m3-cmdk` | [04-m3-cmdk.md](04-m3-cmdk.md) |
+
+## Layer 2 — customer portal surfaces
+
+Each surface is split into a UI-only milestone, and (when needed) a
+data milestone that lands first. Outlines below; detail filled in
+when the predecessor merges.
+
+| ID | Title | Branch | Detail |
+|---|---|---|---|
+| M4 | Fleet UI — greeting + summary + 4 metric cards + InstanceCard grid + right rail | `aron/portal-m4-fleet-ui` | [05-m4-fleet-ui.md](05-m4-fleet-ui.md) |
+| M5 | Fleet data — active users / posts 24h / sig fails / spark feeds on portal-list-instances | `aron/portal-m5-fleet-data` | [06-m5-fleet-data.md](06-m5-fleet-data.md) |
+| M6 | Instance Detail Overview UI — 4 metric cards + Stack card + Activity panel + Souls preview + right rail | `aron/portal-m6-instance-overview-ui` | [07-m6-instance-overview-ui.md](07-m6-instance-overview-ui.md) |
+| M7 | Instance Detail Overview data — owners endpoint if missing; sparkline backfill | `aron/portal-m7-instance-overview-data` | [08-m7-instance-overview-data.md](08-m7-instance-overview-data.md) |
+| M8 | Instance Detail Cost & usage UI — "Where the dollars go" table + budget-alarm rows | `aron/portal-m8-instance-cost-ui` | [09-m8-instance-cost-ui.md](09-m8-instance-cost-ui.md) |
+| M9 | Instance Detail Configuration + Keys UI — identity / federation / limits sections; Keys formatting | `aron/portal-m9-instance-config-keys-ui` | [10-m9-instance-config-keys-ui.md](10-m9-instance-config-keys-ui.md) |
+| M10 | Instance Detail Souls tab UI — table + "Request soul" CTA | `aron/portal-m10-instance-souls-ui` | [11-m10-instance-souls-ui.md](11-m10-instance-souls-ui.md) |
+| M11 | Billing UI — 4 metric cards + weekly stacked bar + breakdown table | `aron/portal-m11-billing-ui` | [12-m11-billing-ui.md](12-m11-billing-ui.md) |
+| M12 | Billing data — invoices history + payment-method endpoint | `aron/portal-m12-billing-data` | [13-m12-billing-data.md](13-m12-billing-data.md) |
+| M13 | Souls top-level UI — roster table + Roster Status + Minting guidance | `aron/portal-m13-souls-top-ui` | [14-m13-souls-top-ui.md](14-m13-souls-top-ui.md) |
+| M14 | Soul Detail UI — manifest + anchor gauge + continuity-loop + activity timeline | `aron/portal-m14-soul-detail-ui` | [15-m14-soul-detail-ui.md](15-m14-soul-detail-ui.md) |
+| M15 | Trust UI — federation health dashboard + peer constellation + sparklines | `aron/portal-m15-trust-ui` | [16-m15-trust-ui.md](16-m15-trust-ui.md) |
+| M16 | Trust data — federation peer roll-up + sig-fail counters + trust score + vouches endpoint | `aron/portal-m16-trust-data` | [17-m16-trust-data.md](17-m16-trust-data.md) |
+| M17 | Account UI — slim identity + session view; preserved current behaviours | `aron/portal-m17-account-ui` | [18-m17-account-ui.md](18-m17-account-ui.md) |
+
+## Layer 3 — operator console
+
+Detailed planning deferred until Layer 2 lands. Placeholder lives at
+[operator-console-layer.md](operator-console-layer.md).
+
+## Dependency posture
+
+- **M0** has no dependencies.
+- **M1, M2, M3** depend on M0 landing (so the legacy bugs don't drift
+  back in during foundation work).
+- **M4 onward** depend on M1, M2, M3 landing (primitives + shell +
+  ⌘K must be in place before any per-surface UI work).
+- **Data milestones** (M5, M7, M12, M16) land before their UI
+  counterparts.
+- The remaining UI milestones (M4, M6, M8, M9, M10, M11, M13, M14,
+  M15, M17) are independently sequenceable after their data
+  prerequisites — arch may reorder to optimise reviewer load or
+  customer visibility.
+
+## Acceptance contract (applies to every milestone)
+
+Per the bundle README:
+
+- ≤ 8 tasks; single concern; one PR off `main`.
+- Each design-touching milestone commits a side-by-side fidelity
+  artifact under
+  `gov-infra/evidence/design-fidelity/<milestone>/<surface>.{png,md}`.
+- Gov rubric green; no CSP loosening; no new external origins; AGPL
+  headers on new files.
+- Lab deploy + visual smoke against the design fixture before merge.

--- a/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
+++ b/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
@@ -4,14 +4,15 @@
 **PR title (arch-specified).** `fix(portal): M0 correctness and immediate chrome hygiene`
 **Project / parent.** equaltoai/projects/42 · parent issue `equaltoai/lesser-host#525`
 **Source brief.** `arch.equaltoai@theorymcp.ai` delivery
-`delivery-d08bce036c8f3243` (2026-05-27 17:48 UTC).
-**Concern.** Six P0 audit rows + two chrome-hygiene rows, total
-eight tasks. No design changes, no new components, no new endpoints,
-no token changes.
+`delivery-d08bce036c8f3243` (2026-05-27 17:48 UTC), corrected for
+M0.4 in `delivery-3ef80b6c7ccc6fea` (2026-05-27 18:32 UTC).
+**Concern.** Six P0 audit rows + two chrome-hygiene rows, total eight
+tasks. This is not a redesign milestone. Seven tasks are UI/chrome
+correctness fixes; M0.4 is the corrected backend data-source fix that
+wires the existing portal cost route to managed Lesser instance metrics.
 
-Per the bundle rules, this milestone exists separately from any
-design work so the legacy portal is stable before foundation
-redesign begins.
+Per the bundle rules, this milestone exists separately from design work
+so the legacy portal is stable before foundation redesign begins.
 
 ## Scope — sub-issues (≤ 8 tasks)
 
@@ -22,165 +23,107 @@ Arch-created sub-issues under parent `#525`:
 | 1 | `#526` M0.1 | Route Trust and Account inside portal chrome |
 | 2 | `#527` M0.2 | Correct Billing page heading |
 | 3 | `#528` M0.3 | Hide provisioning form for live instances |
-| 4 | `#529` M0.4 | Degrade cost telemetry failure without hiding root cause |
+| 4 | `#529` M0.4 | Wire portal cost/usage to managed Lesser instance metrics |
 | 5 | `#530` M0.5 | Fix Instance Souls bound-agent fetch |
 | 6 | `#531` M0.6 | Remove literal slug template leak |
 | 7 | `#532` M0.7 | Replace raw sidebar wallet identity preview or prove deferred |
 | 8 | `#533` M0.8 | Resolve or defer duplicate Instance Overview Refresh control |
 
-## Original outline (kept for traceability)
+## Corrected outline
 
 1. **Route fix — Trust + Account inside portal namespace.** Move
-   `/trust` and `/account` under `/portal/*` (matching the design's
-   `/portal/trust` and `/portal/account`). Preserve the PortalShell on
-   both routes. Update sidebar nav entries to the new paths. Verify
-   refresh + deep-link both work.
-2. **Billing h1 fix.** Replace the page `<h1>` "Portal Dashboard"
-   with "Billing" on `/portal/billing`. Verify other Portal pages
-   are unaffected.
-3. **Hide provisioning form on healthy instances.** In
-   `InstanceDetail.svelte` (and/or `Instances.svelte`), gate the
-   "Not started" warning banner + "Start provisioning" form behind
-   `instance.status === 'provisioning' || instance.status === 'unprovisioned'`.
-   For active / live instances the section disappears entirely.
-4. **Graceful cost-telemetry degradation.** Wrap the
-   `portalGetInstanceCost` call in `InstanceCost.svelte` so an HTTP
-   500 or network failure renders a soft empty state ("Cost
-   telemetry warming up · last value at HH:MM" or "temporarily
-   unavailable") instead of bubbling the error to the page. Keep the
-   budget + summary sections functional independently per the
-   existing pattern noted in M3.12.
-5. **Souls tab fetch fix.** Investigate why `InstanceSouls.svelte`
-   shows the "no souls bound" empty state on instances that have
-   souls. Likely candidates: wrong filter key, mismatched slug vs.
-   instance ID, missing pagination, or wrong endpoint. Fix the
-   fetch; preserve the existing empty-state markup for instances
-   that genuinely have no souls.
-6. **Slug template literal fix.** `Instances.svelte` description
-   string contains a literal `{slug}` token. Replace with the
-   selected slug, or rephrase the description so the literal is
-   not exposed.
-7. **Sidebar identity fix (preview only).** Replace the raw wallet
-   hash in the sidebar footer with `@{display_name}` + truncated
-   wallet (`0x4f29…f9c2` pattern). The full M2 redesign supersedes
-   this; this task is the immediate-fix variant.
-
-Optional 8th task (stretch, can defer to M2):
-
-8. **Remove duplicate Refresh button on Instance Overview if
-   trivially safe.** The audit flagged two identically styled
-   Refresh buttons. If the panel-scoped one is clearly redundant,
-   remove it; if behaviour differs, leave both for M6 to address
-   properly.
+   `/trust` and `/account` under `/portal/*` for the portal experience;
+   preserve legacy links and public attestation behavior.
+2. **Billing h1 fix.** Replace the page `<h1>` "Portal Dashboard" with
+   "Billing" on `/portal/billing`; avoid relabeling other portal pages.
+3. **Hide provisioning form on healthy instances.** Gate the "Not
+   started" warning/banner/form behind genuinely unprovisioned or retryable
+   provisioning states.
+4. **Managed Lesser metrics access.** The existing host portal route
+   `GET /api/v1/portal/instances/{slug}/cost` must enforce
+   `requireInstanceAccess`, resolve the instance API key server-side from
+   `LesserHostInstanceKeySecretARN`, call the managed Lesser instance with
+   bearer instance-key auth, and map real Lesser daily usage/cost rows into
+   `PortalCostResponse`. This supersedes the original graceful-degradation
+   wording; copy-only masking or host-local CloudWatch/Cost Explorer data
+   does not close `#529`.
+5. **Souls tab fetch fix.** Match bound agents against the canonical managed
+   Lesser domain shape so instances with bound souls do not show a false
+   empty state.
+6. **Slug template literal fix.** Remove the visible literal `{slug}` token
+   from customer copy.
+7. **Sidebar identity fix (preview only).** Replace the raw wallet hash in
+   the sidebar footer with bounded safe identity preview copy; full identity
+   chip design remains M2.
+8. **Duplicate Refresh control.** Distinguish or remove duplicate Instance
+   Overview refresh controls if safe; otherwise document the M6 follow-up.
 
 ## Out of scope
 
 - No layout redesign.
 - No new metric cards / sparklines / gauges.
 - No right-rail panels.
-- No new endpoints.
+- No new host customer-facing route beyond the existing portal cost route.
+- No host-local cost-telemetry producer work for M0.4; the data source is the
+  managed Lesser instance metrics contract.
 - No `gov-infra/pack.json` bump (no new verifier).
 - No primitives.
 
 ## Acceptance criteria
 
-- Each P0 row in `../audit-mapping.md` flagged "M0" is reproducible
-  before the PR and not reproducible after.
+- Each P0 row in `../audit-mapping.md` flagged "M0" is reproducible before
+  the PR and not reproducible after.
+- `#529` proof shows the portal handler reads real managed Lesser metrics via
+  instance-key bearer auth; tests use a fake managed Lesser HTTP server and
+  prove authorization, non-empty mapping, empty-data behavior, upstream-error
+  handling, and no raw-key/browser leakage.
 - `web lint`, `web typecheck`, `web test` green.
-- `cd cdk && npm test` unchanged.
-- `gov-infra/verifiers/gov-verify-rubric.sh` green at existing
-  pass count.
-- Manual smoke: navigate to `/portal/trust`, `/portal/account`,
-  `/portal/billing`, `/portal/instances/{slug}` (Souls tab and
-  Cost tab) on a lab-deployed branch; verify each P0 is fixed.
+- `go test ./...` green because M0.4 touches the control-plane backend.
+- `cd cdk && npm test` green because M0.4 grants control-plane-api the
+  managed instance assume-role path.
+- `gov-infra/verifiers/gov-verify-rubric.sh` green at existing pass count.
+- Manual smoke after merge/deploy: navigate to `/portal/trust`,
+  `/portal/account`, `/portal/billing`, `/portal/instances/{slug}` (Souls tab
+  and Cost tab) on a lab-deployed branch; verify each P0 is fixed and the Cost
+  tab returns managed Lesser data once the Lesser contract PR is deployed.
 
 ## Risks
 
-- The Souls tab fetch fix may reveal an underlying backend bug
-  rather than a UI bug. If so, split: fix the obvious UI path
-  here, file an issue for the backend regression, document the
-  finding in the PR body.
-- Trust + Account route changes may regress sidebar nav active-
-  state matching; verify the active highlight still tracks
-  correctly on both old and new paths during the transition.
+- The host PR depends on the Lesser-side route contract from
+  `equaltoai/lesser#1097`: `GET /api/v1/instance/metrics/daily` with bearer
+  instance-key auth. If that contract changes, the host client/tests must be
+  updated before M0 can close.
+- Trust + Account route changes may regress sidebar nav active-state matching;
+  verify the active highlight still tracks correctly on both old and new paths
+  during the transition.
 
 ## Evidence
 
 - M0 is correctness-only, so no design-fidelity artifact.
-- Capture before/after screenshots in the PR description for each
-  P0 row.
+- Capture before/after screenshots or written lab evidence in the PR
+  description for each P0 row.
 - No new gov-infra evidence artifact required.
-
-## Estimated size
-
-≤ 8 commits, ≤ 400 lines diff total. Reviewable in ≤ 20 minutes.
 
 ## Post-implementation findings (2026-05-27)
 
-The milestone landed as PR #534 (draft) with 7/8 sub-issues fixed in
-commits b09d5e9, cdf04a2, 829a6ea, 8201061, 1dd67da, 4e7d5d2, 44be898
-(plus the planning-bundle docs commit 378d45a). The 8th sub-issue
-(#529 M0.4) revealed a Lesser-side contract gap that arch's
-"important dependency rule" requires reporting upstream rather than
-masking on the host side.
+PR #534 now carries all eight M0 fixes. Commits b09d5e9, cdf04a2,
+829a6ea, 8201061, 1dd67da, 4e7d5d2, and 44be898 cover the seven
+UI/chrome correctness tasks. The M0.4 follow-up replaces the host-local
+`ListCostTelemetryByInstance` source with a managed Lesser metrics client:
 
-### #529 M0.4 — Lesser route gap (blocks M0 closure)
+1. `requireInstanceAccess` runs before any secret read or upstream call.
+2. The upstream origin is derived from `HostedBaseDomain` through the managed
+   stage-domain helper, not from `LesserHostBaseURL`.
+3. The raw instance key is resolved server-side from
+   `LesserHostInstanceKeySecretARN` using the commworker/provisionworker
+   cross-account assume-role + Secrets Manager pattern.
+4. Host calls `GET /api/v1/instance/metrics/daily?from=...&to=...` on the
+   managed Lesser instance with `Authorization: Bearer <instance-key>`.
+5. Daily Lesser rows are mapped into the existing `PortalCostResponse` shape;
+   empty data remains empty, and upstream failures are surfaced honestly
+   without echoing keys or upstream bodies to the browser.
 
-Read-only audit of `/home/aron/ai-workspace/codebases/equaltoai/lesser`:
-
-- `cmd/api/handlers/metrics.go:15` defines
-  `HandleGetInstanceMetricsLift` exactly per arch's reference
-  (reads `Analytics().GetActiveUserCount`,
-  `Cost().GetCostsByDateRange`, `Cost().GetDailyAggregates`).
-- `cmd/api/handlers/round11_metrics_test.go:41` and
-  `cmd/api/handlers/metrics_round12_coverage_test.go:247,255`
-  exercise the handler directly in tests.
-- **`cmd/api/routes.go` and `cmd/api/main.go` contain NO
-  `app.Get(...)` mount for this handler.** Exhaustive grep across
-  `cmd/` and `pkg/` finds the symbol only in (a) the handler
-  definition and (b) those two test files. There is no route
-  registration anywhere in the Lesser repo.
-
-Auth is moot until the route exists; the missing route is the
-blocking gap.
-
-### What host's M0.4 follow-up PR needs from Lesser
-
-Lesser must mount `HandleGetInstanceMetricsLift` (or a sibling
-cost-only handler shaped to `PortalCostResponse`'s needs) under a
-stable path with instance-API-key bearer auth. Once that lands,
-host's follow-up PR on Project 42 (narrow scope, still under M0
-parent #525 until closed) lands:
-
-1. `requireInstanceAccess` first.
-2. `internal/manageddomain.StageDomain(stage, inst.HostedBaseDomain)`
-   to derive `https://api.<stage-domain>` as the upstream origin.
-3. `internal/commworker/server.go`'s `instanceSecretFetchInputs` +
-   `getSecretsManagerSecretPlaintext` pattern (cross-account
-   assume-role when present, same-account fallback otherwise) to
-   resolve `LesserHostInstanceKeySecretARN`.
-4. `http.NewRequestWithContext(ctx, http.MethodGet, "https://api.<stage-domain>/...", nil)`
-   with `Authorization: Bearer <key>`.
-5. Map response into `PortalCostResponse` (bounded DTO change
-   allowed in the same follow-up PR per arch's correction email
-   `delivery-3ef80b6c7ccc6fea`).
-
-Required tests in the follow-up PR (per arch's correction):
-
-- Fake managed Lesser HTTP server: assert `Authorization` header
-  equals `Bearer <key>`; assert non-empty Lesser response maps
-  into the portal cost shape.
-- Ownership-failure test: `requireInstanceAccess` returns
-  `app.forbidden` before any HTTP call is made.
-- No-leak / no-log key proof: response body never contains the
-  raw key; log lines never emit it.
-- Empty-instance-data test: empty Lesser response maps to a
-  genuine empty state (not fabricated).
-- Upstream-failure test: 5xx from Lesser propagates as an
-  appropriate `app.upstream_*` code with the underlying error
-  logged but not echoed to the browser.
-
-### Standing instructions captured during M0.4 investigation
+### Standing instruction captured during M0.4 investigation
 
 Aron's directive, recorded verbatim for the steward stack:
 
@@ -188,29 +131,13 @@ Aron's directive, recorded verbatim for the steward stack:
 > we deal with the missing pipeline honestly or we don't ship the
 > masking.
 
-The half-measure rejected during M0.4 was a server-side
-`log.Printf` of the underlying DynamoDB error PLUS a softened UI
-empty-state ("Cost telemetry warming up · last value at HH:MM").
-Both individually defensible, but together they would have
-promised data that the platform cannot deliver — the cost-telemetry
-producer pipeline (`internal/costtelemetry/server.go:60` returning
-`{scaffold: "cost-telemetry-worker M3.7 scaffold — no business
-logic yet"}`) is unwired, and even the M3.8/M3.9/M3.10 path arch's
-correction rejected as wrong-source. The Lesser-side metrics path
-is the correct data source per arch.
+That remains the rule for future cost/usage work. PR #522's host-local
+telemetry scaffolding is not the source of truth for managed instance cost
+and usage in the portal.
 
 ### M0 closure path
 
-M0 is incomplete by arch's definition until #529 either reads real
-instance metrics OR an explicit split is authorized. Two paths:
-
-A) **Wait for Lesser route mount, then host follow-up PR closes
-   #529 against the same parent #525.** M0 PR #534 stays in draft
-   (or remains the parent PR with the follow-up as a stacked PR)
-   until both land.
-B) **Explicit arch-authorized split: merge #534 with 7 fixes,
-   keep #529 open as a Lesser contract tracker.** M0 closes
-   partially; the Lesser route mount drives reopening / final
-   closure when ready.
-
-Arch's call. Reported via `delivery-da9c3196f24b229a` (2026-05-27).
+M0 closes when PR #534 and the Lesser contract it depends on are merged and
+lab smoke confirms the portal cost route returns real managed Lesser metrics.
+Until then, do not advance M1 as if PR #522 already solved the instance data
+source.

--- a/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
+++ b/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
@@ -1,0 +1,116 @@
+# M0 — P0 correctness bundle
+
+**Branch (arch-specified).** `aron/project42-m0-portal-correctness`
+**PR title (arch-specified).** `fix(portal): M0 correctness and immediate chrome hygiene`
+**Project / parent.** equaltoai/projects/42 · parent issue `equaltoai/lesser-host#525`
+**Source brief.** `arch.equaltoai@theorymcp.ai` delivery
+`delivery-d08bce036c8f3243` (2026-05-27 17:48 UTC).
+**Concern.** Six P0 audit rows + two chrome-hygiene rows, total
+eight tasks. No design changes, no new components, no new endpoints,
+no token changes.
+
+Per the bundle rules, this milestone exists separately from any
+design work so the legacy portal is stable before foundation
+redesign begins.
+
+## Scope — sub-issues (≤ 8 tasks)
+
+Arch-created sub-issues under parent `#525`:
+
+| # | Sub-issue | Task |
+|---|---|---|
+| 1 | `#526` M0.1 | Route Trust and Account inside portal chrome |
+| 2 | `#527` M0.2 | Correct Billing page heading |
+| 3 | `#528` M0.3 | Hide provisioning form for live instances |
+| 4 | `#529` M0.4 | Degrade cost telemetry failure without hiding root cause |
+| 5 | `#530` M0.5 | Fix Instance Souls bound-agent fetch |
+| 6 | `#531` M0.6 | Remove literal slug template leak |
+| 7 | `#532` M0.7 | Replace raw sidebar wallet identity preview or prove deferred |
+| 8 | `#533` M0.8 | Resolve or defer duplicate Instance Overview Refresh control |
+
+## Original outline (kept for traceability)
+
+1. **Route fix — Trust + Account inside portal namespace.** Move
+   `/trust` and `/account` under `/portal/*` (matching the design's
+   `/portal/trust` and `/portal/account`). Preserve the PortalShell on
+   both routes. Update sidebar nav entries to the new paths. Verify
+   refresh + deep-link both work.
+2. **Billing h1 fix.** Replace the page `<h1>` "Portal Dashboard"
+   with "Billing" on `/portal/billing`. Verify other Portal pages
+   are unaffected.
+3. **Hide provisioning form on healthy instances.** In
+   `InstanceDetail.svelte` (and/or `Instances.svelte`), gate the
+   "Not started" warning banner + "Start provisioning" form behind
+   `instance.status === 'provisioning' || instance.status === 'unprovisioned'`.
+   For active / live instances the section disappears entirely.
+4. **Graceful cost-telemetry degradation.** Wrap the
+   `portalGetInstanceCost` call in `InstanceCost.svelte` so an HTTP
+   500 or network failure renders a soft empty state ("Cost
+   telemetry warming up · last value at HH:MM" or "temporarily
+   unavailable") instead of bubbling the error to the page. Keep the
+   budget + summary sections functional independently per the
+   existing pattern noted in M3.12.
+5. **Souls tab fetch fix.** Investigate why `InstanceSouls.svelte`
+   shows the "no souls bound" empty state on instances that have
+   souls. Likely candidates: wrong filter key, mismatched slug vs.
+   instance ID, missing pagination, or wrong endpoint. Fix the
+   fetch; preserve the existing empty-state markup for instances
+   that genuinely have no souls.
+6. **Slug template literal fix.** `Instances.svelte` description
+   string contains a literal `{slug}` token. Replace with the
+   selected slug, or rephrase the description so the literal is
+   not exposed.
+7. **Sidebar identity fix (preview only).** Replace the raw wallet
+   hash in the sidebar footer with `@{display_name}` + truncated
+   wallet (`0x4f29…f9c2` pattern). The full M2 redesign supersedes
+   this; this task is the immediate-fix variant.
+
+Optional 8th task (stretch, can defer to M2):
+
+8. **Remove duplicate Refresh button on Instance Overview if
+   trivially safe.** The audit flagged two identically styled
+   Refresh buttons. If the panel-scoped one is clearly redundant,
+   remove it; if behaviour differs, leave both for M6 to address
+   properly.
+
+## Out of scope
+
+- No layout redesign.
+- No new metric cards / sparklines / gauges.
+- No right-rail panels.
+- No new endpoints.
+- No `gov-infra/pack.json` bump (no new verifier).
+- No primitives.
+
+## Acceptance criteria
+
+- Each P0 row in `../audit-mapping.md` flagged "M0" is reproducible
+  before the PR and not reproducible after.
+- `web lint`, `web typecheck`, `web test` green.
+- `cd cdk && npm test` unchanged.
+- `gov-infra/verifiers/gov-verify-rubric.sh` green at existing
+  pass count.
+- Manual smoke: navigate to `/portal/trust`, `/portal/account`,
+  `/portal/billing`, `/portal/instances/{slug}` (Souls tab and
+  Cost tab) on a lab-deployed branch; verify each P0 is fixed.
+
+## Risks
+
+- The Souls tab fetch fix may reveal an underlying backend bug
+  rather than a UI bug. If so, split: fix the obvious UI path
+  here, file an issue for the backend regression, document the
+  finding in the PR body.
+- Trust + Account route changes may regress sidebar nav active-
+  state matching; verify the active highlight still tracks
+  correctly on both old and new paths during the transition.
+
+## Evidence
+
+- M0 is correctness-only, so no design-fidelity artifact.
+- Capture before/after screenshots in the PR description for each
+  P0 row.
+- No new gov-infra evidence artifact required.
+
+## Estimated size
+
+≤ 8 commits, ≤ 400 lines diff total. Reviewable in ≤ 20 minutes.

--- a/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
+++ b/docs/project-42-portal-redesign/milestones/01-m0-p0-correctness.md
@@ -114,3 +114,103 @@ Optional 8th task (stretch, can defer to M2):
 ## Estimated size
 
 ≤ 8 commits, ≤ 400 lines diff total. Reviewable in ≤ 20 minutes.
+
+## Post-implementation findings (2026-05-27)
+
+The milestone landed as PR #534 (draft) with 7/8 sub-issues fixed in
+commits b09d5e9, cdf04a2, 829a6ea, 8201061, 1dd67da, 4e7d5d2, 44be898
+(plus the planning-bundle docs commit 378d45a). The 8th sub-issue
+(#529 M0.4) revealed a Lesser-side contract gap that arch's
+"important dependency rule" requires reporting upstream rather than
+masking on the host side.
+
+### #529 M0.4 — Lesser route gap (blocks M0 closure)
+
+Read-only audit of `/home/aron/ai-workspace/codebases/equaltoai/lesser`:
+
+- `cmd/api/handlers/metrics.go:15` defines
+  `HandleGetInstanceMetricsLift` exactly per arch's reference
+  (reads `Analytics().GetActiveUserCount`,
+  `Cost().GetCostsByDateRange`, `Cost().GetDailyAggregates`).
+- `cmd/api/handlers/round11_metrics_test.go:41` and
+  `cmd/api/handlers/metrics_round12_coverage_test.go:247,255`
+  exercise the handler directly in tests.
+- **`cmd/api/routes.go` and `cmd/api/main.go` contain NO
+  `app.Get(...)` mount for this handler.** Exhaustive grep across
+  `cmd/` and `pkg/` finds the symbol only in (a) the handler
+  definition and (b) those two test files. There is no route
+  registration anywhere in the Lesser repo.
+
+Auth is moot until the route exists; the missing route is the
+blocking gap.
+
+### What host's M0.4 follow-up PR needs from Lesser
+
+Lesser must mount `HandleGetInstanceMetricsLift` (or a sibling
+cost-only handler shaped to `PortalCostResponse`'s needs) under a
+stable path with instance-API-key bearer auth. Once that lands,
+host's follow-up PR on Project 42 (narrow scope, still under M0
+parent #525 until closed) lands:
+
+1. `requireInstanceAccess` first.
+2. `internal/manageddomain.StageDomain(stage, inst.HostedBaseDomain)`
+   to derive `https://api.<stage-domain>` as the upstream origin.
+3. `internal/commworker/server.go`'s `instanceSecretFetchInputs` +
+   `getSecretsManagerSecretPlaintext` pattern (cross-account
+   assume-role when present, same-account fallback otherwise) to
+   resolve `LesserHostInstanceKeySecretARN`.
+4. `http.NewRequestWithContext(ctx, http.MethodGet, "https://api.<stage-domain>/...", nil)`
+   with `Authorization: Bearer <key>`.
+5. Map response into `PortalCostResponse` (bounded DTO change
+   allowed in the same follow-up PR per arch's correction email
+   `delivery-3ef80b6c7ccc6fea`).
+
+Required tests in the follow-up PR (per arch's correction):
+
+- Fake managed Lesser HTTP server: assert `Authorization` header
+  equals `Bearer <key>`; assert non-empty Lesser response maps
+  into the portal cost shape.
+- Ownership-failure test: `requireInstanceAccess` returns
+  `app.forbidden` before any HTTP call is made.
+- No-leak / no-log key proof: response body never contains the
+  raw key; log lines never emit it.
+- Empty-instance-data test: empty Lesser response maps to a
+  genuine empty state (not fabricated).
+- Upstream-failure test: 5xx from Lesser propagates as an
+  appropriate `app.upstream_*` code with the underlying error
+  logged but not echoed to the browser.
+
+### Standing instructions captured during M0.4 investigation
+
+Aron's directive, recorded verbatim for the steward stack:
+
+> Do not patch over gaps in our data with "graceful degradation" —
+> we deal with the missing pipeline honestly or we don't ship the
+> masking.
+
+The half-measure rejected during M0.4 was a server-side
+`log.Printf` of the underlying DynamoDB error PLUS a softened UI
+empty-state ("Cost telemetry warming up · last value at HH:MM").
+Both individually defensible, but together they would have
+promised data that the platform cannot deliver — the cost-telemetry
+producer pipeline (`internal/costtelemetry/server.go:60` returning
+`{scaffold: "cost-telemetry-worker M3.7 scaffold — no business
+logic yet"}`) is unwired, and even the M3.8/M3.9/M3.10 path arch's
+correction rejected as wrong-source. The Lesser-side metrics path
+is the correct data source per arch.
+
+### M0 closure path
+
+M0 is incomplete by arch's definition until #529 either reads real
+instance metrics OR an explicit split is authorized. Two paths:
+
+A) **Wait for Lesser route mount, then host follow-up PR closes
+   #529 against the same parent #525.** M0 PR #534 stays in draft
+   (or remains the parent PR with the follow-up as a stacked PR)
+   until both land.
+B) **Explicit arch-authorized split: merge #534 with 7 fixes,
+   keep #529 open as a Lesser contract tracker.** M0 closes
+   partially; the Lesser route mount drives reopening / final
+   closure when ready.
+
+Arch's call. Reported via `delivery-da9c3196f24b229a` (2026-05-27).

--- a/docs/project-42-portal-redesign/milestones/02-m1-primitives.md
+++ b/docs/project-42-portal-redesign/milestones/02-m1-primitives.md
@@ -1,0 +1,84 @@
+# M1 — Foundation primitives
+
+**Branch.** `aron/portal-m1-primitives`
+**PR title.** `feat(portal): primitives for Project 39 design (CostGauge, Sparkline, Metric, Eyebrow)`
+**Concern.** Add the visual primitives every later milestone consumes.
+No surfaces are modified by this PR. No data wiring. No layout
+changes.
+
+## Scope (≤ 7 tasks)
+
+1. **Inventory check against greater-components.** Verify whether
+   `@equaltoai/greater-components-primitives` already exports
+   equivalents of `Metric`, `Eyebrow`, `Sparkline`, `CostGauge`,
+   `ProgressBar` with `tone` variants, or close-enough versions.
+   Add only what is missing. Where greater has an equivalent,
+   either consume it directly or, if a small extension is needed,
+   open a coordination signal with the greater steward via
+   `coordinate-framework-feedback` (separate scope; this PR does
+   not block on it).
+2. **`Eyebrow.svelte`** — uppercase tracked label primitive
+   (`primitives.jsx:7–9`, CSS `.eyebrow`).
+3. **`Metric.svelte`** — metric tile: label + value + sub + delta
+   with direction arrow, optional icon, optional accent colour.
+   Maps to `primitives.jsx:102–120` and the `.metric` CSS block.
+4. **`CostGauge.svelte`** — circular SVG gauge for budget %; rotates
+   at -90deg, stroke colour switches at 70 % / 90 % thresholds, big
+   pct label + small all-caps `label` prop in the centre. Maps to
+   `primitives.jsx:198–218`.
+5. **`Sparkline.svelte`** — tiny SVG line chart with optional area
+   fill; props `values`, `width`, `height`, `color`, `fill`. Maps to
+   `primitives.jsx:133–147`.
+6. **`ProgressBar` tone variants.** If host's existing ProgressBar
+   does not accept `tone in {warning, error, success, accent}`, add
+   it. The design uses warning when spend > 80 % of budget.
+7. **Tests + visual fixtures.** One unit test per primitive covering
+   the prop matrix. Add a small `web/src/lib/primitives/__fixtures__/`
+   page (or Storybook stories if the project uses them) so the
+   primitives render in isolation for the design-fidelity check in
+   later milestones.
+
+## Out of scope
+
+- No surface mounts these primitives yet — that lands in later
+  milestones.
+- No shell changes — those are M2.
+- No ⌘K — that is M3.
+- No new tokens unless a primitive needs one that doesn't exist
+  yet; if so, scope minimal additions inside this PR and note
+  them in the PR body. **Do not** restructure the existing token
+  set.
+
+## Acceptance criteria
+
+- Each primitive renders correctly against the design fixture at a
+  matched viewport (compare to the relevant section of
+  `project/src/primitives.jsx` and `project/assets/app.css`).
+- All primitives are pure Svelte components with no fetch logic and
+  no global state.
+- Unit tests pass for every prop variant exercised by the design
+  (e.g. CostGauge at 0 %, 50 %, 75 %, 95 %).
+- Web lint + typecheck + test + build green.
+- CSP unchanged (no inline styles, no third-party origins).
+- AGPL headers on new files.
+
+## Risks
+
+- Greater-components may have a different `Metric` shape; consuming
+  the existing one is preferred to a host-local copy. If consuming,
+  document the mapping in the PR body so future updates trace
+  upstream.
+- `CostGauge` and `Sparkline` are SVG; verify they render correctly
+  in the SSR snapshot (FaceTheory) without hydration mismatch.
+
+## Evidence
+
+- Design-fidelity artifact under
+  `gov-infra/evidence/design-fidelity/m1-primitives/primitives.{png,md}`
+  showing each primitive rendered in the fixtures page next to the
+  design's rendering. Markdown notes record exact dimensions,
+  colours used, and any deliberate deviations.
+
+## Estimated size
+
+≤ 8 commits, ≤ 600 lines diff. Reviewable in ≤ 20 minutes.

--- a/docs/project-42-portal-redesign/milestones/03-m2-shell.md
+++ b/docs/project-42-portal-redesign/milestones/03-m2-shell.md
@@ -1,0 +1,85 @@
+# M2 — PortalShell redesign
+
+**Branch.** `aron/portal-m2-shell`
+**PR title.** `feat(portal): redesigned PortalShell — grouped sidebar, identity chip, bell, ⌘K trigger`
+**Concern.** Redesign the customer portal's outer chrome to match
+the design fixture. **No content surface changes.** Each
+content surface continues to render exactly what it renders today;
+only the shell wrapping them changes.
+
+## Scope (≤ 7 tasks)
+
+1. **Grouped sidebar nav.** Render four sections with eyebrow
+   labels: `Overview`, `Instances`, `Agents`, `Settings`. Maps to
+   `project/src/shell.jsx:128–162`.
+2. **Per-instance sidebar entries.** Under the `Instances` section,
+   render one entry per instance the customer owns: status dot
+   (success / warning / accent for provisioning / error), slug
+   label, and an alert badge ("!") when `status === 'warning'`.
+   Click navigates to `/portal/instances/{slug}`.
+3. **User chip footer.** Replace today's raw-wallet footer with the
+   design's pattern: avatar + `@{display_name}` + `{role} · {method}`
+   subtext + sign-out icon button. The M0 immediate-fix is replaced
+   by this richer version.
+4. **"Operator console" footer button.** Below the user chip, when
+   `session.role in {admin, operator}`, render an outlined button
+   with a shield icon that navigates to `/operator`. Reuses the
+   existing operator route.
+5. **Topbar bell icon (placeholder).** Add a non-functional bell
+   icon button on the topbar right side. Clicking opens an empty
+   popover that says "Notifications coming soon." This is a
+   placeholder; wiring the bell to real data is a future milestone.
+6. **Topbar ⌘K trigger button.** Add the "Search instances, souls,
+   jobs… ⌘K" button. Clicking it dispatches an event the M3 palette
+   will hook. In M2 the button is rendered but inert (the M3 PR
+   wires it up). Document this in the PR body.
+7. **Crumb-rendering cleanup.** Audit the existing breadcrumb
+   logic; if it mismatches the design's path → crumb mapping for
+   any portal route, fix here. The design's mapping lives in
+   `project/src/app.jsx:60–106`.
+
+## Out of scope
+
+- ⌘K command palette — that's M3.
+- Notification bell wiring — future milestone.
+- Operator shell redesign — Layer 3.
+- Any surface-content change.
+- New endpoints.
+
+## Acceptance criteria
+
+- Side-by-side fidelity artifact at 1440 × 900 viewport for:
+  - Sidebar full height (showing groups + per-instance entries +
+    user chip + Operator-console button).
+  - Topbar full width (showing crumbs + ⌘K trigger + bell).
+- Per-instance status dots use the same colour tokens the design
+  uses (`--ds-success-500`, `--ds-warning-500`, `--ds-accent-500`,
+  `--ds-error-500`).
+- Sign-out button still works (no regression).
+- Operator-console button visible only when role is admin or
+  operator; hidden otherwise. Unit test covers both branches.
+- CSP unchanged; no new external origins.
+- AGPL headers on new files.
+- Web lint + typecheck + test + build green.
+- Gov rubric green.
+
+## Risks
+
+- The per-instance list in the sidebar depends on the instance list
+  already loading client-side at shell mount. Verify the load order;
+  if the list arrives asynchronously, the sidebar should skeleton
+  the section rather than show "no instances" momentarily.
+- The CommandPalette M3 PR will hook into the ⌘K trigger; if M2
+  ships first and M3 lags, the button is visibly inert. Acceptable
+  as long as M3 follows promptly.
+- Operator-console button must navigate but not pre-fetch operator
+  data, to keep customer-side requests scoped.
+
+## Evidence
+
+- Design-fidelity artifact under
+  `gov-infra/evidence/design-fidelity/m2-shell/{sidebar,topbar,full-shell}.{png,md}`.
+
+## Estimated size
+
+≤ 7 commits, ≤ 500 lines diff. Reviewable in ≤ 20 minutes.

--- a/docs/project-42-portal-redesign/milestones/04-m3-cmdk.md
+++ b/docs/project-42-portal-redesign/milestones/04-m3-cmdk.md
@@ -1,0 +1,79 @@
+# M3 — ⌘K command palette
+
+**Branch.** `aron/portal-m3-cmdk`
+**PR title.** `feat(portal): ⌘K command palette`
+**Concern.** Global command palette that opens with ⌘K (and Ctrl-K
+on non-mac), exposes Navigate / Actions / Instances / Souls groups,
+fuzzy-filters by label and hint, navigates on Enter, closes on
+Escape and click-outside.
+
+## Scope (≤ 5 tasks)
+
+1. **Global keybinding.** Register `metaKey/ctrlKey + 'k'` at the
+   PortalShell root via a `window.addEventListener('keydown', …)`
+   inside an `onMount` lifecycle, with matching `onDestroy` cleanup.
+   `Escape` closes when open.
+2. **CommandPalette component.** A modal backdrop + centered panel
+   with a search input. Four groups: Navigate (static seed),
+   Actions (static seed), Instances (dynamic from session
+   instance list), Souls (dynamic from session soul list). Maps to
+   `project/src/shell.jsx:249–329`.
+3. **Fuzzy filter.** Filter each group by case-insensitive substring
+   match against `label` or `hint`. Hide groups whose item list is
+   empty. Map order matches the design's group order.
+4. **Wire to existing routes.** Selecting an item navigates via
+   the existing router (`onNavigate(path)`); no new routes are
+   created. Action items without paths (e.g. "Refresh data") are
+   either deferred (stubbed onClick that logs) or wired to existing
+   no-op behaviours; pick whichever is honest per item and
+   document in the PR body.
+5. **A11y + tests.**
+   - Focus traps inside the modal while open; Tab cycles within it.
+   - ARIA `role="dialog"`, `aria-label="Command palette"`.
+   - Unit tests: opens on ⌘K, closes on Esc, click-outside closes,
+     filter narrows results, enter navigates.
+
+## Out of scope
+
+- Real action wiring for items the design lists as "Refresh data",
+  "New instance…", "Request a soul…" — those land with their
+  respective surface milestones. M3 stubs them with a TODO log.
+- Search-on-the-server. Filtering is fully client-side over the
+  in-memory session lists.
+- Operator-console palette variants — Layer 3.
+
+## Acceptance criteria
+
+- Side-by-side fidelity artifact at the design's modal size.
+- Opens reliably on ⌘K and Ctrl-K from any portal page; topbar
+  trigger button (wired in M2) also opens it.
+- Closes on Esc, click-outside, and after selecting an item.
+- Keyboard navigation works (arrow up / down highlights items,
+  Enter selects). Optional in M3 if it inflates scope past
+  task limit — if so, file as a polish milestone.
+- No new dependencies added to `web/package.json`.
+- CSP unchanged.
+- Web lint + typecheck + test + build green.
+- Gov rubric green.
+
+## Risks
+
+- ⌘K bindings can clash with browser extensions (1Password etc.).
+  This is acceptable; ⌘K is industry-standard for command palettes
+  and users with conflicts can use the topbar trigger.
+- SSR + global listener registration: bind inside `onMount` to
+  avoid running on the server.
+- Focus-trap is a small but real a11y surface; using a vetted
+  library is fine if one is already in `web/`; otherwise hand-roll
+  the trap with the minimum elements needed.
+
+## Evidence
+
+- Design-fidelity artifact under
+  `gov-infra/evidence/design-fidelity/m3-cmdk/cmdk.{png,md}`.
+- A short markdown note recording the action items that were
+  stubbed (not yet wired) so a later milestone can sweep them up.
+
+## Estimated size
+
+≤ 5 commits, ≤ 350 lines diff. Reviewable in ≤ 15 minutes.

--- a/docs/project-42-portal-redesign/milestones/05-m4-fleet-ui.md
+++ b/docs/project-42-portal-redesign/milestones/05-m4-fleet-ui.md
@@ -1,0 +1,36 @@
+# M4 — Fleet UI
+
+**Branch.** `aron/portal-m4-fleet-ui`
+**Concern.** Replace the current Fleet page chrome with the design's
+greeting + summary + 4 metric cards + InstanceCard grid + right rail.
+UI-only; consumes data already on the wire plus whatever M5 will add.
+Where M5 data is missing, the surface skeletons or shows "no data
+yet" cells so M4 can ship independently.
+
+## Scope (≤ 7 tasks)
+
+1. Greeting + smart-summary header (uses session display name +
+   computed sentence from instance state).
+2. Four metric cards (Live instances, Souls, MTD spend, Federation).
+3. Fleet panel with Cards / Table tabs (Cards view first; Table
+   view is a stretch task).
+4. InstanceCard component (cost gauge donut + sparkline + four
+   metric chips + provisioning state branch).
+5. Right rail: Cost pulse panel (with sparkline + live dot).
+6. Right rail: Right-now / Provisioning panel.
+7. Right rail: Heads-up / Alerts panel.
+
+## Out of scope
+
+- Backend changes for active users / posts 24h / sig fails (M5).
+- Real provisioning live state (M5 or later).
+- Operator console.
+
+## Acceptance criteria
+
+- Side-by-side artifact for fleet at 1440 × 900.
+- Existing customers see a coherent surface even before M5 lands
+  (skeleton or "no data yet" cells where M5 fields are missing).
+- Web lint + typecheck + test + build + gov rubric green.
+
+Detail filled in when M3 merges.

--- a/docs/project-42-portal-redesign/milestones/06-m5-fleet-data.md
+++ b/docs/project-42-portal-redesign/milestones/06-m5-fleet-data.md
@@ -1,0 +1,41 @@
+# M5 — Fleet data
+
+**Branch.** `aron/portal-m5-fleet-data`
+**Concern.** Add the fields the Fleet card needs that aren't on the
+wire today: active users (rolling 30d), posts in last 24h, signature
+failures (24h), 7-day activity sparkline, 7-day cost sparkline, and
+federation-peer counts (peers + severed). Backend-only; no UI.
+
+## Scope (≤ 6 tasks)
+
+1. Extend `portalListInstances` DTO with the missing fields,
+   redacted (no account_id, no PK/SK).
+2. Compute active-user counts in the existing portal usage service
+   or add a thin handler if needed.
+3. Compute posts-24h via the existing activity counters; expose in
+   the DTO.
+4. Compute sig-fail counters; verify tenant-isolation (sig fails
+   are per-instance, not cross-tenant).
+5. Compute spark series (activity + cost) — 7 bucketed daily
+   values per instance.
+6. Unit + handler tests; redaction proof in `_test.go` similar to
+   the M3.11 pattern.
+
+## Out of scope
+
+- New UI consumption — M4 already renders skeletons; this PR
+  populates them.
+- Federation health detail — M16.
+
+## Acceptance criteria
+
+- Handler tests cover happy / forbidden / not-found / empty.
+- Redaction proof: marshalled DTO does not contain account_id,
+  PK, SK, ttl, or EntriesJSON fields.
+- Existing `portalListInstances` consumers unaffected (additive).
+- Web side smoke: M4-rendered Fleet now shows real numbers.
+- Gov rubric green; no SEC verifier additions unless redaction
+  surface changes.
+
+Detail filled in when M4 merges (or precedes M4 if arch sequences
+data-first).

--- a/docs/project-42-portal-redesign/milestones/07-m6-instance-overview-ui.md
+++ b/docs/project-42-portal-redesign/milestones/07-m6-instance-overview-ui.md
@@ -1,0 +1,34 @@
+# M6 — Instance Detail Overview UI
+
+**Branch.** `aron/portal-m6-instance-overview-ui`
+**Concern.** Replace the existing Overview tab with the design's
+layout: four metric cards, Stack card (Lesser / Body / MCP wiring),
+7-day Activity panel, Souls preview, right rail with Snapshot /
+Operate / Owners. UI-only.
+
+## Scope (≤ 7 tasks)
+
+1. Four metric cards (MTD spend, Active users 30d, Posts 24h, Sig failures).
+2. Stack card: Lesser row, Body row (or "Add agentic" CTA), MCP wiring row with drift warning.
+3. Activity panel (two 7-day sparklines).
+4. Souls preview (top-5 souls bound to this instance).
+5. Right rail — Snapshot panel (Instance ID, Region, Created, Domain, Anchor freshness as relative time).
+6. Right rail — Operate panel (Refresh anchor, Export config, Open config…).
+7. Right rail — Owners panel (people with avatars + roles).
+
+## Out of scope
+
+- Cost & usage tab — M8.
+- Configuration / Domains / Keys / Souls tabs — M9, M10.
+- New endpoints — M7 covers the data gaps.
+
+## Acceptance criteria
+
+- Side-by-side artifact for Overview at 1440 × 900.
+- ISO 8601 timestamps replaced with human dates / relative strings.
+- Duplicate Refresh button removed.
+- Hidden "Start provisioning" form when instance is live (already
+  done in M0; just verify no regression here).
+- Web lint + typecheck + test + build + gov rubric green.
+
+Detail filled in when M5 merges.

--- a/docs/project-42-portal-redesign/milestones/08-m7-instance-overview-data.md
+++ b/docs/project-42-portal-redesign/milestones/08-m7-instance-overview-data.md
@@ -1,0 +1,23 @@
+# M7 — Instance Detail Overview data
+
+**Branch.** `aron/portal-m7-instance-overview-data`
+**Concern.** Add the data fields the Overview right-rail and Stack
+card need: owners list (handles + roles + avatars), anchor freshness
+relative timestamp, and any additional Stack-card fields not yet
+exposed. Backend-only.
+
+## Scope (≤ 5 tasks)
+
+1. Owners endpoint or DTO extension (handle, role, avatar hash).
+2. Anchor-freshness field on instance state.
+3. Stack-card field audit: confirm Lesser version, Body version,
+   MCP-wiring state, MCP drift flag are all exposed.
+4. Handler tests + redaction proof.
+5. SEC-* verifier addition only if a new sensitive field is
+   added (probably not).
+
+## Out of scope
+
+- UI consumption — M6.
+
+Detail filled in when M6 outline solidifies.

--- a/docs/project-42-portal-redesign/milestones/09-m8-instance-cost-ui.md
+++ b/docs/project-42-portal-redesign/milestones/09-m8-instance-cost-ui.md
@@ -4,8 +4,9 @@
 **Concern.** Re-skin the Cost & usage tab to the design: three header
 cards (MTD vs budget with progress, Compute GB-sec sparkline, Egress
 GB), the "Where the dollars go" breakdown table with progress bars,
-and Budget alarms panel. Live telemetry already shipped in PR #522;
-this PR is presentation only.
+and Budget alarms panel. M8 assumes M0.4's managed Lesser metrics path is
+available through the existing portal cost route; PR #522's host-local telemetry
+scaffolding is not the authoritative instance data source.
 
 ## Scope (≤ 6 tasks)
 
@@ -19,8 +20,9 @@ this PR is presentation only.
 
 ## Out of scope
 
-- New telemetry data (already shipped).
-- Per-tenant Cost Explorer integration (M3.7+ from prior bundle,
-  deferrable).
+- Replacing the M0.4 managed Lesser metrics data source with host-local,
+  synthetic, or Cost Explorer-only telemetry.
+- New portal cost endpoint shape unless M8 proves the existing
+  `PortalCostResponse` cannot express the design honestly.
 
 Detail filled in when M7 merges.

--- a/docs/project-42-portal-redesign/milestones/09-m8-instance-cost-ui.md
+++ b/docs/project-42-portal-redesign/milestones/09-m8-instance-cost-ui.md
@@ -1,0 +1,26 @@
+# M8 — Instance Detail Cost & usage UI
+
+**Branch.** `aron/portal-m8-instance-cost-ui`
+**Concern.** Re-skin the Cost & usage tab to the design: three header
+cards (MTD vs budget with progress, Compute GB-sec sparkline, Egress
+GB), the "Where the dollars go" breakdown table with progress bars,
+and Budget alarms panel. Live telemetry already shipped in PR #522;
+this PR is presentation only.
+
+## Scope (≤ 6 tasks)
+
+1. Three header cards (MTD, Compute, Egress).
+2. Breakdown table by service with per-row progress bar + % of total.
+3. Budget alarms panel with three threshold rows (warning / critical / cap).
+4. Switch component on each alarm row (consumes greater Switch).
+5. Replace credit-based metrics surface with dollar / GB-sec / GB
+   surface (the audit P1 row).
+6. Side-by-side artifact + tests.
+
+## Out of scope
+
+- New telemetry data (already shipped).
+- Per-tenant Cost Explorer integration (M3.7+ from prior bundle,
+  deferrable).
+
+Detail filled in when M7 merges.

--- a/docs/project-42-portal-redesign/milestones/10-m9-instance-config-keys-ui.md
+++ b/docs/project-42-portal-redesign/milestones/10-m9-instance-config-keys-ui.md
@@ -1,0 +1,23 @@
+# M9 — Instance Detail Configuration + Keys UI
+
+**Branch.** `aron/portal-m9-instance-config-keys-ui`
+**Concern.** Re-skin the Configuration tab (now actually called
+"Configuration", not "Config") with three sections (Instance
+identity, Federation policy, Rate limits) and re-skin Keys with
+formatted IDs, copy buttons, and table layout.
+
+## Scope (≤ 7 tasks)
+
+1. Rename tab label "Config" → "Configuration".
+2. Instance identity section (Display name, Description, Default
+   visibility, Reg open).
+3. Federation policy section with ConfigToggle rows (Accept
+   federation, Allow quote posts, Auto-thread sync, AI moderation
+   hint, Public webfinger).
+4. Rate limits section (DL of Posts/hour, Inbox delivery, Search
+   QPS, Outbound HTTP).
+5. Normalise toggle sizing (audit row P3.3).
+6. Keys table: formatted token IDs with copy chip + masking.
+7. Side-by-side artifact + tests.
+
+Detail filled in when M8 merges.

--- a/docs/project-42-portal-redesign/milestones/11-m10-instance-souls-ui.md
+++ b/docs/project-42-portal-redesign/milestones/11-m10-instance-souls-ui.md
@@ -1,0 +1,15 @@
+# M10 — Instance Detail Souls tab UI
+
+**Branch.** `aron/portal-m10-instance-souls-ui`
+**Concern.** Re-skin the Souls tab on Instance Detail to the
+design's table format with a "+ Request soul" CTA. Data fetch
+bug is already fixed in M0; this PR is layout only.
+
+## Scope (≤ 4 tasks)
+
+1. Table with columns: Handle (avatar + handle), Stage badge, Model, Anchor freshness, Tips MTD.
+2. "+ Request soul" CTA in tab header.
+3. Row click navigates to `/portal/souls/{handle}`.
+4. Side-by-side artifact + tests.
+
+Detail filled in when M9 merges.

--- a/docs/project-42-portal-redesign/milestones/12-m11-billing-ui.md
+++ b/docs/project-42-portal-redesign/milestones/12-m11-billing-ui.md
@@ -1,0 +1,19 @@
+# M11 — Billing UI
+
+**Branch.** `aron/portal-m11-billing-ui`
+**Concern.** Re-skin `/portal/billing` to the design: four metric
+cards, stacked weekly bar chart, per-instance breakdown table, right
+rail (This month / Payment method / Recent invoices). UI-only;
+payment-method + invoice data lands in M12.
+
+## Scope (≤ 7 tasks)
+
+1. Page header with eyebrow + title + sub.
+2. Four metric cards (MTD, Projected EOM, Per active user, Per federated post).
+3. Stacked weekly bar chart (5 weeks; stacks by instance; projection bar).
+4. Per-instance breakdown table with burn progress bars.
+5. Right rail — This month panel (sparkline + delta).
+6. Right rail — Payment method panel (skeleton if no data).
+7. Right rail — Recent invoices panel (skeleton until M12).
+
+Detail filled in when M10 merges.

--- a/docs/project-42-portal-redesign/milestones/13-m12-billing-data.md
+++ b/docs/project-42-portal-redesign/milestones/13-m12-billing-data.md
@@ -1,0 +1,20 @@
+# M12 — Billing data
+
+**Branch.** `aron/portal-m12-billing-data`
+**Concern.** Expose invoice history + payment method on the
+control-plane API. Backend-only.
+
+## Scope (≤ 5 tasks)
+
+1. Invoice DTO (id, period, amount, state, download URL) — list
+   handler returning the recent N invoices for the calling
+   customer.
+2. Payment-method DTO (masked card number, network, expiry) — read
+   handler returning the current payment method.
+3. Redaction proof in handler tests (no PAN, no CVV).
+4. Stripe (or equivalent vendor) coordination if needed — if
+   shape differs from internal store, prefer a thin adapter over
+   leaking vendor types into the DTO.
+5. Audit-log emission for invoice access (privacy-aware).
+
+Detail filled in when M11 merges.

--- a/docs/project-42-portal-redesign/milestones/14-m13-souls-top-ui.md
+++ b/docs/project-42-portal-redesign/milestones/14-m13-souls-top-ui.md
@@ -1,0 +1,16 @@
+# M13 — Souls top-level UI
+
+**Branch.** `aron/portal-m13-souls-top-ui`
+**Concern.** Re-skin `/portal/souls` from the legacy fallback page
+to the design's roster table + right rail. Removes the "Secondary
+soul route" warning framing.
+
+## Scope (≤ 5 tasks)
+
+1. Page header with "+ Request a soul" CTA.
+2. Roster table with All / Graduated / In review tabs above it.
+3. Right rail — Roster status counts.
+4. Right rail — Soul minting guidance card with Simulacrum link.
+5. Side-by-side artifact + tests.
+
+Detail filled in when M12 merges.

--- a/docs/project-42-portal-redesign/milestones/15-m14-soul-detail-ui.md
+++ b/docs/project-42-portal-redesign/milestones/15-m14-soul-detail-ui.md
@@ -1,0 +1,19 @@
+# M14 — Soul Detail UI
+
+**Branch.** `aron/portal-m14-soul-detail-ui`
+**Concern.** Re-skin `/portal/souls/{handle}` to the design: header
+with avatar + handle, three metric cards (Posts 30d / Followers /
+Avg tip), continuity-loop 7-day bar chart, activity timeline, right
+rail (Manifest / Anchor / Earnings).
+
+## Scope (≤ 7 tasks)
+
+1. Page header with avatar + name + handle@domain.
+2. Stage / hold / review alert banner conditional on stage.
+3. Three metric cards.
+4. Continuity loop bar chart (7-day).
+5. Activity timeline list.
+6. Right rail — Manifest DL.
+7. Right rail — Anchor gauge + Earnings panel.
+
+Detail filled in when M13 merges.

--- a/docs/project-42-portal-redesign/milestones/16-m15-trust-ui.md
+++ b/docs/project-42-portal-redesign/milestones/16-m15-trust-ui.md
@@ -1,0 +1,33 @@
+# M15 — Trust UI
+
+**Branch.** `aron/portal-m15-trust-ui`
+**Concern.** Replace the legacy attestation-explorer page at
+`/portal/trust` with the design's federation-health dashboard.
+The attestation API endpoints (`/.well-known/*`, `/attestations/*`)
+are **untouched** — the trust API surface stays intact; this PR
+changes what the customer portal renders on the `/portal/trust`
+route.
+
+## Scope (≤ 7 tasks)
+
+1. Page header with title "113 peers, 1 severed." pattern, eyebrow "Trust & federation".
+2. Four metric cards (Reachable peers, Warnings, Severed last 30d, Sig failures 24h).
+3. Peer constellation grid (one square per peer; status dot; follower count; last fetch).
+4. Sparkline panel — HTTP signature failures (last 24h).
+5. Sparkline panel — Inbound queue depth.
+6. Right rail — Trust score gauge.
+7. Right rail — Vouches from peers + Severed alert.
+
+## Out of scope
+
+- Trust API attestation endpoints (untouched).
+- Data wiring — M16.
+
+## Acceptance criteria
+
+- Per-instance scoping: customers see only their own instances'
+  federation data.
+- Multi-tenant isolation preserved.
+- Side-by-side artifact + tests.
+
+Detail filled in when M14 merges.

--- a/docs/project-42-portal-redesign/milestones/17-m16-trust-data.md
+++ b/docs/project-42-portal-redesign/milestones/17-m16-trust-data.md
@@ -1,0 +1,23 @@
+# M16 — Trust data
+
+**Branch.** `aron/portal-m16-trust-data`
+**Concern.** Add the data the federation-health dashboard needs:
+peer roll-up (reachable / warning / severed counters), sig-fail
+counters, inbound queue depth, trust score, vouches.
+
+## Scope (≤ 6 tasks)
+
+1. Federation peer roll-up endpoint (per-instance).
+2. Sig-fail counters (24h, broken out by source instance).
+3. Inbound-queue depth time series.
+4. Trust score endpoint (computed; not on chain).
+5. Vouches endpoint (peer → strength pairs).
+6. Handler tests + redaction proof + tenant-isolation tests.
+
+## Out of scope
+
+- Trust API (`.well-known/*`, `/attestations/*`) — untouched.
+- On-chain anchor coordination — out of bundle scope.
+
+Detail filled in when M15 merges (or precedes M15 if arch
+sequences data-first).

--- a/docs/project-42-portal-redesign/milestones/18-m17-account-ui.md
+++ b/docs/project-42-portal-redesign/milestones/18-m17-account-ui.md
@@ -1,0 +1,16 @@
+# M17 — Account UI
+
+**Branch.** `aron/portal-m17-account-ui`
+**Concern.** Re-skin `/portal/account` to the design's slim
+identity + session view. Preserves all current behaviours
+(rotate token, sign out all).
+
+## Scope (≤ 4 tasks)
+
+1. Page header.
+2. Identity panel (Username, Display name, Email, Role) DL.
+3. Session panel (Method, Wallet, Token expires, IP) DL with
+   Rotate token + Sign out all session buttons.
+4. Side-by-side artifact + tests.
+
+Detail filled in when M16 merges.

--- a/docs/project-42-portal-redesign/milestones/operator-console-layer.md
+++ b/docs/project-42-portal-redesign/milestones/operator-console-layer.md
@@ -1,0 +1,72 @@
+# Layer 3 — Operator Console (deferred)
+
+Detailed planning is intentionally deferred until Layer 2 (the
+customer portal surfaces M4–M17) has landed. The operator console
+is functionally separate, lower-traffic, and easier to plan when
+the customer-side primitives + shell conventions have stabilised
+in production.
+
+## What the design defines
+
+The Claude Design bundle includes a complete Operator console with
+**distinct dark warm-charcoal chrome** so it can never be mistaken
+for the customer portal. Surfaces:
+
+- **Operator Dashboard** (`/operator`). Engine-room view: 4 metric
+  cards (Customers, Instances, MTD revenue, Alarms), Provisioning
+  in-progress panel, Approvals queue summary, Live ops right rail,
+  Fleet anchor freshness, last-24h alarms.
+  Reference: `project/src/operator-pages.jsx:6–106`.
+- **Provisioning** list + job detail. Job kinds: `provision`,
+  `update-lesser`, `update-body`, `wire-mcp`. Live timeline with
+  per-step status; MCP-drift banner with "Wire all" CTA.
+- **Releases** (`/operator/releases`). Two side-by-side release
+  timelines (Lesser + Body), each with channel / breaking / latest
+  badges and per-version fleet adoption bars. Below: Stack Matrix
+  table of every instance's Lesser + Body + MCP wiring state with
+  per-row "Update" or "Wire MCP" CTA.
+  Reference: `project/src/releases.jsx` (entire file).
+- **Approvals** (`/operator/approvals/{domains,users,external}`).
+  Tabbed surfaces for vanity domains, user signups, external
+  registrations. Existing data; new layout.
+- **Audit log** (`/operator/audit`). Existing data; new layout.
+- **Instances** (`/operator/instances`). Cross-customer instance
+  registry view.
+- **Tip registry** (`/operator/tip-registry`). On-chain tip
+  operations view.
+- **Soul registry** (`/operator/soul`). Operator-side soul roster.
+
+## Sub-milestones (placeholder — not detailed)
+
+When this layer is planned, the same bundle rules apply:
+
+- ≤ 8 tasks per milestone.
+- Single concern per milestone.
+- UI vs. data separation.
+- Side-by-side fidelity artifacts per milestone.
+
+Tentative sub-milestone names:
+
+- **L3.M1** Operator dark chrome (OperatorShell + topbar variant + sidebar groups + sidebar footer "Back to portal" button).
+- **L3.M2** Operator Dashboard UI.
+- **L3.M3** Operator Releases UI (the two timelines).
+- **L3.M4** Stack Matrix UI.
+- **L3.M5** Provisioning list UI.
+- **L3.M6** Provisioning job-detail UI (live timeline).
+- **L3.M7** Approvals tabs UI (domains / users / external).
+- **L3.M8** Audit log UI.
+- **L3.M9** Instances registry UI.
+- **L3.M10** Tip registry UI.
+- **L3.M11** Soul registry UI.
+
+Data milestones interleave where new operator endpoints are
+needed (release-timeline data, per-version adoption counts, MCP
+drift roll-up, etc.).
+
+## Trigger to start
+
+Layer 3 detailed planning begins after **M17** merges, **or** after
+a clear operator pain point makes a specific Layer 3 surface a
+priority. Arch may sequence Layer 3 differently based on
+operational needs; this placeholder records the design intent for
+that conversation.

--- a/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
+++ b/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
@@ -1,32 +1,20 @@
 #!/usr/bin/env bash
-# SEC-13: Cost-telemetry redaction + multi-tenant read ordering.
+# SEC-13: Portal cost redaction + multi-tenant downstream-call ordering.
 #
-# Verifies that the portal cost-telemetry endpoint handler:
+# Verifies that the portal instance-cost endpoint handler:
 #   1. Enforces tenant-scoped ownership via requireInstanceAccess before any
-#      cost telemetry database read.
-#   2. Does not expose PII, cross-tenant fields, tenant content, raw instance
+#      instance-key secret resolution or managed Lesser metrics HTTP call.
+#   2. Does not use the deprecated host-local ListCostTelemetryByInstance path.
+#   3. Does not expose PII, cross-tenant fields, tenant content, raw instance
 #      keys, account IDs, table keys (PK/SK), TTL, or raw EntriesJSON storage
-#      payloads in the customer-facing response DTO.
+#      payloads in the customer-facing response DTO or error messages.
 #
-# Multi-tenant read ordering (Dimension 1):
-#   requireInstanceAccess must appear inside handlePortalGetInstanceCost at a
-#   line number strictly before ListCostTelemetryByInstance. This ensures the
-#   ownership check gates all cost telemetry store reads.
+# Project 42 M0.4 correction: the accepted data source is the managed Lesser
+# instance metrics endpoint, reached server-side with an instance API key. The
+# SEC-13 proof must therefore gate the secret read and HTTP call, not the old
+# host-local cost telemetry store read.
 #
-# Redaction (Dimension 2):
-#   The portalCostResponse, portalCostDayEntry, and ReconciledCostEntry types
-#   must exclude account_id, PK, SK, ttl, entries_json, EntriesJSON, raw
-#   instance keys, secrets, request bodies, actor/object/content URIs, and
-#   tenant content. The Go handler source and test file are both checked.
-#
-# Full points: requireInstanceAccess before ListCostTelemetryByInstance, and
-#   the source + tests prove forbidden fields are excluded.
-# Zero points: any violation — wrong ordering, forbidden field present in DTO,
-#   or redaction test missing.
-#
-# No partial credit.
-#
-# Source: Issue equaltoai/lesser-host#457
+# Source: Issue equaltoai/lesser-host#457 and Project 42 M0.4 (#529).
 
 set -euo pipefail
 
@@ -34,95 +22,72 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${REPO_ROOT}"
 
 HANDLER_FILE="internal/controlplane/handlers_portal_cost.go"
+METRICS_FILE="internal/controlplane/managed_instance_metrics.go"
 TEST_FILE="internal/controlplane/handlers_portal_cost_internal_test.go"
 
-echo "SEC-13: Cost-telemetry redaction + multi-tenant read ordering"
+echo "SEC-13: Portal cost redaction + multi-tenant downstream-call ordering"
 echo "Handler file: ${HANDLER_FILE}"
+echo "Metrics file: ${METRICS_FILE}"
 echo "Test file:    ${TEST_FILE}"
 echo ""
 
-# ── Step 1: Files must exist ──────────────────────────────────────────────
 FAIL=0
 
-if [[ ! -f "${HANDLER_FILE}" ]]; then
-  echo "FAIL: handler file missing: ${HANDLER_FILE}" >&2
-  exit 1
-fi
+for file in "${HANDLER_FILE}" "${METRICS_FILE}" "${TEST_FILE}"; do
+  if [[ ! -f "${file}" ]]; then
+    echo "FAIL: required file missing: ${file}" >&2
+    exit 1
+  fi
+done
 
-if [[ ! -f "${TEST_FILE}" ]]; then
-  echo "FAIL: test file missing: ${TEST_FILE}" >&2
-  exit 1
-fi
+non_comment_line() {
+  local pattern="$1"
+  local file="$2"
+  grep -n "${pattern}" "${file}" | grep -v '^\s*[0-9]*:\s*//' | grep -v '^\s*[0-9]*:\s*\*' | head -1 | cut -d: -f1 || true
+}
 
-# ── Dimension 1: Multi-tenant read ordering ───────────────────────────────
-# requireInstanceAccess must be called before ListCostTelemetryByInstance.
+echo "Dimension 1: ownership gates secret resolution and managed Lesser HTTP call"
+AUTH_LINE="$(non_comment_line 'requireInstanceAccess' "${HANDLER_FILE}")"
+KEY_LINE="$(non_comment_line 'resolvePortalCostInstanceKey' "${HANDLER_FILE}")"
+FETCH_LINE="$(non_comment_line 'fetchManagedInstanceMetrics' "${HANDLER_FILE}")"
 
-if ! grep -q 'requireInstanceAccess' "${HANDLER_FILE}"; then
-  echo "FAIL: requireInstanceAccess call not found in handler" >&2
-  FAIL=1
-fi
-
-# Exclude comment lines (//...) to avoid matching doc comments.
-AUTH_LINE="$(grep -n 'requireInstanceAccess' "${HANDLER_FILE}" | grep -v '^\s*[0-9]*:\s*//' | head -1 | cut -d: -f1 || true)"
 if [[ -z "${AUTH_LINE}" ]]; then
-  echo "FAIL: requireInstanceAccess call not found (non-comment)" >&2
+  echo "FAIL: requireInstanceAccess call not found in handler" >&2
   FAIL=1
 else
   echo "Ownership check: requireInstanceAccess at line ${AUTH_LINE}"
 fi
 
-# Find ListCostTelemetryByInstance call site (not definition, not comments).
-STORE_LINE="$(grep -n 'ListCostTelemetryByInstance' "${HANDLER_FILE}" | grep -v '^\s*[0-9]*:\s*//' | grep -v 'func ' | head -1 | cut -d: -f1 || true)"
-if [[ -z "${STORE_LINE}" ]]; then
-  echo "FAIL: ListCostTelemetryByInstance call not found in handler" >&2
+for entry in "secret resolution:${KEY_LINE}:resolvePortalCostInstanceKey" "managed metrics fetch:${FETCH_LINE}:fetchManagedInstanceMetrics"; do
+  label="${entry%%:*}"
+  rest="${entry#*:}"
+  line="${rest%%:*}"
+  symbol="${entry##*:}"
+  if [[ -z "${line}" ]]; then
+    echo "FAIL: ${symbol} call not found in handler" >&2
+    FAIL=1
+    continue
+  fi
+  echo "${label}: ${symbol} at line ${line}"
+  if [[ -n "${AUTH_LINE}" ]] && [[ "${line}" -le "${AUTH_LINE}" ]]; then
+    echo "FAIL: ${symbol} (line ${line}) precedes requireInstanceAccess (line ${AUTH_LINE})" >&2
+    FAIL=1
+  fi
+done
+
+if grep -q 'ListCostTelemetryByInstance' "${HANDLER_FILE}"; then
+  echo "FAIL: handler still reads host-local cost telemetry store" >&2
   FAIL=1
 else
-  echo "Cost telemetry read: ListCostTelemetryByInstance at line ${STORE_LINE}"
-fi
-
-if [[ -n "${AUTH_LINE}" ]] && [[ -n "${STORE_LINE}" ]]; then
-  if [[ "${STORE_LINE}" -le "${AUTH_LINE}" ]]; then
-    echo "FAIL: ListCostTelemetryByInstance (line ${STORE_LINE}) precedes requireInstanceAccess (line ${AUTH_LINE})" >&2
-    FAIL=1
-  else
-    echo "PASS: ownership check precedes cost telemetry read (${AUTH_LINE} < ${STORE_LINE})"
-  fi
+  echo "PASS: handler does not use deprecated ListCostTelemetryByInstance path"
 fi
 
 echo ""
-
-# ── Dimension 2: DTO redaction — handler source ────────────────────────────
-# The portalCostResponse, portalCostDayEntry, and ReconciledCostEntry types
-# (plus buildPortalCostResponse) must not reference forbidden fields on
-# non-comment lines. Doc comments describing excluded fields are legitimate.
-
-HANDLER_CONTENT="$(cat "${HANDLER_FILE}")"
-
-# Extract non-comment source lines (exclude // and block-comment lines).
-NON_COMMENT="$(echo "${HANDLER_CONTENT}" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*/\*')"
-
 echo "Dimension 2a: DTO redaction in handler source"
-
-# EntriesJSON is expected in buildPortalCostResponse for unmarshaling,
-# but must not appear in the DTO struct field tags or response fields.
-# Allow EntriesJSON only in the unmarshal line (rec.EntriesJSON).
-if echo "${NON_COMMENT}" | grep -qF 'EntriesJSON' && ! echo "${NON_COMMENT}" | grep -qF 'rec.EntriesJSON'; then
-  echo "FAIL: EntriesJSON found on non-comment line outside rec.EntriesJSON unmarshal" >&2
-  FAIL=1
-elif echo "${NON_COMMENT}" | grep -qF 'EntriesJSON'; then
-  echo "PASS: EntriesJSON only in rec.EntriesJSON unmarshal (expected)"
-fi
-
-if echo "${NON_COMMENT}" | grep -qF 'entries_json'; then
-  echo "FAIL: entries_json found on non-comment line" >&2
-  FAIL=1
-fi
-
-# Verify the forbidden tokens are explicitly absent from the DTO struct definitions.
-# portalCostResponse and portalCostDayEntry are defined in this file.
+HANDLER_CONTENT="$(cat "${HANDLER_FILE}")"
+NON_COMMENT="$(echo "${HANDLER_CONTENT}" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*/\*')"
 DTO_REGION="$(echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostResponse struct/,/^}/p'; echo; echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostDayEntry struct/,/^}/p')"
 
-# The DTO region must NOT contain json:"account_id", json:"pk", json:"sk", json:"ttl", etc.
 DTO_FORBIDDEN=(
   '"account_id"'
   '"pk"'
@@ -141,39 +106,59 @@ for forbidden in "${DTO_FORBIDDEN[@]}"; do
   fi
 done
 
+if echo "${NON_COMMENT}" | grep -qF 'EntriesJSON'; then
+  echo "FAIL: handler references raw EntriesJSON on a non-comment line" >&2
+  FAIL=1
+fi
+if echo "${NON_COMMENT}" | grep -qF 'entries_json'; then
+  echo "FAIL: handler references entries_json on a non-comment line" >&2
+  FAIL=1
+fi
+
 echo "PASS: DTO struct json tags are clean of forbidden fields"
 
 echo ""
-
-# ── Dimension 2b: Redaction proof in tests ─────────────────────────────────
-# The test file must contain a redaction assertion that proves the response
-# JSON does not contain account_id, PK, SK, ttl, entries_json, or EntriesJSON.
-
+echo "Dimension 2b: redaction and fail-closed proof in tests"
 TEST_CONTENT="$(cat "${TEST_FILE}")"
 
-echo "Dimension 2b: Redaction proof in test file"
-
-# Verify the test calls jsonContains with forbidden field names.
-if echo "${TEST_CONTENT}" | grep -q 'jsonContains.*account_id.*PK.*SK.*ttl.*entries_json.*EntriesJSON'; then
-  echo "PASS: test redaction assertion found (jsonContains with forbidden fields)"
+if echo "${TEST_CONTENT}" | grep -q 'Bearer "+testRawKey' && echo "${TEST_CONTENT}" | grep -q 'NotContains(t, string(resp.Body), testRawKey)'; then
+  echo "PASS: test proves bearer key is sent upstream and excluded from response"
 else
-  echo "FAIL: no jsonContains redaction assertion covering account_id, PK, SK, ttl, entries_json, EntriesJSON" >&2
+  echo "FAIL: missing bearer-auth send plus response redaction proof" >&2
   FAIL=1
 fi
 
-# Verify the WrongOwnerForbidden test proves cost store was never read.
-if echo "${TEST_CONTENT}" | grep -q 'AssertNotCalled.*All'; then
-  echo "PASS: test proves cost telemetry not read on forbidden (AssertNotCalled)"
+for token in 'account_id' 'PK' 'SK' 'ttl' 'entries_json' 'EntriesJSON' 'instance_key' 'raw_key'; do
+  if ! echo "${TEST_CONTENT}" | grep -q "${token}"; then
+    echo "FAIL: test redaction assertion missing forbidden token ${token}" >&2
+    FAIL=1
+  fi
+done
+if echo "${TEST_CONTENT}" | grep -q 'forbidden := range' && echo "${TEST_CONTENT}" | grep -q 'require.NotContains(t, string(resp.Body), forbidden)'; then
+  echo "PASS: test asserts forbidden response fields are absent"
 else
-  echo "FAIL: no AssertNotCalled proof that cost telemetry is skipped on forbidden" >&2
+  echo "FAIL: test does not assert forbidden response fields are absent" >&2
+  FAIL=1
+fi
+
+if echo "${TEST_CONTENT}" | grep -q 'WrongOwnerForbiddenBeforeSecretOrHTTP' && echo "${TEST_CONTENT}" | grep -q 'require.Zero(t, secretReads)' && echo "${TEST_CONTENT}" | grep -q 'require.Zero(t, httpCalls)'; then
+  echo "PASS: forbidden tenant proof skips secret resolution and HTTP call"
+else
+  echo "FAIL: missing wrong-owner proof that secret resolution and HTTP are skipped" >&2
+  FAIL=1
+fi
+
+if echo "${TEST_CONTENT}" | grep -q 'Upstream5xxDoesNotLeakKeyOrBody' && echo "${TEST_CONTENT}" | grep -q 'KeyResolverFailureDoesNotLeak'; then
+  echo "PASS: tests cover upstream/key-resolution error redaction"
+else
+  echo "FAIL: missing upstream/key-resolution redaction tests" >&2
   FAIL=1
 fi
 
 echo ""
-
 if [[ "${FAIL}" -ne 0 ]]; then
-  echo "FAIL: SEC-13 cost-telemetry redaction check failed" >&2
+  echo "FAIL: SEC-13 portal cost redaction check failed" >&2
   exit 1
 fi
 
-echo "PASS: SEC-13 cost-telemetry redaction + multi-tenant read ordering verified"
+echo "PASS: SEC-13 portal cost redaction + downstream-call ordering verified"

--- a/internal/controlplane/handlers_portal_cost.go
+++ b/internal/controlplane/handlers_portal_cost.go
@@ -1,7 +1,6 @@
 package controlplane
 
 import (
-	"encoding/json"
 	"net/http"
 	"strings"
 	"time"
@@ -10,7 +9,6 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/costtelemetry"
 	"github.com/equaltoai/lesser-host/internal/httpx"
-	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 // portalCostResponse is the public DTO returned by
@@ -19,8 +17,9 @@ import (
 // Safety invariants:
 //   - Excludes PK, SK, TTL, account_id, raw EntriesJSON string, raw instance
 //     keys, secrets, request bodies, and tenant content.
-//   - Each day's entries are decoded from the store's cached JSON into
-//     ReconciledCostEntry structs, which carry no account_id or internal fields.
+//   - M0.4 sources daily usage/cost data from the managed Lesser instance via
+//     an instance-key-authenticated server-side call; raw instance keys never
+//     reach the browser.
 type portalCostResponse struct {
 	InstanceSlug string               `json:"instance_slug"`
 	FromDate     string               `json:"from_date"`
@@ -43,14 +42,12 @@ type portalCostDayEntry struct {
 // are supplied (past 30 days inclusive).
 const costQueryDefaultDays = 30
 
-// costQueryMaxLimit caps the number of records returned.
-const costQueryMaxLimit = 200
-
 // handlePortalGetInstanceCost implements GET /api/v1/portal/instances/{slug}/cost.
 //
-// Ownership is enforced via requireInstanceAccess before any cost telemetry
-// read. Optional query params from and to (YYYY-MM-DD) narrow the window;
-// the default is the past 30 days inclusive. Invalid dates fail closed.
+// Ownership is enforced via requireInstanceAccess before any instance-key
+// secret read or managed Lesser HTTP call. Optional query params from and to
+// (YYYY-MM-DD) narrow the window; the default is the past 30 days inclusive.
+// Invalid dates fail closed.
 func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory.Response, error) {
 	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
 	if err != nil {
@@ -63,12 +60,17 @@ func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory
 		return nil, parseErr
 	}
 
-	records, storeErr := s.store.ListCostTelemetryByInstance(ctx.Context(), slug, from, to, costQueryMaxLimit)
-	if storeErr != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to list cost telemetry"}
+	apiKey, keyErr := s.resolvePortalCostInstanceKey(ctx.Context(), inst)
+	if keyErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance metrics access"}
 	}
 
-	resp := buildPortalCostResponse(slug, from, to, records)
+	metrics, metricsErr := s.fetchManagedInstanceMetrics(ctx.Context(), inst, apiKey, from, to)
+	if metricsErr != nil {
+		return nil, metricsErr
+	}
+
+	resp := buildPortalCostResponseFromLesser(slug, from, to, metrics)
 	return apptheory.JSON(http.StatusOK, resp)
 }
 
@@ -103,38 +105,49 @@ func parseCostDateWindow(ctx *apptheory.Context) (from, to string, appErr *appth
 	return from, to, nil
 }
 
-// buildPortalCostResponse decodes EntriesJSON from each CostTelemetry record
-// and assembles the public response DTO. Internal fields (PK, SK, TTL,
-// account_id, raw JSON string) are excluded by construction.
-func buildPortalCostResponse(slug, from, to string, records []*models.CostTelemetry) portalCostResponse {
-	var total float64
-	days := make([]portalCostDayEntry, 0, len(records))
+func buildPortalCostResponseFromLesser(slug, from, to string, metrics lesserInstanceMetricsResponse) portalCostResponse {
+	days := make([]portalCostDayEntry, 0, len(metrics.Daily))
+	total := 0.0
 	currency := "USD"
 
-	for _, rec := range records {
-		if rec == nil {
+	for _, row := range metrics.Daily {
+		date := strings.TrimSpace(row.Date)
+		if date == "" {
 			continue
 		}
 
-		var entries []costtelemetry.ReconciledCostEntry
-		if rec.EntriesJSON != "" {
-			if unmarshalErr := json.Unmarshal([]byte(rec.EntriesJSON), &entries); unmarshalErr != nil {
-				continue
-			}
+		rowCurrency := strings.TrimSpace(row.Currency)
+		if rowCurrency == "" {
+			rowCurrency = "USD"
 		}
-		if entries == nil {
-			entries = []costtelemetry.ReconciledCostEntry{}
-		}
+		currency = rowCurrency
 
-		total += rec.DayCost
-		if rec.Currency != "" {
-			currency = rec.Currency
+		dayCost := row.CostDollars
+		if dayCost == 0 && row.CostCents != 0 {
+			dayCost = float64(row.CostCents) / 100
+		}
+		total += dayCost
+
+		entries := []costtelemetry.ReconciledCostEntry{
+			{
+				Date:     date,
+				Service:  "Managed Lesser",
+				Cost:     dayCost,
+				Currency: rowCurrency,
+				Metrics: []costtelemetry.ServiceAttribution{
+					{Service: "Managed Lesser", MetricName: "Requests", Stat: "Sum", Unit: "Count", Value: float64(row.TotalRequests)},
+					{Service: "Managed Lesser", MetricName: "UniqueUsers", Stat: "Maximum", Unit: "Count", Value: float64(row.UniqueUsers)},
+					{Service: "DynamoDB", MetricName: "ConsumedReadCapacityUnits", Stat: "Sum", Unit: "Count", Value: float64(row.DynamoDBReads)},
+					{Service: "DynamoDB", MetricName: "ConsumedWriteCapacityUnits", Stat: "Sum", Unit: "Count", Value: float64(row.DynamoDBWrites)},
+					{Service: "Lambda", MetricName: "Duration", Stat: "Sum", Unit: "Milliseconds", Value: float64(row.LambdaDurationMs)},
+				},
+			},
 		}
 
 		days = append(days, portalCostDayEntry{
-			Date:     rec.Date,
-			DayCost:  rec.DayCost,
-			Currency: rec.Currency,
+			Date:     date,
+			DayCost:  dayCost,
+			Currency: rowCurrency,
 			Entries:  entries,
 		})
 	}

--- a/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -1,7 +1,12 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -9,36 +14,26 @@ import (
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
-	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
 )
 
-// ---------------------------------------------------------------------------
-// test constants
-// ---------------------------------------------------------------------------
-
 const (
 	testCostSlug1 = "demo"
 	testCostDate1 = "2026-05-25"
 	testCostDate2 = "2026-05-26"
+	testRawKey    = "lhk_test_secret"
 )
 
-// ---------------------------------------------------------------------------
-// helpers
-// ---------------------------------------------------------------------------
-
-// newCostTestDB creates a mock DB pre-wired for Instance and CostTelemetry
-// model queries.
-func newCostTestDB() (*ttmocks.MockExtendedDB, *ttmocks.MockQuery, *ttmocks.MockQuery) {
-	db, qs := newTestDBWithModelQueries("*models.Instance", "*models.CostTelemetry")
-	return db, qs[0], qs[1]
+func newCostTestDB() (*ttmocks.MockExtendedDB, *ttmocks.MockQuery) {
+	db, qs := newTestDBWithModelQueries("*models.Instance")
+	return db, qs[0]
 }
 
-// stubCostInstanceFirst configures the Instance mock query's First to return
-// the given instance.
 func stubCostInstanceFirst(t *testing.T, q *ttmocks.MockQuery, inst models.Instance) {
 	t.Helper()
 	q.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
@@ -47,37 +42,6 @@ func stubCostInstanceFirst(t *testing.T, q *ttmocks.MockQuery, inst models.Insta
 	}).Maybe()
 }
 
-// stubCostRecords configures the CostTelemetry mock query's All to return
-// the given records.
-func stubCostRecords(t *testing.T, q *ttmocks.MockQuery, records []*models.CostTelemetry, err error) {
-	t.Helper()
-	q.On("All", mock.AnythingOfType("*[]*models.CostTelemetry")).Return(err).Run(func(args mock.Arguments) {
-		if err != nil {
-			return
-		}
-		dest := testutil.RequireMockArg[*[]*models.CostTelemetry](t, args, 0)
-		*dest = records
-	}).Once()
-}
-
-// costRecord builds a minimal CostTelemetry record with decoded entries in
-// EntriesJSON.
-func costRecord(slug, date string, dayCost float64, currency string, entries []costtelemetry.ReconciledCostEntry) *models.CostTelemetry {
-	entriesJSON, err := json.Marshal(entries)
-	if err != nil {
-		panic(err)
-	}
-	return &models.CostTelemetry{
-		InstanceSlug: slug,
-		Date:         date,
-		DayCost:      dayCost,
-		Currency:     currency,
-		EntriesJSON:  string(entriesJSON),
-	}
-}
-
-// newCostHandlerCtx builds a context with the given slug and optional query
-// params.
 func newCostHandlerCtx(slug string, query map[string][]string) *apptheory.Context {
 	ctx := &apptheory.Context{
 		AuthIdentity: "alice",
@@ -89,192 +53,234 @@ func newCostHandlerCtx(slug string, query map[string][]string) *apptheory.Contex
 	return ctx
 }
 
-// jsonContains asserts that the marshaled JSON of v does not contain any of
-// the forbidden strings.
-func jsonContains(t *testing.T, v any, forbidden ...string) {
+func baseCostInstance(owner string) models.Instance {
+	return models.Instance{
+		Slug:                           testCostSlug1,
+		Owner:                          owner,
+		HostedAccountID:                "123456789012",
+		HostedRegion:                   "us-east-1",
+		HostedBaseDomain:               "simulacrum.greater.website",
+		LesserHostInstanceKeySecretARN: "arn:aws:secretsmanager:us-east-1:123456789012:secret:demo/instance-key",
+	}
+}
+
+func newCostTestServer(t *testing.T, inst models.Instance, handler http.HandlerFunc) (*Server, *httptest.Server) {
 	t.Helper()
-	b, err := json.Marshal(v)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+	tdb, qInst := newCostTestDB()
+	stubCostInstanceFirst(t, qInst, inst)
+
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	s := &Server{
+		cfg:                  config.Config{Stage: "lab", ManagedInstanceRoleName: "OrganizationAccountAccessRole", ManagedDefaultRegion: "us-east-1"},
+		store:                store.New(tdb),
+		portalCostHTTPClient: ts.Client(),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return testRawKey, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) {
+			return ts.URL, nil
+		},
 	}
-	s := string(b)
-	for _, f := range forbidden {
-		if contains(s, f) {
-			t.Errorf("response contained forbidden field %q", f)
-		}
-	}
+	return s, ts
 }
 
-func contains(s, needle string) bool {
-	return len(s) >= len(needle) && searchSubstring(s, needle)
-}
-
-func searchSubstring(s, needle string) bool {
-	for i := 0; i <= len(s)-len(needle); i++ {
-		if s[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
-}
-
-// ---------------------------------------------------------------------------
-// tests
-// ---------------------------------------------------------------------------
-
-func TestHandlePortalGetInstanceCost_Success(t *testing.T) {
+func TestHandlePortalGetInstanceCost_SendsBearerAuthAndMapsDailyRows(t *testing.T) {
 	t.Parallel()
 
-	tdb, qInst, qCost := newCostTestDB()
-	s := &Server{store: store.New(tdb)}
-
-	stubCostInstanceFirst(t, qInst, models.Instance{
-		Slug:  testCostSlug1,
-		Owner: "alice",
+	var gotAuth string
+	var gotPath string
+	var gotFrom string
+	var gotTo string
+	s, _ := newCostTestServer(t, baseCostInstance("alice"), func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		gotFrom = r.URL.Query().Get("from")
+		gotTo = r.URL.Query().Get("to")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"period":{"start":"2026-05-25","end":"2026-05-26","days":2,"timezone":"UTC"},
+			"daily":[
+				{"date":"2026-05-25","total_requests":100,"unique_users":4,"dynamodb_reads":50,"dynamodb_writes":10,"lambda_duration_ms":250,"cost_cents":12,"cost_dollars":0.12,"currency":"USD"},
+				{"date":"2026-05-26","total_requests":200,"unique_users":7,"dynamodb_reads":70,"dynamodb_writes":20,"lambda_duration_ms":450,"cost_cents":34,"cost_dollars":0.34,"currency":"USD"}
+			]
+		}`))
 	})
-
-	entries := []costtelemetry.ReconciledCostEntry{
-		{Date: testCostDate1, Service: "Lambda", Cost: 0.25, Currency: "USD"},
-		{Date: testCostDate1, Service: "DynamoDB", Cost: 0.10, Currency: "USD"},
-	}
-
-	stubCostRecords(t, qCost, []*models.CostTelemetry{
-		costRecord(testCostSlug1, testCostDate1, 0.35, "USD", entries),
-	}, nil)
 
 	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
 		"from": {testCostDate1},
-		"to":   {testCostDate1},
+		"to":   {testCostDate2},
 	})
-
 	resp, err := s.handlePortalGetInstanceCost(ctx)
-	if err != nil || resp == nil || resp.Status != 200 {
-		t.Fatalf("unexpected response: %#v err=%v", resp, err)
-	}
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, http.StatusOK, resp.Status)
+	require.Equal(t, "Bearer "+testRawKey, gotAuth)
+	require.Equal(t, "/api/v1/instance/metrics/daily", gotPath)
+	require.Equal(t, testCostDate1, gotFrom)
+	require.Equal(t, testCostDate2, gotTo)
 
 	var body portalCostResponse
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, testCostSlug1, body.InstanceSlug)
+	require.Equal(t, testCostDate1, body.FromDate)
+	require.Equal(t, testCostDate2, body.ToDate)
+	require.Equal(t, 2, body.Count)
+	require.InDelta(t, 0.46, body.TotalCost, 0.000001)
+	require.Equal(t, "USD", body.Currency)
+	require.Len(t, body.Days, 2)
+	require.Equal(t, testCostDate1, body.Days[0].Date)
+	require.InDelta(t, 0.12, body.Days[0].DayCost, 0.000001)
+	require.Len(t, body.Days[0].Entries, 1)
+	require.Equal(t, "Managed Lesser", body.Days[0].Entries[0].Service)
+	require.InDelta(t, 0.12, body.Days[0].Entries[0].Cost, 0.000001)
+	require.NotEmpty(t, body.Days[0].Entries[0].Metrics)
+	require.NotContains(t, string(resp.Body), testRawKey)
+	for _, forbidden := range []string{`"account_id"`, `"PK"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, string(resp.Body), forbidden)
 	}
-
-	if body.InstanceSlug != testCostSlug1 {
-		t.Errorf("expected slug %q, got %q", testCostSlug1, body.InstanceSlug)
-	}
-	if body.Count != 1 {
-		t.Fatalf("expected 1 day, got %d", body.Count)
-	}
-	if body.TotalCost != 0.35 {
-		t.Errorf("expected total 0.35, got %f", body.TotalCost)
-	}
-	if body.Currency != "USD" {
-		t.Errorf("expected currency USD, got %q", body.Currency)
-	}
-
-	day := body.Days[0]
-	if day.Date != testCostDate1 {
-		t.Errorf("expected date %q, got %q", testCostDate1, day.Date)
-	}
-	if day.DayCost != 0.35 {
-		t.Errorf("expected day cost 0.35, got %f", day.DayCost)
-	}
-	if len(day.Entries) != 2 {
-		t.Fatalf("expected 2 entries, got %d", len(day.Entries))
-	}
-	if day.Entries[0].Service != "Lambda" || day.Entries[1].Service != "DynamoDB" {
-		t.Errorf("unexpected entries: %+v", day.Entries)
-	}
-
-	// Redaction: response must not contain internal fields.
-	jsonContains(t, body, "account_id", "PK", "SK", "ttl", "entries_json", "EntriesJSON")
 }
 
-func TestHandlePortalGetInstanceCost_WrongOwnerForbidden(t *testing.T) {
+func TestHandlePortalGetInstanceCost_EmptyLesserData(t *testing.T) {
 	t.Parallel()
 
-	tdb, qInst, qCost := newCostTestDB()
-	s := &Server{store: store.New(tdb)}
-
-	// Instance is owned by "bob"; caller is "alice".
-	stubCostInstanceFirst(t, qInst, models.Instance{
-		Slug:  testCostSlug1,
-		Owner: "bob",
+	s, _ := newCostTestServer(t, baseCostInstance("alice"), func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+testRawKey, r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(`{"period":{"start":"2026-05-25","end":"2026-05-25","days":1,"timezone":"UTC"},"daily":[]}`))
 	})
 
-	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+	resp, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
 		"from": {testCostDate1},
 		"to":   {testCostDate1},
-	})
+	}))
+	require.NoError(t, err)
+	var body portalCostResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Equal(t, 0, body.Count)
+	require.Empty(t, body.Days)
+	require.Equal(t, 0.0, body.TotalCost)
+}
 
-	_, err := s.handlePortalGetInstanceCost(ctx)
-	if err == nil {
-		t.Fatal("expected forbidden error for wrong owner")
+func TestHandlePortalGetInstanceCost_WrongOwnerForbiddenBeforeSecretOrHTTP(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst := newCostTestDB()
+	stubCostInstanceFirst(t, qInst, baseCostInstance("bob"))
+
+	secretReads := 0
+	httpCalls := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	s := &Server{
+		cfg:                  config.Config{Stage: "lab"},
+		store:                store.New(tdb),
+		portalCostHTTPClient: ts.Client(),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			secretReads++
+			return testRawKey, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) { return ts.URL, nil },
 	}
+
+	_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	}))
+	require.Error(t, err)
 	appErr, ok := err.(*apptheory.AppError)
-	if !ok || appErr.Code != appErrCodeForbidden {
-		t.Fatalf("expected app.forbidden, got %#v", err)
-	}
-
-	// Prove cost telemetry was never read.
-	qCost.AssertNotCalled(t, "All", mock.Anything)
+	require.True(t, ok)
+	require.Equal(t, appErrCodeForbidden, appErr.Code)
+	require.Zero(t, secretReads)
+	require.Zero(t, httpCalls)
 }
 
-func TestHandlePortalGetInstanceCost_OperatorBypass(t *testing.T) {
+func TestHandlePortalGetInstanceCost_Upstream5xxDoesNotLeakKeyOrBody(t *testing.T) {
 	t.Parallel()
 
-	tdb, qInst, qCost := newCostTestDB()
-	s := &Server{store: store.New(tdb)}
-
-	stubCostInstanceFirst(t, qInst, models.Instance{
-		Slug:  testCostSlug1,
-		Owner: "bob", // not the caller
+	s, _ := newCostTestServer(t, baseCostInstance("alice"), func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+testRawKey, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("upstream body contains " + testRawKey))
 	})
 
-	stubCostRecords(t, qCost, []*models.CostTelemetry{
-		costRecord(testCostSlug1, testCostDate1, 1.50, "USD", nil),
-	}, nil)
-
-	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+	_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
 		"from": {testCostDate1},
 		"to":   {testCostDate1},
-	})
-	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
-
-	resp, err := s.handlePortalGetInstanceCost(ctx)
-	if err != nil || resp == nil || resp.Status != 200 {
-		t.Fatalf("operator should bypass ownership: resp=%#v err=%v", resp, err)
-	}
+	}))
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.upstream_error", appErr.Code)
+	require.NotContains(t, appErr.Message, testRawKey)
+	require.NotContains(t, appErr.Message, "upstream body")
 }
 
-func TestHandlePortalGetInstanceCost_DefaultWindow(t *testing.T) {
+func TestHandlePortalGetInstanceCost_UpstreamUnavailable(t *testing.T) {
 	t.Parallel()
 
-	tdb, qInst, qCost := newCostTestDB()
-	s := &Server{store: store.New(tdb)}
+	tdb, qInst := newCostTestDB()
+	stubCostInstanceFirst(t, qInst, baseCostInstance("alice"))
 
-	stubCostInstanceFirst(t, qInst, models.Instance{
-		Slug:  testCostSlug1,
-		Owner: "alice",
-	})
-
-	// When the handler has no query params, it defaults to past 30 days.
-	// We don't verify exact dates (they depend on time.Now()), but we verify
-	// the handler succeeds and the store is queried.
-	stubCostRecords(t, qCost, []*models.CostTelemetry{}, nil)
-
-	ctx := newCostHandlerCtx(testCostSlug1, nil)
-
-	resp, err := s.handlePortalGetInstanceCost(ctx)
-	if err != nil || resp == nil || resp.Status != 200 {
-		t.Fatalf("unexpected response: %#v err=%v", resp, err)
+	s := &Server{
+		cfg:                  config.Config{Stage: "lab"},
+		store:                store.New(tdb),
+		portalCostHTTPClient: http.DefaultClient,
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return testRawKey, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) {
+			return "http://127.0.0.1:1", nil
+		},
 	}
 
-	var body portalCostResponse
-	if err := json.Unmarshal(resp.Body, &body); err != nil {
-		t.Fatalf("unmarshal response: %v", err)
+	_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	}))
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.upstream_unavailable", appErr.Code)
+	require.NotContains(t, appErr.Message, testRawKey)
+}
+
+func TestHandlePortalGetInstanceCost_KeyResolverFailureDoesNotLeak(t *testing.T) {
+	t.Parallel()
+
+	tdb, qInst := newCostTestDB()
+	stubCostInstanceFirst(t, qInst, baseCostInstance("alice"))
+
+	s := &Server{
+		cfg:   config.Config{Stage: "lab"},
+		store: store.New(tdb),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return "", errors.New("secret failure includes " + testRawKey)
+		},
 	}
-	if body.FromDate == "" || body.ToDate == "" {
-		t.Errorf("expected default date window, got from=%q to=%q", body.FromDate, body.ToDate)
-	}
+
+	_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
+		"from": {testCostDate1},
+		"to":   {testCostDate1},
+	}))
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.internal", appErr.Code)
+	require.NotContains(t, appErr.Message, testRawKey)
+}
+
+func TestHandlePortalGetInstanceCost_DefaultManagedMetricsURL(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{Stage: "lab"}}
+	baseURL, err := s.defaultInstanceMetricsBaseURL(&models.Instance{HostedBaseDomain: "example.greater.website"})
+	require.NoError(t, err)
+	require.Equal(t, "https://api.dev.example.greater.website", baseURL)
 }
 
 func TestHandlePortalGetInstanceCost_InvalidDates(t *testing.T) {
@@ -294,30 +300,22 @@ func TestHandlePortalGetInstanceCost_InvalidDates(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			tdb, qInst, _ := newCostTestDB()
+			tdb, qInst := newCostTestDB()
 			s := &Server{store: store.New(tdb)}
+			stubCostInstanceFirst(t, qInst, baseCostInstance("alice"))
 
-			stubCostInstanceFirst(t, qInst, models.Instance{
-				Slug:  testCostSlug1,
-				Owner: "alice",
-			})
-
-			ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+			_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
 				"from": {tt.from},
 				"to":   {tt.to},
-			})
-
-			_, err := s.handlePortalGetInstanceCost(ctx)
-			if err == nil {
-				t.Fatal("expected error")
-			}
+			}))
+			require.Error(t, err)
 			appErr, ok := err.(*apptheory.AppError)
-			if !ok || appErr.Code != tt.code {
-				t.Fatalf("expected %s, got %#v", tt.code, err)
-			}
+			require.True(t, ok)
+			require.Equal(t, tt.code, appErr.Code)
 		})
 	}
 }
@@ -325,22 +323,26 @@ func TestHandlePortalGetInstanceCost_InvalidDates(t *testing.T) {
 func TestHandlePortalGetInstanceCost_InstanceNotFound(t *testing.T) {
 	t.Parallel()
 
-	tdb, qInst, _ := newCostTestDB()
+	tdb, qInst := newCostTestDB()
 	s := &Server{store: store.New(tdb)}
-
 	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
 
-	ctx := newCostHandlerCtx(testCostSlug1, map[string][]string{
+	_, err := s.handlePortalGetInstanceCost(newCostHandlerCtx(testCostSlug1, map[string][]string{
 		"from": {testCostDate1},
 		"to":   {testCostDate1},
-	})
-
-	_, err := s.handlePortalGetInstanceCost(ctx)
-	if err == nil {
-		t.Fatal("expected not_found")
-	}
+	}))
+	require.Error(t, err)
 	appErr, ok := err.(*apptheory.AppError)
-	if !ok || appErr.Code != soulMintAppErrCodeNotFound {
-		t.Fatalf("expected app.not_found, got %#v", err)
-	}
+	require.True(t, ok)
+	require.Equal(t, soulMintAppErrCodeNotFound, appErr.Code)
+}
+
+func TestBuildManagedInstanceMetricsURL(t *testing.T) {
+	t.Parallel()
+
+	got, err := buildManagedInstanceMetricsURL("https://api.dev.example.greater.website/", testCostDate1, testCostDate2)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(got, "https://api.dev.example.greater.website/api/v1/instance/metrics/daily?"))
+	require.Contains(t, got, "from=2026-05-25")
+	require.Contains(t, got, "to=2026-05-26")
 }

--- a/internal/controlplane/managed_instance_metrics.go
+++ b/internal/controlplane/managed_instance_metrics.go
@@ -1,0 +1,302 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const instanceMetricsTimeout = 10 * time.Second
+
+type controlPlaneSTSAPI interface {
+	AssumeRole(ctx context.Context, params *sts.AssumeRoleInput, optFns ...func(*sts.Options)) (*sts.AssumeRoleOutput, error)
+}
+
+type controlPlaneSecretsManagerAPI interface {
+	GetSecretValue(ctx context.Context, params *secretsmanager.GetSecretValueInput, optFns ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+type lesserInstanceMetricsResponse struct {
+	Period struct {
+		Start    string `json:"start"`
+		End      string `json:"end"`
+		Days     int    `json:"days"`
+		Timezone string `json:"timezone"`
+	} `json:"period"`
+	Daily []lesserInstanceMetricsDailyRow `json:"daily"`
+}
+
+type lesserInstanceMetricsDailyRow struct {
+	Date             string  `json:"date"`
+	TotalRequests    int64   `json:"total_requests"`
+	UniqueUsers      int64   `json:"unique_users"`
+	DynamoDBReads    int64   `json:"dynamodb_reads"`
+	DynamoDBWrites   int64   `json:"dynamodb_writes"`
+	LambdaDurationMs int64   `json:"lambda_duration_ms"`
+	CostCents        int64   `json:"cost_cents"`
+	CostDollars      float64 `json:"cost_dollars"`
+	Currency         string  `json:"currency"`
+}
+
+func (s *Server) resolvePortalCostInstanceKey(ctx context.Context, inst *models.Instance) (string, error) {
+	if s != nil && s.fetchInstanceKeyPlaintextFunc != nil {
+		return s.fetchInstanceKeyPlaintextFunc(ctx, inst)
+	}
+	return s.defaultFetchInstanceKeyPlaintext(ctx, inst)
+}
+
+func (s *Server) fetchManagedInstanceMetrics(ctx context.Context, inst *models.Instance, apiKey string, from string, to string) (lesserInstanceMetricsResponse, *apptheory.AppError) {
+	apiKey = strings.TrimSpace(apiKey)
+	if apiKey == "" {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance metrics access"}
+	}
+
+	baseURL, err := s.resolvePortalCostMetricsBaseURL(inst)
+	if err != nil {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance metrics endpoint"}
+	}
+
+	endpoint, err := buildManagedInstanceMetricsURL(baseURL, from, to)
+	if err != nil {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance metrics endpoint"}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.internal", Message: "failed to create instance metrics request"}
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+
+	client := s.portalCostHTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: instanceMetricsTimeout}
+	}
+
+	resp, err := client.Do(req) //nolint:gosec // URL is derived from managed instance metadata or an injected test seam, not from browser input.
+	if err != nil {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.upstream_unavailable", Message: "failed to reach instance metrics"}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.upstream_error", Message: "failed to fetch instance metrics"}
+	}
+
+	var decoded lesserInstanceMetricsResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&decoded); err != nil {
+		return lesserInstanceMetricsResponse{}, &apptheory.AppError{Code: "app.upstream_error", Message: "failed to decode instance metrics"}
+	}
+	if decoded.Daily == nil {
+		decoded.Daily = []lesserInstanceMetricsDailyRow{}
+	}
+	return decoded, nil
+}
+
+func (s *Server) resolvePortalCostMetricsBaseURL(inst *models.Instance) (string, error) {
+	if s != nil && s.resolveInstanceMetricsBaseURLFunc != nil {
+		return s.resolveInstanceMetricsBaseURLFunc(inst)
+	}
+	return s.defaultInstanceMetricsBaseURL(inst)
+}
+
+func (s *Server) defaultInstanceMetricsBaseURL(inst *models.Instance) (string, error) {
+	if inst == nil {
+		return "", fmt.Errorf("instance is nil")
+	}
+	baseDomain := strings.TrimSpace(inst.HostedBaseDomain)
+	if baseDomain == "" {
+		return "", fmt.Errorf("hosted base domain is not configured")
+	}
+	stage := ""
+	if s != nil {
+		stage = s.cfg.Stage
+	}
+	stageDomain := managedInstanceStageDomain(stage, baseDomain)
+	if strings.TrimSpace(stageDomain) == "" {
+		return "", fmt.Errorf("managed instance domain is not configured")
+	}
+	return "https://api." + strings.TrimSpace(stageDomain), nil
+}
+
+func buildManagedInstanceMetricsURL(baseURL string, from string, to string) (string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return "", fmt.Errorf("base url is required")
+	}
+	u, err := url.Parse(baseURL + "/api/v1/instance/metrics/daily")
+	if err != nil {
+		return "", err
+	}
+	q := u.Query()
+	q.Set("from", strings.TrimSpace(from))
+	q.Set("to", strings.TrimSpace(to))
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func (s *Server) defaultFetchInstanceKeyPlaintext(ctx context.Context, inst *models.Instance) (string, error) {
+	secretArn, accountID, roleName, region, err := s.instanceSecretFetchInputs(inst)
+	if err != nil {
+		return "", err
+	}
+
+	stsClient, secretsClient, err := s.instanceMetricsAWSClients(ctx)
+	if err != nil {
+		return "", err
+	}
+	if accountID == "" || roleName == "" || stsClient == nil {
+		return getControlPlaneSecretPlaintext(ctx, secretsClient, secretArn)
+	}
+
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountID, roleName)
+	sessionName := fmt.Sprintf("lesser-host-%s-cost-%s", strings.TrimSpace(s.cfg.Stage), strings.TrimSpace(inst.Slug))
+	if len(sessionName) > 64 {
+		sessionName = sessionName[:64]
+	}
+
+	assumed, err := stsClient.AssumeRole(ctx, &sts.AssumeRoleInput{
+		RoleArn:         aws.String(roleArn),
+		RoleSessionName: aws.String(sessionName),
+		DurationSeconds: aws.Int32(900),
+	})
+	if err != nil {
+		return "", fmt.Errorf("assume instance role: %w", err)
+	}
+	if assumed == nil || assumed.Credentials == nil {
+		return "", fmt.Errorf("assume role returned empty credentials")
+	}
+
+	creds := credentials.NewStaticCredentialsProvider(
+		aws.ToString(assumed.Credentials.AccessKeyId),
+		aws.ToString(assumed.Credentials.SecretAccessKey),
+		aws.ToString(assumed.Credentials.SessionToken),
+	)
+	child := secretsmanager.New(secretsmanager.Options{
+		Region:      region,
+		Credentials: aws.NewCredentialsCache(creds),
+	})
+
+	return getControlPlaneSecretPlaintext(ctx, child, secretArn)
+}
+
+func (s *Server) instanceMetricsAWSClients(ctx context.Context) (controlPlaneSTSAPI, controlPlaneSecretsManagerAPI, error) {
+	if s != nil && s.sts != nil && s.secrets != nil {
+		return s.sts, s.secrets, nil
+	}
+
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	baseSTS := sts.NewFromConfig(awsCfg)
+	stsClient := controlPlaneSTSAPI(baseSTS)
+	if s != nil && strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN) != "" {
+		roleArn := strings.TrimSpace(s.cfg.ManagedOrgVendingRoleARN)
+		provider := stscreds.NewAssumeRoleProvider(baseSTS, roleArn, func(o *stscreds.AssumeRoleOptions) {
+			sessionName := fmt.Sprintf("lesser-host-%s-cost-vending", strings.TrimSpace(s.cfg.Stage))
+			if len(sessionName) > 64 {
+				sessionName = sessionName[:64]
+			}
+			o.RoleSessionName = sessionName
+			o.Duration = 3600 * time.Second
+		})
+		mgmtCfg := awsCfg
+		mgmtCfg.Credentials = aws.NewCredentialsCache(provider)
+		stsClient = sts.NewFromConfig(mgmtCfg)
+	}
+
+	return stsClient, secretsmanager.NewFromConfig(awsCfg), nil
+}
+
+func (s *Server) instanceSecretFetchInputs(inst *models.Instance) (secretArn string, accountID string, roleName string, region string, err error) {
+	if s == nil {
+		return "", "", "", "", fmt.Errorf("server not initialized")
+	}
+	if inst == nil {
+		return "", "", "", "", fmt.Errorf("instance is nil")
+	}
+	secretArn = strings.TrimSpace(inst.LesserHostInstanceKeySecretARN)
+	if secretArn == "" {
+		return "", "", "", "", fmt.Errorf("instance api key secret arn is not configured")
+	}
+	accountID = strings.TrimSpace(inst.HostedAccountID)
+	roleName = strings.TrimSpace(s.cfg.ManagedInstanceRoleName)
+	region = managedInstanceSecretRegion(inst, s.cfg.ManagedDefaultRegion)
+	return secretArn, accountID, roleName, region, nil
+}
+
+func managedInstanceSecretRegion(inst *models.Instance, fallback string) string {
+	region := ""
+	if inst != nil {
+		region = strings.TrimSpace(inst.HostedRegion)
+	}
+	if region != "" {
+		return region
+	}
+	if fallback = strings.TrimSpace(fallback); fallback != "" {
+		return fallback
+	}
+	return "us-east-1"
+}
+
+func getControlPlaneSecretPlaintext(ctx context.Context, sm controlPlaneSecretsManagerAPI, secretArn string) (string, error) {
+	secretArn = strings.TrimSpace(secretArn)
+	if secretArn == "" {
+		return "", fmt.Errorf("secret arn is required")
+	}
+	if sm == nil {
+		return "", fmt.Errorf("secrets manager client not initialized")
+	}
+
+	out, err := sm.GetSecretValue(ctx, &secretsmanager.GetSecretValueInput{SecretId: aws.String(secretArn)})
+	if err != nil {
+		return "", fmt.Errorf("get secret value: %w", err)
+	}
+
+	raw := strings.TrimSpace(aws.ToString(out.SecretString))
+	if raw == "" && len(out.SecretBinary) > 0 {
+		raw = strings.TrimSpace(string(out.SecretBinary))
+	}
+	plaintext, err := unwrapControlPlaneSecretString(raw)
+	if err != nil {
+		return "", fmt.Errorf("parse secret value: %w", err)
+	}
+	return plaintext, nil
+}
+
+func unwrapControlPlaneSecretString(raw string) (string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", fmt.Errorf("secret value is empty")
+	}
+	if strings.HasPrefix(raw, "{") {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			return "", fmt.Errorf("unmarshal secret string: %w", err)
+		}
+		val := strings.TrimSpace(parsed["secret"])
+		if val == "" {
+			return "", fmt.Errorf("secret payload missing 'secret' key")
+		}
+		return val, nil
+	}
+	return raw, nil
+}

--- a/internal/controlplane/managed_instance_metrics_internal_test.go
+++ b/internal/controlplane/managed_instance_metrics_internal_test.go
@@ -1,0 +1,282 @@
+package controlplane
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type fakeControlPlaneSecretsManager struct {
+	out         *secretsmanager.GetSecretValueOutput
+	err         error
+	gotSecretID string
+}
+
+func (f *fakeControlPlaneSecretsManager) GetSecretValue(_ context.Context, params *secretsmanager.GetSecretValueInput, _ ...func(*secretsmanager.Options)) (*secretsmanager.GetSecretValueOutput, error) {
+	if params != nil {
+		f.gotSecretID = aws.ToString(params.SecretId)
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.out, nil
+}
+
+type fakeControlPlaneSTS struct {
+	out            *sts.AssumeRoleOutput
+	err            error
+	gotRoleArn     string
+	gotSessionName string
+}
+
+func (f *fakeControlPlaneSTS) AssumeRole(_ context.Context, params *sts.AssumeRoleInput, _ ...func(*sts.Options)) (*sts.AssumeRoleOutput, error) {
+	if params != nil {
+		f.gotRoleArn = aws.ToString(params.RoleArn)
+		f.gotSessionName = aws.ToString(params.RoleSessionName)
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.out, nil
+}
+
+func TestManagedInstanceSecretRegion(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "us-west-2", managedInstanceSecretRegion(&models.Instance{HostedRegion: " us-west-2 "}, "us-east-1"))
+	require.Equal(t, "eu-central-1", managedInstanceSecretRegion(&models.Instance{}, " eu-central-1 "))
+	require.Equal(t, "us-east-1", managedInstanceSecretRegion(nil, ""))
+}
+
+func TestInstanceSecretFetchInputs(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{ManagedInstanceRoleName: " OrgRole ", ManagedDefaultRegion: " us-west-2 "}}
+	inst := &models.Instance{
+		LesserHostInstanceKeySecretARN: " arn:secret ",
+		HostedAccountID:                " 123456789012 ",
+	}
+
+	secretArn, accountID, roleName, region, err := s.instanceSecretFetchInputs(inst)
+	require.NoError(t, err)
+	require.Equal(t, "arn:secret", secretArn)
+	require.Equal(t, "123456789012", accountID)
+	require.Equal(t, "OrgRole", roleName)
+	require.Equal(t, "us-west-2", region)
+
+	_, _, _, _, err = (*Server)(nil).instanceSecretFetchInputs(inst)
+	require.ErrorContains(t, err, "server not initialized")
+	_, _, _, _, err = s.instanceSecretFetchInputs(nil)
+	require.ErrorContains(t, err, "instance is nil")
+	_, _, _, _, err = s.instanceSecretFetchInputs(&models.Instance{})
+	require.ErrorContains(t, err, "secret arn")
+}
+
+func TestUnwrapControlPlaneSecretString(t *testing.T) {
+	t.Parallel()
+
+	raw, err := unwrapControlPlaneSecretString(" raw-secret ")
+	require.NoError(t, err)
+	require.Equal(t, "raw-secret", raw)
+
+	jsonSecret, err := unwrapControlPlaneSecretString(`{"secret":" json-secret "}`)
+	require.NoError(t, err)
+	require.Equal(t, "json-secret", jsonSecret)
+
+	_, err = unwrapControlPlaneSecretString("")
+	require.ErrorContains(t, err, "empty")
+	_, err = unwrapControlPlaneSecretString(`{"secret":`)
+	require.ErrorContains(t, err, "unmarshal")
+	_, err = unwrapControlPlaneSecretString(`{"other":"value"}`)
+	require.ErrorContains(t, err, "missing 'secret'")
+}
+
+func TestGetControlPlaneSecretPlaintext(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := &fakeControlPlaneSecretsManager{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String(`{"secret":" key-from-json "}`)}}
+	got, err := getControlPlaneSecretPlaintext(ctx, fake, " arn:secret ")
+	require.NoError(t, err)
+	require.Equal(t, "key-from-json", got)
+	require.Equal(t, "arn:secret", fake.gotSecretID)
+
+	binary := &fakeControlPlaneSecretsManager{out: &secretsmanager.GetSecretValueOutput{SecretBinary: []byte(" binary-key ")}}
+	got, err = getControlPlaneSecretPlaintext(ctx, binary, "arn:binary")
+	require.NoError(t, err)
+	require.Equal(t, "binary-key", got)
+
+	_, err = getControlPlaneSecretPlaintext(ctx, fake, "")
+	require.ErrorContains(t, err, "secret arn")
+	_, err = getControlPlaneSecretPlaintext(ctx, nil, "arn:secret")
+	require.ErrorContains(t, err, "not initialized")
+	_, err = getControlPlaneSecretPlaintext(ctx, &fakeControlPlaneSecretsManager{err: errors.New("boom")}, "arn:secret")
+	require.ErrorContains(t, err, "get secret value")
+}
+
+func TestDefaultFetchInstanceKeyPlaintextSameAccountUsesInjectedSecrets(t *testing.T) {
+	t.Parallel()
+
+	fakeSecrets := &fakeControlPlaneSecretsManager{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String(" host-key ")}}
+	s := &Server{cfg: config.Config{ManagedDefaultRegion: "us-east-2"}, sts: &fakeControlPlaneSTS{}, secrets: fakeSecrets}
+	got, err := s.defaultFetchInstanceKeyPlaintext(context.Background(), &models.Instance{LesserHostInstanceKeySecretARN: "arn:secret"})
+	require.NoError(t, err)
+	require.Equal(t, "host-key", got)
+	require.Equal(t, "arn:secret", fakeSecrets.gotSecretID)
+}
+
+func TestDefaultFetchInstanceKeyPlaintextCrossAccountAssumeRoleFailures(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fakeSecrets := &fakeControlPlaneSecretsManager{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("unused")}}
+	assumeDenied := &fakeControlPlaneSTS{err: errors.New("denied")}
+	s := &Server{
+		cfg:     config.Config{Stage: "lab", ManagedInstanceRoleName: "OrgRole", ManagedDefaultRegion: "us-east-1"},
+		sts:     assumeDenied,
+		secrets: fakeSecrets,
+	}
+	inst := &models.Instance{
+		Slug:                           "demo",
+		HostedAccountID:                "123456789012",
+		HostedRegion:                   "us-west-2",
+		LesserHostInstanceKeySecretARN: "arn:secret",
+	}
+
+	_, err := s.defaultFetchInstanceKeyPlaintext(ctx, inst)
+	require.ErrorContains(t, err, "assume instance role")
+	require.Equal(t, "arn:aws:iam::123456789012:role/OrgRole", assumeDenied.gotRoleArn)
+	require.Equal(t, "lesser-host-lab-cost-demo", assumeDenied.gotSessionName)
+
+	emptyAssume := &fakeControlPlaneSTS{out: &sts.AssumeRoleOutput{}}
+	s.sts = emptyAssume
+	_, err = s.defaultFetchInstanceKeyPlaintext(ctx, inst)
+	require.ErrorContains(t, err, "empty credentials")
+}
+
+func TestBuildPortalCostResponseFromLesserUsesCentsAndSkipsEmptyDates(t *testing.T) {
+	t.Parallel()
+
+	resp := buildPortalCostResponseFromLesser("demo", testCostDate1, testCostDate2, lesserInstanceMetricsResponse{Daily: []lesserInstanceMetricsDailyRow{
+		{CostDollars: 99, Currency: "USD"},
+		{Date: testCostDate2, CostCents: 34, TotalRequests: 2},
+	}})
+
+	require.Equal(t, 1, resp.Count)
+	require.Len(t, resp.Days, 1)
+	require.Equal(t, testCostDate2, resp.Days[0].Date)
+	require.InDelta(t, 0.34, resp.Days[0].DayCost, 0.000001)
+	require.Equal(t, "USD", resp.Currency)
+}
+
+func TestParseCostDateWindowDefaults(t *testing.T) {
+	t.Parallel()
+
+	from, to, appErr := parseCostDateWindow(newCostHandlerCtx(testCostSlug1, nil))
+	require.Nil(t, appErr)
+	fromTime, err := time.Parse("2006-01-02", from)
+	require.NoError(t, err)
+	toTime, err := time.Parse("2006-01-02", to)
+	require.NoError(t, err)
+	require.Equal(t, costQueryDefaultDays, int(toTime.Sub(fromTime).Hours()/24))
+}
+
+func TestBuildManagedInstanceMetricsURLRequiresBaseURL(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildManagedInstanceMetricsURL(" ", testCostDate1, testCostDate2)
+	require.ErrorContains(t, err, "base url")
+}
+
+func TestInstanceMetricsAWSClientsUsesInjectedClients(t *testing.T) {
+	t.Parallel()
+
+	fakeSecrets := &fakeControlPlaneSecretsManager{out: &secretsmanager.GetSecretValueOutput{SecretString: aws.String("key")}}
+	s := &Server{sts: &fakeControlPlaneSTS{}, secrets: fakeSecrets}
+	stsClient, secretsClient, err := s.instanceMetricsAWSClients(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, stsClient)
+	require.Same(t, fakeSecrets, secretsClient)
+}
+
+func TestDefaultInstanceMetricsBaseURLValidation(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{Stage: "lab"}}
+	_, err := s.defaultInstanceMetricsBaseURL(nil)
+	require.ErrorContains(t, err, "instance is nil")
+	_, err = s.defaultInstanceMetricsBaseURL(&models.Instance{})
+	require.ErrorContains(t, err, "hosted base domain")
+}
+
+func TestResolvePortalCostInstanceKeyUsesInjectedResolver(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+		return "injected-key", nil
+	}}
+	got, err := s.resolvePortalCostInstanceKey(context.Background(), &models.Instance{})
+	require.NoError(t, err)
+	require.Equal(t, "injected-key", got)
+
+	_, err = (*Server)(nil).resolvePortalCostInstanceKey(context.Background(), &models.Instance{})
+	require.ErrorContains(t, err, "server not initialized")
+}
+
+func TestResolvePortalCostMetricsBaseURLUsesInjectedResolver(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) {
+		return "https://metrics.example", nil
+	}}
+	got, err := s.resolvePortalCostMetricsBaseURL(&models.Instance{})
+	require.NoError(t, err)
+	require.Equal(t, "https://metrics.example", got)
+}
+
+func TestFetchManagedInstanceMetricsAdditionalFailures(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) {
+		return "https://metrics.example", nil
+	}}
+	_, appErr := s.fetchManagedInstanceMetrics(context.Background(), &models.Instance{}, " ", testCostDate1, testCostDate2)
+	require.NotNil(t, appErr)
+	require.Equal(t, "app.internal", appErr.Code)
+
+	s.resolveInstanceMetricsBaseURLFunc = func(*models.Instance) (string, error) { return "://bad", nil }
+	_, appErr = s.fetchManagedInstanceMetrics(context.Background(), &models.Instance{}, testRawKey, testCostDate1, testCostDate2)
+	require.NotNil(t, appErr)
+	require.Equal(t, "app.internal", appErr.Code)
+}
+
+func TestFetchManagedInstanceMetricsDecodeError(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not-json"))
+	}))
+	defer ts.Close()
+
+	s := &Server{
+		portalCostHTTPClient: ts.Client(),
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) {
+			return ts.URL, nil
+		},
+	}
+	_, appErr := s.fetchManagedInstanceMetrics(context.Background(), &models.Instance{}, testRawKey, testCostDate1, testCostDate2)
+	require.NotNil(t, appErr)
+	require.Equal(t, "app.upstream_error", appErr.Code)
+	require.NotContains(t, appErr.Message, testRawKey)
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"log"
+	"net/http"
 	"strings"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
@@ -12,6 +13,7 @@ import (
 	"github.com/equaltoai/lesser-host/internal/commworker"
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 type soulPackStore interface {
@@ -30,6 +32,13 @@ type Server struct {
 	mailboxContentStore commmailbox.ContentStore
 	dialEVM             ethRPCDialer
 	soulAvatarCache     *soulPublicAvatarCache
+
+	sts     controlPlaneSTSAPI
+	secrets controlPlaneSecretsManagerAPI
+
+	portalCostHTTPClient              *http.Client
+	fetchInstanceKeyPlaintextFunc     func(ctx context.Context, inst *models.Instance) (string, error)
+	resolveInstanceMetricsBaseURLFunc func(inst *models.Instance) (string, error)
 
 	ssmGetParameter     func(ctx context.Context, name string) (string, error)
 	ssmPutSecureValue   func(ctx context.Context, name string, value string, overwrite bool) error

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -35,6 +35,12 @@
 	let isOperatorRoute = $derived($currentPath === '/operator' || $currentPath.startsWith('/operator/'));
 	// Project 39 customer surfaces render inside the shell. /portal is the
 	// canonical fleet view; /portal/fleet remains a compatibility alias.
+	// Project 42 M0.1 (#526): /portal/trust and /portal/account are now
+	// canonical paths for Trust + Account inside portal chrome; /trust and
+	// /account remain backward-compat aliases so existing bookmarks /
+	// deep-links continue to work without redirect (and the public
+	// attestation inspector subroute under /trust/attestations/* keeps
+	// resolving via the same Trust component).
 	let isPortalShellRoute = $derived(
 		$currentPath === '/portal' ||
 			$currentPath === '/portal/fleet' ||
@@ -53,6 +59,15 @@
 			$currentPath === '/account'
 		)
 	);
+	// Project 42 M0.1: helpers for /portal/trust + /portal/account dispatch.
+	// Specific paths checked before the generic /portal/ catch-all so they
+	// render Trust + Account directly under PortalShell (matching the
+	// design's namespacing) rather than falling through to Portal.svelte's
+	// instance-list switch (which would return "Unknown portal path").
+	let isPortalTrustRoute = $derived(
+		$currentPath === '/portal/trust' || $currentPath.startsWith('/portal/trust/')
+	);
+	let isPortalAccountRoute = $derived($currentPath === '/portal/account');
 
 	onMount(() => {
 		if (!isSafeAppPath() || get(currentPath) !== '/') return;
@@ -72,6 +87,10 @@
 		<PortalShell>
 			{#if $currentPath === '/portal' || $currentPath === '/portal/fleet' || $currentPath.startsWith('/portal/fleet/')}
 				<PortalFleet token={$session?.token ?? ''} />
+			{:else if isPortalTrustRoute}
+				<Trust />
+			{:else if isPortalAccountRoute}
+				<Account />
 			{:else if $currentPath.startsWith('/portal/')}
 				<Portal />
 			{:else if $currentPath === '/trust' || $currentPath.startsWith('/trust/')}

--- a/web/src/lib/components/PortalShell.svelte
+++ b/web/src/lib/components/PortalShell.svelte
@@ -267,6 +267,52 @@ Issue: equaltoai/lesser-host#391
 		return ev.metaKey || ev.ctrlKey;
 	}
 
+	// Project 42 M0.7 (#532): the sidebar footer used to render
+	// `@{session.username}` literally. For wallet-login customers the
+	// username is auto-generated as `wallet-<64-hex>` and the audit
+	// caught the result rendering as `@wallet-f7c8c15eefb7a907ceee47ae…`
+	// — visible, unreadable, and operator-hostile. The full display-name
+	// surfacing belongs to M2 (PortalShell redesign), which fetches the
+	// `display_name` field returned by `/api/v1/portal/me`. This M0 fix
+	// is the bounded interim: detect the wallet-* synthetic-username
+	// pattern and substitute a short, recognizable identity built from
+	// the session.walletAddress already on the wire.
+	const WALLET_USERNAME_PATTERN = /^wallet-[0-9a-f]+$/i;
+
+	function shortWalletAddress(addr: string | undefined): string {
+		const a = (addr ?? '').trim();
+		if (!a) return '';
+		if (a.length <= 14) return a;
+		return `${a.slice(0, 6)}…${a.slice(-4)}`;
+	}
+
+	const displayHandle = $derived.by((): string => {
+		if (!$session) return '';
+		const u = ($session.username || '').trim();
+		if (!u) return '';
+		if (!WALLET_USERNAME_PATTERN.test(u)) {
+			return `@${u}`;
+		}
+		// Synthetic wallet-* username: prefer the truncated wallet address
+		// when present, fall back to a short prefix of the synthetic name.
+		const short = shortWalletAddress($session.walletAddress);
+		if (short) return short;
+		const tail = u.slice('wallet-'.length, 'wallet-'.length + 6);
+		return tail ? `@wallet-${tail}…` : '@wallet';
+	});
+
+	const avatarInitials = $derived.by((): string => {
+		if (!$session) return '';
+		const u = ($session.username || '').trim();
+		if (!u) return '?';
+		if (!WALLET_USERNAME_PATTERN.test(u)) {
+			return u.slice(0, 2).toUpperCase();
+		}
+		const addr = ($session.walletAddress || '').trim();
+		if (addr.startsWith('0x') && addr.length >= 4) return addr.slice(2, 4).toUpperCase();
+		return 'W•';
+	});
+
 	onMount(() => {
 		function onKeydown(ev: KeyboardEvent) {
 			if (!isPaletteHotkey(ev)) return;
@@ -299,7 +345,7 @@ Issue: equaltoai/lesser-host#391
 			{#snippet end()}
 				<div class="portal-shell__topbar-end">
 					{#if $session}
-						<Text size="sm" weight="medium">{$session.username}</Text>
+						<Text size="sm" weight="medium">{displayHandle}</Text>
 						<Text size="sm" color="secondary">{$session.role}</Text>
 						<Button variant="outline" onclick={() => void handleLogout()}>Logout</Button>
 					{:else}
@@ -370,10 +416,10 @@ Issue: equaltoai/lesser-host#391
 					{#if $session}
 						<div class="portal-shell__user-chip">
 							<span class="portal-shell__avatar" aria-hidden="true">
-								{$session.username.slice(0, 2).toUpperCase()}
+								{avatarInitials}
 							</span>
 							<span class="portal-shell__user-copy">
-								<Text size="sm" weight="medium">@{$session.username}</Text>
+								<Text size="sm" weight="medium">{displayHandle}</Text>
 								<Text size="sm" color="secondary">{$session.role} · {$session.method ?? 'session'}</Text>
 							</span>
 						</div>

--- a/web/src/lib/components/PortalShell.svelte
+++ b/web/src/lib/components/PortalShell.svelte
@@ -230,10 +230,14 @@ Issue: equaltoai/lesser-host#391
 				navigate('/portal/souls');
 				return;
 			case 'nav.trust':
-				navigate('/trust');
+				// Project 42 M0.1 (#526): canonical Trust path is now under
+				// portal chrome. /trust still resolves (App.svelte routes it
+				// to the same Trust component) but the command palette
+				// always navigates to the canonical entrypoint.
+				navigate('/portal/trust');
 				return;
 			case 'nav.account':
-				navigate('/account');
+				navigate('/portal/account');
 				return;
 			case 'nav.billing':
 				navigate('/portal/billing');
@@ -341,16 +345,18 @@ Issue: equaltoai/lesser-host#391
 					Billing
 				</Link>
 				<Link
-					{...linkProps('/trust')}
+					{...linkProps('/portal/trust')}
 					variant="ghost"
-					aria-current={isActive('/trust') ? 'page' : undefined}
+					aria-current={isActive('/portal/trust') || isActive('/trust') ? 'page' : undefined}
 				>
 					Trust
 				</Link>
 				<Link
-					{...linkProps('/account')}
+					{...linkProps('/portal/account')}
 					variant="ghost"
-					aria-current={isActive('/account', true) ? 'page' : undefined}
+					aria-current={isActive('/portal/account', true) || isActive('/account', true)
+						? 'page'
+						: undefined}
 				>
 					Account
 				</Link>

--- a/web/src/pages/Portal.svelte
+++ b/web/src/pages/Portal.svelte
@@ -46,6 +46,15 @@
 		| { kind: 'billing' }
 		| { kind: 'notFound' };
 
+	// Project 42 M0.2 (#527): the outer page <h1> in this component used to
+	// render "Portal Dashboard" for every /portal/* sub-route, which the
+	// 2026-05-27 audit caught as wrong for /portal/billing (the h1 read
+	// "Portal Dashboard" while the Billing eyebrow + title appeared
+	// further down the page). The h1 + description are now derived from
+	// portalRoute so each sub-route names itself correctly without copying
+	// the inner section's eyebrow. Other sub-routes still default to the
+	// existing "Portal Dashboard" copy until their own redesign milestone
+	// owns the page.
 	const portalRoute = $derived.by<PortalRoute>(() => {
 		const path = $currentPath;
 		if (!path.startsWith('/portal')) return { kind: 'instances' };
@@ -82,6 +91,29 @@
 		}
 
 		return { kind: 'notFound' };
+	});
+
+	// Project 42 M0.2 (#527): scoped title + description per sub-route.
+	// /portal/billing now reads "Billing" (audit P0 fix); other sub-routes
+	// continue to render the existing dashboard copy until their owning
+	// milestone (M11 Billing UI / M13 Souls UI / M6 Instance Overview UI /
+	// etc.) redesigns them.
+	const pageTitle = $derived.by((): string => {
+		switch (portalRoute.kind) {
+			case 'billing':
+				return 'Billing';
+			default:
+				return 'Portal Dashboard';
+		}
+	});
+
+	const pageDescription = $derived.by((): string => {
+		switch (portalRoute.kind) {
+			case 'billing':
+				return 'Credits, usage, and invoices for the signed-in account.';
+			default:
+				return 'Self-serve customer dashboard.';
+		}
 	});
 
 	function formatError(err: unknown): string {
@@ -132,8 +164,8 @@
 	<div class="portal">
 		<header class="portal__header">
 			<div class="portal__title">
-				<Heading level={1}>Portal Dashboard</Heading>
-				<Text color="secondary">Self-serve customer dashboard.</Text>
+				<Heading level={1}>{pageTitle}</Heading>
+				<Text color="secondary">{pageDescription}</Text>
 			</div>
 			<div class="portal__actions">
 				<Button variant="outline" onclick={() => void loadMe()} disabled={loading}>Refresh</Button>

--- a/web/src/pages/Trust.svelte
+++ b/web/src/pages/Trust.svelte
@@ -36,11 +36,22 @@ Issue: equaltoai/lesser-host#412
 		| { kind: 'attestation'; id: string }
 		| { kind: 'notFound' };
 
+	// Project 42 M0.1 (#526): the Trust UI now serves at two equivalent
+	// prefixes — /portal/trust (canonical, inside portal chrome) and /trust
+	// (legacy alias). Derive the active prefix so subroute parsing +
+	// navigate() calls work for either entry point. The trust API itself
+	// (`/.well-known/*`, `/attestations/*`) is Lambda-served and unchanged.
+	const trustBasePath = $derived(
+		$currentPath === '/portal/trust' || $currentPath.startsWith('/portal/trust/')
+			? '/portal/trust'
+			: '/trust'
+	);
+
 	const trustRoute = $derived.by<TrustRoute>(() => {
 		const path = $currentPath;
-		if (!path.startsWith('/trust')) return { kind: 'home' };
+		if (!path.startsWith(trustBasePath)) return { kind: 'home' };
 
-		const rest = path.slice('/trust'.length);
+		const rest = path.slice(trustBasePath.length);
 		const parts = rest.split('/').filter(Boolean);
 		if (parts.length === 0) return { kind: 'home' };
 		if (parts[0] === 'attestations' && parts[1]) return { kind: 'attestation', id: parts[1] };
@@ -77,7 +88,7 @@ Issue: equaltoai/lesser-host#412
 	function openById() {
 		const normalized = normalizeId(idInput);
 		if (!normalized) return;
-		navigate(`/trust/attestations/${normalized}`);
+		navigate(`${trustBasePath}/attestations/${normalized}`);
 	}
 
 	async function lookup() {
@@ -103,7 +114,7 @@ Issue: equaltoai/lesser-host#412
 				module: m,
 				policy_version: p,
 			});
-			navigate(`/trust/attestations/${res.id}`);
+			navigate(`${trustBasePath}/attestations/${res.id}`);
 		} catch (err) {
 			lookupError = formatError(err);
 		} finally {

--- a/web/src/pages/portal/InstanceDetail.svelte
+++ b/web/src/pages/portal/InstanceDetail.svelte
@@ -547,8 +547,23 @@
 
 <div class="instance-detail">
 	<div class="instance-detail__overview-actions">
-		<Button variant="outline" onclick={() => void refreshAll()} disabled={instanceLoading || domainsLoading || provisioningLoading}>
-			Refresh
+		<!--
+		Project 42 M0.8 (#533): the audit caught two identically labeled,
+		identically styled "Refresh" buttons on the Instance Overview —
+		the page-scoped one here (refreshes instance + domains +
+		provisioning via refreshAll()) and a stack-scoped one inside the
+		StackCard panel (refreshes just the stack-state telemetry).
+		Distinguish the page-scoped action with an explicit label so the
+		operator can tell the two refresh affordances apart. The
+		StackCard's "Refresh" stays as-is because its parent panel header
+		"Stack" already disambiguates its scope.
+		-->
+		<Button
+			variant="outline"
+			onclick={() => void refreshAll()}
+			disabled={instanceLoading || domainsLoading || provisioningLoading}
+		>
+			Refresh page
 		</Button>
 	</div>
 

--- a/web/src/pages/portal/InstanceDetail.svelte
+++ b/web/src/pages/portal/InstanceDetail.svelte
@@ -701,7 +701,56 @@
 						{/if}
 					</Alert>
 				{/if}
-			{:else}
+			{:else if instance.provision_status === 'ok'}
+				<!--
+				Project 42 M0.3 (#528): instance is already provisioned but
+				the current provisioning-job record was not returned (typical
+				when the job is archived). Surface the provisioned state
+				explicitly instead of falling through to the "Not started"
+				form, which used to render on every healthy/live managed
+				instance that no longer carried a live job record.
+				-->
+				<Alert variant="success" title="Provisioned">
+					<Text size="sm">
+						Managed infrastructure is allocated for this instance. The current provisioning-job record is
+						no longer retained; use the Updates section below to apply configuration changes or rotate the
+						instance key.
+					</Text>
+				</Alert>
+			{:else if instance.provision_status === 'error'}
+				<!--
+				Project 42 M0.3 (#528): explicit failure path when the
+				last provisioning attempt errored but no job record is
+				currently returned. Re-show the form so the operator can
+				retry; this is the original audit-rationale fallback,
+				preserved deliberately for failed instances.
+				-->
+				<Alert variant="warning" title="Provisioning failed previously">
+					<Text size="sm">
+						The last provisioning attempt errored and the job record is no longer retained. Update the inputs
+						(optional) and retry.
+					</Text>
+				</Alert>
+
+				<div class="instance-detail__form">
+					<TextField label="Admin username" bind:value={provisionAdminUsername} placeholder={slug} />
+					<TextField label="Region (optional)" bind:value={provisionRegion} placeholder="us-east-1" />
+					<TextField label="Lesser version (optional)" bind:value={provisionLesserVersion} placeholder="v1.2.3 or latest" />
+				</div>
+
+				<div class="instance-detail__row">
+					<Button variant="solid" onclick={() => void startProvisioning()} disabled={provisioningLoading}>
+						Restart provisioning
+					</Button>
+				</div>
+			{:else if instance.hosted_account_id && instance.hosted_region && instance.hosted_base_domain}
+				<!--
+				Project 42 M0.3 (#528): the form only appears for managed
+				instances that have never been provisioned (provision_status
+				is empty AND no live provisioning-job record). Non-managed /
+				externally-registered instances skip this entire branch and
+				render the explanatory alert below.
+				-->
 				<Alert variant="info" title="Not started">
 					<Text size="sm">Start managed provisioning to allocate infrastructure for this instance.</Text>
 				</Alert>
@@ -717,6 +766,20 @@
 						Start provisioning
 					</Button>
 				</div>
+			{:else}
+				<!--
+				Project 42 M0.3 (#528): externally-registered (non-managed)
+				instance — managed provisioning does not apply. Suppress
+				the "Start provisioning" form entirely so the operator
+				doesn't see misleading allocation inputs for an instance
+				the control plane never provisions.
+				-->
+				<Alert variant="info" title="Externally registered">
+					<Text size="sm">
+						This instance is not managed by lesser.host. Managed provisioning does not apply; lifecycle
+						management is owned by the external operator.
+					</Text>
+				</Alert>
 			{/if}
 		</Card>
 

--- a/web/src/pages/portal/InstanceSouls.svelte
+++ b/web/src/pages/portal/InstanceSouls.svelte
@@ -100,13 +100,47 @@ Issue: equaltoai/lesser-host#419
 		}
 	}
 
+	// Project 42 M0.5 (#530): the audit caught "No souls bound to this
+	// instance" rendering on instances that demonstrably have bound souls.
+	//
+	// Root-caused binding mismatch (server vs client):
+	//   - Server `handleSoulListMyAgents` walks the owner's instances and
+	//     gathers BOTH per-instance verified domains AND the stage-prefixed
+	//     managed domain (`internal/controlplane/handlers_soul_mine.go`
+	//     :103-122; the stage prefix comes from
+	//     `managedInstanceStageDomain(stage, HostedBaseDomain)` =
+	//     `<stage>.<base>` for non-live stages — e.g. `dev.simulacrum.greater.website`).
+	//   - Soul agents on a managed instance are registered against the
+	//     stage-prefixed managed domain (the URL the customer's browser
+	//     actually hits), so `agent.domain` is the stage-prefixed form.
+	//   - The previous client filter compared `agent.domain ===
+	//     instance.hosted_base_domain`. `hosted_base_domain` is the BASE
+	//     (without stage prefix); on every non-live stage the comparison
+	//     therefore mismatches the stage-prefixed `agent.domain` and the
+	//     filter silently dropped every bound soul.
+	//
+	// Fix (matches server semantics without backend churn):
+	//   - The portal instance DTO ALREADY exposes `managed_lesser_domain`
+	//     (the stage-prefixed canonical form, computed in
+	//     `internal/controlplane/instance_response_derived.go`). Compare
+	//     `agent.domain` against the set { hosted_base_domain,
+	//     managed_lesser_domain } so live-stage instances (where the two
+	//     are equal) and non-live stages both match correctly.
 	const boundAgents = $derived.by<SoulMineAgentItem[]>(() => {
 		if (!instance) return [];
-		const targetDomain = (instance.hosted_base_domain || '').trim().toLowerCase();
-		if (!targetDomain) return [];
-		return allAgents.filter(
-			(item) => (item.agent.domain || '').trim().toLowerCase() === targetDomain,
-		);
+		// Use plain object (Record), not Set: svelte/prefer-svelte-reactivity
+		// prohibits Map/Set in .svelte files even in local function scope.
+		const candidateDomains: Record<string, true> = {};
+		const baseDomain = (instance.hosted_base_domain || '').trim().toLowerCase();
+		const managedDomain = (instance.managed_lesser_domain || '').trim().toLowerCase();
+		if (baseDomain) candidateDomains[baseDomain] = true;
+		if (managedDomain) candidateDomains[managedDomain] = true;
+		const candidateCount = Object.keys(candidateDomains).length;
+		if (candidateCount === 0) return [];
+		return allAgents.filter((item) => {
+			const domain = (item.agent.domain || '').trim().toLowerCase();
+			return Boolean(candidateDomains[domain]);
+		});
 	});
 
 	onMount(() => {

--- a/web/src/pages/portal/Instances.svelte
+++ b/web/src/pages/portal/Instances.svelte
@@ -106,8 +106,21 @@
 			<Heading level={2} size="xl">Instances</Heading>
 		{/snippet}
 
+		<!--
+		Project 42 M0.6 (#531): the previous template rendered the literal
+		`{slug}` to the DOM (audit P3 — unrendered template variable),
+		because Svelte text expressions output their string contents
+		verbatim once escaped. Replace with reactive copy that mirrors the
+		operator's current input (and gives an explicit placeholder
+		instructional when empty) so no literal template token leaks.
+		-->
 		<Text size="sm" color="secondary">
-			Create a slug to reserve <code>{'{slug}'}</code> and start provisioning managed hosting.
+			{#if createSlug.trim()}
+				Create a slug to reserve <code>{createSlug.trim()}</code> and start provisioning managed hosting.
+			{:else}
+				Enter a slug below (lowercase letters, digits, hyphens) to reserve a managed-hosting
+				instance.
+			{/if}
 		</Text>
 
 		<div class="instances__create">


### PR DESCRIPTION
## Milestone

Project 42 M0 — portal P0 correctness bundle for parent issue #525. This PR now includes the corrected M0.4 path: host-side portal cost reads are sourced from the managed Lesser instance metrics contract instead of host-local placeholder telemetry.

## Issue linkage

Refs #525.

Closes #526.
Closes #527.
Closes #528.
Closes #529.
Closes #530.
Closes #531.
Closes #532.
Closes #533.

## Sub-issue checklist

| # | Sub-issue | Status |
|---|---|---|
| #526 | M0.1 — Route Trust and Account inside portal chrome | Fixed |
| #527 | M0.2 — Correct Billing page heading | Fixed |
| #528 | M0.3 — Hide provisioning form for live instances | Fixed |
| #529 | M0.4 — Instance Cost sources managed Lesser metrics | Fixed in host; depends on equaltoai/lesser#1097 for the managed-instance endpoint contract |
| #530 | M0.5 — Fix Instance Souls bound-agent fetch | Fixed |
| #531 | M0.6 — Remove literal `{slug}` template leak | Fixed |
| #532 | M0.7 — Replace raw sidebar wallet identity preview | Fixed as bounded interim; M2 still owns full display-name surfacing |
| #533 | M0.8 — Resolve duplicate Instance Overview Refresh | Fixed |

## M0.4 implementation summary

- `GET /api/v1/portal/instances/{slug}/cost` now enforces `requireInstanceAccess` before resolving any instance key or making a managed Lesser HTTP call.
- The control plane resolves the managed instance API key via Secrets Manager / optional managed-org vending role / managed instance role flow, then calls `GET /api/v1/instance/metrics/daily` with `Authorization: Bearer <instance-key>`.
- The response is mapped into the existing `PortalCostResponse` DTO as `Managed Lesser` daily entries with request/user/DynamoDB/Lambda usage metrics and cost.
- Tests prove bearer auth is sent upstream, raw keys and forbidden storage fields are not returned, wrong-owner requests skip secret resolution and HTTP entirely, and upstream/key-resolution errors do not leak secrets or response bodies.
- `SEC-13` was updated to enforce the corrected M0.4 invariant instead of the old host-local `ListCostTelemetryByInstance` read path.

## Cross-repo dependency

- equaltoai/lesser#1097 adds the instance-key-authenticated managed metrics route and OpenAPI/GraphQL coverage entries.
- Current Lesser dependency head used for validation: `c530489b60ff96dbd691017822406779373a5e7c`.
- Deployment order: merge/deploy Lesser #1097 before expecting lab/live cost-page smoke to show managed metrics from this host PR.

## Validation

Latest local validation on this branch:

- `git diff --check` — PASS
- `go test ./...` — PASS
- `cd cdk && npm test` — PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (`40 pass / 0 fail / 0 blocked`, coverage `80.1%`)

Previously-run web validation remains applicable; this final patch did not touch `web/`:

- `cd web && npm run lint` — PASS
- `cd web && npm run typecheck` — PASS
- `cd web && npm test` — PASS

## Posture

- Strict-no-inline-CSP: preserved; no web CSP relaxations introduced.
- Multi-tenant isolation: strengthened for cost reads by proving ownership before secret resolution or managed-instance HTTP.
- Secret handling: instance keys stay server-side and are redacted from success and error paths.
- AGPL/dependency posture: no new third-party dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
