### PR TITLE
fix(portal): Project 42 issue 572 — trust telemetry data

### DIFF
--- a/gov-infra/evidence/design-fidelity/m16-trust-data/corrective-572-trust-telemetry.md
+++ b/gov-infra/evidence/design-fidelity/m16-trust-data/corrective-572-trust-telemetry.md
@@ -1,0 +1,101 @@
+# Project 42 M16 corrective (#572): Trust federation and queue telemetry
+
+Date: 2026-05-29
+Branch: `aron/issue-572-trust-federation-queue-telemetry`
+
+## Scope
+
+Corrects M16's placeholder trust telemetry for:
+
+- `GET /api/v1/portal/instances/{slug}/trust/data` federation counters and peer rows
+- signature-failure dashboard window
+- queue-depth time series
+
+This change does **not** modify public trust/attestation routes (`/.well-known/*`, `/attestations/*`) and does not do M15/#573 Trust UI rendering work.
+
+## Data sources and windows
+
+### Federation
+
+Source: the requested owner-owned managed Lesser instance, fetched server-side with the instance key resolved through the existing managed-instance secret path (`LesserHostInstanceKeySecretARN` / Bearer instance key pattern used by managed metrics/activity/roster bridges).
+
+Endpoints used:
+
+- `GET /api/v1/admin/federation/statistics` — availability/time-range probe of the managed admin federation surface
+- `GET /api/v1/admin/federation/instances?limit=100[&cursor=...]` — peer rows used for counters and bounded DTO rows
+
+Counter semantics:
+
+- `reachable`: peer is not suspended, not silenced, not stale, and not low-trust degraded
+- `warning`: peer is silenced, stale (`last_seen` older than 30 days), or has a low non-zero Lesser `trust_score` (`0 < trust_score < 50`)
+- `severed`: peer is suspended (`is_suspended=true`)
+
+Bounds:
+
+- Host fetches at most 500 peer rows per request from the managed instance.
+- Browser DTO returns at most 50 `federation.peers` rows.
+- If Lesser pagination remains after the fetch cap, `federation.truncated=true`; counters then honestly represent fetched rows only.
+
+Peer DTO redaction:
+
+- Returned: `domain`, `status`, and `last_seen` when Lesser provides it; otherwise host returns an honest `last_fetch` timestamp.
+- `follower_count` is nullable/omitted because Lesser's federation admin response does not provide a real follower count. `active_users` is **not** mapped to follower count.
+- Not returned: hosted AWS account ID, Route53 zone ID, PK/SK/GSI/TTL keys, raw instance keys, raw secrets, admin bearer tokens, message/content data, PAN/CVV, or cross-tenant identifiers.
+
+### Signature failures
+
+Source: `SoulAgentFailure` rows scoped by bound soul agent IDs for the requested instance's verified/managed domains.
+
+Window: `24h` (`signatures.window_hours=24`). Rows older than 24 hours are excluded. The by-source DTO remains bounded to 50 source rows and uses bound soul agent IDs as the source labels, not remote federation peers.
+
+Isolation proof:
+
+1. The handler calls `requireInstanceAccess(slug)` before any signature query.
+2. Domain resolution uses only the requested instance's verified domains plus its managed stage domain.
+3. Failure queries are per-agent partition (`SOUL#AGENT#{agentId}`) for agents resolved from those domains.
+4. Tests cover forbidden/not-owned access and 24h exclusion.
+
+### Queue depth
+
+Source: host-side, instance-scoped soul communication mailbox state.
+
+- Current snapshots count `SoulCommMailboxMessage` rows with `direction=inbound`, `status=queued`, and `deleted=false`.
+- Each count query is scoped to a single partition: `COMM#MAILBOX#INSTANCE#{instanceSlug}#AGENT#{agentId}`.
+- No global SQS queue, global DynamoDB scan, or cross-tenant queue partition is queried.
+- Snapshots persist as `TrustQueueDepthSample` rows under `TRUST#QUEUE_DEPTH#INSTANCE#{instanceSlug}`.
+
+Window/bounds:
+
+- `queue_depth.window_hours=24`
+- DTO returns at most 48 points from the 24h window.
+- `TrustQueueDepthSample` rows retain for 31 days; the dashboard reads only the 24h window.
+
+DTO redaction:
+
+- Returned: timestamp + aggregate depth + source/window metadata.
+- Not returned: agent IDs, delivery IDs, message IDs, content pointers, content hashes, mailbox subjects/previews/body, PK/SK/GSI/TTL keys, account IDs, raw secrets/keys, PAN/CVV, or other tenants' slugs.
+
+## Unavoidable nullable/empty fields
+
+- `federation.peers[].follower_count` is omitted/null until a real follower-count source exists. This is intentional; Lesser's `active_users` is a different metric and is not used as a substitute.
+- External/non-managed instances, old managed Lesser releases without the admin federation endpoints, or soul-disabled instances may still return empty federation/queue sections. That is a scoped no-data state, not a placeholder implementation path for managed instances with telemetry.
+
+## Tests added/updated
+
+- Managed Lesser federation happy path with nonzero counters and bounded redacted peer rows.
+- Silenced/suspended/degraded/stale status mapping.
+- Peer row cap of 50 with counters from real fetched peer rows.
+- Forbidden/not-owned access proves upstream federation is not called.
+- Signature-failure window changed to 24h and excludes 25h/older rows.
+- Queue-depth current snapshot counts only instance+agent scoped mailbox partitions.
+- Queue-depth series bounded to 48 points and filters cross-tenant sample rows.
+- Store model tests for `TrustQueueDepthSample` keys/TTL/redaction shape.
+
+## Trust-and-safety audit summary
+
+- Public trust API contract: unchanged (`cmd/trust-api`, `internal/trust`, `/.well-known/*`, `/attestations/*` untouched).
+- Attestation shape/signing: unchanged.
+- Instance-auth for trust API: unchanged (`sha256(raw_key)` matching untouched).
+- Portal managed-instance access: uses existing server-side instance-key secret resolution; raw key is used only in the outbound Bearer header to the owner-owned managed instance and is never returned or logged.
+- CSP/web rendering: no rendering changes; API TypeScript types were only made additive for new backend DTO fields.
+- Governance/rubric: evidence added here; no verifier or pack weakening.

--- a/internal/controlplane/handlers_portal_trust.go
+++ b/internal/controlplane/handlers_portal_trust.go
@@ -2,8 +2,11 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -21,9 +24,8 @@ import (
 type portalTrustDataResponse struct {
 	InstanceSlug string `json:"instance_slug"`
 
-	// Federation contains federation-peer health counters and (optionally)
-	// a bounded set of peer rows. When host-side federation telemetry is not
-	// yet instrumented, counters are zero and the peers list is empty.
+	// Federation contains federation-peer health counters and a bounded set of
+	// peer rows from the requested managed Lesser instance's admin federation API.
 	Federation portalTrustFederationResponse `json:"federation"`
 
 	// Signatures contains signature-failure counters scoped to the dashboard
@@ -31,8 +33,9 @@ type portalTrustDataResponse struct {
 	// configured and agents are bound to the requesting instance.
 	Signatures portalTrustSignaturesResponse `json:"signatures"`
 
-	// QueueDepth contains an inbound queue depth time series. When host-side
-	// queue-depth telemetry is not yet persisted, the series is empty.
+	// QueueDepth contains an inbound queue depth time series. Populated from
+	// instance-scoped queue-depth samples; current snapshots are derived from
+	// canonical soul-comm mailbox rows scoped by instance slug + bound agent ID.
 	QueueDepth portalTrustQueueDepthResponse `json:"queue_depth"`
 
 	// TrustScore exposes a computed trust score with documented formula and
@@ -49,13 +52,14 @@ type portalTrustDataResponse struct {
 // portalTrustFederationResponse contains federation-peer health data for a
 // single managed instance.
 //
-// Data source (planned):
-//   - Managed Lesser instances expose federation health via
-//     /api/v1/admin/federation/*. Host-side aggregation (worker or
-//     polling-based) will persist roll-up counters and bounded peer rows.
+// Data source: the requested owner-scoped managed Lesser instance's admin
+// federation endpoints, reached server-side with its one-time instance key:
+//   - /api/v1/admin/federation/statistics (availability/time-range probe)
+//   - /api/v1/admin/federation/instances (peer rows and health counters)
 //
-// Current status: host-side federation telemetry is not yet instrumented.
-// Counters are zero and the peers list is empty.
+// If the requested instance has no managed endpoint/key (for example, external
+// registrations), the response degrades to zero/empty values without consulting
+// any global or cross-tenant data source.
 type portalTrustFederationResponse struct {
 	// Reachable is the count of federation peers currently reachable.
 	Reachable int `json:"reachable"`
@@ -63,28 +67,38 @@ type portalTrustFederationResponse struct {
 	// Warning is the count of peers with degraded reachability.
 	Warning int `json:"warning"`
 
-	// Severed is the count of peers whose federation link has been severed.
+	// Severed is the count of peers whose federation link has been suspended.
 	Severed int `json:"severed"`
 
-	// Peers is an optional bounded list of peer rows (max 50). Each row
-	// includes the peer domain and its status.
+	// Peers is a bounded list of peer rows (max 50). Each row includes the peer
+	// domain, status, and an honest last_seen or last_fetch timestamp.
 	Peers []portalTrustFederationPeerRow `json:"peers"`
+
+	// Source names the backing telemetry source for audit/debug display.
+	Source string `json:"source"`
+
+	// Truncated is true when host hit its admin API fetch cap before Lesser's
+	// pagination was exhausted. Counters then reflect fetched rows only.
+	Truncated bool `json:"truncated,omitempty"`
 }
 
 // portalTrustFederationPeerRow is a single federation peer row. Sensitive
 // fields (hosting account IDs, raw connection credentials) are never included.
 type portalTrustFederationPeerRow struct {
-	Domain string `json:"domain"`
-	Status string `json:"status"` // reachable, warning, severed
+	Domain        string `json:"domain"`
+	Status        string `json:"status"` // reachable, warning, severed
+	LastSeen      string `json:"last_seen,omitempty"`
+	LastFetch     string `json:"last_fetch,omitempty"`
+	FollowerCount *int   `json:"follower_count,omitempty"`
 }
 
 // portalTrustSignaturesResponse contains signature-failure counters over the
 // dashboard window, scoped to agents bound to the requesting instance.
 //
 // Data source: SoulAgentFailure rows (FailureType = "signature_failure")
-// queried per resolved agent, filtered to the 168-hour dashboard window.
+// queried per resolved agent, filtered to the 24-hour dashboard window.
 type portalTrustSignaturesResponse struct {
-	// WindowHours is the lookback window in hours (default 168 = 7 days).
+	// WindowHours is the lookback window in hours (default 24 hours).
 	WindowHours int `json:"window_hours"`
 
 	// TotalFailures is the total signature-failure count in the window.
@@ -102,16 +116,20 @@ type portalTrustSignaturesSourceRow struct {
 }
 
 // portalTrustQueueDepthResponse contains an inbound queue depth time series
-// for the customer-owned instance(s).
+// for the customer-owned instance.
 //
-// Data source (planned):
-//   - SQS queue depth metrics (ApproximateNumberOfMessages) collected
-//     periodically and stored in a host-side time-series model.
-//
-// Current status: host-side queue-depth time series is not yet persisted.
-// The series is empty.
+// Data source: TrustQueueDepthSample rows scoped to the requested instance slug.
+// Current samples are recorded from SoulCommMailboxMessage Count() queries that
+// are scoped by instance slug + bound agent ID; no global SQS or cross-tenant
+// queue is queried.
 type portalTrustQueueDepthResponse struct {
-	// Series contains time-series data points (max 168 hourly points = 7 days).
+	// WindowHours is the lookback window in hours (default 24 hours).
+	WindowHours int `json:"window_hours"`
+
+	// Source names the backing telemetry source.
+	Source string `json:"source"`
+
+	// Series contains time-series data points (max 48 points in the 24h window).
 	Series []portalTrustQueueDepthPoint `json:"series"`
 }
 
@@ -199,14 +217,47 @@ const trustScoreFormula = "trust_score = average(Composite) across agents; " +
 // trustScoreSource identifies the backing data model.
 const trustScoreSource = "lesser-host:soul_agent_reputation"
 
-// trustSignaturesWindowHours is the dashboard lookback window (7 days).
-const trustSignaturesWindowHours = 168
+// trustFederationSource identifies the Lesser admin API used for peer telemetry.
+const trustFederationSource = "lesser:/api/v1/admin/federation"
+
+// trustQueueDepthSource identifies the scoped host model used for queue telemetry.
+const trustQueueDepthSource = "lesser-host:soul_comm_mailbox_queue"
+
+const (
+	trustFederationStatusReachable = "reachable"
+	trustFederationStatusWarning   = "warning"
+	trustFederationStatusSevered   = "severed"
+)
+
+// trustSignaturesWindowHours is the dashboard lookback window (24 hours).
+const trustSignaturesWindowHours = 24
+
+// trustQueueDepthWindowHours is the queue-depth dashboard lookback window (24 hours).
+const trustQueueDepthWindowHours = 24
 
 // trustVouchesMaxItems caps the number of vouch items returned.
 const trustVouchesMaxItems = 50
 
 // trustSignaturesMaxSources caps the number of by-source rows returned.
 const trustSignaturesMaxSources = 50
+
+// trustFederationPeerRowsMax caps peer rows returned to the browser.
+const trustFederationPeerRowsMax = 50
+
+// trustFederationFetchLimit is the page size used against Lesser's admin API.
+const trustFederationFetchLimit = 100
+
+// trustFederationFetchCap bounds host-side federation pages consumed per request.
+const trustFederationFetchCap = 500
+
+// trustFederationDegradedTrustThreshold maps low non-zero Lesser trust scores to warnings.
+const trustFederationDegradedTrustThreshold = 50.0
+
+// trustFederationStaleSeenHours maps stale peers to warning status.
+const trustFederationStaleSeenHours = 30 * 24
+
+// trustQueueDepthMaxSeriesPoints caps queue-depth points returned to the browser.
+const trustQueueDepthMaxSeriesPoints = 48
 
 // signatureFailureType is the normalized SoulAgentFailure.FailureType value
 // for signature failures. The model normalises FailureType to lowercase.
@@ -217,6 +268,51 @@ const signatureFailureType = "signature_failure"
 // vouches as a list/count rather than a comparative strength bar until a
 // numeric strength source exists.
 const vouchDefaultStrength = 1.0
+
+type lesserFederationInstanceInfo struct {
+	Domain        string  `json:"domain"`
+	IsSilenced    bool    `json:"is_silenced"`
+	IsSuspended   bool    `json:"is_suspended"`
+	FirstSeen     string  `json:"first_seen"`
+	LastSeen      string  `json:"last_seen"`
+	ActiveUsers   int64   `json:"active_users"`
+	TotalMessages int64   `json:"total_messages"`
+	TrustScore    float64 `json:"trust_score"`
+	Software      string  `json:"software"`
+	Version       string  `json:"version"`
+}
+
+type lesserFederationInstancesPage struct {
+	Instances  []lesserFederationInstanceInfo `json:"instances"`
+	NextCursor *string                        `json:"next_cursor"`
+}
+
+func (p *lesserFederationInstancesPage) UnmarshalJSON(data []byte) error {
+	var arr []lesserFederationInstanceInfo
+	if err := json.Unmarshal(data, &arr); err == nil {
+		p.Instances = arr
+		p.NextCursor = nil
+		return nil
+	}
+	type pageAlias lesserFederationInstancesPage
+	var obj pageAlias
+	if err := json.Unmarshal(data, &obj); err != nil {
+		return err
+	}
+	p.Instances = obj.Instances
+	p.NextCursor = obj.NextCursor
+	return nil
+}
+
+type lesserFederationStatisticsResponse struct {
+	ActiveInstances int `json:"active_instances"`
+	TotalUsers      int `json:"total_users"`
+	TotalMessages   int `json:"total_messages"`
+	TimeRange       struct {
+		Start string `json:"start"`
+		End   string `json:"end"`
+	} `json:"time_range"`
+}
 
 // handlePortalGetTrustData returns per-instance trust data for the Trust
 // dashboard. Requires customer authentication and instance ownership (or
@@ -230,12 +326,13 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 	}
 
 	resp := portalTrustDataResponse{
-		InstanceSlug: inst.Slug,
+		InstanceSlug: strings.ToLower(strings.TrimSpace(inst.Slug)),
 		Federation: portalTrustFederationResponse{
 			Reachable: 0,
 			Warning:   0,
 			Severed:   0,
 			Peers:     []portalTrustFederationPeerRow{},
+			Source:    trustFederationSource,
 		},
 		Signatures: portalTrustSignaturesResponse{
 			WindowHours:   trustSignaturesWindowHours,
@@ -243,7 +340,9 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 			BySource:      []portalTrustSignaturesSourceRow{},
 		},
 		QueueDepth: portalTrustQueueDepthResponse{
-			Series: []portalTrustQueueDepthPoint{},
+			WindowHours: trustQueueDepthWindowHours,
+			Source:      trustQueueDepthSource,
+			Series:      []portalTrustQueueDepthPoint{},
 		},
 		TrustScore: portalTrustScoreResponse{
 			Score:      0,
@@ -257,11 +356,16 @@ func (s *Server) handlePortalGetTrustData(ctx *apptheory.Context) (*apptheory.Re
 		},
 	}
 
+	if federation, appErr := s.loadTrustFederation(ctx, inst); appErr == nil {
+		resp.Federation = federation
+	}
+
 	// Populate soul-backed data when the soul registry is configured.
 	if s.cfg.SoulEnabled {
 		agentIDs := s.resolveAgentIDsForInstance(ctx, inst)
 		if len(agentIDs) > 0 {
 			resp.Signatures = s.loadTrustSignatures(ctx.Context(), agentIDs)
+			resp.QueueDepth = s.loadTrustQueueDepth(ctx.Context(), inst, agentIDs)
 			resp.TrustScore = s.loadTrustScore(ctx.Context(), agentIDs)
 			resp.Vouches = s.loadTrustVouches(ctx.Context(), agentIDs)
 		}
@@ -288,8 +392,322 @@ func (s *Server) resolveAgentIDsForInstance(ctx *apptheory.Context, inst *models
 	return agentIDs
 }
 
+func (s *Server) loadTrustFederation(ctx *apptheory.Context, inst *models.Instance) (portalTrustFederationResponse, *apptheory.AppError) {
+	resp := portalTrustFederationResponse{
+		Peers:  []portalTrustFederationPeerRow{},
+		Source: trustFederationSource,
+	}
+	if s == nil || inst == nil {
+		return resp, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+
+	apiKey, keyErr := s.resolvePortalCostInstanceKey(ctx.Context(), inst)
+	if keyErr != nil || strings.TrimSpace(apiKey) == "" {
+		return resp, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance federation access"}
+	}
+	baseURL, urlErr := s.resolvePortalCostMetricsBaseURL(inst)
+	if urlErr != nil {
+		return resp, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve instance federation endpoint"}
+	}
+
+	client := s.portalCostHTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: instanceMetricsTimeout}
+	}
+
+	// Probe statistics first. The current DTO does not expose the aggregate
+	// active-users/messages counters, but this call verifies the managed admin
+	// federation surface and future-proofs the same server-side access path.
+	_ = s.fetchLesserFederationStatistics(ctx.Context(), client, baseURL, apiKey)
+
+	instances, truncated, appErr := s.fetchLesserFederationInstances(ctx.Context(), client, baseURL, apiKey)
+	if appErr != nil {
+		return resp, appErr
+	}
+	return buildTrustFederationResponse(instances, time.Now().UTC(), truncated), nil
+}
+
+func (s *Server) fetchLesserFederationStatistics(ctx context.Context, client *http.Client, baseURL string, apiKey string) *apptheory.AppError {
+	endpoint, err := buildManagedInstanceFederationURL(baseURL, "/api/v1/admin/federation/statistics", nil)
+	if err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to resolve federation statistics endpoint"}
+	}
+	var decoded lesserFederationStatisticsResponse
+	return decodeManagedLesserJSON(ctx, client, http.MethodGet, endpoint, apiKey, &decoded)
+}
+
+func (s *Server) fetchLesserFederationInstances(ctx context.Context, client *http.Client, baseURL string, apiKey string) ([]lesserFederationInstanceInfo, bool, *apptheory.AppError) {
+	out := make([]lesserFederationInstanceInfo, 0)
+	cursor := ""
+	truncated := false
+
+	for len(out) < trustFederationFetchCap {
+		q := url.Values{}
+		q.Set("limit", fmt.Sprintf("%d", trustFederationFetchLimit))
+		if strings.TrimSpace(cursor) != "" {
+			q.Set("cursor", strings.TrimSpace(cursor))
+		}
+		endpoint, err := buildManagedInstanceFederationURL(baseURL, "/api/v1/admin/federation/instances", q)
+		if err != nil {
+			return nil, false, &apptheory.AppError{Code: "app.internal", Message: "failed to resolve federation instances endpoint"}
+		}
+
+		var page lesserFederationInstancesPage
+		if appErr := decodeManagedLesserJSON(ctx, client, http.MethodGet, endpoint, apiKey, &page); appErr != nil {
+			return nil, false, appErr
+		}
+		out = append(out, page.Instances...)
+		if page.NextCursor == nil || strings.TrimSpace(*page.NextCursor) == "" {
+			return out, false, nil
+		}
+		cursor = strings.TrimSpace(*page.NextCursor)
+	}
+	truncated = strings.TrimSpace(cursor) != ""
+	return out, truncated, nil
+}
+
+func buildManagedInstanceFederationURL(baseURL string, path string, q url.Values) (string, error) {
+	baseURL = strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	if baseURL == "" {
+		return "", fmt.Errorf("base url is required")
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	u, err := url.Parse(baseURL + path)
+	if err != nil {
+		return "", err
+	}
+	if q != nil {
+		u.RawQuery = q.Encode()
+	}
+	return u.String(), nil
+}
+
+func decodeManagedLesserJSON(ctx context.Context, client *http.Client, method string, endpoint string, apiKey string, dest any) *apptheory.AppError {
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, nil)
+	if err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to create managed Lesser request"}
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(apiKey))
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req) //nolint:gosec // endpoint is derived from managed instance metadata or an injected test seam.
+	if err != nil {
+		return &apptheory.AppError{Code: "app.upstream_unavailable", Message: "failed to reach managed Lesser"}
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1024))
+		return &apptheory.AppError{Code: "app.upstream_error", Message: "managed Lesser request failed"}
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(dest); err != nil {
+		return &apptheory.AppError{Code: "app.upstream_error", Message: "failed to decode managed Lesser response"}
+	}
+	return nil
+}
+
+func buildTrustFederationResponse(instances []lesserFederationInstanceInfo, fetchedAt time.Time, truncated bool) portalTrustFederationResponse {
+	resp := portalTrustFederationResponse{
+		Peers:     []portalTrustFederationPeerRow{},
+		Source:    trustFederationSource,
+		Truncated: truncated,
+	}
+	if fetchedAt.IsZero() {
+		fetchedAt = time.Now().UTC()
+	}
+
+	seen := make(map[string]struct{}, len(instances))
+	for _, info := range instances {
+		domain := strings.ToLower(strings.TrimSpace(info.Domain))
+		if domain == "" {
+			continue
+		}
+		if _, ok := seen[domain]; ok {
+			continue
+		}
+		seen[domain] = struct{}{}
+
+		status := trustFederationStatus(info, fetchedAt)
+		switch status {
+		case trustFederationStatusSevered:
+			resp.Severed++
+		case trustFederationStatusWarning:
+			resp.Warning++
+		default:
+			resp.Reachable++
+		}
+
+		if len(resp.Peers) >= trustFederationPeerRowsMax {
+			continue
+		}
+		row := portalTrustFederationPeerRow{
+			Domain: domain,
+			Status: status,
+		}
+		lastSeen := strings.TrimSpace(info.LastSeen)
+		if lastSeen != "" {
+			row.LastSeen = lastSeen
+		} else {
+			row.LastFetch = fetchedAt.UTC().Format(time.RFC3339)
+		}
+		resp.Peers = append(resp.Peers, row)
+	}
+
+	sort.Slice(resp.Peers, func(i, j int) bool {
+		return resp.Peers[i].Domain < resp.Peers[j].Domain
+	})
+	return resp
+}
+
+func trustFederationStatus(info lesserFederationInstanceInfo, now time.Time) string {
+	if info.IsSuspended {
+		return trustFederationStatusSevered
+	}
+	if info.IsSilenced {
+		return trustFederationStatusWarning
+	}
+	if info.TrustScore > 0 && info.TrustScore < trustFederationDegradedTrustThreshold {
+		return trustFederationStatusWarning
+	}
+	lastSeen := strings.TrimSpace(info.LastSeen)
+	if lastSeen != "" {
+		if ts, err := time.Parse(time.RFC3339, lastSeen); err == nil && !ts.IsZero() && ts.Before(now.UTC().Add(-trustFederationStaleSeenHours*time.Hour)) {
+			return trustFederationStatusWarning
+		}
+	}
+	return trustFederationStatusReachable
+}
+
+// loadTrustQueueDepth records a best-effort current queue-depth sample and then
+// returns persisted instance-scoped samples in the 24-hour dashboard window.
+func (s *Server) loadTrustQueueDepth(ctx context.Context, inst *models.Instance, agentIDs []string) portalTrustQueueDepthResponse {
+	resp := newPortalTrustQueueDepthResponse()
+	if !canLoadTrustQueueDepth(s, inst, agentIDs) {
+		return resp
+	}
+
+	slug := strings.ToLower(strings.TrimSpace(inst.Slug))
+	now := time.Now().UTC()
+	if sample, err := s.recordTrustQueueDepthSnapshot(ctx, slug, agentIDs, now); err == nil && sample != nil {
+		resp.Series = []portalTrustQueueDepthPoint{trustQueueDepthPointFromSample(sample)}
+	}
+	if points, err := s.loadPersistedTrustQueueDepthPoints(ctx, slug, now); err == nil && len(points) > 0 {
+		resp.Series = points
+	}
+	return resp
+}
+
+func newPortalTrustQueueDepthResponse() portalTrustQueueDepthResponse {
+	return portalTrustQueueDepthResponse{
+		WindowHours: trustQueueDepthWindowHours,
+		Source:      trustQueueDepthSource,
+		Series:      []portalTrustQueueDepthPoint{},
+	}
+}
+
+func canLoadTrustQueueDepth(s *Server, inst *models.Instance, agentIDs []string) bool {
+	return s != nil && s.store != nil && s.store.DB != nil && inst != nil && strings.TrimSpace(inst.Slug) != "" && len(agentIDs) > 0
+}
+
+func (s *Server) loadPersistedTrustQueueDepthPoints(ctx context.Context, slug string, now time.Time) ([]portalTrustQueueDepthPoint, error) {
+	var samples []*models.TrustQueueDepthSample
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.TrustQueueDepthSample{}).
+		Where("PK", "=", models.TrustQueueDepthSamplePK(slug)).
+		Where("SK", "begins_with", "SAMPLE#").
+		OrderBy("SK", "DESC").
+		Limit(trustQueueDepthMaxSeriesPoints).
+		All(&samples)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		return nil, err
+	}
+	return trustQueueDepthPointsFromSamples(samples, slug, now), nil
+}
+
+func trustQueueDepthPointsFromSamples(samples []*models.TrustQueueDepthSample, slug string, now time.Time) []portalTrustQueueDepthPoint {
+	windowStart := now.Add(-trustQueueDepthWindowHours * time.Hour)
+	points := make([]portalTrustQueueDepthPoint, 0, minInt(len(samples), trustQueueDepthMaxSeriesPoints))
+	for _, sample := range samples {
+		if !trustQueueDepthSampleInScope(sample, slug, windowStart) {
+			continue
+		}
+		points = append(points, trustQueueDepthPointFromSample(sample))
+		if len(points) >= trustQueueDepthMaxSeriesPoints {
+			break
+		}
+	}
+	sort.Slice(points, func(i, j int) bool {
+		return points[i].Timestamp < points[j].Timestamp
+	})
+	return points
+}
+
+func trustQueueDepthSampleInScope(sample *models.TrustQueueDepthSample, slug string, windowStart time.Time) bool {
+	return sample != nil && strings.ToLower(strings.TrimSpace(sample.InstanceSlug)) == slug && !sample.Timestamp.Before(windowStart)
+}
+
+func (s *Server) recordTrustQueueDepthSnapshot(ctx context.Context, instanceSlug string, agentIDs []string, now time.Time) (*models.TrustQueueDepthSample, error) {
+	depth := 0
+	for _, agentID := range uniqueSortedStrings(agentIDs) {
+		if agentID == "" {
+			continue
+		}
+		count, err := s.store.DB.WithContext(ctx).
+			Model(&models.SoulCommMailboxMessage{}).
+			Where("PK", "=", models.SoulCommMailboxAgentPK(instanceSlug, agentID)).
+			Filter("direction", "=", models.SoulCommDirectionInbound).
+			Filter("status", "=", models.SoulCommMailboxStatusQueued).
+			Filter("deleted", "=", false).
+			Count()
+		if err != nil && !theoryErrors.IsNotFound(err) {
+			continue
+		}
+		if count > 0 {
+			depth += int(count)
+		}
+	}
+
+	sample := &models.TrustQueueDepthSample{
+		InstanceSlug: strings.ToLower(strings.TrimSpace(instanceSlug)),
+		Timestamp:    now,
+		Depth:        depth,
+		Source:       trustQueueDepthSource,
+	}
+	if err := s.store.DB.WithContext(ctx).Model(sample).Create(); err != nil && !theoryErrors.IsConditionFailed(err) {
+		return sample, err
+	}
+	return sample, nil
+}
+
+func trustQueueDepthPointFromSample(sample *models.TrustQueueDepthSample) portalTrustQueueDepthPoint {
+	if sample == nil {
+		return portalTrustQueueDepthPoint{}
+	}
+	return portalTrustQueueDepthPoint{
+		Timestamp: sample.Timestamp.UTC().Format(time.RFC3339),
+		Depth:     sample.Depth,
+	}
+}
+
+func uniqueSortedStrings(values []string) []string {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			set[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // loadTrustSignatures queries SoulAgentFailure rows for the given agent IDs,
-// filters to signature_failure types within the 168-hour window, and returns
+// filters to signature_failure types within the 24-hour window, and returns
 // total and per-agent breakdown counts.
 func (s *Server) loadTrustSignatures(ctx context.Context, agentIDs []string) portalTrustSignaturesResponse {
 	windowStart := time.Now().UTC().Add(-trustSignaturesWindowHours * time.Hour)

--- a/internal/controlplane/handlers_portal_trust_internal_test.go
+++ b/internal/controlplane/handlers_portal_trust_internal_test.go
@@ -1,9 +1,11 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -19,6 +21,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+const portalTrustTestInstanceSecret = "instance-secret"
 
 // portalTrustTestDB wraps mock DB and queries for trust-data handler tests.
 type portalTrustTestDB struct {
@@ -94,7 +98,7 @@ func TestHandlePortalGetTrustData_HappyPath(t *testing.T) {
 	require.Len(t, data.Federation.Peers, 0)
 
 	// Signatures: zero defaults with correct window
-	require.Equal(t, 168, data.Signatures.WindowHours)
+	require.Equal(t, 24, data.Signatures.WindowHours)
 	require.Equal(t, 0, data.Signatures.TotalFailures)
 	require.NotNil(t, data.Signatures.BySource)
 	require.Len(t, data.Signatures.BySource, 0)
@@ -392,6 +396,163 @@ func TestHandlePortalGetTrustData_ResponseShapeStability(t *testing.T) {
 	}
 }
 
+func TestHandlePortalGetTrustData_FederationFromManagedLesser(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	instances := []lesserFederationInstanceInfo{
+		{Domain: "reachable.example", LastSeen: now.Add(-1 * time.Hour).Format(time.RFC3339), TrustScore: 95},
+		{Domain: "silenced.example", IsSilenced: true, LastSeen: now.Add(-2 * time.Hour).Format(time.RFC3339), TrustScore: 90},
+		{Domain: "suspended.example", IsSuspended: true, LastSeen: now.Add(-3 * time.Hour).Format(time.RFC3339), TrustScore: 90},
+		{Domain: "degraded.example", LastSeen: now.Add(-4 * time.Hour).Format(time.RFC3339), TrustScore: 25},
+	}
+
+	statsCalled := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "Bearer "+portalTrustTestInstanceSecret, r.Header.Get("Authorization"))
+		switch r.URL.Path {
+		case "/api/v1/admin/federation/statistics":
+			statsCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"active_instances": 1,
+				"total_users":      4,
+				"total_messages":   12,
+				"time_range": map[string]string{
+					"start": now.Add(-24 * time.Hour).Format(time.RFC3339),
+					"end":   now.Format(time.RFC3339),
+				},
+			})
+		case "/api/v1/admin/federation/instances":
+			require.Equal(t, "100", r.URL.Query().Get("limit"))
+			_ = json.NewEncoder(w).Encode(map[string]any{"instances": instances})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+	s := &Server{
+		store:                store.New(tdb.db),
+		cfg:                  config.Config{},
+		portalCostHTTPClient: ts.Client(),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return portalTrustTestInstanceSecret, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) { return ts.URL, nil },
+	}
+
+	resp, err := s.handlePortalGetTrustData(&apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}})
+	require.NoError(t, err)
+	require.True(t, statsCalled, "statistics endpoint should be probed before peer rows")
+
+	var data portalTrustDataResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &data))
+	require.Equal(t, 1, data.Federation.Reachable)
+	require.Equal(t, 2, data.Federation.Warning)
+	require.Equal(t, 1, data.Federation.Severed)
+	require.Equal(t, trustFederationSource, data.Federation.Source)
+	require.Len(t, data.Federation.Peers, 4)
+
+	byDomain := map[string]portalTrustFederationPeerRow{}
+	for _, row := range data.Federation.Peers {
+		byDomain[row.Domain] = row
+		require.NotEmpty(t, row.LastSeen)
+		require.Empty(t, row.LastFetch)
+		require.Nil(t, row.FollowerCount, "active_users must not be mapped to follower_count")
+	}
+	require.Equal(t, trustFederationStatusReachable, byDomain["reachable.example"].Status)
+	require.Equal(t, trustFederationStatusWarning, byDomain["silenced.example"].Status)
+	require.Equal(t, trustFederationStatusWarning, byDomain["degraded.example"].Status)
+	require.Equal(t, trustFederationStatusSevered, byDomain["suspended.example"].Status)
+}
+
+func TestTrustFederationStatusMapping(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	require.Equal(t, trustFederationStatusSevered, trustFederationStatus(lesserFederationInstanceInfo{IsSuspended: true, IsSilenced: true, TrustScore: 100}, now))
+	require.Equal(t, trustFederationStatusWarning, trustFederationStatus(lesserFederationInstanceInfo{IsSilenced: true, TrustScore: 100}, now))
+	require.Equal(t, trustFederationStatusWarning, trustFederationStatus(lesserFederationInstanceInfo{TrustScore: 25}, now))
+	require.Equal(t, trustFederationStatusWarning, trustFederationStatus(lesserFederationInstanceInfo{TrustScore: 100, LastSeen: now.Add(-31 * 24 * time.Hour).Format(time.RFC3339)}, now))
+	require.Equal(t, trustFederationStatusReachable, trustFederationStatus(lesserFederationInstanceInfo{TrustScore: 100, LastSeen: now.Add(-1 * time.Hour).Format(time.RFC3339)}, now))
+}
+
+func TestHandlePortalGetTrustData_FederationPeersBounded(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	instances := make([]lesserFederationInstanceInfo, 60)
+	for i := range instances {
+		instances[i] = lesserFederationInstanceInfo{
+			Domain:     fmt.Sprintf("peer-%02d.example", i),
+			LastSeen:   now.Format(time.RFC3339),
+			TrustScore: 90,
+		}
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v1/admin/federation/statistics":
+			_ = json.NewEncoder(w).Encode(map[string]any{"active_instances": 60, "time_range": map[string]string{"start": now.Add(-24 * time.Hour).Format(time.RFC3339), "end": now.Format(time.RFC3339)}})
+		case "/api/v1/admin/federation/instances":
+			_ = json.NewEncoder(w).Encode(map[string]any{"instances": instances})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+	s := &Server{
+		store:                store.New(tdb.db),
+		portalCostHTTPClient: ts.Client(),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return portalTrustTestInstanceSecret, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) { return ts.URL, nil },
+	}
+
+	resp, err := s.handlePortalGetTrustData(&apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}})
+	require.NoError(t, err)
+	var data portalTrustDataResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &data))
+	require.Equal(t, 60, data.Federation.Reachable)
+	require.Len(t, data.Federation.Peers, trustFederationPeerRowsMax)
+	require.Equal(t, "peer-00.example", data.Federation.Peers[0].Domain)
+	require.Equal(t, "peer-49.example", data.Federation.Peers[49].Domain)
+}
+
+func TestHandlePortalGetTrustData_ForbiddenDoesNotCallFederation(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		http.Error(w, "should not be called", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	tdb := newPortalTrustTestDB(t)
+	stubOwnedInstance(t, tdb.qInstance, "bob-instance", "bob")
+	s := &Server{
+		store:                store.New(tdb.db),
+		portalCostHTTPClient: ts.Client(),
+		fetchInstanceKeyPlaintextFunc: func(context.Context, *models.Instance) (string, error) {
+			return portalTrustTestInstanceSecret, nil
+		},
+		resolveInstanceMetricsBaseURLFunc: func(*models.Instance) (string, error) { return ts.URL, nil },
+	}
+
+	_, err := s.handlePortalGetTrustData(&apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "bob-instance"}})
+	require.Error(t, err)
+	appErr, ok := err.(*apptheory.AppError)
+	require.True(t, ok)
+	require.Equal(t, "app.forbidden", appErr.Code)
+	require.False(t, called, "not-owned instances must not trigger upstream federation fetches")
+}
+
 // ============================================================================
 // M16 populated-data tests — soul registry enabled with bound agents
 // ============================================================================
@@ -407,6 +568,8 @@ type soulTrustTestDB struct {
 	qRep      *ttmocks.MockQuery
 	qFailure  *ttmocks.MockQuery
 	qEndorse  *ttmocks.MockQuery
+	qMailbox  *ttmocks.MockQuery
+	qQueue    *ttmocks.MockQuery
 }
 
 func newSoulTrustTestDB(t *testing.T) *soulTrustTestDB {
@@ -427,6 +590,8 @@ func newSoulTrustTestDB(t *testing.T) *soulTrustTestDB {
 		{"*models.SoulAgentReputation", "qRep"},
 		{"*models.SoulAgentFailure", "qFailure"},
 		{"*models.SoulAgentPeerEndorsement", "qEndorse"},
+		{"*models.SoulCommMailboxMessage", "qMailbox"},
+		{"*models.TrustQueueDepthSample", "qQueue"},
 	}
 
 	for _, m := range md {
@@ -446,6 +611,8 @@ func newSoulTrustTestDB(t *testing.T) *soulTrustTestDB {
 		qRep:      qs["qRep"],
 		qFailure:  qs["qFailure"],
 		qEndorse:  qs["qEndorse"],
+		qMailbox:  qs["qMailbox"],
+		qQueue:    qs["qQueue"],
 	}
 
 	// Default: user "alice" exists as customer
@@ -453,6 +620,15 @@ func newSoulTrustTestDB(t *testing.T) *soulTrustTestDB {
 		dest := testutil.RequireMockArg[*models.User](t, args, 0)
 		*dest = models.User{Username: "alice", Role: "customer", Approved: true}
 	}).Maybe()
+
+	// Default queue telemetry path: no queued mailbox rows and no persisted
+	// samples. Tests that need populated queue data reset these expectations.
+	tdb.qMailbox.On("Filter", mock.Anything, mock.Anything, mock.Anything).Return(tdb.qMailbox).Maybe()
+	tdb.qMailbox.On("Count").Return(int64(0), nil).Maybe()
+	tdb.qQueue.On("OrderBy", mock.Anything, mock.Anything).Return(tdb.qQueue).Maybe()
+	tdb.qQueue.On("Limit", mock.Anything).Return(tdb.qQueue).Maybe()
+	tdb.qQueue.On("Create").Return(nil).Maybe()
+	tdb.qQueue.On("All", mock.Anything).Return(theoryErrors.ErrItemNotFound).Maybe()
 
 	return tdb
 }
@@ -656,13 +832,14 @@ func TestHandlePortalGetTrustData_SoulPopulatedSignatureFailures(t *testing.T) {
 	// No reputation for either agent
 	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Twice()
 
-	// Agent A: 3 signature failures within window, 1 outside window, 1 non-signature
+	// Agent A: 3 signature failures within the 24h window, 2 outside window, 1 non-signature
 	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
 		*dest = []*models.SoulAgentFailure{
 			{FailureType: "signature_failure", Timestamp: now.Add(-1 * time.Hour)},
 			{FailureType: "signature_failure", Timestamp: now.Add(-2 * time.Hour)},
 			{FailureType: "signature_failure", Timestamp: now.Add(-3 * time.Hour)},
+			{FailureType: "signature_failure", Timestamp: now.Add(-25 * time.Hour)},  // outside 24h window
 			{FailureType: "signature_failure", Timestamp: now.Add(-200 * time.Hour)}, // outside window
 			{FailureType: "crash_loop", Timestamp: now.Add(-1 * time.Hour)},          // not signature
 		}
@@ -698,7 +875,7 @@ func TestHandlePortalGetTrustData_SoulPopulatedSignatureFailures(t *testing.T) {
 
 	// Total: 3 (agent A) + 1 (agent B) = 4
 	require.Equal(t, 4, data.Signatures.TotalFailures)
-	require.Equal(t, 168, data.Signatures.WindowHours)
+	require.Equal(t, 24, data.Signatures.WindowHours)
 
 	// By-source: 2 entries (one per agent)
 	require.Len(t, data.Signatures.BySource, 2)
@@ -716,6 +893,109 @@ func TestHandlePortalGetTrustData_SoulPopulatedSignatureFailures(t *testing.T) {
 	require.NotContains(t, body, `"failure_id"`)
 	require.NotContains(t, body, `"FailureID"`)
 	require.NotContains(t, body, `"description"`)
+}
+
+func TestHandlePortalGetTrustData_QueueDepthSnapshotCountsScopedMailboxRows(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+
+	stubOwnedInstance(t, tdb.qInstance, "demo", "alice")
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "example.com", InstanceSlug: "demo", Status: models.DomainStatusVerified}}
+	}).Once()
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{{Domain: "example.com", LocalID: "agent", AgentID: agentID}}
+	}).Once()
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Once()
+
+	// Override the default zero-count queue mock. The production query is scoped
+	// to COMM#MAILBOX#INSTANCE#demo#AGENT#{agentID}; no global queue is read.
+	tdb.qMailbox.ExpectedCalls = nil
+	tdb.qMailbox.On("Where", "PK", "=", models.SoulCommMailboxAgentPK("demo", agentID)).Return(tdb.qMailbox).Once()
+	tdb.qMailbox.On("Filter", "direction", "=", models.SoulCommDirectionInbound).Return(tdb.qMailbox).Once()
+	tdb.qMailbox.On("Filter", "status", "=", models.SoulCommMailboxStatusQueued).Return(tdb.qMailbox).Once()
+	tdb.qMailbox.On("Filter", "deleted", "=", false).Return(tdb.qMailbox).Once()
+	tdb.qMailbox.On("Count").Return(int64(7), nil).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	resp, err := s.handlePortalGetTrustData(&apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "demo"}})
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &data))
+	require.Equal(t, trustQueueDepthWindowHours, data.QueueDepth.WindowHours)
+	require.Equal(t, trustQueueDepthSource, data.QueueDepth.Source)
+	require.Len(t, data.QueueDepth.Series, 1)
+	require.Equal(t, 7, data.QueueDepth.Series[0].Depth)
+}
+
+func TestHandlePortalGetTrustData_QueueDepthSeriesBoundedAndScoped(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulTrustTestDB(t)
+	agentID := "0x0000000000000000000000000000000000000000000000000000000000000aaa"
+	now := time.Now().UTC().Truncate(time.Second)
+
+	stubOwnedInstance(t, tdb.qInstance, "alice-inst", "alice")
+	tdb.qDomain.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Domain](t, args, 0)
+		*dest = []*models.Domain{{Domain: "alice.example", InstanceSlug: "alice-inst", Status: models.DomainStatusVerified}}
+	}).Once()
+	tdb.qIdx.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulDomainAgentIndex](t, args, 0)
+		*dest = []*models.SoulDomainAgentIndex{{Domain: "alice.example", LocalID: "agent", AgentID: agentID}}
+	}).Once()
+	tdb.qRep.On("First", mock.AnythingOfType("*models.SoulAgentReputation")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qFailure.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentFailure](t, args, 0)
+		*dest = []*models.SoulAgentFailure{}
+	}).Once()
+	tdb.qEndorse.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.SoulAgentPeerEndorsement](t, args, 0)
+		*dest = []*models.SoulAgentPeerEndorsement{}
+	}).Once()
+
+	// Return more rows than the DTO cap and one cross-tenant row; the handler
+	// must bound and filter the response even if storage returns unexpected rows.
+	tdb.qQueue.ExpectedCalls = nil
+	tdb.qQueue.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(tdb.qQueue).Maybe()
+	tdb.qQueue.On("OrderBy", "SK", "DESC").Return(tdb.qQueue).Once()
+	tdb.qQueue.On("Limit", trustQueueDepthMaxSeriesPoints).Return(tdb.qQueue).Once()
+	tdb.qQueue.On("Create").Return(nil).Maybe()
+	samples := make([]*models.TrustQueueDepthSample, 0, 61)
+	for i := 0; i < 60; i++ {
+		samples = append(samples, &models.TrustQueueDepthSample{InstanceSlug: "alice-inst", Timestamp: now.Add(-time.Duration(i) * time.Minute), Depth: i + 1, Source: trustQueueDepthSource})
+	}
+	samples = append(samples, &models.TrustQueueDepthSample{InstanceSlug: "bob-inst", Timestamp: now, Depth: 999, Source: trustQueueDepthSource})
+	tdb.qQueue.On("All", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.TrustQueueDepthSample](t, args, 0)
+		*dest = samples
+	}).Once()
+
+	s := &Server{store: store.New(tdb.db), cfg: soulEnabledConfig()}
+	resp, err := s.handlePortalGetTrustData(&apptheory.Context{AuthIdentity: "alice", Params: map[string]string{"slug": "alice-inst"}})
+	require.NoError(t, err)
+
+	var data portalTrustDataResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &data))
+	require.Len(t, data.QueueDepth.Series, trustQueueDepthMaxSeriesPoints)
+	for _, point := range data.QueueDepth.Series {
+		require.NotEqual(t, 999, point.Depth)
+	}
+	body := string(resp.Body)
+	require.NotContains(t, body, "bob-inst")
 }
 
 func TestHandlePortalGetTrustData_SoulNoAgentsBound(t *testing.T) {

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -87,6 +87,7 @@ func LambdaInit() (DB, error) {
 		&models.SoulChannelAgentIndex{},
 		&models.SoulRelationshipFromIndex{},
 		&models.SoulAgentDispute{},
+		&models.TrustQueueDepthSample{},
 	)
 	if err != nil {
 		return nil, err

--- a/internal/store/models/trust_queue_depth_sample.go
+++ b/internal/store/models/trust_queue_depth_sample.go
@@ -1,0 +1,82 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TrustQueueDepthSampleRetentionDays bounds host-side trust dashboard queue
+// telemetry. The Trust dashboard only reads the last 24 hours, but samples are
+// retained briefly for operational debugging and verifier evidence.
+const TrustQueueDepthSampleRetentionDays = 31
+
+// TrustQueueDepthSample stores an instance-scoped queue-depth snapshot for the
+// Trust dashboard.
+//
+// Keys:
+//
+//	PK: TRUST#QUEUE_DEPTH#INSTANCE#{instanceSlug}
+//	SK: SAMPLE#{timestamp}
+//
+// The item intentionally stores only the tenant slug, sample timestamp, count,
+// and source label. It does not store account IDs, raw keys, mailbox delivery
+// IDs, agent IDs, message IDs, or mailbox content.
+type TrustQueueDepthSample struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	InstanceSlug string    `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	Timestamp    time.Time `theorydb:"attr:timestamp" json:"timestamp"`
+	Depth        int       `theorydb:"attr:depth" json:"depth"`
+	Source       string    `theorydb:"attr:source" json:"source"`
+}
+
+// TableName returns the database table name for TrustQueueDepthSample.
+func (TrustQueueDepthSample) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating TrustQueueDepthSample.
+func (s *TrustQueueDepthSample) BeforeCreate() error {
+	if s.Timestamp.IsZero() {
+		s.Timestamp = time.Now().UTC()
+	}
+	if s.Depth < 0 {
+		s.Depth = 0
+	}
+	if err := s.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", s.InstanceSlug); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateKeys normalizes TrustQueueDepthSample and derives storage keys.
+func (s *TrustQueueDepthSample) UpdateKeys() error {
+	s.InstanceSlug = strings.ToLower(strings.TrimSpace(s.InstanceSlug))
+	s.Source = strings.TrimSpace(s.Source)
+	s.Timestamp = s.Timestamp.UTC()
+	if s.Depth < 0 {
+		s.Depth = 0
+	}
+	ts := s.Timestamp.Format("2006-01-02T15:04:05.000000000Z")
+	s.PK = TrustQueueDepthSamplePK(s.InstanceSlug)
+	s.SK = fmt.Sprintf("SAMPLE#%s", ts)
+	s.TTL = s.Timestamp.Add(TrustQueueDepthSampleRetentionDays * 24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for TrustQueueDepthSample.
+func (s *TrustQueueDepthSample) GetPK() string { return s.PK }
+
+// GetSK returns the sort key for TrustQueueDepthSample.
+func (s *TrustQueueDepthSample) GetSK() string { return s.SK }
+
+// TrustQueueDepthSamplePK returns the instance-scoped queue-depth partition key.
+func TrustQueueDepthSamplePK(instanceSlug string) string {
+	return fmt.Sprintf("TRUST#QUEUE_DEPTH#INSTANCE#%s", strings.ToLower(strings.TrimSpace(instanceSlug)))
+}

--- a/internal/store/models/trust_queue_depth_sample_test.go
+++ b/internal/store/models/trust_queue_depth_sample_test.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTrustQueueDepthSampleKeysAndTTL(t *testing.T) {
+	t.Parallel()
+
+	ts := time.Date(2026, 5, 29, 20, 30, 0, 123, time.UTC)
+	sample := &TrustQueueDepthSample{
+		InstanceSlug: " Demo ",
+		Timestamp:    ts,
+		Depth:        7,
+		Source:       "lesser-host:soul_comm_mailbox_queue",
+	}
+
+	require.NoError(t, sample.BeforeCreate())
+	require.Equal(t, "demo", sample.InstanceSlug)
+	require.Equal(t, "TRUST#QUEUE_DEPTH#INSTANCE#demo", sample.PK)
+	require.Equal(t, "SAMPLE#2026-05-29T20:30:00.000000123Z", sample.SK)
+	require.Equal(t, ts.Add(TrustQueueDepthSampleRetentionDays*24*time.Hour).Unix(), sample.TTL)
+	require.Equal(t, sample.PK, sample.GetPK())
+	require.Equal(t, sample.SK, sample.GetSK())
+}
+
+func TestTrustQueueDepthSampleRedactionShape(t *testing.T) {
+	t.Parallel()
+
+	sample := &TrustQueueDepthSample{InstanceSlug: "demo", Timestamp: time.Now().UTC(), Depth: -5}
+	require.NoError(t, sample.BeforeCreate())
+	require.Equal(t, 0, sample.Depth)
+	require.NotContains(t, sample.PK, "ACCOUNT")
+	require.NotContains(t, sample.SK, "SECRET")
+}

--- a/web/src/lib/api/portalTrust.ts
+++ b/web/src/lib/api/portalTrust.ts
@@ -12,10 +12,16 @@ import { fetchJson } from './http';
 /** Federation peer status values. */
 export type PeerStatus = 'reachable' | 'warning' | 'severed';
 
-/** A single federation peer row (domain + status). */
+/** A single federation peer row (domain + status + redacted timing). */
 export interface TrustFederationPeerRow {
 	domain: string;
 	status: PeerStatus;
+	/** Lesser admin federation last_seen timestamp, when provided. */
+	last_seen?: string;
+	/** Host fetch timestamp when Lesser has no last_seen value. */
+	last_fetch?: string;
+	/** Nullable/omitted until a real follower-count source exists. */
+	follower_count?: number | null;
 }
 
 /** Federation health counters and optional peer list. */
@@ -24,6 +30,8 @@ export interface TrustFederationResponse {
 	warning: number;
 	severed: number;
 	peers: TrustFederationPeerRow[];
+	source?: string;
+	truncated?: boolean;
 }
 
 /** Per-bound-agent signature failure count. */
@@ -48,6 +56,8 @@ export interface TrustQueueDepthPoint {
 
 /** Inbound queue depth time series. */
 export interface TrustQueueDepthResponse {
+	window_hours?: number;
+	source?: string;
 	series: TrustQueueDepthPoint[];
 }
 


### PR DESCRIPTION
## Summary

Implements the Project 42 #572 corrective for `GET /api/v1/portal/instances/{slug}/trust/data` so the Trust dashboard no longer relies on placeholder federation/queue data when real scoped telemetry exists.

Closes #572

## Data sources and windows

- **Federation:** server-side managed Lesser admin federation APIs for the requested owner-owned instance, using the existing managed-instance Bearer key path (`LesserHostInstanceKeySecretARN`/instance-key secret resolution). Host probes `/api/v1/admin/federation/statistics` and reads `/api/v1/admin/federation/instances` with bounded pagination.
- **Federation statuses:** suspended → `severed`; silenced, stale `last_seen` (>30d), or low non-zero `trust_score` (<50) → `warning`; otherwise `reachable`.
- **Peer rows:** bounded to 50; expose `domain`, `status`, and honest `last_seen` or `last_fetch`. `follower_count` is nullable/omitted because no real follower source exists; `active_users` is not mapped to it.
- **Signature failures:** `SoulAgentFailure` scoped to bound agents for the requested instance; window changed to **24h**.
- **Queue depth:** persisted `TrustQueueDepthSample` model under `TRUST#QUEUE_DEPTH#INSTANCE#{slug}`. Current snapshots count canonical `SoulCommMailboxMessage` rows scoped by `COMM#MAILBOX#INSTANCE#{slug}#AGENT#{agentId}` with inbound queued non-deleted filters. DTO window is **24h**, bounded to 48 points.

## Isolation / redaction proof

- `requireInstanceAccess(slug)` runs before any managed Lesser call, signature query, or queue query.
- Federation calls target only the requested managed instance endpoint; no global federation graph is queried.
- Signature failures are loaded only from agent IDs resolved through the requested instance’s verified/managed domains.
- Queue counts are per instance+agent partition; no global SQS depth or global DynamoDB queue scan is used.
- DTOs intentionally omit PK/SK/GSI/TTL/internal keys, account IDs, raw secrets/keys, raw Bearer tokens, mailbox message/content identifiers, PAN/CVV, and cross-tenant slugs.
- Public trust/attestation routes (`/.well-known/*`, `/attestations/*`) are untouched.

## Evidence

- Added `gov-infra/evidence/design-fidelity/m16-trust-data/corrective-572-trust-telemetry.md` with data-source, window, isolation, redaction, and nullable-field notes.

## Validation

- `go test ./internal/controlplane ./internal/store/...` ✅
- `go vet ./internal/controlplane ./internal/store/...` ✅
- `go test ./...` ✅
- `go vet ./...` ✅
- `cd web && npm run typecheck && npm test` ✅
- `bash gov-infra/verifiers/gov-verify-rubric.sh` ✅ (PASS 40/40)
- `git diff --check` ✅
- Targeted `gofmt -l` on touched Go files ✅ (empty)

Note: `gofmt -l .` is not a useful repo-wide gate in this checkout because it descends into generated CDK assets and `cdk/node_modules` Go templates; it reported pre-existing generated/template paths outside this change.

## Caveats

- External/non-managed instances or older managed Lesser releases without the admin federation APIs still degrade to empty federation data rather than querying global/cross-tenant sources.
- `follower_count` remains omitted/null until a real follower-count source is available.
- Federation counters are based on fetched Lesser admin rows; if the host-side fetch cap is hit, `federation.truncated=true` and counters honestly reflect fetched rows only.
