### PR TITLE
feat(portal): Project 42 M16 — trust data prerequisites

### DIFF
--- a/internal/controlplane/handlers_portal_trust.go
+++ b/internal/controlplane/handlers_portal_trust.go
@@ -14,7 +14,7 @@ import (
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
-// portaltTrustDataResponse is the top-level response for the portal trust-data
+// portalTrustDataResponse is the top-level response for the portal trust-data
 // endpoint. All five categories are populated even when backing telemetry does
 // not yet exist; in those cases the fields carry safe zero/empty/null values
 // with documented semantics.
@@ -90,11 +90,12 @@ type portalTrustSignaturesResponse struct {
 	// TotalFailures is the total signature-failure count in the window.
 	TotalFailures int `json:"total_failures"`
 
-	// BySource is a bounded per-agent breakdown (max 50 entries).
+	// BySource is a bounded per-bound-agent breakdown (max 50 entries).
 	BySource []portalTrustSignaturesSourceRow `json:"by_source"`
 }
 
-// portalTrustSignaturesSourceRow is a per-source signature-failure count.
+// portalTrustSignaturesSourceRow is a per-bound-agent signature-failure count.
+// Source is the bound soul agent ID, not a remote federation peer.
 type portalTrustSignaturesSourceRow struct {
 	Source   string `json:"source"`
 	Failures int    `json:"failures"`
@@ -133,7 +134,7 @@ type portalTrustQueueDepthPoint struct {
 //   - economic    ← Economic
 //   - integrity   ← Integrity
 //
-// Each dimension is averaged across agents that have non-zero values.
+// Each dimension is averaged across all agents with reputation rows.
 // When no agent reputation rows exist, score is 0 and dimensions are 0.
 type portalTrustScoreResponse struct {
 	// Score is the aggregate composite trust score (0.0–100.0).
@@ -179,8 +180,8 @@ type portalTrustVouchItem struct {
 	// Peer is the peer identifier (endorser agent ID).
 	Peer string `json:"peer"`
 
-	// Strength is the vouch strength (0.0–1.0). Default 1.0 for endorsements
-	// since SoulAgentPeerEndorsement has no numeric strength field.
+	// Strength is currently a fixed presence marker (1.0) for endorsements
+	// because SoulAgentPeerEndorsement has no numeric strength field.
 	Strength float64 `json:"strength"`
 
 	// Type is the vouch relationship type ("endorsement").
@@ -211,8 +212,10 @@ const trustSignaturesMaxSources = 50
 // for signature failures. The model normalises FailureType to lowercase.
 const signatureFailureType = "signature_failure"
 
-// vouchDefaultStrength is the documented default vouch strength (1.0) when the
-// backing model has no numeric strength field.
+// vouchDefaultStrength is the documented default vouch presence marker (1.0)
+// when the backing model has no numeric strength field. M15 should render
+// vouches as a list/count rather than a comparative strength bar until a
+// numeric strength source exists.
 const vouchDefaultStrength = 1.0
 
 // handlePortalGetTrustData returns per-instance trust data for the Trust

--- a/internal/controlplane/handlers_portal_trust.go
+++ b/internal/controlplane/handlers_portal_trust.go
@@ -1,0 +1,247 @@
+package controlplane
+
+import (
+	"net/http"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+// portaltTrustDataResponse is the top-level response for the portal trust-data
+// endpoint. All five categories are populated even when backing telemetry does
+// not yet exist; in those cases the fields carry safe zero/empty/null values
+// with documented semantics.
+type portalTrustDataResponse struct {
+	InstanceSlug string `json:"instance_slug"`
+
+	// Federation contains federation-peer health counters and (optionally)
+	// a bounded set of peer rows. When host-side federation telemetry is not
+	// yet instrumented, counters are zero and the peers list is empty.
+	Federation portalTrustFederationResponse `json:"federation"`
+
+	// Signatures contains signature-failure counters scoped to the dashboard
+	// window. When host-side signature-failure tracking is not yet
+	// instrumented, counters are zero.
+	Signatures portalTrustSignaturesResponse `json:"signatures"`
+
+	// QueueDepth contains an inbound queue depth time series. When host-side
+	// queue-depth telemetry is not yet persisted, the series is empty.
+	QueueDepth portalTrustQueueDepthResponse `json:"queue_depth"`
+
+	// TrustScore exposes a computed trust score with documented formula and
+	// dimension breakdown. When the backing reputation store does not yet
+	// contain per-instance aggregates, the score is returned as a documented
+	// placeholder (score = 0, formula = explicit string, dimensions = empty).
+	TrustScore portalTrustScoreResponse `json:"trust_score"`
+
+	// Vouches exposes per-peer vouches (peer/strength pairs) with sensitive
+	// provenance redacted. When host-side vouch aggregation is not yet
+	// instrumented, the list is empty.
+	Vouches portalTrustVouchesResponse `json:"vouches"`
+}
+
+// portalTrustFederationResponse contains federation-peer health data for a
+// single managed instance.
+//
+// Data source (planned):
+//   - Managed Lesser instances expose federation health via
+//     /api/v1/admin/federation/*. Host-side aggregation (worker or
+//     polling-based) will persist roll-up counters and bounded peer rows.
+//
+// Current status: host-side federation telemetry is not yet instrumented.
+// Counters are zero and the peers list is empty.
+type portalTrustFederationResponse struct {
+	// Reachable is the count of federation peers currently reachable.
+	Reachable int `json:"reachable"`
+
+	// Warning is the count of peers with degraded reachability.
+	Warning int `json:"warning"`
+
+	// Severed is the count of peers whose federation link has been severed.
+	Severed int `json:"severed"`
+
+	// Peers is an optional bounded list of peer rows (max 50). Each row
+	// includes the peer domain and its status.
+	Peers []portalTrustFederationPeerRow `json:"peers"`
+}
+
+// portalTrustFederationPeerRow is a single federation peer row. Sensitive
+// fields (hosting account IDs, raw connection credentials) are never included.
+type portalTrustFederationPeerRow struct {
+	Domain string `json:"domain"`
+	Status string `json:"status"` // reachable, warning, severed
+}
+
+// portalTrustSignaturesResponse contains signature-failure counters over the
+// dashboard window, scoped to sources owned by the requesting instance.
+//
+// Data source (planned):
+//   - Managed Lesser instances log signature-failure events via the soul
+//     agent failure recording API (SoulAgentFailure with
+//     FailureType="signature_failure"). Host-side aggregation will sum
+//     failures over the window.
+//
+// Current status: host-side signature-failure aggregation is not yet
+// instrumented. Counters are zero and per-source breakdown is empty.
+type portalTrustSignaturesResponse struct {
+	// WindowHours is the lookback window in hours (default 168 = 7 days).
+	WindowHours int `json:"window_hours"`
+
+	// TotalFailures is the total signature-failure count in the window.
+	TotalFailures int `json:"total_failures"`
+
+	// BySource is an optional per-source breakdown (max 50 entries).
+	BySource []portalTrustSignaturesSourceRow `json:"by_source"`
+}
+
+// portalTrustSignaturesSourceRow is a per-source signature-failure count.
+type portalTrustSignaturesSourceRow struct {
+	Source   string `json:"source"`
+	Failures int    `json:"failures"`
+}
+
+// portalTrustQueueDepthResponse contains an inbound queue depth time series
+// for the customer-owned instance(s).
+//
+// Data source (planned):
+//   - SQS queue depth metrics (ApproximateNumberOfMessages) collected
+//     periodically and stored in a host-side time-series model.
+//
+// Current status: host-side queue-depth time series is not yet persisted.
+// The series is empty.
+type portalTrustQueueDepthResponse struct {
+	// Series contains time-series data points (max 168 hourly points = 7 days).
+	Series []portalTrustQueueDepthPoint `json:"series"`
+}
+
+// portalTrustQueueDepthPoint is a single time-series data point.
+type portalTrustQueueDepthPoint struct {
+	Timestamp string `json:"timestamp"` // ISO 8601 UTC
+	Depth     int    `json:"depth"`
+}
+
+// portalTrustScoreResponse exposes a computed trust score with clear
+// semantics, dimensions, and formula documentation.
+//
+// Formula (documented):
+//
+//	trust_score = sum(weight_i * dimension_i) / sum(weight_i)
+//	Default weights: all dimensions equal weight (1.0).
+//	Scoring window: trailing 30 days where data exists.
+//
+// Dimensions:
+//   - operational: derived from instance status, uptime, provision health
+//   - attestation: derived from attestation coverage and recency
+//   - social: derived from peer endorsements and relationship graph metrics
+//   - economic: derived from tip flow and budget health
+//   - integrity: derived from failure/recovery ratio and dispute history
+//
+// Current status: the dimensions are documented but scores are returned as
+// zero placeholders. The backing SoulAgentReputation store contains per-agent
+// dimension scores (Trust, Social, Economic, Integrity, etc.) but the
+// instance→agent index required for per-instance aggregation is not yet
+// materialized.
+type portalTrustScoreResponse struct {
+	// Score is the composite trust score (0.0–100.0). Zero means no score
+	// has been computed yet.
+	Score float64 `json:"score"`
+
+	// Formula is a human-readable description of the scoring formula.
+	Formula string `json:"formula"`
+
+	// Dimensions contains individual dimension scores.
+	Dimensions portalTrustScoreDimensions `json:"dimensions"`
+
+	// Source describes where the score data originates.
+	Source string `json:"source"`
+}
+
+// portalTrustScoreDimensions contains the individual dimension scores that
+// compose the trust score.
+type portalTrustScoreDimensions struct {
+	Operational float64 `json:"operational"`
+	Attestation float64 `json:"attestation"`
+	Social      float64 `json:"social"`
+	Economic    float64 `json:"economic"`
+	Integrity   float64 `json:"integrity"`
+}
+
+// portalTrustVouchesResponse exposes vouches as peer/strength pairs with
+// sensitive provenance redacted.
+//
+// Data source (planned):
+//   - SoulAgentPeerEndorsement and SoulAgentRelationship records (type
+//     endorsement or trust_grant) aggregated per instance.
+//
+// Current status: host-side vouch aggregation is not yet instrumented. The
+// items list is empty.
+type portalTrustVouchesResponse struct {
+	// Items is a bounded list of vouch entries (max 50).
+	Items []portalTrustVouchItem `json:"items"`
+
+	// Count is the total number of vouches available (may exceed Items length).
+	Count int `json:"count"`
+}
+
+// portalTrustVouchItem is a single vouch entry. Sensitive provenance fields
+// (raw signatures, internal PK/SK, account IDs) are never included.
+type portalTrustVouchItem struct {
+	// Peer is the peer identifier (agent ID or domain).
+	Peer string `json:"peer"`
+
+	// Strength is the vouch strength (0.0–1.0).
+	Strength float64 `json:"strength"`
+
+	// Type is the vouch relationship type (e.g. endorsement, trust_grant).
+	Type string `json:"type,omitempty"`
+
+	// CreatedAt is when the vouch was recorded (ISO 8601 UTC).
+	CreatedAt string `json:"created_at,omitempty"`
+}
+
+// handlePortalGetTrustData returns per-instance trust data for the Trust
+// dashboard. Requires customer authentication and instance ownership (or
+// operator role).
+//
+//	GET /api/v1/portal/instances/{slug}/trust/data
+func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+
+	resp := portalTrustDataResponse{
+		InstanceSlug: inst.Slug,
+		Federation: portalTrustFederationResponse{
+			Reachable: 0,
+			Warning:   0,
+			Severed:   0,
+			Peers:     []portalTrustFederationPeerRow{},
+		},
+		Signatures: portalTrustSignaturesResponse{
+			WindowHours:   168, // 7 days
+			TotalFailures: 0,
+			BySource:      []portalTrustSignaturesSourceRow{},
+		},
+		QueueDepth: portalTrustQueueDepthResponse{
+			Series: []portalTrustQueueDepthPoint{},
+		},
+		TrustScore: portalTrustScoreResponse{
+			Score:   0,
+			Formula: "trust_score = sum(weight_i * dimension_i) / sum(weight_i); weights: operational=1.0, attestation=1.0, social=1.0, economic=1.0, integrity=1.0; window: trailing 30 days",
+			Dimensions: portalTrustScoreDimensions{
+				Operational: 0,
+				Attestation: 0,
+				Social:      0,
+				Economic:    0,
+				Integrity:   0,
+			},
+			Source: "preliminary: per-agent SoulAgentReputation scores exist but per-instance aggregation index is not yet materialized",
+		},
+		Vouches: portalTrustVouchesResponse{
+			Items: []portalTrustVouchItem{},
+			Count: 0,
+		},
+	}
+
+	return apptheory.JSON(http.StatusOK, resp)
+}

--- a/internal/controlplane/handlers_portal_trust.go
+++ b/internal/controlplane/handlers_portal_trust.go
@@ -1,9 +1,17 @@
 package controlplane
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"sort"
+	"strings"
+	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
 // portaltTrustDataResponse is the top-level response for the portal trust-data
@@ -19,8 +27,8 @@ type portalTrustDataResponse struct {
 	Federation portalTrustFederationResponse `json:"federation"`
 
 	// Signatures contains signature-failure counters scoped to the dashboard
-	// window. When host-side signature-failure tracking is not yet
-	// instrumented, counters are zero.
+	// window. Populated from SoulAgentFailure rows when soul registry is
+	// configured and agents are bound to the requesting instance.
 	Signatures portalTrustSignaturesResponse `json:"signatures"`
 
 	// QueueDepth contains an inbound queue depth time series. When host-side
@@ -28,14 +36,13 @@ type portalTrustDataResponse struct {
 	QueueDepth portalTrustQueueDepthResponse `json:"queue_depth"`
 
 	// TrustScore exposes a computed trust score with documented formula and
-	// dimension breakdown. When the backing reputation store does not yet
-	// contain per-instance aggregates, the score is returned as a documented
-	// placeholder (score = 0, formula = explicit string, dimensions = empty).
+	// dimension breakdown. Populated from SoulAgentReputation rows when soul
+	// registry is configured and agents are bound to the instance.
 	TrustScore portalTrustScoreResponse `json:"trust_score"`
 
 	// Vouches exposes per-peer vouches (peer/strength pairs) with sensitive
-	// provenance redacted. When host-side vouch aggregation is not yet
-	// instrumented, the list is empty.
+	// provenance redacted. Populated from SoulAgentPeerEndorsement rows when
+	// soul registry is configured and agents are bound to the instance.
 	Vouches portalTrustVouchesResponse `json:"vouches"`
 }
 
@@ -72,16 +79,10 @@ type portalTrustFederationPeerRow struct {
 }
 
 // portalTrustSignaturesResponse contains signature-failure counters over the
-// dashboard window, scoped to sources owned by the requesting instance.
+// dashboard window, scoped to agents bound to the requesting instance.
 //
-// Data source (planned):
-//   - Managed Lesser instances log signature-failure events via the soul
-//     agent failure recording API (SoulAgentFailure with
-//     FailureType="signature_failure"). Host-side aggregation will sum
-//     failures over the window.
-//
-// Current status: host-side signature-failure aggregation is not yet
-// instrumented. Counters are zero and per-source breakdown is empty.
+// Data source: SoulAgentFailure rows (FailureType = "signature_failure")
+// queried per resolved agent, filtered to the 168-hour dashboard window.
 type portalTrustSignaturesResponse struct {
 	// WindowHours is the lookback window in hours (default 168 = 7 days).
 	WindowHours int `json:"window_hours"`
@@ -89,7 +90,7 @@ type portalTrustSignaturesResponse struct {
 	// TotalFailures is the total signature-failure count in the window.
 	TotalFailures int `json:"total_failures"`
 
-	// BySource is an optional per-source breakdown (max 50 entries).
+	// BySource is a bounded per-agent breakdown (max 50 entries).
 	BySource []portalTrustSignaturesSourceRow `json:"by_source"`
 }
 
@@ -119,30 +120,23 @@ type portalTrustQueueDepthPoint struct {
 	Depth     int    `json:"depth"`
 }
 
-// portalTrustScoreResponse exposes a computed trust score with clear
-// semantics, dimensions, and formula documentation.
+// portalTrustScoreResponse exposes a computed trust score with documented
+// formula and per-dimension breakdown.
 //
-// Formula (documented):
+// Score formula: aggregate trust_score = average(Composite) across all
+// bound agents that have a SoulAgentReputation row.
 //
-//	trust_score = sum(weight_i * dimension_i) / sum(weight_i)
-//	Default weights: all dimensions equal weight (1.0).
-//	Scoring window: trailing 30 days where data exists.
+// Dimension mapping (SoulAgentReputation field → trust dimension):
+//   - operational ← Trust (reflects operational reliability signals)
+//   - attestation ← Validation (validation records proxy for attestation)
+//   - social      ← Social
+//   - economic    ← Economic
+//   - integrity   ← Integrity
 //
-// Dimensions:
-//   - operational: derived from instance status, uptime, provision health
-//   - attestation: derived from attestation coverage and recency
-//   - social: derived from peer endorsements and relationship graph metrics
-//   - economic: derived from tip flow and budget health
-//   - integrity: derived from failure/recovery ratio and dispute history
-//
-// Current status: the dimensions are documented but scores are returned as
-// zero placeholders. The backing SoulAgentReputation store contains per-agent
-// dimension scores (Trust, Social, Economic, Integrity, etc.) but the
-// instance→agent index required for per-instance aggregation is not yet
-// materialized.
+// Each dimension is averaged across agents that have non-zero values.
+// When no agent reputation rows exist, score is 0 and dimensions are 0.
 type portalTrustScoreResponse struct {
-	// Score is the composite trust score (0.0–100.0). Zero means no score
-	// has been computed yet.
+	// Score is the aggregate composite trust score (0.0–100.0).
 	Score float64 `json:"score"`
 
 	// Formula is a human-readable description of the scoring formula.
@@ -168,12 +162,9 @@ type portalTrustScoreDimensions struct {
 // portalTrustVouchesResponse exposes vouches as peer/strength pairs with
 // sensitive provenance redacted.
 //
-// Data source (planned):
-//   - SoulAgentPeerEndorsement and SoulAgentRelationship records (type
-//     endorsement or trust_grant) aggregated per instance.
-//
-// Current status: host-side vouch aggregation is not yet instrumented. The
-// items list is empty.
+// Data source: SoulAgentPeerEndorsement rows queried per resolved agent.
+// Each signed endorsement is a vouch; strength defaults to 1.0 per the
+// documented default since the model has no numeric strength field.
 type portalTrustVouchesResponse struct {
 	// Items is a bounded list of vouch entries (max 50).
 	Items []portalTrustVouchItem `json:"items"`
@@ -185,18 +176,44 @@ type portalTrustVouchesResponse struct {
 // portalTrustVouchItem is a single vouch entry. Sensitive provenance fields
 // (raw signatures, internal PK/SK, account IDs) are never included.
 type portalTrustVouchItem struct {
-	// Peer is the peer identifier (agent ID or domain).
+	// Peer is the peer identifier (endorser agent ID).
 	Peer string `json:"peer"`
 
-	// Strength is the vouch strength (0.0–1.0).
+	// Strength is the vouch strength (0.0–1.0). Default 1.0 for endorsements
+	// since SoulAgentPeerEndorsement has no numeric strength field.
 	Strength float64 `json:"strength"`
 
-	// Type is the vouch relationship type (e.g. endorsement, trust_grant).
+	// Type is the vouch relationship type ("endorsement").
 	Type string `json:"type,omitempty"`
 
 	// CreatedAt is when the vouch was recorded (ISO 8601 UTC).
 	CreatedAt string `json:"created_at,omitempty"`
 }
+
+// trustScoreFormula is the documented formula string returned in every response.
+const trustScoreFormula = "trust_score = average(Composite) across agents; " +
+	"dimensions: operational←Trust, attestation←Validation, social←Social, economic←Economic, integrity←Integrity; " +
+	"weights: all equal (1.0); source: soul_agent_reputation"
+
+// trustScoreSource identifies the backing data model.
+const trustScoreSource = "lesser-host:soul_agent_reputation"
+
+// trustSignaturesWindowHours is the dashboard lookback window (7 days).
+const trustSignaturesWindowHours = 168
+
+// trustVouchesMaxItems caps the number of vouch items returned.
+const trustVouchesMaxItems = 50
+
+// trustSignaturesMaxSources caps the number of by-source rows returned.
+const trustSignaturesMaxSources = 50
+
+// signatureFailureType is the normalized SoulAgentFailure.FailureType value
+// for signature failures. The model normalises FailureType to lowercase.
+const signatureFailureType = "signature_failure"
+
+// vouchDefaultStrength is the documented default vouch strength (1.0) when the
+// backing model has no numeric strength field.
+const vouchDefaultStrength = 1.0
 
 // handlePortalGetTrustData returns per-instance trust data for the Trust
 // dashboard. Requires customer authentication and instance ownership (or
@@ -218,7 +235,7 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 			Peers:     []portalTrustFederationPeerRow{},
 		},
 		Signatures: portalTrustSignaturesResponse{
-			WindowHours:   168, // 7 days
+			WindowHours:   trustSignaturesWindowHours,
 			TotalFailures: 0,
 			BySource:      []portalTrustSignaturesSourceRow{},
 		},
@@ -226,16 +243,10 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 			Series: []portalTrustQueueDepthPoint{},
 		},
 		TrustScore: portalTrustScoreResponse{
-			Score:   0,
-			Formula: "trust_score = sum(weight_i * dimension_i) / sum(weight_i); weights: operational=1.0, attestation=1.0, social=1.0, economic=1.0, integrity=1.0; window: trailing 30 days",
-			Dimensions: portalTrustScoreDimensions{
-				Operational: 0,
-				Attestation: 0,
-				Social:      0,
-				Economic:    0,
-				Integrity:   0,
-			},
-			Source: "preliminary: per-agent SoulAgentReputation scores exist but per-instance aggregation index is not yet materialized",
+			Score:      0,
+			Formula:    trustScoreFormula,
+			Dimensions: portalTrustScoreDimensions{},
+			Source:     trustScoreSource,
 		},
 		Vouches: portalTrustVouchesResponse{
 			Items: []portalTrustVouchItem{},
@@ -243,5 +254,222 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 		},
 	}
 
+	// Populate soul-backed data when the soul registry is configured.
+	if s.cfg.SoulEnabled {
+		agentIDs := s.resolveAgentIDsForInstance(ctx, inst)
+		if len(agentIDs) > 0 {
+			resp.Signatures = s.loadTrustSignatures(ctx.Context(), agentIDs)
+			resp.TrustScore = s.loadTrustScore(ctx.Context(), agentIDs)
+			resp.Vouches = s.loadTrustVouches(ctx.Context(), agentIDs)
+		}
+	}
+
 	return apptheory.JSON(http.StatusOK, resp)
+}
+
+// resolveAgentIDsForInstance derives the set of agent IDs bound to a single
+// instance by resolving its verified/managed domains through the soul domain
+// agent index. Returns nil on any error so callers degrade to zero/empty.
+func (s *Server) resolveAgentIDsForInstance(ctx *apptheory.Context, inst *models.Instance) []string {
+	// Build domain set: verified domains + managed stage domain.
+	instances := []*models.Instance{inst}
+	domainSet, appErr := s.listDomainsForInstances(ctx.Context(), instances)
+	if appErr != nil {
+		return nil
+	}
+	agentIDs, appErr := s.listAgentIDsForDomains(ctx.Context(), domainSet)
+	if appErr != nil {
+		return nil
+	}
+	sort.Strings(agentIDs)
+	return agentIDs
+}
+
+// loadTrustSignatures queries SoulAgentFailure rows for the given agent IDs,
+// filters to signature_failure types within the 168-hour window, and returns
+// total and per-agent breakdown counts.
+func (s *Server) loadTrustSignatures(ctx context.Context, agentIDs []string) portalTrustSignaturesResponse {
+	windowStart := time.Now().UTC().Add(-trustSignaturesWindowHours * time.Hour)
+
+	resp := portalTrustSignaturesResponse{
+		WindowHours: trustSignaturesWindowHours,
+	}
+
+	bySource := make(map[string]int) // agentID → failure count
+	totalFailures := 0
+
+	for _, agentID := range agentIDs {
+		pk := fmt.Sprintf("SOUL#AGENT#%s", agentID)
+		var failures []*models.SoulAgentFailure
+		err := s.store.DB.WithContext(ctx).
+			Model(&models.SoulAgentFailure{}).
+			Where("PK", "=", pk).
+			Where("SK", "begins_with", "FAILURE#").
+			All(&failures)
+		if err != nil && !theoryErrors.IsNotFound(err) {
+			continue // degrade gracefully on read errors
+		}
+
+		for _, f := range failures {
+			if f == nil {
+				continue
+			}
+			// Only count signature failures within the window.
+			if strings.ToLower(strings.TrimSpace(f.FailureType)) != signatureFailureType {
+				continue
+			}
+			if f.Timestamp.Before(windowStart) {
+				continue
+			}
+			totalFailures++
+			bySource[agentID]++
+		}
+	}
+
+	resp.TotalFailures = totalFailures
+	resp.BySource = sortedSourceRows(bySource, trustSignaturesMaxSources)
+	return resp
+}
+
+// sortedSourceRows returns a bounded, descending-sorted slice of source rows.
+func sortedSourceRows(bySource map[string]int, maxRows int) []portalTrustSignaturesSourceRow {
+	type entry struct {
+		source   string
+		failures int
+	}
+	entries := make([]entry, 0, len(bySource))
+	for source, count := range bySource {
+		entries = append(entries, entry{source, count})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].failures > entries[j].failures ||
+			(entries[i].failures == entries[j].failures && entries[i].source < entries[j].source)
+	})
+	limit := len(entries)
+	if limit > maxRows {
+		limit = maxRows
+	}
+	rows := make([]portalTrustSignaturesSourceRow, limit)
+	for i := 0; i < limit; i++ {
+		rows[i] = portalTrustSignaturesSourceRow{
+			Source:   entries[i].source,
+			Failures: entries[i].failures,
+		}
+	}
+	return rows
+}
+
+// loadTrustScore computes an aggregate trust score from SoulAgentReputation
+// rows for the given agent IDs. Score is the average Composite across agents;
+// dimensions are the average of each mapped field. When no reputation rows
+// exist, returns documented zero/empty semantics.
+func (s *Server) loadTrustScore(ctx context.Context, agentIDs []string) portalTrustScoreResponse {
+	resp := portalTrustScoreResponse{
+		Formula: trustScoreFormula,
+		Source:  trustScoreSource,
+	}
+
+	var (
+		totalComposite   float64
+		totalOperational float64 // ← Trust
+		totalAttestation float64 // ← Validation
+		totalSocial      float64 // ← Social
+		totalEconomic    float64 // ← Economic
+		totalIntegrity   float64 // ← Integrity
+		agentCount       int
+	)
+
+	for _, agentID := range agentIDs {
+		rep, err := s.getSoulAgentReputation(ctx, agentID)
+		if theoryErrors.IsNotFound(err) || rep == nil {
+			continue
+		}
+		if err != nil {
+			continue // degrade on read error
+		}
+		agentCount++
+		totalComposite += rep.Composite
+		totalOperational += rep.Trust
+		totalAttestation += rep.Validation
+		totalSocial += rep.Social
+		totalEconomic += rep.Economic
+		totalIntegrity += rep.Integrity
+	}
+
+	if agentCount == 0 {
+		return resp
+	}
+
+	n := float64(agentCount)
+	resp.Score = totalComposite / n
+	resp.Dimensions = portalTrustScoreDimensions{
+		Operational: totalOperational / n,
+		Attestation: totalAttestation / n,
+		Social:      totalSocial / n,
+		Economic:    totalEconomic / n,
+		Integrity:   totalIntegrity / n,
+	}
+
+	return resp
+}
+
+// loadTrustVouches queries SoulAgentPeerEndorsement rows for the given agent
+// IDs, returning bounded peer/strength pairs with provenance redacted. Count
+// reflects total available endorsements even when items are bounded.
+func (s *Server) loadTrustVouches(ctx context.Context, agentIDs []string) portalTrustVouchesResponse {
+	resp := portalTrustVouchesResponse{}
+
+	type vouchEntry struct {
+		peer      string
+		createdAt time.Time
+	}
+	var all []vouchEntry
+
+	for _, agentID := range agentIDs {
+		pk := fmt.Sprintf("SOUL#AGENT#%s", agentID)
+		var endorsements []*models.SoulAgentPeerEndorsement
+		err := s.store.DB.WithContext(ctx).
+			Model(&models.SoulAgentPeerEndorsement{}).
+			Where("PK", "=", pk).
+			Where("SK", "begins_with", "ENDORSEMENT#").
+			All(&endorsements)
+		if err != nil && !theoryErrors.IsNotFound(err) {
+			continue // degrade on read error
+		}
+
+		for _, e := range endorsements {
+			if e == nil {
+				continue
+			}
+			all = append(all, vouchEntry{
+				peer:      strings.TrimSpace(e.EndorserAgentID),
+				createdAt: e.CreatedAt,
+			})
+		}
+	}
+
+	resp.Count = len(all)
+
+	// Stable sort by created_at descending.
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].createdAt.After(all[j].createdAt)
+	})
+
+	limit := len(all)
+	if limit > trustVouchesMaxItems {
+		limit = trustVouchesMaxItems
+	}
+
+	items := make([]portalTrustVouchItem, limit)
+	for i := 0; i < limit; i++ {
+		items[i] = portalTrustVouchItem{
+			Peer:      all[i].peer,
+			Strength:  vouchDefaultStrength,
+			Type:      "endorsement",
+			CreatedAt: all[i].createdAt.UTC().Format(time.RFC3339),
+		}
+	}
+	resp.Items = items
+
+	return resp
 }

--- a/internal/controlplane/handlers_portal_trust_internal_test.go
+++ b/internal/controlplane/handlers_portal_trust_internal_test.go
@@ -2,8 +2,11 @@ package controlplane
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
+	"strings"
 	"testing"
+	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
@@ -100,12 +103,12 @@ func TestHandlePortalGetTrustData_HappyPath(t *testing.T) {
 	require.NotNil(t, data.QueueDepth.Series)
 	require.Len(t, data.QueueDepth.Series, 0)
 
-	// Trust score: documented placeholder
+	// Trust score: documented zero placeholder (soul not enabled)
 	require.Equal(t, 0.0, data.TrustScore.Score)
 	require.NotEmpty(t, data.TrustScore.Formula)
 	require.Contains(t, data.TrustScore.Formula, "trust_score")
 	require.NotEmpty(t, data.TrustScore.Source)
-	require.Contains(t, data.TrustScore.Source, "preliminary")
+	require.Contains(t, data.TrustScore.Source, "soul_agent_reputation")
 	require.Equal(t, 0.0, data.TrustScore.Dimensions.Operational)
 	require.Equal(t, 0.0, data.TrustScore.Dimensions.Attestation)
 	require.Equal(t, 0.0, data.TrustScore.Dimensions.Social)
@@ -386,5 +389,770 @@ func TestHandlePortalGetTrustData_ResponseShapeStability(t *testing.T) {
 			}
 		}
 		require.True(t, found, "unexpected key in response: %s", key)
+	}
+}
+
+// ============================================================================
+// M16 populated-data tests — soul registry enabled with bound agents
+// ============================================================================
+
+// soulTrustTestDB is the extended mock DB for tests that exercise the
+// soul-backed trust-data resolution path.
+type soulTrustTestDB struct {
+	db        *ttmocks.MockExtendedDB
+	qUser     *ttmocks.MockQuery
+	qInstance *ttmocks.MockQuery
+	qDomain   *ttmocks.MockQuery
+	qIdx      *ttmocks.MockQuery
+	qRep      *ttmocks.MockQuery
+	qFailure  *ttmocks.MockQuery
+	qEndorse  *ttmocks.MockQuery
+}
+
+func newSoulTrustTestDB(t *testing.T) *soulTrustTestDB {
+	t.Helper()
+
+	db := ttmocks.NewMockExtendedDB()
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+
+	qs := make(map[string]*ttmocks.MockQuery)
+	md := []struct {
+		typeName string
+		key      string
+	}{
+		{"*models.User", "qUser"},
+		{"*models.Instance", "qInstance"},
+		{"*models.Domain", "qDomain"},
+		{"*models.SoulDomainAgentIndex", "qIdx"},
+		{"*models.SoulAgentReputation", "qRep"},
+		{"*models.SoulAgentFailure", "qFailure"},
+		{"*models.SoulAgentPeerEndorsement", "qEndorse"},
+	}
+
+	for _, m := range md {
+		q := new(ttmocks.MockQuery)
+		qs[m.key] = q
+		db.On("Model", mock.AnythingOfType(m.typeName)).Return(q).Maybe()
+		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
+		q.On("Index", mock.Anything).Return(q).Maybe()
+	}
+
+	tdb := &soulTrustTestDB{
+		db:        db,
+		qUser:     qs["qUser"],
+		qInstance: qs["qInstance"],
+		qDomain:   qs["qDomain"],
+		qIdx:      qs["qIdx"],
+		qRep:      qs["qRep"],
+		qFailure:  qs["qFailure"],
+		qEndorse:  qs["qEndorse"],
+	}
+
+	// Default: user "alice" exists as customer
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.User](t, args, 0)
+		*dest = models.User{Username: "alice", Role: "customer", Approved: true}
+	}).Maybe()
+
+	return tdb
+}
+
+// soulEnabledConfig returns a config with soul enabled but all other fields
+// at safe zero/empty defaults so handlers don't panic on missing rpc/chain/etc.
+func soulEnabledConfig() config.Config {
+	return config.Config{
+		SoulEnabled:                 true,
+		SoulChainID:                 1,
+		SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
+	}
+}
+
+func TestHandlePortalGetTrustData_SoulPopulatedReputation(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+
+	// 1. Instance owned by alice
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	// 2. Verified domain for the instance
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	// 3. SoulDomainAgentIndex returns one agent
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "agent-0", AgentID: agentID},
+		}
+	}).Once()
+
+	// 4. Reputation row with Composite = 80.0 and dimension scores
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{
+			AgentID:    agentID,
+			Composite:  80.0,
+			Trust:      75.0,
+			Validation: 82.0,
+			Social:     70.0,
+			Economic:   88.0,
+			Integrity:  85.0,
+		}
+	}).Once()
+
+	// 5. No signature failures
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+
+	// 6. No endorsements
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Status)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// Trust score should be populated from the reputation row
+	require.Equal(t, 80.0, data.TrustScore.Score)
+	require.NotEmpty(t, data.TrustScore.Formula)
+	require.Contains(t, data.TrustScore.Source, "soul_agent_reputation")
+	require.Equal(t, 75.0, data.TrustScore.Dimensions.Operational) // ← Trust
+	require.Equal(t, 82.0, data.TrustScore.Dimensions.Attestation) // ← Validation
+	require.Equal(t, 70.0, data.TrustScore.Dimensions.Social)      // ← Social
+	require.Equal(t, 88.0, data.TrustScore.Dimensions.Economic)    // ← Economic
+	require.Equal(t, 85.0, data.TrustScore.Dimensions.Integrity)   // ← Integrity
+}
+
+func TestHandlePortalGetTrustData_SoulPopulatedVouches(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "agent-0", AgentID: agentID},
+		}
+	}).Once()
+
+	// No reputation
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+
+	// No signature failures
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+
+	// Two endorsements from peers
+	now := time.Now().UTC()
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{
+			{
+				AgentID:         agentID,
+				EndorserAgentID: "0xpeer1111111111111111111111111111111111111111111111111111111111111111",
+				Signature:       "0xsig1",
+				CreatedAt:       now,
+			},
+			{
+				AgentID:         agentID,
+				EndorserAgentID: "0xpeer2222222222222222222222222222222222222222222222222222222222222222",
+				Signature:       "0xsig2",
+				CreatedAt:       now.Add(-1 * time.Hour),
+			},
+		}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Status)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// Vouches should be populated
+	require.Equal(t, 2, data.Vouches.Count)
+	require.Len(t, data.Vouches.Items, 2)
+
+	for _, item := range data.Vouches.Items {
+		require.NotEmpty(t, item.Peer)
+		require.Equal(t, 1.0, item.Strength)
+		require.Equal(t, "endorsement", item.Type)
+		require.NotEmpty(t, item.CreatedAt)
+		// No raw signature leaked
+		require.NotEqual(t, "0xsig1", item.Peer)
+		require.NotEqual(t, "0xsig2", item.Peer)
+	}
+
+	// Verify no raw signature leaks into the response
+	body := string(resp.Body)
+	require.NotContains(t, body, `"signature"`)
+	require.NotContains(t, body, `"PK"`)
+	require.NotContains(t, body, `"SK"`)
+}
+
+func TestHandlePortalGetTrustData_SoulPopulatedSignatureFailures(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentA := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+	agentB := "0x0000000000000000000000000000000000000000000000000000000000000bbb"
+	now := time.Now().UTC()
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	// Two verified domains
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{
+			{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified},
+			{Domain: "other.com", InstanceSlug: "demo", Status: models.DomainStatusVerified},
+		}
+	}).Once()
+
+	// Two domains → two SoulDomainAgentIndex queries; return agents for both.
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "agent-a", AgentID: agentA},
+			{Domain: "other.com", LocalID: "agent-b", AgentID: agentB},
+		}
+	}).Twice()
+
+	// No reputation for either agent
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Twice()
+
+	// Agent A: 3 signature failures within window, 1 outside window, 1 non-signature
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{
+			{FailureType: "signature_failure", Timestamp: now.Add(-1 * time.Hour)},
+			{FailureType: "signature_failure", Timestamp: now.Add(-2 * time.Hour)},
+			{FailureType: "signature_failure", Timestamp: now.Add(-3 * time.Hour)},
+			{FailureType: "signature_failure", Timestamp: now.Add(-200 * time.Hour)}, // outside window
+			{FailureType: "crash_loop", Timestamp: now.Add(-1 * time.Hour)},          // not signature
+		}
+	}).Once()
+
+	// Agent B: 1 signature failure within window
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{
+			{FailureType: "signature_failure", Timestamp: now.Add(-5 * time.Hour)},
+		}
+	}).Once()
+
+	// No endorsements
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Twice()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.Status)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// Total: 3 (agent A) + 1 (agent B) = 4
+	require.Equal(t, 4, data.Signatures.TotalFailures)
+	require.Equal(t, 168, data.Signatures.WindowHours)
+
+	// By-source: 2 entries (one per agent)
+	require.Len(t, data.Signatures.BySource, 2)
+
+	// Build a map for easy assertion
+	srcMap := make(map[string]int)
+	for _, row := range data.Signatures.BySource {
+		srcMap[row.Source] = row.Failures
+	}
+	require.Equal(t, 3, srcMap[agentA])
+	require.Equal(t, 1, srcMap[agentB])
+
+	// Verify no raw failure data leaks
+	body := string(resp.Body)
+	require.NotContains(t, body, `"failure_id"`)
+	require.NotContains(t, body, `"FailureID"`)
+	require.NotContains(t, body, `"description"`)
+}
+
+func TestHandlePortalGetTrustData_SoulNoAgentsBound(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	// Instance has verified domains, but no agents are bound through the index
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	// No agent index entries
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// All soul-backed fields remain zero/empty since no agents found
+	require.Equal(t, 0.0, data.TrustScore.Score)
+	require.Equal(t, 0, data.Signatures.TotalFailures)
+	require.Equal(t, 0, data.Vouches.Count)
+	require.Len(t, data.Vouches.Items, 0)
+}
+
+func TestHandlePortalGetTrustData_SoulNoVerifiedDomains(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	// Only pending (unverified) domains — should be filtered out
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "pending.example", InstanceSlug: "demo", Status: models.DomainStatusPending}}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	require.Equal(t, 0.0, data.TrustScore.Score)
+	require.Equal(t, 0, data.Signatures.TotalFailures)
+	require.Equal(t, 0, data.Vouches.Count)
+}
+
+func TestHandlePortalGetTrustData_SoulRedactionProofWithPopulatedData(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+	now := time.Now().UTC()
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "agent-0", AgentID: agentID},
+		}
+	}).Once()
+
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{AgentID: agentID, Composite: 50.0, Trust: 50.0}
+	}).Once()
+
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{
+			{
+				FailureType: "signature_failure",
+				FailureID:   "fail-001",
+				Description: "sensitive description should not leak",
+				Timestamp:   now,
+			},
+		}
+	}).Once()
+
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{
+			{
+				AgentID:         agentID,
+				EndorserAgentID: "0xpeer1111111111111111111111111111111111111111111111111111111111111111",
+				Signature:       "0xsensitive_raw_signature",
+				Message:         "secret message",
+				CreatedAt:       now,
+			},
+		}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	body := string(resp.Body)
+
+	// Standard redaction checks
+	require.NotContains(t, body, `"PK"`)
+	require.NotContains(t, body, `"SK"`)
+	require.NotContains(t, body, `"TTL"`)
+	require.NotContains(t, body, `"account_id"`)
+
+	// Soul-specific: no raw failure data leaked
+	require.NotContains(t, body, `"failure_id"`)
+	require.NotContains(t, body, `"fail-001"`)
+	require.NotContains(t, body, `"sensitive description should not leak"`)
+
+	// No raw endorsement data leaked
+	require.NotContains(t, body, `"signature"`)
+	require.NotContains(t, body, `"0xsensitive_raw_signature"`)
+	require.NotContains(t, body, `"secret message"`)
+
+	// No internal model keys leaked
+	require.NotContains(t, body, `"endorser_agent_id"`)
+	require.NotContains(t, body, `"message"`)
+}
+
+func TestHandlePortalGetTrustData_SoulTenantIsolationWithPopulatedData(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentA := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+
+	// Alice's instance "alice-inst" has its own agents
+	stubOwnedInstance(t, tdb.qInstance, "alice-inst", "alice")
+
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "alice.example", InstanceSlug: "alice-inst", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "alice.example", LocalID: "alice-agent", AgentID: agentA},
+		}
+	}).Once()
+
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{AgentID: agentA, Composite: 99.0}
+	}).Once()
+
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "alice-inst"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	require.Equal(t, "alice-inst", data.InstanceSlug)
+	require.Equal(t, 99.0, data.TrustScore.Score)
+
+	// Verify no cross-tenant data leaked — response should not mention other slugs
+	body := string(resp.Body)
+	require.NotContains(t, body, "bob-inst")
+}
+
+func TestHandlePortalGetTrustData_SoulNotEnabledReturnsZeroDefaults(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	// SoulEnabled = false (cfg is empty)
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// All zero defaults — soul path not taken
+	require.Equal(t, 0.0, data.TrustScore.Score)
+	require.Equal(t, 0, data.Signatures.TotalFailures)
+	require.Equal(t, 0, data.Vouches.Count)
+}
+
+func TestHandlePortalGetTrustData_SoulMultiAgentAverageScore(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentA := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+	agentB := "0x0000000000000000000000000000000000000000000000000000000000000bbb"
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "a", AgentID: agentA},
+			{Domain: "example.com", LocalID: "b", AgentID: agentB},
+		}
+	}).Once()
+
+	// Agent A: composite 60, dimensions around 60
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{
+			AgentID:    agentA,
+			Composite:  60.0,
+			Trust:      55.0,
+			Validation: 65.0,
+			Social:     50.0,
+			Economic:   70.0,
+			Integrity:  60.0,
+		}
+	}).Once()
+
+	// Agent B: composite 40, dimensions around 40
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{
+			AgentID:    agentB,
+			Composite:  40.0,
+			Trust:      45.0,
+			Validation: 35.0,
+			Social:     50.0,
+			Economic:   30.0,
+			Integrity:  40.0,
+		}
+	}).Once()
+
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Twice()
+
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Twice()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// Average composite: (60 + 40) / 2 = 50
+	require.Equal(t, 50.0, data.TrustScore.Score)
+
+	// Average dimensions
+	require.Equal(t, 50.0, data.TrustScore.Dimensions.Operational) // (55+45)/2
+	require.Equal(t, 50.0, data.TrustScore.Dimensions.Attestation) // (65+35)/2
+	require.Equal(t, 50.0, data.TrustScore.Dimensions.Social)      // (50+50)/2
+	require.Equal(t, 50.0, data.TrustScore.Dimensions.Economic)    // (70+30)/2
+	require.Equal(t, 50.0, data.TrustScore.Dimensions.Integrity)   // (60+40)/2
+}
+
+func TestHandlePortalGetTrustData_SoulIncludesManagedStageDomain(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+
+	// Instance with HostedBaseDomain so managed stage domain is computed.
+	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: "demo", Owner: "alice", Status: models.InstanceStatusActive, HostedBaseDomain: "demo.greater.website"}
+	}).Once()
+
+	// Verified domain
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "demo.greater.website", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	// Agent bound to managed stage domain (dev.demo.greater.website) — two calls:
+	// one for the verified domain, one for the managed stage domain.
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "dev.demo.greater.website", LocalID: "agent-0", AgentID: agentID},
+		}
+	}).Maybe()
+
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentReputation](t, args, 0)
+		*dest = models.SoulAgentReputation{AgentID: agentID, Composite: 75.0, Trust: 70.0}
+	}).Once()
+
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	require.Equal(t, 75.0, data.TrustScore.Score)
+}
+
+func TestHandlePortalGetTrustData_SoulVouchesBoundedTo50(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+	now := time.Now().UTC()
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{
+			{Domain: "example.com", LocalID: "agent-0", AgentID: agentID},
+		}
+	}).Once()
+
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+
+	// 60 endorsements — items should be capped at 50 but count = 60
+	endorsements := make([]*models.SoulAgentPeerEndorsement, 60)
+	for i := 0; i < 60; i++ {
+		endorsements[i] = &models.SoulAgentPeerEndorsement{
+			AgentID:         agentID,
+			EndorserAgentID: "0xpeer" + strings.Repeat("x", 58) + fmt.Sprintf("%02d", i),
+			Signature:       "0xsig",
+			CreatedAt:       now.Add(-time.Duration(i) * time.Hour),
+		}
+	}
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = endorsements
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	require.Equal(t, 60, data.Vouches.Count) // total count
+	require.Len(t, data.Vouches.Items, 50)   // bounded to 50
+	for _, item := range data.Vouches.Items {
+		require.Equal(t, 1.0, item.Strength)
+		require.Equal(t, "endorsement", item.Type)
 	}
 }

--- a/internal/controlplane/handlers_portal_trust_internal_test.go
+++ b/internal/controlplane/handlers_portal_trust_internal_test.go
@@ -1,0 +1,390 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// portalTrustTestDB wraps mock DB and queries for trust-data handler tests.
+type portalTrustTestDB struct {
+	db        *ttmocks.MockExtendedDB
+	qUser     *ttmocks.MockQuery
+	qInstance *ttmocks.MockQuery
+}
+
+// newPortalTrustTestDB constructs a mock DB with queries for User and Instance models.
+func newPortalTrustTestDB(t *testing.T) *portalTrustTestDB {
+	t.Helper()
+	db, queries := newTestDBWithModelQueries("*models.User", "*models.Instance")
+	tdb := &portalTrustTestDB{
+		db:        db,
+		qUser:     queries[0],
+		qInstance: queries[1],
+	}
+
+	// Default: user "alice" exists as customer
+	tdb.qUser.On("First", mock.AnythingOfType("*models.User")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.User](t, args, 0)
+		*dest = models.User{Username: "alice", Role: "customer", Approved: true}
+	}).Maybe()
+
+	return tdb
+}
+
+// stubOwnedInstance makes qInstance.First return an instance owned by owner.
+func stubOwnedInstance(t *testing.T, q *ttmocks.MockQuery, slug, owner string) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{Slug: slug, Owner: owner, Status: models.InstanceStatusActive}
+	}).Once()
+}
+
+// stubInstanceNotFound makes qInstance.First return ErrItemNotFound.
+func stubInstanceNotFound(t *testing.T, q *ttmocks.MockQuery) {
+	t.Helper()
+	q.On("First", mock.AnythingOfType("*models.Instance")).Return(theoryErrors.ErrItemNotFound).Once()
+}
+
+func TestHandlePortalGetTrustData_HappyPath(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.Equal(t, http.StatusOK, resp.Status)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+
+	// Verify instance slug
+	require.Equal(t, "demo", data.InstanceSlug)
+
+	// Federation: zero defaults
+	require.Equal(t, 0, data.Federation.Reachable)
+	require.Equal(t, 0, data.Federation.Warning)
+	require.Equal(t, 0, data.Federation.Severed)
+	require.NotNil(t, data.Federation.Peers)
+	require.Len(t, data.Federation.Peers, 0)
+
+	// Signatures: zero defaults with correct window
+	require.Equal(t, 168, data.Signatures.WindowHours)
+	require.Equal(t, 0, data.Signatures.TotalFailures)
+	require.NotNil(t, data.Signatures.BySource)
+	require.Len(t, data.Signatures.BySource, 0)
+
+	// Queue depth: empty series
+	require.NotNil(t, data.QueueDepth.Series)
+	require.Len(t, data.QueueDepth.Series, 0)
+
+	// Trust score: documented placeholder
+	require.Equal(t, 0.0, data.TrustScore.Score)
+	require.NotEmpty(t, data.TrustScore.Formula)
+	require.Contains(t, data.TrustScore.Formula, "trust_score")
+	require.NotEmpty(t, data.TrustScore.Source)
+	require.Contains(t, data.TrustScore.Source, "preliminary")
+	require.Equal(t, 0.0, data.TrustScore.Dimensions.Operational)
+	require.Equal(t, 0.0, data.TrustScore.Dimensions.Attestation)
+	require.Equal(t, 0.0, data.TrustScore.Dimensions.Social)
+	require.Equal(t, 0.0, data.TrustScore.Dimensions.Economic)
+	require.Equal(t, 0.0, data.TrustScore.Dimensions.Integrity)
+
+	// Vouches: empty list
+	require.NotNil(t, data.Vouches.Items)
+	require.Len(t, data.Vouches.Items, 0)
+	require.Equal(t, 0, data.Vouches.Count)
+}
+
+func TestHandlePortalGetTrustData_Unauthenticated(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		Params: map[string]string{"slug": "demo"},
+	}
+
+	_, err := s.handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.unauthorized", appErr.Code)
+}
+
+func TestHandlePortalGetTrustData_Forbidden(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "bob") // owned by bob, not alice
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	_, err := s.handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.forbidden", appErr.Code)
+}
+
+func TestHandlePortalGetTrustData_NotFound(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubInstanceNotFound(t, tdb.qInstance)
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "missing"},
+	}
+
+	_, err := s.handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.not_found", appErr.Code)
+}
+
+func TestHandlePortalGetTrustData_OperatorBypass(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "bob") // owned by bob
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "admin",
+		Params:       map[string]string{"slug": "demo"},
+	}
+	ctx.Set(ctxKeyOperatorRole, models.RoleAdmin)
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+	require.Equal(t, "demo", data.InstanceSlug)
+}
+
+func TestHandlePortalGetTrustData_EmptySlug(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": ""},
+	}
+
+	_, err := s.handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.bad_request", appErr.Code)
+}
+
+func TestHandlePortalGetTrustData_NilServer(t *testing.T) {
+	t.Parallel()
+
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	_, err := (*Server)(nil).handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.internal", appErr.Code)
+}
+
+func TestHandlePortalGetTrustData_NilStore(t *testing.T) {
+	t.Parallel()
+
+	s := &Server{cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	_, err := s.handlePortalGetTrustData(ctx)
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.internal", appErr.Code)
+}
+
+// TestHandlePortalGetTrustData_RedactionProof verifies that the response DTO
+// does not leak internal storage fields, raw secrets, account IDs, or
+// cross-tenant identifiers.
+func TestHandlePortalGetTrustData_RedactionProof(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	body := string(resp.Body)
+
+	// No PK/SK/internal storage fields
+	require.NotContains(t, body, `"PK"`)
+	require.NotContains(t, body, `"SK"`)
+	require.NotContains(t, body, `"gsi1PK"`)
+	require.NotContains(t, body, `"gsi1SK"`)
+	require.NotContains(t, body, `"TTL"`)
+	require.NotContains(t, body, `"ttl"`)
+
+	// No account IDs
+	require.NotContains(t, body, `"account_id"`)
+	require.NotContains(t, body, `"accountId"`)
+	require.NotContains(t, body, `"hostedAccountId"`)
+	require.NotContains(t, body, `"hosted_account_id"`)
+
+	// No raw secrets or keys
+	require.NotContains(t, body, `"secret"`)
+	require.NotContains(t, body, `"key_id"`)
+	require.NotContains(t, body, `"raw_key"`)
+	require.NotContains(t, body, `"jws"`)
+
+	// No PII patterns (partial check)
+	require.NotContains(t, body, `"PAN"`)
+	require.NotContains(t, body, `"CVV"`)
+
+	// Verify we CAN unmarshal — structure is clean
+	var data portalTrustDataResponse
+	err = json.Unmarshal(resp.Body, &data)
+	require.NoError(t, err)
+}
+
+// TestHandlePortalGetTrustData_TenantIsolation verifies that a customer
+// cannot access another customer's trust data, and that the response does
+// not leak a global federation graph.
+func TestHandlePortalGetTrustData_TenantIsolation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("customer_cannot_access_other_instance", func(t *testing.T) {
+		t.Parallel()
+
+		tdb := newPortalTrustTestDB(t)
+		// Stub bob's instance — owned by bob, not alice
+		stubOwnedInstance(t, tdb.qInstance, "bob-instance", "bob")
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+
+		// Alice tries to access bob's instance — should get forbidden
+		ctx := &apptheory.Context{
+			AuthIdentity: "alice",
+			Params:       map[string]string{"slug": "bob-instance"},
+		}
+		_, err := s.handlePortalGetTrustData(ctx)
+		require.Error(t, err)
+		appErr, ok := err.(*apptheory.AppError)
+		require.True(t, ok)
+		require.Equal(t, "app.forbidden", appErr.Code)
+	})
+
+	t.Run("response_contains_only_own_instance_data", func(t *testing.T) {
+		t.Parallel()
+
+		tdb := newPortalTrustTestDB(t)
+		stubOwnedInstance(t, tdb.qInstance, "my-instance", "alice")
+
+		s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+		ctx := &apptheory.Context{
+			AuthIdentity: "alice",
+			Params:       map[string]string{"slug": "my-instance"},
+		}
+
+		resp, err := s.handlePortalGetTrustData(ctx)
+		require.NoError(t, err)
+
+		var data portalTrustDataResponse
+		err = json.Unmarshal(resp.Body, &data)
+		require.NoError(t, err)
+
+		// Only own instance slug in response
+		require.Equal(t, "my-instance", data.InstanceSlug)
+
+		// No other slugs in response body
+		body := string(resp.Body)
+		require.NotContains(t, body, "other-instance")
+	})
+}
+
+// TestHandlePortalGetTrustData_ResponseShapeStability verifies the response
+// JSON shape is stable — all expected top-level keys are present.
+func TestHandlePortalGetTrustData_ResponseShapeStability(t *testing.T) {
+	t.Parallel()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{}}
+	ctx := &apptheory.Context{
+		AuthIdentity: "alice",
+		Params:       map[string]string{"slug": "demo"},
+	}
+
+	resp, err := s.handlePortalGetTrustData(ctx)
+	require.NoError(t, err)
+
+	var raw map[string]json.RawMessage
+	err = json.Unmarshal(resp.Body, &raw)
+	require.NoError(t, err)
+
+	// Verify all expected top-level keys are present
+	expectedKeys := []string{"instance_slug", "federation", "signatures", "queue_depth", "trust_score", "vouches"}
+	for _, key := range expectedKeys {
+		_, ok := raw[key]
+		require.True(t, ok, "missing key: %s", key)
+	}
+
+	// Verify no unexpected top-level keys
+	for key := range raw {
+		found := false
+		for _, expected := range expectedKeys {
+			if key == expected {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "unexpected key in response: %s", key)
+	}
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -174,6 +174,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Get("/api/v1/portal/instances/{slug}/usage/{month}/summary", s.handlePortalGetInstanceUsageSummary, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/cost", s.handlePortalGetInstanceCost, apptheory.RequireAuth())
 	app.Get("/api/v1/portal/instances/{slug}/activity", s.handlePortalGetInstanceActivity, apptheory.RequireAuth())
+	app.Get("/api/v1/portal/instances/{slug}/trust/data", s.handlePortalGetTrustData, apptheory.RequireAuth())
 
 	// Portal domains (owner-scoped).
 	app.Get("/api/v1/portal/instances/{slug}/domains", s.handlePortalListInstanceDomains, apptheory.RequireAuth())


### PR DESCRIPTION
Closes #549

## Scope — M16 Trust Data (backend/data, review rework)

`GET /api/v1/portal/instances/{slug}/trust/data` returns per-instance trust data for the Trust dashboard (M15). Five categories, three populated from the soul registry when `SoulEnabled`:

| Category | Status | Notes |
|----------|--------|-------|
| Federation peer roll-up | zero defaults | host-side federation telemetry not yet instrumented |
| Signature-failure counters | **populated** (168h window) | counted from `SoulAgentFailure` rows (`FailureType=signature_failure`) per resolved agent |
| Inbound queue depth series | empty series | SQS depth time-series model TBD |
| Trust score | **populated** | average `Composite` across bound agents with per-dimension breakdown |
| Vouches | **populated** | bounded peer/strength pairs from `SoulAgentPeerEndorsement`, raw signatures/messages redacted |

### Agent resolution

After `requireInstanceAccess`, agent IDs bound to the instance are resolved via existing owner-scoped helpers: `listDomainsForInstances` (verified domains + managed stage domain) and `listAgentIDsForDomains`. Soul-backed enrichment is gated behind `SoulEnabled`; no bound agents returns safe zero/empty values.

### Data population details

- **Signatures:** `SoulAgentFailure` rows are queried per bound agent, filtered to normalized `signature_failure` within the 168h dashboard window. Response includes total failures and a bounded per-agent `by_source` breakdown where `source` is the bound soul agent ID, not a remote federation peer. Raw failure IDs/descriptions/internal keys are not returned.
- **Trust score:** aggregate score is `average(Composite)` across bound agents with `SoulAgentReputation` rows. Dimensions map as: Operational←Trust, Attestation←Validation, Social←Social, Economic←Economic, Integrity←Integrity. Zero semantics apply when no reputation rows exist.
- **Vouches:** `SoulAgentPeerEndorsement` rows are queried per agent. Each endorsement maps to `{peer, strength: 1.0, type: endorsement, created_at}`; items are bounded to 50 and count reflects total available. Because strength is currently a fixed presence marker, M15 should render vouches as a list/count rather than a comparative strength bar. Raw signatures/messages/internal keys are not returned.
- **Federation / queue depth:** remain explicit safe zero/empty placeholders because no host-side federation or queue-depth telemetry model exists yet.

## Hard boundaries preserved

- No Trust UI rendering; M15 owns the UI.
- No public attestation API changes; `internal/trust/server.go` is unchanged.
- No on-chain anchor coordination.
- CSP unchanged: no new origins and no inline scripts/styles.
- Multi-tenant isolation: `requireInstanceAccess` enforces owner match or operator bypass before soul data lookup.
- API shape is additive/stable: the original endpoint/JSON keys remain.
- DTOs expose no PK/SK, TTL, account IDs, raw secrets, raw keys, raw failure descriptions, raw signatures, PAN/CVV, or cross-tenant identifiers.

## Validation

```text
✅ gofmt -l internal/controlplane/handlers_portal_trust.go internal/controlplane/handlers_portal_trust_internal_test.go — clean
✅ go vet ./internal/controlplane/... ./internal/trust/... — clean
✅ go test -count=1 ./internal/controlplane/... — pass
✅ go test -count=1 ./internal/trust/... — pass
✅ git diff main -- internal/trust/server.go — empty
```

Trust-data tests cover: happy path, unauthenticated, forbidden, not found, operator bypass, empty slug, nil server/store, response shape stability, soul not enabled, no bound agents, no verified domains, populated reputation, multi-agent score averaging, populated vouches, vouches bounded to 50, populated signature failures with out-of-window/non-signature exclusions, managed stage domain inclusion, populated-data redaction, and tenant isolation.

## Files changed

- `internal/controlplane/handlers_portal_trust.go` — endpoint DTOs and soul-backed population helpers.
- `internal/controlplane/handlers_portal_trust_internal_test.go` — M16 handler tests and redaction/tenant-isolation proofs.
- `internal/controlplane/server.go` — route registration.

## Scope confirmation

Backend/data only. No Trust UI rendering. No design-touching web UI changes. No public attestation semantic changes.
