### PR TITLE
feat(portal): add owner enrichment, soul anchor, and drift fields to instance detail (M7)

### DIFF
--- a/gov-infra/evidence/design-fidelity/m7-instance-overview-data/contract-note.md
+++ b/gov-infra/evidence/design-fidelity/m7-instance-overview-data/contract-note.md
@@ -33,7 +33,7 @@ account-level membership or cross-tenant identifiers are leaked.
 |---------------------|--------|--------------------------|------------------------------|
 | `soul_anchor_state` | string | `deriveSoulAnchorState`  | `""` if soul not enabled     |
 |                     |        |                          | `"anchored"` if provisioned  |
-| `soul_anchor_at`    | time   | `Instance.SoulProvisionedAt` | Zero time if not provisioned |
+| `soul_anchor_at`    | *time  | `Instance.SoulProvisionedAt` | `null` (absent from JSON) if not provisioned |
 
 No additional DB query is required — these are derived entirely from the
 existing Instance model fields (`SoulEnabled`, `SoulProvisionedAt`).
@@ -57,7 +57,7 @@ Drift values match the dedicated `/stack` endpoint contract:
 
 All new fields use `omitempty`. When the underlying data is absent:
 - Strings default to `""` (empty string, omitted from JSON)
-- Times default to `0001-01-01T00:00:00Z` (zero time, omitted from JSON via `omitempty`)
+- Times use `*time.Time` pointers — `nil` when not provisioned, absent from JSON via `omitempty`
 - `owner_avatar_hash` is intentionally always empty — no avatar storage exists
 
 ## Multi-tenant isolation
@@ -77,8 +77,9 @@ Go tests cover:
 - `TestHandlePortalGetInstance_CrossTenantIsolation` — Alice can't read Bob's instance
 - `TestHandlePortalGetInstance_DriftFields` — successful update jobs → drift=ok
 - `TestHandlePortalGetInstance_DriftWireStale` — MCP wired against old body
-- `TestHandlePortalGetInstance_SoulAnchorFields` — soul disabled vs. anchored
-- `TestInstanceResponseDTO_RedactionProof` — no PK/SK/TTL/GSI/account_id/secret leaks
+- `TestHandlePortalGetInstance_SoulAnchorFields` — soul disabled (nil pointer) vs. anchored
+- `TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence` — `soul_anchor_at` absent from JSON when not provisioned (guards against Go `time.Time` zero-serialization)
+- `TestInstanceResponseDTO_RedactionProof` — no PK/SK/TTL/GSI/account_id/secret leaks; `soul_anchor_at` present when anchored
 - `TestEnrichDerivedDrift_NilResponse` — nil safety
 - `TestEnrichDerivedDrift_EmptyJobs` — empty jobs → all unknown
 - `TestComputeMCPDriftForDetail_*` — nil, non-OK edge cases

--- a/gov-infra/evidence/design-fidelity/m7-instance-overview-data/contract-note.md
+++ b/gov-infra/evidence/design-fidelity/m7-instance-overview-data/contract-note.md
@@ -1,0 +1,97 @@
+# M7 — Instance Overview data prerequisites — Contract Note
+
+Date: 2026-05-28
+Branch: `aron/portal-m7-instance-overview-data`
+Issue: [#540](https://github.com/equaltoai/lesser-host/issues/540)
+
+## Audit result
+
+The instance detail endpoint `GET /api/v1/portal/instances/{slug}` already returned
+`Owner`, `LesserVersion`, `LesserBodyVersion`, `McpWiredAt`, `SoulEnabled`,
+`BodyEnabled`, `ProvisionStatus`, `SoulProvisionedAt`, and `BodyProvisionedAt`.
+However, owner identity was a bare username (wallet-derived), soul anchor
+state/freshness were absent, and per-component drift flags were not in the
+detail response (only in the separate `/stack` endpoint).
+
+## Additive fields added to `instanceResponse`
+
+### Owner enrichment (additive; `json:"owner_handle,omitempty"` etc.)
+
+| Field               | Type   | Source                    | Empty semantics                  |
+|---------------------|--------|---------------------------|----------------------------------|
+| `owner_handle`      | string | `User.DisplayName`        | Falls back to `User.Username`    |
+| `owner_role`        | string | `User.Role`               | Empty if User record not found   |
+| `owner_avatar_hash` | string | (none)                    | Always empty — no avatar storage |
+
+The lookup is best-effort (graceful fallback). If the instance owner's `User`
+profile is not found, `owner_handle` and `owner_role` remain empty. No
+account-level membership or cross-tenant identifiers are leaked.
+
+### Soul anchor freshness (additive; derived from `Instance` model)
+
+| Field               | Type   | Source                   | Empty semantics              |
+|---------------------|--------|--------------------------|------------------------------|
+| `soul_anchor_state` | string | `deriveSoulAnchorState`  | `""` if soul not enabled     |
+|                     |        |                          | `"anchored"` if provisioned  |
+| `soul_anchor_at`    | time   | `Instance.SoulProvisionedAt` | Zero time if not provisioned |
+
+No additional DB query is required — these are derived entirely from the
+existing Instance model fields (`SoulEnabled`, `SoulProvisionedAt`).
+
+### Per-component drift (additive; computed from update jobs already loaded)
+
+| Field               | Type   | Source                    | Empty semantics                    |
+|---------------------|--------|---------------------------|------------------------------------|
+| `lesser_drift`      | string | `computeDriftForKind`     | `"unknown"` if no successful job   |
+| `lesser_body_drift` | string | `computeDriftForKind`     | `"unknown"` if no successful job   |
+| `mcp_drift`         | string | `computeMCPDriftForDetail`| `"unknown"` if no successful job   |
+| `drift_summary`     | string | `deriveDriftSummary`      | `"partial telemetry"` if no jobs   |
+
+Drift values match the dedicated `/stack` endpoint contract:
+- `"ok"` — current matches target
+- `"stale"` — current is older than target
+- `"wire-stale"` — MCP wired against a body version that differs from deployed
+- `"unknown"` — no target / no telemetry yet
+
+## Null/empty semantics
+
+All new fields use `omitempty`. When the underlying data is absent:
+- Strings default to `""` (empty string, omitted from JSON)
+- Times default to `0001-01-01T00:00:00Z` (zero time, omitted from JSON via `omitempty`)
+- `owner_avatar_hash` is intentionally always empty — no avatar storage exists
+
+## Multi-tenant isolation
+
+- Owner enrichment reads the `User` record by the instance's `Owner` username,
+  which is the same identity that `requireInstanceAccess` already verified
+  against the caller's `AuthIdentity`.
+- No cross-instance, cross-owner, or account-membership data is exposed.
+
+## Tests
+
+Go tests cover:
+- `TestDeriveSoulAnchorState` — pure function: nil, not-enabled, nil-enabled, enabled-but-empty, enabled-and-provisioned
+- `TestHandlePortalGetInstance_OwnerEnrichment` — happy path with rich profile
+- `TestHandlePortalGetInstance_OwnerEnrichmentFallbackToUsername` — empty DisplayName → username fallback
+- `TestHandlePortalGetInstance_OwnerUserNotFoundGraceful` — User record not found → fields empty
+- `TestHandlePortalGetInstance_CrossTenantIsolation` — Alice can't read Bob's instance
+- `TestHandlePortalGetInstance_DriftFields` — successful update jobs → drift=ok
+- `TestHandlePortalGetInstance_DriftWireStale` — MCP wired against old body
+- `TestHandlePortalGetInstance_SoulAnchorFields` — soul disabled vs. anchored
+- `TestInstanceResponseDTO_RedactionProof` — no PK/SK/TTL/GSI/account_id/secret leaks
+- `TestEnrichDerivedDrift_NilResponse` — nil safety
+- `TestEnrichDerivedDrift_EmptyJobs` — empty jobs → all unknown
+- `TestComputeMCPDriftForDetail_*` — nil, non-OK edge cases
+- `TestComputeDriftForKind_*` — nil, non-OK edge cases
+- `TestEnrichOwnerIdentity_NilArgs` — nil safety
+
+## API compatibility
+
+All changes are additive. No existing field was renamed, removed, or re-typed.
+The `instanceResponse` struct gains only `omitempty`-tagged fields. Existing
+callers (including M6 UI) can ignore the new fields.
+
+## Governance
+
+- No SEC verifier changes required — no new sensitive boundaries.
+- All existing tests pass; gov-infra rubric remains green.

--- a/internal/controlplane/handlers_instances.go
+++ b/internal/controlplane/handlers_instances.go
@@ -110,8 +110,8 @@ type instanceResponse struct {
 
 	// Soul anchor freshness derived from instance state (additive; M7).
 	// SoulAnchorState is "anchored" when SoulProvisionedAt is set, else "".
-	SoulAnchorState string    `json:"soul_anchor_state,omitempty"`
-	SoulAnchorAt    time.Time `json:"soul_anchor_at,omitempty"`
+	SoulAnchorState string     `json:"soul_anchor_state,omitempty"`
+	SoulAnchorAt    *time.Time `json:"soul_anchor_at,omitempty"`
 
 	// Per-component drift flags and summary (additive; M7).
 	// These mirror the instance stack endpoint but are available inline
@@ -252,8 +252,19 @@ func instanceResponseFromModel(inst *models.Instance) instanceResponse {
 		CreatedAt:                 inst.CreatedAt,
 		UpdatedAt:                 inst.UpdatedAt,
 		SoulAnchorState:           deriveSoulAnchorState(inst),
-		SoulAnchorAt:              inst.SoulProvisionedAt,
+		SoulAnchorAt:              soulAnchorPtrFromTime(inst.SoulProvisionedAt),
 	}
+}
+
+// soulAnchorPtrFromTime returns nil when t is zero, otherwise a pointer to t.
+// This ensures JSON serialization with omitempty correctly omits the field
+// for unprovisioned souls instead of emitting "0001-01-01T00:00:00Z".
+// Go's encoding/json does not treat zero time.Time as "empty" for omitempty.
+func soulAnchorPtrFromTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
 }
 
 // soulAnchorStateAnchored is the human-readable label returned when a soul

--- a/internal/controlplane/handlers_instances.go
+++ b/internal/controlplane/handlers_instances.go
@@ -102,6 +102,25 @@ type instanceResponse struct {
 	AIMaxInflightJobs         int64     `json:"ai_max_inflight_jobs"`
 	CreatedAt                 time.Time `json:"created_at"`
 	UpdatedAt                 time.Time `json:"updated_at,omitempty"`
+
+	// Owner enrichment from the User profile (additive; M7).
+	OwnerHandle     string `json:"owner_handle,omitempty"`
+	OwnerRole       string `json:"owner_role,omitempty"`
+	OwnerAvatarHash string `json:"owner_avatar_hash,omitempty"`
+
+	// Soul anchor freshness derived from instance state (additive; M7).
+	// SoulAnchorState is "anchored" when SoulProvisionedAt is set, else "".
+	SoulAnchorState string    `json:"soul_anchor_state,omitempty"`
+	SoulAnchorAt    time.Time `json:"soul_anchor_at,omitempty"`
+
+	// Per-component drift flags and summary (additive; M7).
+	// These mirror the instance stack endpoint but are available inline
+	// on the instance detail response so the Instance Overview right rail
+	// and Stack card can consume them without a second request.
+	LesserDrift     string `json:"lesser_drift,omitempty"`
+	LesserBodyDrift string `json:"lesser_body_drift,omitempty"`
+	MCPDrift        string `json:"mcp_drift,omitempty"`
+	DriftSummary    string `json:"drift_summary,omitempty"`
 }
 
 type listInstancesResponse struct {
@@ -232,7 +251,32 @@ func instanceResponseFromModel(inst *models.Instance) instanceResponse {
 		AIMaxInflightJobs:         effectiveAIMaxInflightJobs(inst.AIMaxInflightJobs),
 		CreatedAt:                 inst.CreatedAt,
 		UpdatedAt:                 inst.UpdatedAt,
+		SoulAnchorState:           deriveSoulAnchorState(inst),
+		SoulAnchorAt:              inst.SoulProvisionedAt,
 	}
+}
+
+// soulAnchorStateAnchored is the human-readable label returned when a soul
+// agent is enabled and has been provisioned for the instance.
+const soulAnchorStateAnchored = "anchored"
+
+// deriveSoulAnchorState returns a human-readable anchor-state label derived
+// from the instance's soul-enablement and provisioning fields — no additional
+// DB query required.
+//
+//	"anchored"  — soul enabled and provisioned
+//	""          — soul not enabled or not yet provisioned (honest empty)
+func deriveSoulAnchorState(inst *models.Instance) string {
+	if inst == nil {
+		return ""
+	}
+	if !effectiveSoulEnabled(inst.SoulEnabled) {
+		return ""
+	}
+	if inst.SoulProvisionedAt.IsZero() {
+		return ""
+	}
+	return soulAnchorStateAnchored
 }
 
 func (s *Server) getInstance(ctx *apptheory.Context, slug string) (*models.Instance, error) {

--- a/internal/controlplane/handlers_portal_instances_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_internal_test.go
@@ -1660,6 +1660,65 @@ func TestHandlePortalGetInstance_DriftFields(t *testing.T) {
 	}
 }
 
+// TestHandlePortalGetInstance_DriftOkFallback ensures that when a newer
+// non-ok (e.g. error) update job exists alongside an older ok job for the
+// same component kind, the detail endpoint drift categorisation matches the
+// /stack endpoint: it skips the non-ok job and reports the latest ok job's
+// drift (ok), rather than picking the newest job regardless of status and
+// reporting "unknown".
+func TestHandlePortalGetInstance_DriftOkFallback(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// Newer error job + older ok job for lesser.  ListUpdateJobsByInstance
+	// returns newest-first, so the error job comes first.
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{ID: "lesser-err", InstanceSlug: "demo", Status: models.UpdateJobStatusError, LesserVersion: "v1.2.8", UpdatedAt: now},
+			{ID: "lesser-ok", InstanceSlug: "demo", Status: models.UpdateJobStatusOK, LesserVersion: "v1.2.7", UpdatedAt: now.Add(-1 * time.Hour)},
+		}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Drift must be "ok" (from the successful job), matching /stack.
+	if body.LesserDrift != stackDriftOK {
+		t.Fatalf("LesserDrift = %q, want %q (should fall back to older ok job, not newer error job)", body.LesserDrift, stackDriftOK)
+	}
+
+	// Managed-update status must reflect the newest job (error).
+	if body.LesserUpdateStatus != models.UpdateJobStatusError {
+		t.Fatalf("LesserUpdateStatus = %q, want %q (should reflect newest job)", body.LesserUpdateStatus, models.UpdateJobStatusError)
+	}
+
+	// Soul anchor absence regression: zero-time must not appear in JSON.
+	if body.SoulAnchorAt != nil {
+		t.Fatalf("SoulAnchorAt = %v, want nil (zero-time absence regression)", body.SoulAnchorAt)
+	}
+}
+
 func TestHandlePortalGetInstance_DriftWireStale(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_portal_instances_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_internal_test.go
@@ -1735,8 +1735,8 @@ func TestHandlePortalGetInstance_SoulAnchorFields(t *testing.T) {
 		if body.SoulAnchorState != "" {
 			t.Fatalf("SoulAnchorState = %q, want empty", body.SoulAnchorState)
 		}
-		if !body.SoulAnchorAt.IsZero() {
-			t.Fatalf("SoulAnchorAt = %v, want zero", body.SoulAnchorAt)
+		if body.SoulAnchorAt != nil {
+			t.Fatalf("SoulAnchorAt = %v, want nil pointer", body.SoulAnchorAt)
 		}
 	})
 
@@ -1772,10 +1772,41 @@ func TestHandlePortalGetInstance_SoulAnchorFields(t *testing.T) {
 		if body.SoulAnchorState != "anchored" {
 			t.Fatalf("SoulAnchorState = %q, want \"anchored\"", body.SoulAnchorState)
 		}
-		if !body.SoulAnchorAt.Equal(now) {
-			t.Fatalf("SoulAnchorAt = %v, want %v", body.SoulAnchorAt, now)
-		}
+		assertSoulAnchorAtEqual(t, body.SoulAnchorAt, now)
 	})
+}
+
+// TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence verifies that
+// soul_anchor_at is absent from JSON (not "0001-01-01T00:00:00Z") when
+// the soul is not provisioned. This guards against Go's time.Time omitempty
+// behavior where zero time still serializes.
+func TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Maybe()
+
+	f := false
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive, SoulEnabled: &f}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	assertJSONFieldAbsent(t, resp.Body, "soul_anchor_at")
 }
 
 func TestInstanceResponseDTO_RedactionProof(t *testing.T) {
@@ -1788,7 +1819,7 @@ func TestInstanceResponseDTO_RedactionProof(t *testing.T) {
 		OwnerHandle:     "Alice Example",
 		OwnerRole:       "customer",
 		SoulAnchorState: "anchored",
-		SoulAnchorAt:    time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+		SoulAnchorAt:    soulAnchorTestTime(),
 		LesserDrift:     stackDriftOK,
 		LesserBodyDrift: stackDriftOK,
 		MCPDrift:        stackDriftUnknown,
@@ -1907,4 +1938,28 @@ func TestEnrichOwnerIdentity_NilArgs(t *testing.T) {
 	enrichOwnerIdentity(nil, nil, nil, nil)
 	enrichOwnerIdentity(&apptheory.Context{}, nil, &models.Instance{Owner: "alice"}, &instanceResponse{})
 	enrichOwnerIdentity(&apptheory.Context{}, &Server{}, nil, &instanceResponse{})
+}
+
+// soulAnchorTestTime returns a pointer to a deterministic test timestamp.
+// Used by DTO tests that need a non-nil *time.Time for the SoulAnchorAt field.
+func soulAnchorTestTime() *time.Time {
+	t := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+	return &t
+}
+
+// assertSoulAnchorAtEqual fails t if at is nil or does not equal want.
+func assertSoulAnchorAtEqual(t *testing.T, at *time.Time, want time.Time) {
+	t.Helper()
+	if at == nil || !at.Equal(want) {
+		t.Fatalf("SoulAnchorAt = %v, want %v", at, want)
+	}
+}
+
+// assertJSONFieldAbsent fails t if raw contains a JSON key for field.
+func assertJSONFieldAbsent(t *testing.T, raw []byte, field string) {
+	t.Helper()
+	needle := "\"" + field + "\""
+	if strings.Contains(string(raw), needle) {
+		t.Fatalf("JSON contains %s, want absent: %s", needle, string(raw))
+	}
 }

--- a/internal/controlplane/handlers_portal_instances_internal_test.go
+++ b/internal/controlplane/handlers_portal_instances_internal_test.go
@@ -1403,3 +1403,508 @@ func TestHandlePortalInstanceDomainOps_PrimaryConflict(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// M7 — Instance Overview data prerequisites (Project 42)
+// ---------------------------------------------------------------------------
+
+func TestDeriveSoulAnchorState(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil instance returns empty", func(t *testing.T) {
+		if got := deriveSoulAnchorState(nil); got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("soul not enabled returns empty", func(t *testing.T) {
+		f := false
+		inst := &models.Instance{SoulEnabled: &f}
+		if got := deriveSoulAnchorState(inst); got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("soul nil returns empty", func(t *testing.T) {
+		inst := &models.Instance{SoulEnabled: nil}
+		if got := deriveSoulAnchorState(inst); got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("soul enabled but not provisioned returns empty", func(t *testing.T) {
+		tru := true
+		inst := &models.Instance{SoulEnabled: &tru}
+		if got := deriveSoulAnchorState(inst); got != "" {
+			t.Fatalf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("soul enabled and provisioned returns anchored", func(t *testing.T) {
+		tru := true
+		inst := &models.Instance{
+			SoulEnabled:       &tru,
+			SoulProvisionedAt: time.Date(2026, 1, 15, 0, 0, 0, 0, time.UTC),
+		}
+		if got := deriveSoulAnchorState(inst); got != "anchored" {
+			t.Fatalf("expected anchored, got %q", got)
+		}
+	})
+}
+
+func TestHandlePortalGetInstance_OwnerEnrichment(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Maybe()
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// Clear the .Maybe() User stub from newPortalTestDB before adding a .Once()
+	// override. test-assert mock matches expected calls in order, so our .Once()
+	// would never be reached if we left the .Maybe() ahead of it.
+	tdb.qUser.ExpectedCalls = nil
+	addStandardMockQueryStubs(tdb.qUser)
+
+	// Override with a .Once() returning a richer owner profile.
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.User](t, args, 0)
+		*dest = models.User{Username: "alice", DisplayName: "Alice Example", Role: models.RoleCustomer}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.OwnerHandle != "Alice Example" {
+		t.Fatalf("OwnerHandle = %q, want \"Alice Example\"", body.OwnerHandle)
+	}
+	if body.OwnerRole != models.RoleCustomer {
+		t.Fatalf("OwnerRole = %q, want %q", body.OwnerRole, models.RoleCustomer)
+	}
+	if body.OwnerAvatarHash != "" {
+		t.Fatalf("OwnerAvatarHash = %q, want empty (no avatar storage)", body.OwnerAvatarHash)
+	}
+}
+
+func TestHandlePortalGetInstance_OwnerEnrichmentFallbackToUsername(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Maybe()
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// User exists but has no DisplayName — OwnerHandle should fall back to Username.
+	tdb.qUser.ExpectedCalls = nil
+	addStandardMockQueryStubs(tdb.qUser)
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.User](t, args, 0)
+		*dest = models.User{Username: "alice", DisplayName: "", Role: models.RoleCustomer}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.OwnerHandle != testUsernameAlice {
+		t.Fatalf("OwnerHandle = %q, want %q (username fallback)", body.OwnerHandle, testUsernameAlice)
+	}
+}
+
+func TestHandlePortalGetInstance_OwnerUserNotFoundGraceful(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Maybe()
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "wallet-abc123", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// Override with a .Once() returning not-found.
+	tdb.qUser.ExpectedCalls = nil
+	addStandardMockQueryStubs(tdb.qUser)
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "wallet-abc123", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body.OwnerHandle != "" {
+		t.Fatalf("OwnerHandle = %q, want empty (user not found)", body.OwnerHandle)
+	}
+	if body.OwnerRole != "" {
+		t.Fatalf("OwnerRole = %q, want empty", body.OwnerRole)
+	}
+}
+
+func TestHandlePortalGetInstance_CrossTenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "bob", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// Alice requests Bob's instance — must be forbidden.
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	_, err := s.handlePortalGetInstance(ctx)
+	if err == nil {
+		t.Fatalf("expected forbidden error")
+	}
+	appErr, ok := err.(*apptheory.AppError)
+	if !ok || appErr.Code != appErrCodeForbidden {
+		t.Fatalf("expected %s, got %#v", appErrCodeForbidden, err)
+	}
+}
+
+func TestHandlePortalGetInstance_DriftFields(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive}
+	}).Once()
+
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{ID: "lesser-1", InstanceSlug: "demo", Status: models.UpdateJobStatusOK, LesserVersion: "v1.2.7", UpdatedAt: now},
+			{ID: "body-1", InstanceSlug: "demo", Status: models.UpdateJobStatusOK, BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now},
+		}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if body.LesserDrift != stackDriftOK {
+		t.Fatalf("LesserDrift = %q, want %q", body.LesserDrift, stackDriftOK)
+	}
+	if body.LesserBodyDrift != stackDriftOK {
+		t.Fatalf("LesserBodyDrift = %q, want %q", body.LesserBodyDrift, stackDriftOK)
+	}
+	if body.MCPDrift != stackDriftUnknown {
+		t.Fatalf("MCPDrift = %q, want %q (no MCP job)", body.MCPDrift, stackDriftUnknown)
+	}
+	if body.DriftSummary == "" {
+		t.Fatalf("DriftSummary is empty")
+	}
+}
+
+func TestHandlePortalGetInstance_DriftWireStale(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive}
+	}).Once()
+
+	// MCP wired against old body version; body has a newer version.
+	qUpdate := new(ttmocks.MockQuery)
+	tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+	addStandardMockQueryStubs(qUpdate)
+	qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{
+			{ID: "mcp-1", InstanceSlug: "demo", Status: models.UpdateJobStatusOK, MCPOnly: true, LesserBodyVersion: "v0.2.0", UpdatedAt: now.Add(-1 * time.Hour)},
+			{ID: "body-1", InstanceSlug: "demo", Status: models.UpdateJobStatusOK, BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now},
+		}
+	}).Once()
+
+	ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+	resp, err := s.handlePortalGetInstance(ctx)
+	if err != nil || resp == nil || resp.Status != 200 {
+		t.Fatalf("resp=%#v err=%v", resp, err)
+	}
+
+	var body instanceResponse
+	if err := json.Unmarshal(resp.Body, &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if body.MCPDrift != stackDriftWireStale {
+		t.Fatalf("MCPDrift = %q, want %q", body.MCPDrift, stackDriftWireStale)
+	}
+}
+
+func TestHandlePortalGetInstance_SoulAnchorFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("soul disabled returns empty anchor state", func(t *testing.T) {
+		tdb := newPortalTestDB()
+		s := &Server{store: store.New(tdb.db)}
+
+		qUpdate := new(ttmocks.MockQuery)
+		tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+		addStandardMockQueryStubs(qUpdate)
+		qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+			*dest = []*models.UpdateJob{}
+		}).Maybe()
+
+		f := false
+		tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+			*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive, SoulEnabled: &f}
+		}).Once()
+
+		ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+		resp, err := s.handlePortalGetInstance(ctx)
+		if err != nil || resp == nil || resp.Status != 200 {
+			t.Fatalf("resp=%#v err=%v", resp, err)
+		}
+
+		var body instanceResponse
+		if err := json.Unmarshal(resp.Body, &body); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if body.SoulAnchorState != "" {
+			t.Fatalf("SoulAnchorState = %q, want empty", body.SoulAnchorState)
+		}
+		if !body.SoulAnchorAt.IsZero() {
+			t.Fatalf("SoulAnchorAt = %v, want zero", body.SoulAnchorAt)
+		}
+	})
+
+	t.Run("soul enabled and provisioned returns anchored", func(t *testing.T) {
+		tdb := newPortalTestDB()
+		s := &Server{store: store.New(tdb.db)}
+
+		qUpdate := new(ttmocks.MockQuery)
+		tdb.db.On("Model", mock.AnythingOfType("*models.UpdateJob")).Return(qUpdate).Maybe()
+		addStandardMockQueryStubs(qUpdate)
+		qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+			*dest = []*models.UpdateJob{}
+		}).Maybe()
+
+		now := time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)
+		tru := true
+		tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+			*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive, SoulEnabled: &tru, SoulProvisionedAt: now}
+		}).Once()
+
+		ctx := &apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}}
+		resp, err := s.handlePortalGetInstance(ctx)
+		if err != nil || resp == nil || resp.Status != 200 {
+			t.Fatalf("resp=%#v err=%v", resp, err)
+		}
+
+		var body instanceResponse
+		if err := json.Unmarshal(resp.Body, &body); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if body.SoulAnchorState != "anchored" {
+			t.Fatalf("SoulAnchorState = %q, want \"anchored\"", body.SoulAnchorState)
+		}
+		if !body.SoulAnchorAt.Equal(now) {
+			t.Fatalf("SoulAnchorAt = %v, want %v", body.SoulAnchorAt, now)
+		}
+	})
+}
+
+func TestInstanceResponseDTO_RedactionProof(t *testing.T) {
+	t.Parallel()
+
+	resp := instanceResponse{
+		Slug:            "demo",
+		Owner:           "alice",
+		Status:          "active",
+		OwnerHandle:     "Alice Example",
+		OwnerRole:       "customer",
+		SoulAnchorState: "anchored",
+		SoulAnchorAt:    time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC),
+		LesserDrift:     stackDriftOK,
+		LesserBodyDrift: stackDriftOK,
+		MCPDrift:        stackDriftUnknown,
+		DriftSummary:    "partial telemetry",
+	}
+
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	raw := string(b)
+
+	// Forbidden: internal storage keys.
+	for _, forbidden := range []string{
+		`"pk"`, `"PK"`,
+		`"sk"`, `"SK"`,
+		`"ttl"`, `"TTL"`,
+		`"gsi1PK"`, `"gsi1pk"`,
+		`"gsi1SK"`, `"gsi1sk"`,
+		`"gsi2PK"`, `"gsi2pk"`,
+		`"gsi2SK"`, `"gsi2sk"`,
+	} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("leaked internal key %q in JSON: %s", forbidden, raw)
+		}
+	}
+
+	// Forbidden: account identifiers and secrets.
+	for _, forbidden := range []string{
+		`"account_id"`,
+		`"accountId"`,
+		`"instance_key_secret"`,
+		`"secret_arn"`,
+		`"raw_key"`,
+		`"raw_secret"`,
+	} {
+		if strings.Contains(raw, forbidden) {
+			t.Fatalf("leaked sensitive field %q in JSON: %s", forbidden, raw)
+		}
+	}
+
+	// Confirm the new M7 fields are present.
+	for _, want := range []string{
+		`"owner_handle"`,
+		`"owner_role"`,
+		`"soul_anchor_state"`,
+		`"lesser_drift"`,
+		`"lesser_body_drift"`,
+		`"mcp_drift"`,
+		`"drift_summary"`,
+	} {
+		if !strings.Contains(raw, want) {
+			t.Fatalf("missing expected field %q in JSON: %s", want, raw)
+		}
+	}
+}
+
+func TestEnrichDerivedDrift_NilResponse(t *testing.T) {
+	t.Parallel()
+	enrichDerivedDrift(nil, nil, nil, nil)
+}
+
+func TestEnrichDerivedDrift_EmptyJobs(t *testing.T) {
+	t.Parallel()
+
+	resp := &instanceResponse{}
+	enrichDerivedDrift(resp, nil, nil, nil)
+
+	if resp.LesserDrift != stackDriftUnknown {
+		t.Fatalf("LesserDrift = %q, want %q", resp.LesserDrift, stackDriftUnknown)
+	}
+	if resp.LesserBodyDrift != stackDriftUnknown {
+		t.Fatalf("LesserBodyDrift = %q, want %q", resp.LesserBodyDrift, stackDriftUnknown)
+	}
+	if resp.MCPDrift != stackDriftUnknown {
+		t.Fatalf("MCPDrift = %q, want %q", resp.MCPDrift, stackDriftUnknown)
+	}
+	if resp.DriftSummary == "" {
+		t.Fatalf("DriftSummary is empty")
+	}
+}
+
+func TestComputeMCPDriftForDetail_NilMCPJob(t *testing.T) {
+	t.Parallel()
+	if got := computeMCPDriftForDetail(nil, nil); got != stackDriftUnknown {
+		t.Fatalf("expected unknown, got %q", got)
+	}
+}
+
+func TestComputeMCPDriftForDetail_NonOKMCPJob(t *testing.T) {
+	t.Parallel()
+	job := &models.UpdateJob{Status: models.UpdateJobStatusRunning}
+	if got := computeMCPDriftForDetail(job, nil); got != stackDriftUnknown {
+		t.Fatalf("expected unknown, got %q", got)
+	}
+}
+
+func TestComputeDriftForKind_NilJob(t *testing.T) {
+	t.Parallel()
+	if got := computeDriftForKind(nil); got != stackDriftUnknown {
+		t.Fatalf("expected unknown, got %q", got)
+	}
+}
+
+func TestComputeDriftForKind_NonOKJob(t *testing.T) {
+	t.Parallel()
+	job := &models.UpdateJob{Status: models.UpdateJobStatusError}
+	if got := computeDriftForKind(job); got != stackDriftUnknown {
+		t.Fatalf("expected unknown, got %q", got)
+	}
+}
+
+func TestEnrichOwnerIdentity_NilArgs(t *testing.T) {
+	t.Parallel()
+	enrichOwnerIdentity(nil, nil, nil, nil)
+	enrichOwnerIdentity(&apptheory.Context{}, nil, &models.Instance{Owner: "alice"}, &instanceResponse{})
+	enrichOwnerIdentity(&apptheory.Context{}, &Server{}, nil, &instanceResponse{})
+}

--- a/internal/controlplane/portal_instance_response.go
+++ b/internal/controlplane/portal_instance_response.go
@@ -1,10 +1,12 @@
 package controlplane
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
@@ -33,6 +35,13 @@ func (s *Server) portalInstanceDetailResponse(ctx *apptheory.Context, inst *mode
 	if s == nil || s.store == nil || ctx == nil || inst == nil {
 		return resp
 	}
+
+	// Owner enrichment: look up the User profile for the instance owner.
+	// Best-effort with graceful fallback — owner may not have a User profile
+	// (operator-created instances assigned to an owner who hasn't logged in
+	// through the portal yet). Only handle, role, and avatar hash are surfaced;
+	// account-level membership and internal fields are never leaked.
+	enrichOwnerIdentity(ctx, s, inst, &resp)
 
 	items, err := s.store.ListUpdateJobsByInstance(ctx.Context(), strings.TrimSpace(inst.Slug), 20)
 	if err != nil {
@@ -65,7 +74,89 @@ func (s *Server) portalInstanceDetailResponse(ctx *apptheory.Context, inst *mode
 	applyDerivedManagedUpdateSummary(&resp, latestLesser, updateJobKindLesser)
 	applyDerivedManagedUpdateSummary(&resp, latestBody, updateJobKindBody)
 	applyDerivedManagedUpdateSummary(&resp, latestMCP, updateJobKindMCP)
+
+	// Per-component drift flags and summary from the same update jobs already loaded.
+	enrichDerivedDrift(&resp, latestLesser, latestBody, latestMCP)
+
 	return resp
+}
+
+// enrichOwnerIdentity reads the User profile for the instance owner and populates
+// OwnerHandle, OwnerRole, and OwnerAvatarHash on the response. The lookup is
+// best-effort: if the user record is not found or an error occurs, the fields
+// remain empty (honest null/empty semantics).
+func enrichOwnerIdentity(ctx *apptheory.Context, s *Server, inst *models.Instance, resp *instanceResponse) {
+	if ctx == nil || s == nil || s.store == nil || s.store.DB == nil || inst == nil || resp == nil {
+		return
+	}
+	ownerUsername := strings.TrimSpace(inst.Owner)
+	if ownerUsername == "" {
+		return
+	}
+
+	var user models.User
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.User{}).
+		Where("PK", "=", fmt.Sprintf(models.KeyPatternUser, ownerUsername)).
+		Where("SK", "=", models.SKProfile).
+		First(&user)
+	if theoryErrors.IsNotFound(err) || err != nil {
+		return
+	}
+
+	resp.OwnerHandle = strings.TrimSpace(user.DisplayName)
+	if resp.OwnerHandle == "" {
+		resp.OwnerHandle = strings.TrimSpace(user.Username)
+	}
+	resp.OwnerRole = strings.TrimSpace(user.Role)
+	// OwnerAvatarHash is intentionally empty — no avatar storage exists.
+}
+
+// enrichDerivedDrift computes per-component drift flags and a summary string
+// from the latest update job per component kind. The drift values mirror the
+// dedicated stack endpoint so the Instance Overview can consume them inline.
+func enrichDerivedDrift(resp *instanceResponse, latestLesser *models.UpdateJob, latestBody *models.UpdateJob, latestMCP *models.UpdateJob) {
+	if resp == nil {
+		return
+	}
+	resp.LesserDrift = computeDriftForKind(latestLesser)
+	resp.LesserBodyDrift = computeDriftForKind(latestBody)
+	resp.MCPDrift = computeMCPDriftForDetail(latestMCP, latestBody)
+	resp.DriftSummary = deriveDriftSummary(resp.LesserDrift, resp.LesserBodyDrift, resp.MCPDrift, resp.BodyEnabled)
+}
+
+// computeDriftForKind returns a drift label for a single component kind.
+// Only ok-status jobs are treated as successfully deployed; all others
+// (including queued, running, error, and nil) produce "unknown".
+func computeDriftForKind(job *models.UpdateJob) string {
+	if job == nil {
+		return stackDriftUnknown
+	}
+	if strings.ToLower(strings.TrimSpace(job.Status)) != models.UpdateJobStatusOK {
+		return stackDriftUnknown
+	}
+	return stackDriftOK
+}
+
+// computeMCPDriftForDetail returns drift for the MCP wiring in the instance
+// detail context. Returns "wire-stale" when MCP was wired against a body version
+// that differs from the currently deployed body version.
+func computeMCPDriftForDetail(mcpJob *models.UpdateJob, bodyJob *models.UpdateJob) string {
+	if mcpJob == nil {
+		return stackDriftUnknown
+	}
+	if strings.ToLower(strings.TrimSpace(mcpJob.Status)) != models.UpdateJobStatusOK {
+		return stackDriftUnknown
+	}
+	currentBodyVersion := ""
+	if bodyJob != nil && strings.ToLower(strings.TrimSpace(bodyJob.Status)) == models.UpdateJobStatusOK {
+		currentBodyVersion = strings.TrimSpace(bodyJob.LesserBodyVersion)
+	}
+	wiredAgainst := strings.TrimSpace(mcpJob.LesserBodyVersion)
+	if wiredAgainst != "" && currentBodyVersion != "" && wiredAgainst != currentBodyVersion {
+		return stackDriftWireStale
+	}
+	return stackDriftOK
 }
 
 func applyDerivedManagedUpdateSummary(resp *instanceResponse, job *models.UpdateJob, kind string) {

--- a/internal/controlplane/portal_instance_response.go
+++ b/internal/controlplane/portal_instance_response.go
@@ -48,35 +48,17 @@ func (s *Server) portalInstanceDetailResponse(ctx *apptheory.Context, inst *mode
 		return resp
 	}
 
-	var latestLesser *models.UpdateJob
-	var latestBody *models.UpdateJob
-	var latestMCP *models.UpdateJob
-	for _, item := range items {
-		if item == nil {
-			continue
-		}
-		switch updateJobKind(item) {
-		case updateJobKindBody:
-			if latestBody == nil {
-				latestBody = item
-			}
-		case updateJobKindMCP:
-			if latestMCP == nil {
-				latestMCP = item
-			}
-		default:
-			if latestLesser == nil {
-				latestLesser = item
-			}
-		}
-	}
+	cats := categorizeDetailUpdateJobs(items)
 
-	applyDerivedManagedUpdateSummary(&resp, latestLesser, updateJobKindLesser)
-	applyDerivedManagedUpdateSummary(&resp, latestBody, updateJobKindBody)
-	applyDerivedManagedUpdateSummary(&resp, latestMCP, updateJobKindMCP)
+	applyDerivedManagedUpdateSummary(&resp, cats.latestLesser, updateJobKindLesser)
+	applyDerivedManagedUpdateSummary(&resp, cats.latestBody, updateJobKindBody)
+	applyDerivedManagedUpdateSummary(&resp, cats.latestMCP, updateJobKindMCP)
 
-	// Per-component drift flags and summary from the same update jobs already loaded.
-	enrichDerivedDrift(&resp, latestLesser, latestBody, latestMCP)
+	// Per-component drift flags and summary.  Drift uses the latest
+	// successful (ok-status) job per kind, matching the /stack endpoint
+	// contract.  The status summary above uses the latest job overall so
+	// operators see the real current state (running, error, etc.).
+	enrichDerivedDrift(&resp, cats.latestOkLesser, cats.latestOkBody, cats.latestOkMCP)
 
 	return resp
 }
@@ -157,6 +139,58 @@ func computeMCPDriftForDetail(mcpJob *models.UpdateJob, bodyJob *models.UpdateJo
 		return stackDriftWireStale
 	}
 	return stackDriftOK
+}
+
+
+// categorizedDetailUpdateJobs holds the latest job per component kind,
+// separated into two tiers: the latest overall (any status, for managed
+// update status fields) and the latest successful (ok) job (for drift,
+// matching the /stack endpoint contract).
+type categorizedDetailUpdateJobs struct {
+	latestLesser   *models.UpdateJob
+	latestBody     *models.UpdateJob
+	latestMCP      *models.UpdateJob
+	latestOkLesser *models.UpdateJob
+	latestOkBody   *models.UpdateJob
+	latestOkMCP    *models.UpdateJob
+}
+
+// categorizeDetailUpdateJobs extracts the latest overall and latest
+// successful job per component kind from a list of update jobs (newest
+// first).  The caller receives both tiers so status summary can report
+// the real current state while drift uses the ok-tier only.
+func categorizeDetailUpdateJobs(items []*models.UpdateJob) categorizedDetailUpdateJobs {
+	var out categorizedDetailUpdateJobs
+	for _, item := range items {
+		if item == nil {
+			continue
+		}
+		isOK := strings.ToLower(strings.TrimSpace(item.Status)) == models.UpdateJobStatusOK
+		switch updateJobKind(item) {
+		case updateJobKindBody:
+			if out.latestBody == nil {
+				out.latestBody = item
+			}
+			if out.latestOkBody == nil && isOK {
+				out.latestOkBody = item
+			}
+		case updateJobKindMCP:
+			if out.latestMCP == nil {
+				out.latestMCP = item
+			}
+			if out.latestOkMCP == nil && isOK {
+				out.latestOkMCP = item
+			}
+		default:
+			if out.latestLesser == nil {
+				out.latestLesser = item
+			}
+			if out.latestOkLesser == nil && isOK {
+				out.latestOkLesser = item
+			}
+		}
+	}
+	return out
 }
 
 func applyDerivedManagedUpdateSummary(resp *instanceResponse, job *models.UpdateJob, kind string) {

--- a/internal/controlplane/portal_instance_response.go
+++ b/internal/controlplane/portal_instance_response.go
@@ -141,7 +141,6 @@ func computeMCPDriftForDetail(mcpJob *models.UpdateJob, bodyJob *models.UpdateJo
 	return stackDriftOK
 }
 
-
 // categorizedDetailUpdateJobs holds the latest job per component kind,
 // separated into two tiers: the latest overall (any status, for managed
 // update status fields) and the latest successful (ok) job (for drift,
@@ -168,29 +167,41 @@ func categorizeDetailUpdateJobs(items []*models.UpdateJob) categorizedDetailUpda
 		isOK := strings.ToLower(strings.TrimSpace(item.Status)) == models.UpdateJobStatusOK
 		switch updateJobKind(item) {
 		case updateJobKindBody:
-			if out.latestBody == nil {
-				out.latestBody = item
-			}
-			if out.latestOkBody == nil && isOK {
-				out.latestOkBody = item
-			}
+			out.setBody(item, isOK)
 		case updateJobKindMCP:
-			if out.latestMCP == nil {
-				out.latestMCP = item
-			}
-			if out.latestOkMCP == nil && isOK {
-				out.latestOkMCP = item
-			}
+			out.setMCP(item, isOK)
 		default:
-			if out.latestLesser == nil {
-				out.latestLesser = item
-			}
-			if out.latestOkLesser == nil && isOK {
-				out.latestOkLesser = item
-			}
+			out.setLesser(item, isOK)
 		}
 	}
 	return out
+}
+
+func (c *categorizedDetailUpdateJobs) setLesser(item *models.UpdateJob, isOK bool) {
+	c.setIfNil(&c.latestLesser, item)
+	if isOK {
+		c.setIfNil(&c.latestOkLesser, item)
+	}
+}
+
+func (c *categorizedDetailUpdateJobs) setBody(item *models.UpdateJob, isOK bool) {
+	c.setIfNil(&c.latestBody, item)
+	if isOK {
+		c.setIfNil(&c.latestOkBody, item)
+	}
+}
+
+func (c *categorizedDetailUpdateJobs) setMCP(item *models.UpdateJob, isOK bool) {
+	c.setIfNil(&c.latestMCP, item)
+	if isOK {
+		c.setIfNil(&c.latestOkMCP, item)
+	}
+}
+
+func (c *categorizedDetailUpdateJobs) setIfNil(dst **models.UpdateJob, item *models.UpdateJob) {
+	if *dst == nil {
+		*dst = item
+	}
 }
 
 func applyDerivedManagedUpdateSummary(resp *instanceResponse, job *models.UpdateJob, kind string) {


### PR DESCRIPTION
## Summary

M7 — Instance Overview data prerequisites for Project 42 (#540). Backend/data only.

- **Owner enrichment**: `owner_handle`, `owner_role`, `owner_avatar_hash` — from User profile, best-effort with graceful fallback
- **Soul anchor freshness**: `soul_anchor_state` ("anchored" or ""), `soul_anchor_at` — derived from Instance model, no extra DB query. **Uses `*time.Time` (pointer) with `omitempty`** so that unprovisioned/disabled soul states produce _absent_ JSON keys (nil pointer → omitted), while provisioned soul states return a non-nil RFC 3339 timestamp. This avoids the standard `time.Time` zero-value serialization trap (`0001-01-01T00:00:00Z` would not be omitted by `omitempty`).
- **Per-component drift**: `lesser_drift`, `lesser_body_drift`, `mcp_drift`, `drift_summary` — computed from update jobs already loaded in `portalInstanceDetailResponse`

Fields are additive with `omitempty`. `soul_anchor_at` uses a pointer-wrapping helper (`soulAnchorPtrFromTime`) to guarantee JSON absence for unprovisioned states. No breaking changes.

## Files changed

- `internal/controlplane/handlers_instances.go` — +44 (struct fields, `deriveSoulAnchorState` helper, `soulAnchorPtrFromTime`, constant)
- `internal/controlplane/portal_instance_response.go` — +91 (owner enrichment, drift computation in `portalInstanceDetailResponse`)
- `internal/controlplane/handlers_portal_instances_internal_test.go` — +505 (17 new M7 tests)
- `gov-infra/evidence/design-fidelity/m7-instance-overview-data/contract-note.md` — evidence

## Validation

- `go test ./internal/controlplane/` — PASS (all existing + 17 M7 tests)
- `go vet ./internal/controlplane/` — PASS
- `gov-infra/verifiers/gov-verify-rubric.sh` — **40/40 PASS** (0 fail, 0 blocked)
- Head SHA: `6fcd4a9122996a01d78b729ee0a500105989490f`

## SoulAnchorAt `*time.Time` rework

The `soul_anchor_at` field resolved to `*time.Time` (pointer) rather than `time.Time` (value) to handle the zero-time / omitempty interaction correctly:

- **Unprovisioned or soul-disabled** → `SoulAnchorAt` is `nil` → `omitempty` suppresses the JSON key entirely (field is absent, not `"0001-01-01T00:00:00Z"`)
- **Soul provisioned** → `SoulAnchorAt` is a non-nil `*time.Time` → JSON includes the RFC 3339 timestamp
- Guarded explicitly by `TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence` which verifies `soul_anchor_at` is absent from the JSON payload for unprovisioned states

This is the correct pattern for optional timestamps in Go JSON: a nil `*time.Time` with `omitempty` omits; a `time.Time` zero value with `omitempty` still serializes because Go's `time.Time` is never "empty" per `encoding/json`.

## M4/M5 exclusion confirmation

- Branch based on `origin/main` (merge-base: `8259d94`)
- Zero commits in history from M4 (#556) or M5 (#555)
- Only 3 Go source files changed — no unintended bundle

## Test coverage

| Test | Coverage |
|------|----------|
| `TestDeriveSoulAnchorState` | nil, not-enabled, nil-enabled, enabled-but-empty, enabled-and-provisioned |
| `TestHandlePortalGetInstance_OwnerEnrichment` | happy path with rich profile |
| `TestHandlePortalGetInstance_OwnerEnrichmentFallbackToUsername` | empty DisplayName → username fallback |
| `TestHandlePortalGetInstance_OwnerUserNotFoundGraceful` | User not found → fields empty |
| `TestHandlePortalGetInstance_CrossTenantIsolation` | Alice can't read Bob's instance |
| `TestHandlePortalGetInstance_DriftFields` | successful jobs → drift=ok |
| `TestHandlePortalGetInstance_DriftWireStale` | MCP wired against old body |
| `TestHandlePortalGetInstance_SoulAnchorFields` | soul disabled vs. anchored |
| `TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence` | `soul_anchor_at` absent from JSON for unprovisioned states (guards against zero-time serialization) |
| `TestInstanceResponseDTO_RedactionProof` | no PK/SK/TTL/GSI/account_id/secret leaks |
| +7 unit-level tests for edge cases and nil safety |

## Caveats

- `owner_avatar_hash` is intentionally always empty — no avatar storage exists in host
- Soul anchor state is derived from Instance fields only (not SoulAgentIdentity) — an instance-based view, not an on-chain confirmation
- Owner enrichment is best-effort; if the User profile is not found, fields remain empty (honest null semantics)
- `soul_anchor_at` is omitted from JSON for unprovisioned/disabled soul states and returned only as a non-nil timestamp for provisioned soul states (guarded by `TestHandlePortalGetInstance_SoulAnchorFields_JSONAbsence`)

Closes #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)