### PR TITLE
[Project 43] lesser-host M2 — Governance verifier soundness (release → main)

### DIFF
--- a/gov-infra/evidence/CMP-4-output.log
+++ b/gov-infra/evidence/CMP-4-output.log
@@ -32,10 +32,12 @@ PASS: roadmap requires bounded retention/encryption/audit semantics
 PASS: roadmap requires list redaction semantics
 PASS: roadmap requires hash-match instance auth semantics
 PASS: threat model includes bounded mailbox threat
+PASS: threat model includes representative T-* threat
 PASS: threat model names content/state drift
 PASS: threat model enumerates insecure mailbox expansion cases
 PASS: controls matrix includes CMP-4
 PASS: controls matrix maps THR-11
+PASS: controls matrix maps representative T-* threat
 PASS: controls matrix enumerates bounded mailbox controls with semantics
 PASS: evidence plan includes CMP-4
 PASS: evidence plan names CMP-4 evidence path

--- a/gov-infra/evidence/CMP-4-output.log
+++ b/gov-infra/evidence/CMP-4-output.log
@@ -68,10 +68,29 @@ PASS: raw-key retention semantics absent
 PASS: cross-tenant mailbox query semantics absent
 PASS: body-owned mailbox authority semantics absent
 PASS: negative fixture rejected for retention
+PASS: literal negative fixture rejected for retention: retention policy is disabled
+PASS: literal negative fixture rejected for retention: purge is turned off
 PASS: negative fixture rejected for encryption
+PASS: literal negative fixture rejected for encryption: encryption is disabled
+PASS: literal negative fixture rejected for encryption: encryption is turned off
 PASS: negative fixture rejected for access audit
+PASS: literal negative fixture rejected for access audit: access audit is disabled
+PASS: literal negative fixture rejected for access audit: audit logging is turned off
 PASS: negative fixture rejected for list/content split
+PASS: literal negative fixture rejected for list/content split: list redaction is disabled
+PASS: literal negative fixture rejected for list/content split: unredacted list responses are enabled
+PASS: literal negative fixture rejected for list/content split: full content list responses are permitted
 PASS: negative fixture rejected for hash-only auth
+PASS: literal negative fixture rejected for hash-only auth: raw instance key storage is enabled
+PASS: literal negative fixture rejected for hash-only auth: plaintext instance-key fallback is turned on
+PASS: literal negative fixture rejected for hash-only auth: hash-only instance auth is disabled
 PASS: negative fixture rejected for tenant isolation
+PASS: literal negative fixture rejected for tenant isolation: cross-tenant search is enabled
+PASS: literal negative fixture rejected for tenant isolation: cross-tenant mailbox analytics are turned on
+PASS: literal negative fixture rejected for tenant isolation: cross-tenant access is permitted
+PASS: literal negative fixture rejected for tenant isolation: tenant isolation is disabled
 PASS: negative fixture rejected for body-owned mailbox authority
+PASS: literal negative fixture rejected for body-owned mailbox authority: body-owned mailbox storage is enabled
+PASS: literal negative fixture rejected for body-owned mailbox authority: body mailbox authority is permitted
+PASS: literal negative fixture rejected for body-owned mailbox authority: body-owned mailbox truth is in scope
 PASS: bounded soul comm mailbox governance controls are explicit

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -1902,7 +1902,9 @@ forbid_pattern() {
 assert_negative_fixture_rejected() {
   local pattern="$1"
   local label="$2"
+  shift 2
   local fixture
+  local literal
   fixture="$(mktemp)"
   cat > "${fixture}" <<'__CMP4_NEGATIVE_FIXTURE__'
 # Bounded soul comm mailbox authority
@@ -1928,6 +1930,9 @@ tenant isolation not required; not required to isolate tenants; tenant boundarie
 Body-owned: body may own mailbox storage; mailbox truth may be body-owned; body primary mailbox authority;
 mailbox authority belongs to body; body can act as mailbox owner; not required for host to own mailbox.
 __CMP4_NEGATIVE_FIXTURE__
+  for literal in "$@"; do
+    printf '%s\n' "${literal}" >> "${fixture}"
+  done
   if grep -Eiq -- "${pattern}" "${fixture}"; then
     echo "PASS: negative fixture rejected for ${label}"
   else
@@ -1935,6 +1940,15 @@ __CMP4_NEGATIVE_FIXTURE__
     echo "  forbidden pattern: ${pattern}"
     fail=1
   fi
+  for literal in "$@"; do
+    if printf '%s\n' "${literal}" | grep -Eiq -- "${pattern}"; then
+      echo "PASS: literal negative fixture rejected for ${label}: ${literal}"
+    else
+      echo "FAIL: literal negative fixture did not exercise forbidden semantic for ${label}: ${literal}"
+      echo "  forbidden pattern: ${pattern}"
+      fail=1
+    fi
+  done
   rm -f "${fixture}"
 }
 
@@ -1996,18 +2010,21 @@ require_pattern "${evidence}" 'CMP-4-output\.log' 'evidence plan names CMP-4 evi
 	# ensures circumlocution regressions are caught by the fixture assertions, not
 	# just by the policy-file scans. Categories: retention, encryption, access-audit,
 	# list/content-split, raw-keys, cross-tenant, body-owned mailbox authority.
-	PAT_RETENTION='no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention|retention (is )?(optional|not (required|mandatory|enforced|needed|necessary))|optional retention|skip retention|best[- ]effort retention|keep (content|messages?|mailbox items?) forever|never purge|not (required|mandatory|enforced) to (retain|purge|expire)|(retention|purge|expir(y|ation)).*(not|no) (required|mandatory|enforced|needed)|may (be )?(retained|stored|kept) (indefinitely|forever|without limit)|without (any )?(retention|purging|expiry)|no (requirement|need|obligation) to (retain|purge)|retention (may|can) be (skipped|omitted|avoided|bypassed|waived)|content (may|can) persist (forever|indefinitely|without limit)|(retention|purge).*(not|never|no) (applied?|enforced|implemented)'
-	PAT_ENCRYPTION='unencrypted|without encryption|do not encrypt|skip encryption|encryption (is )?(optional|not (required|mandatory|enforced|needed|necessary))|optional encryption|stored? in plaintext|plaintext (mailbox|message|content|body)|not (required|mandatory|enforced) to encrypt|may (be )?(stored|sent|kept|persisted) (unencrypted|in (the )?clear|without encryption)|(stored?|content|messages?|mailbox).*(without|not|no|never) encrypt|encrypt.*(may|can) be (skipped|omitted|avoided|bypassed|waived)|(at rest|in transit).*(not|no|without) encrypt|no (requirement|need|obligation) (for|to) encrypt'
-	PAT_ACCESS_AUDIT='without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped|audit logging (is )?(optional|not (required|mandatory|enforced|needed|necessary))|optional audit|unaudited (read|content|state|mutation)|read(s)? without audit|audit (is )?not (required|mandatory|enforced|needed|necessary)|not (required|mandatory|enforced) to audit|audit (logging )?(may|can) be (skipped|omitted|avoided|bypassed|waived)|without (any )?(audit|auditing|audit trail)|no (requirement|need|obligation) (for|to) audit|(access|content|state|mutation).*(may|can) (be|go) unaudited|audit trail.*(not|no|never) (required?|mandatory|enforced)'
-	PAT_LIST_CONTENT='list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list|list (responses|payloads|results) include (full|complete|raw).*(message|content|bod(y|ies))|complete (message|content|bod(y|ies)).*list (responses|payloads|results)|list (responses?|payloads?|endpoints?|results?).*(may|can) include (full|complete|raw|entire).*(bod(y|ies)|message|content)|(full|complete|raw|entire) (bod(y|ies)|message|content).*(may|can) (be )?included in list|list.*not required to redact|redaction.*not (required|mandatory|enforced)|redaction (may|can) be (skipped|omitted|avoided)|list (may|can) return unredacted|unredacted.*list'
-	PAT_RAW_KEYS='raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys|plaintext (instance[- ]?)?key fallback|instance[- ]auth falls back to plaintext|accept raw (instance )?keys from storage|instance keys? (may|can) be (stored|kept|persisted|retained) (in|as) (plaintext|raw)|(may|can) store (raw|plaintext) (instance )?keys?|keys? (may|can) be (stored|kept|persisted) without hash|hash.*not (required|mandatory|enforced|needed)|not (required|mandatory|enforced) to hash (instance )?keys?|without hash.*instance (auth|key)|instance (auth|key).*without hash|(may|can) accept (raw|plaintext) (instance )?keys?'
-	PAT_CROSS_TENANT='cross-tenant (mailbox )?(search|analytics) is allowed|allow(s|ed)? cross-tenant (mailbox )?(search|analytics)|global mailbox (search|analytics) (is )?allowed|search (mailbox )?content across tenants|cross-tenant.*not (prohibited|forbidden|restricted|prevented|blocked)|(may|can) (search|query|access) (mailbox )?(content|data|items?) across tenants|tenant isolation.*not (required|mandatory|enforced|needed|necessary)|not (required|mandatory|enforced) to isolate tenants?|tenant boundar(y|ies).*(may|can) be crossed|cross-tenant (mailbox )?(search|analytics|access).*not (prohibited|forbidden|restricted)'
-	PAT_BODY_OWNED='body-owned mailbox storage is allowed|body (owns|stores|persists) mailbox truth|body (may|can) own mailbox (storage|truth|state)|mailbox (storage|truth|state).*(may|can) be body-owned|body.*primary mailbox authority|mailbox authority.*belongs to body|body (may|can) (be|act as) (the )?mailbox (authority|owner)|not (required|mandatory) for host to own mailbox'
+	PAT_RETENTION='no (explicit )?retention policy|without (a[n]? )?retention policy|retained? indefinitely|indefinite retention|unbounded retention|retention (is )?(optional|not (required|mandatory|enforced|needed|necessary))|optional retention|skip retention|best[- ]effort retention|keep (content|messages?|mailbox items?) forever|never purge|not (required|mandatory|enforced) to (retain|purge|expire)|(retention|purge|expir(y|ation)).*(not|no) (required|mandatory|enforced|needed)|may (be )?(retained|stored|kept) (indefinitely|forever|without limit)|without (any )?(retention|purging|expiry)|no (requirement|need|obligation) to (retain|purge)|retention (may|can) be (skipped|omitted|avoided|bypassed|waived)|content (may|can) persist (forever|indefinitely|without limit)|(retention|purge).*(not|never|no) (applied?|enforced|implemented)|(retention policy|retention|purge|purging|expir(y|ation)) (is )?(disabled|turned off)'
+	PAT_ENCRYPTION='unencrypted|without encryption|do not encrypt|skip encryption|encryption (is )?(optional|not (required|mandatory|enforced|needed|necessary)|disabled|turned off)|optional encryption|stored? in plaintext|plaintext (mailbox|message|content|body)|not (required|mandatory|enforced) to encrypt|may (be )?(stored|sent|kept|persisted) (unencrypted|in (the )?clear|without encryption)|(stored?|content|messages?|mailbox).*(without|not|no|never) encrypt|encrypt.*(may|can) be (skipped|omitted|avoided|bypassed|waived)|(at rest|in transit).*(not|no|without) encrypt|no (requirement|need|obligation) (for|to) encrypt|(at rest|in transit) encryption (is )?(disabled|turned off)'
+	PAT_ACCESS_AUDIT='without access[- ]audit|skip access[- ]audit|no access[- ]audit|access audit can be skipped|audit logging (is )?(optional|not (required|mandatory|enforced|needed|necessary)|disabled|turned off)|optional audit|unaudited (read|content|state|mutation)|read(s)? without audit|audit (is )?(not (required|mandatory|enforced|needed|necessary)|disabled|turned off)|not (required|mandatory|enforced) to audit|audit (logging )?(may|can) be (skipped|omitted|avoided|bypassed|waived)|without (any )?(audit|auditing|audit trail)|no (requirement|need|obligation) (for|to) audit|(access|content|state|mutation).*(may|can) (be|go) unaudited|audit trail.*(not|no|never) (required?|mandatory|enforced)|(access[- ]audit|audit trail) (is )?(disabled|turned off)'
+	PAT_LIST_CONTENT='list endpoints return (full|complete|raw).*bod(y|ies)|full bod(y|ies).*list endpoints|include full bod(y|ies).*list|list (responses|payloads|results) include (full|complete|raw).*(message|content|bod(y|ies))|complete (message|content|bod(y|ies)).*list (responses|payloads|results)|list (responses?|payloads?|endpoints?|results?).*(may|can) include (full|complete|raw|entire).*(bod(y|ies)|message|content)|(full|complete|raw|entire) (bod(y|ies)|message|content).*(may|can) (be )?included in list|list.*not required to redact|redaction.*not (required|mandatory|enforced)|redaction (may|can) be (skipped|omitted|avoided)|list (may|can) return unredacted|unredacted.*list|(redaction|list redaction) (is )?(disabled|turned off)|(full|complete|raw|entire).*(bod(y|ies)|message|content).*list.*(enabled|turned on|permitted|in scope)|unredacted.*list.*(enabled|turned on|permitted|in scope)|list.*unredacted.*(enabled|turned on|permitted|in scope)'
+	PAT_RAW_KEYS='raw instance keys are stored|store raw (instance )?keys|log raw (instance )?keys|return raw (instance )?keys|plaintext (instance[- ]?)?key fallback|instance[- ]auth falls back to plaintext|accept raw (instance )?keys from storage|instance keys? (may|can) be (stored|kept|persisted|retained) (in|as) (plaintext|raw)|(may|can) store (raw|plaintext) (instance )?keys?|keys? (may|can) be (stored|kept|persisted) without hash|hash.*not (required|mandatory|enforced|needed)|not (required|mandatory|enforced) to hash (instance )?keys?|without hash.*instance (auth|key)|instance (auth|key).*without hash|(may|can) accept (raw|plaintext) (instance )?keys?|(raw|plaintext) (instance[- ]?)?key (storage|retention|fallback) (is )?(enabled|turned on|permitted|in scope)|plaintext (instance[- ]?)?key fallback (is )?(enabled|turned on|permitted|in scope)|(hashing|hash-only instance auth|hash-only authentication) (is )?(disabled|turned off)'
+	PAT_CROSS_TENANT='cross-tenant (mailbox )?(search|analytics|access) ((is|are) )?(allowed|enabled|turned on|permitted|in scope)|allow(s|ed)? cross-tenant (mailbox )?(search|analytics|access)|global mailbox (search|analytics|access) ((is|are) )?(allowed|enabled|turned on|permitted|in scope)|search (mailbox )?content across tenants|cross-tenant.*not (prohibited|forbidden|restricted|prevented|blocked)|(may|can) (search|query|access) (mailbox )?(content|data|items?) across tenants|tenant isolation.*not (required|mandatory|enforced|needed|necessary)|not (required|mandatory|enforced) to isolate tenants?|tenant boundar(y|ies).*(may|can) be crossed|cross-tenant (mailbox )?(search|analytics|access).*not (prohibited|forbidden|restricted)|tenant isolation (is )?(disabled|turned off)|tenant boundar(y|ies).*(disabled|turned off)'
+	PAT_BODY_OWNED='body-owned mailbox (storage|truth|state|authority) (is )?(allowed|enabled|turned on|permitted|in scope)|body (owns|stores|persists) mailbox truth|body (may|can) own mailbox (storage|truth|state)|mailbox (storage|truth|state).*(may|can) be body-owned|body.*primary mailbox authority|mailbox authority.*belongs to body|body (may|can) (be|act as) (the )?mailbox (authority|owner)|body mailbox authority (is )?(enabled|turned on|permitted|in scope)|not (required|mandatory) for host to own mailbox'
 
 	for f in "${adr}" "${soul}" "${roadmap}" "${controls}"; do
   # CSR-022: forbid patterns expanded to catch semantically-equivalent insecure
   # wording that would bypass simpler regex matches. Covers circumlocutions:
-  # "not required", "may be", "can be", "optional", "without", "no requirement".
+  # "not required", "may be", "can be", "optional", "without",
+  # "no requirement", plus affirmative weakening verbs ("enabled",
+  # "turned on", "permitted", "in scope") and control-disabling verbs
+  # ("disabled", "turned off") where they weaken the category.
   forbid_pattern "${f}" "${PAT_RETENTION}" 'insecure retention semantics'
   forbid_pattern "${f}" "${PAT_ENCRYPTION}" 'insecure encryption semantics'
   forbid_pattern "${f}" "${PAT_ACCESS_AUDIT}" 'insecure access-audit semantics'
@@ -2017,13 +2034,32 @@ require_pattern "${evidence}" 'CMP-4-output\.log' 'evidence plan names CMP-4 evi
   forbid_pattern "${f}" "${PAT_BODY_OWNED}" 'body-owned mailbox authority semantics'
 done
 
-assert_negative_fixture_rejected "${PAT_RETENTION}" 'retention'
-assert_negative_fixture_rejected "${PAT_ENCRYPTION}" 'encryption'
-assert_negative_fixture_rejected "${PAT_ACCESS_AUDIT}" 'access audit'
-assert_negative_fixture_rejected "${PAT_LIST_CONTENT}" 'list/content split'
-assert_negative_fixture_rejected "${PAT_RAW_KEYS}" 'hash-only auth'
-assert_negative_fixture_rejected "${PAT_CROSS_TENANT}" 'tenant isolation'
-assert_negative_fixture_rejected "${PAT_BODY_OWNED}" 'body-owned mailbox authority'
+assert_negative_fixture_rejected "${PAT_RETENTION}" 'retention' \
+  'retention policy is disabled' \
+  'purge is turned off'
+assert_negative_fixture_rejected "${PAT_ENCRYPTION}" 'encryption' \
+  'encryption is disabled' \
+  'encryption is turned off'
+assert_negative_fixture_rejected "${PAT_ACCESS_AUDIT}" 'access audit' \
+  'access audit is disabled' \
+  'audit logging is turned off'
+assert_negative_fixture_rejected "${PAT_LIST_CONTENT}" 'list/content split' \
+  'list redaction is disabled' \
+  'unredacted list responses are enabled' \
+  'full content list responses are permitted'
+assert_negative_fixture_rejected "${PAT_RAW_KEYS}" 'hash-only auth' \
+  'raw instance key storage is enabled' \
+  'plaintext instance-key fallback is turned on' \
+  'hash-only instance auth is disabled'
+assert_negative_fixture_rejected "${PAT_CROSS_TENANT}" 'tenant isolation' \
+  'cross-tenant search is enabled' \
+  'cross-tenant mailbox analytics are turned on' \
+  'cross-tenant access is permitted' \
+  'tenant isolation is disabled'
+assert_negative_fixture_rejected "${PAT_BODY_OWNED}" 'body-owned mailbox authority' \
+  'body-owned mailbox storage is enabled' \
+  'body mailbox authority is permitted' \
+  'body-owned mailbox truth is in scope'
 
 if [[ "${fail}" -ne 0 ]]; then
   exit 1

--- a/gov-infra/verifiers/gov-verify-rubric.sh
+++ b/gov-infra/verifiers/gov-verify-rubric.sh
@@ -1223,7 +1223,7 @@ check_parity() {
     record_result "DOC-5" "Docs" "BLOCKED" "Threat model or controls matrix missing" "${evidence_path}"
   else
     local threat_ids
-    threat_ids=$(grep -oE 'THR-[0-9]+' "${threat_model}" | sort -u || true)
+    threat_ids=$(grep -oE '(THR-[0-9]+|T-[A-Z][A-Z0-9-]*-[0-9]+)' "${threat_model}" | sort -u || true)
 
     local missing=""
     for thr_id in ${threat_ids}; do
@@ -1994,11 +1994,13 @@ require_pattern "${roadmap}" 'list endpoints return redacted previews/metadata' 
 require_pattern "${roadmap}" 'bearer token is hashed \(`sha256\(raw_key\)`\) and matched to the' 'roadmap requires hash-match instance auth semantics'
 
 require_pattern "${threats}" 'THR-11' 'threat model includes bounded mailbox threat'
+require_pattern "${threats}" 'T-AUTH-DRIFT-001' 'threat model includes representative T-* threat'
 require_pattern "${threats}" 'Bounded mailbox content/state drift' 'threat model names content/state drift'
 require_pattern "${threats}" 'retained indefinitely, list endpoints expose full bodies, read/archive/delete state lacks audit, instance-auth falls back to plaintext, or mailbox data crosses tenant boundaries' 'threat model enumerates insecure mailbox expansion cases'
 
 require_pattern "${controls}" 'CMP-4' 'controls matrix includes CMP-4'
 require_pattern "${controls}" 'THR-11' 'controls matrix maps THR-11'
+require_pattern "${controls}" 'T-AUTH-DRIFT-001' 'controls matrix maps representative T-* threat'
 require_pattern "${controls}" 'retention, encryption, access audit, list/content split, no semantic-memory role, hash-only instance auth, write-once events, protected identity/provenance fields, and no body-owned mailbox truth' 'controls matrix enumerates bounded mailbox controls with semantics'
 
 require_pattern "${evidence}" 'CMP-4' 'evidence plan includes CMP-4'

--- a/gov-infra/verifiers/sec/cloudfront-composition-regression.sh
+++ b/gov-infra/verifiers/sec/cloudfront-composition-regression.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression harness for SEC-8 CloudFront composition verifier.
+#
+# These synthetic templates prove LH-12 fails closed for the residual unsafe
+# paths called out in equaltoai/lesser-host#589:
+#   (a) default-origin Lambda Function URL AuthType != AWS_IAM
+#   (b) bearer behavior routed to the wrong existing non-OAC origin
+#   (c) resolve*/health*/webhooks/* removed from required behavior coverage
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+VERIFIER="${SCRIPT_DIR}/cloudfront-composition.sh"
+FIXTURE_DIR="${SCRIPT_DIR}/fixtures/cloudfront-composition"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+run_expect_pass() {
+  local name="$1"
+  local fixture="$2"
+  local log="${TMP_DIR}/${name}.log"
+
+  if SEC8_TEMPLATE_FILE="${fixture}" bash "${VERIFIER}" >"${log}" 2>&1; then
+    echo "PASS: ${name} accepted"
+  else
+    echo "FAIL: ${name} should have passed" >&2
+    cat "${log}" >&2
+    exit 1
+  fi
+}
+
+run_expect_fail() {
+  local name="$1"
+  local fixture="$2"
+  local expected="$3"
+  local log="${TMP_DIR}/${name}.log"
+
+  if SEC8_TEMPLATE_FILE="${fixture}" bash "${VERIFIER}" >"${log}" 2>&1; then
+    echo "FAIL: ${name} should have failed closed" >&2
+    cat "${log}" >&2
+    exit 1
+  fi
+
+  if ! grep -Fq "${expected}" "${log}"; then
+    echo "FAIL: ${name} failed, but did not emit expected evidence: ${expected}" >&2
+    cat "${log}" >&2
+    exit 1
+  fi
+
+  echo "PASS: ${name} failed closed (${expected})"
+}
+
+cd "${REPO_ROOT}"
+
+run_expect_pass \
+  "fixture-pass-current-shape" \
+  "${FIXTURE_DIR}/pass-current-shape.json"
+
+run_expect_fail \
+  "fixture-fail-default-lambda-url-auth-none" \
+  "${FIXTURE_DIR}/fail-default-lambda-url-auth-none.json" \
+  "AuthType 'NONE' is not AWS_IAM"
+
+run_expect_fail \
+  "fixture-fail-bearer-behavior-wrong-origin" \
+  "${FIXTURE_DIR}/fail-bearer-behavior-wrong-origin.json" \
+  "api/v1/trust/* routes to origin 'control-plane-origin', expected trust origin 'trust-origin'"
+
+run_expect_fail \
+  "fixture-fail-expanded-required-patterns-missing" \
+  "${FIXTURE_DIR}/fail-expanded-required-patterns-missing.json" \
+  "required cache behavior 'resolve*' is missing"

--- a/gov-infra/verifiers/sec/cloudfront-composition.sh
+++ b/gov-infra/verifiers/sec/cloudfront-composition.sh
@@ -5,12 +5,13 @@
 # the CloudFront distribution composition shape:
 #
 #   1. The SSR Lambda Function URL is the OAC-protected default origin
-#      (AuthType: AWS_IAM, origin access control present)
+#      (AuthType: AWS_IAM, origin access control present).
 #   2. /_facetheory/data/* routes to the S3 htmlStoreBucket (OAC-protected,
-#      GET/HEAD/OPTIONS only)
+#      GET/HEAD/OPTIONS only).
 #   3. Every required bearer-auth cache behavior is present with exact
-#      PathPattern matching (no fuzzy fallback). The target origin must
-#      exist and must NOT carry OAC. Missing → FAIL.
+#      PathPattern matching (no fuzzy fallback), routes to its intended named
+#      origin (trust API, control-plane HTTP API, or control-plane SSE), and
+#      the target origin must NOT carry OAC. Missing or misrouted → FAIL.
 #   4. S3 origins (framework-driven by AppTheorySsrSite + our htmlStoreBucket
 #      sidecar) and the default SSR Function URL origin may carry OAC.
 #      Custom/HTTP bearer-auth origins must NOT carry OAC (auth is in the
@@ -20,61 +21,86 @@
 # No partial credit.
 #
 # Source: docs/governance-rubric-web-ui-rework-2026-05-24.md SEC-8
-# Issue: equaltoai/lesser-host#400
+# Issue: equaltoai/lesser-host#400; strengthened for LH-12 / #589
+#
+# Test hook: set SEC8_TEMPLATE_FILE to a synthesized or fixture template to
+# skip CDK synth and analyze that template directly. Normal CI/rubric runs do
+# not set this and therefore validate the current synthesized CDK output.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 CDK_DIR="${REPO_ROOT}/cdk"
 
-echo "SEC-8: CloudFront distribution composition"
+# Role markers are intentionally source-derived logical-ID substrings in the
+# synthesized template. CDK-generated Origin IDs are opaque, so SEC-8 resolves
+# the intended named origins from their resource references, then pins every
+# required behavior to those resolved origin IDs.
+TRUST_ORIGIN_MARKER="TrustHttpApi"
+CONTROL_PLANE_ORIGIN_MARKER="ControlPlaneHttpApi"
+CONTROL_PLANE_SSE_ORIGIN_MARKER="ControlPlaneSseRestApi"
 
-if [[ ! -d "${CDK_DIR}" ]]; then
-  echo "BLOCKED: cdk/ directory not found at ${CDK_DIR}" >&2
-  exit 2
-fi
+# Patterns are sourced from cdk/lib/lesser-host-stack.ts attachBearerBehavior()
+# calls. Missing any required behavior is a FAIL (fail-closed). The third field
+# is the intended named origin role for route-pinning.
+REQUIRED_BEARER_BEHAVIORS=$'resolve*|trust|trust-api resolver\nhealth*|trust|trust-api health\napi/v1/previews*|trust|trust-api previews\napi/v1/renders*|trust|trust-api renders\napi/v1/trust/*|trust|trust-api trust\napi/v1/publish/jobs*|trust|trust-api publish jobs\napi/v1/soul/agents/*/update-registration|trust|trust-api update-registration\napi/v1/ai/*|trust|trust-api AI\napi/v1/budget/debit|trust|trust-api budget debit\napi/v1/soul/agents/register/*/mint-conversation*|sse|control-plane SSE mint-conversation (register)\napi/v1/soul/agents/*/mint-conversation*|sse|control-plane SSE mint-conversation\napi/*|control-plane|control-plane API catch-all\nauth/*|control-plane|control-plane auth\nwebhooks/*|control-plane|control-plane webhooks\nsetup/status|control-plane|control-plane setup status\nsetup/bootstrap/*|control-plane|control-plane setup bootstrap\nsetup/admin|control-plane|control-plane setup admin\nsetup/finalize|control-plane|control-plane setup finalize\n.well-known/*|trust|trust-api .well-known\nattestations|trust|trust-api attestations exact\nattestations/*|trust|trust-api attestations wildcard'
+REQUIRED_BEARER_BEHAVIOR_COUNT=21
 
-if [[ ! -f "${CDK_DIR}/package.json" ]]; then
-  echo "BLOCKED: cdk/package.json not found" >&2
-  exit 2
-fi
+TEMPLATE_FILE="${SEC8_TEMPLATE_FILE:-}"
 
-if ! command -v node >/dev/null 2>&1; then
-  echo "BLOCKED: node is required" >&2
-  exit 2
-fi
+printf 'SEC-8: CloudFront distribution composition\n'
 
-# Synthesize the CDK stack for lab stage (requires no AWS credentials for synth).
-echo "Synthesizing CDK (lab stage)..."
-set +e
-cdk_synth_output="$(cd "${CDK_DIR}" && npm ci --no-audit --no-fund 2>&1 && npx cdk synth -c stage=lab 2>&1)"
-ec=$?
-set -e
-
-if [[ $ec -ne 0 ]]; then
-  echo "" >&2
-  echo "BLOCKED: CDK synth failed:" >&2
-  printf '%s\n' "${cdk_synth_output}" >&2
-  exit 2
-fi
-
-# Find the synthesized template.
-TEMPLATE_DIR="${CDK_DIR}/cdk.out"
-TEMPLATE_FILE=""
-for f in "${TEMPLATE_DIR}/"*.template.json; do
-  if [[ -f "${f}" ]]; then
-    TEMPLATE_FILE="${f}"
-    break
+if [[ -n "${TEMPLATE_FILE}" ]]; then
+  if [[ ! -f "${TEMPLATE_FILE}" ]]; then
+    echo "BLOCKED: SEC8_TEMPLATE_FILE does not exist: ${TEMPLATE_FILE}" >&2
+    exit 2
   fi
-done
+  echo "Using provided CloudFormation template: ${TEMPLATE_FILE#"${REPO_ROOT}"/}"
+else
+  if [[ ! -d "${CDK_DIR}" ]]; then
+    echo "BLOCKED: cdk/ directory not found at ${CDK_DIR}" >&2
+    exit 2
+  fi
 
-if [[ -z "${TEMPLATE_FILE}" ]]; then
-  echo "BLOCKED: no synthesized template found under ${TEMPLATE_DIR}" >&2
-  exit 2
+  if [[ ! -f "${CDK_DIR}/package.json" ]]; then
+    echo "BLOCKED: cdk/package.json not found" >&2
+    exit 2
+  fi
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo "BLOCKED: node is required" >&2
+    exit 2
+  fi
+
+  # Synthesize the CDK stack for lab stage (requires no AWS credentials for synth).
+  echo "Synthesizing CDK (lab stage)..."
+  set +e
+  cdk_synth_output="$(cd "${CDK_DIR}" && npm ci --no-audit --no-fund 2>&1 && npx cdk synth -c stage=lab 2>&1)"
+  ec=$?
+  set -e
+
+  if [[ ${ec} -ne 0 ]]; then
+    echo "" >&2
+    echo "BLOCKED: CDK synth failed:" >&2
+    printf '%s\n' "${cdk_synth_output}" >&2
+    exit 2
+  fi
+
+  # Find the synthesized template.
+  TEMPLATE_DIR="${CDK_DIR}/cdk.out"
+  TEMPLATE_FILE=""
+  for f in "${TEMPLATE_DIR}/"*.template.json; do
+    if [[ -f "${f}" ]]; then
+      TEMPLATE_FILE="${f}"
+      break
+    fi
+  done
+
+  if [[ -z "${TEMPLATE_FILE}" ]]; then
+    echo "BLOCKED: no synthesized template found under ${TEMPLATE_DIR}" >&2
+    exit 2
+  fi
 fi
-
-echo "Analyzing template: ${TEMPLATE_FILE#${REPO_ROOT}/}"
-echo ""
 
 # We need jq for parsing the CloudFormation template.
 if ! command -v jq >/dev/null 2>&1; then
@@ -82,24 +108,126 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 2
 fi
 
+echo "Analyzing template: ${TEMPLATE_FILE#"${REPO_ROOT}"/}"
+echo ""
+
 fail=0
 
+jq_dist() {
+  local filter="$1"
+  jq -r --arg dist "${DISTRIBUTION_ID}" "${filter}" "${TEMPLATE_FILE}"
+}
+
+origin_field() {
+  local origin_id="$1"
+  local filter="$2"
+  jq -r \
+    --arg dist "${DISTRIBUTION_ID}" \
+    --arg oid "${origin_id}" \
+    ".Resources[\$dist].Properties.DistributionConfig.Origins[]? | select(.Id == \$oid) | ${filter}" \
+    "${TEMPLATE_FILE}"
+}
+
+resolve_origin_by_marker() {
+  local role="$1"
+  local marker="$2"
+  local -a ids=()
+
+  mapfile -t ids < <(
+    jq -r \
+      --arg dist "${DISTRIBUTION_ID}" \
+      --arg marker "${marker}" \
+      '.Resources[$dist].Properties.DistributionConfig.Origins[]?
+       | select(.CustomOriginConfig != null)
+       | select((.DomainName | tojson) | contains($marker))
+       | .Id' \
+      "${TEMPLATE_FILE}" | sort -u
+  )
+
+  if [[ ${#ids[@]} -eq 0 ]]; then
+    echo "FAIL: could not resolve ${role} origin from marker '${marker}'" >&2
+    return 1
+  fi
+
+  if [[ ${#ids[@]} -gt 1 ]]; then
+    echo "FAIL: marker '${marker}' resolved multiple ${role} origins: ${ids[*]}" >&2
+    return 1
+  fi
+
+  printf '%s' "${ids[0]}"
+}
+
+expected_origin_for_role() {
+  local role="$1"
+  case "${role}" in
+    trust)
+      printf '%s' "${TRUST_ORIGIN_ID:-}"
+      ;;
+    control-plane)
+      printf '%s' "${CONTROL_PLANE_ORIGIN_ID:-}"
+      ;;
+    sse)
+      printf '%s' "${CONTROL_PLANE_SSE_ORIGIN_ID:-}"
+      ;;
+    *)
+      echo "FAIL: internal verifier error: unknown origin role '${role}'" >&2
+      return 1
+      ;;
+  esac
+}
+
 # --- Check 1: CloudFront distribution exists ---
-DISTRIBUTION_ID="$(jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::CloudFront::Distribution") | .key' "${TEMPLATE_FILE}")"
-if [[ -z "${DISTRIBUTION_ID}" ]]; then
+mapfile -t DISTRIBUTION_IDS < <(
+  jq -r '.Resources | to_entries[] | select(.value.Type == "AWS::CloudFront::Distribution") | .key' "${TEMPLATE_FILE}" | sort -u
+)
+
+if [[ ${#DISTRIBUTION_IDS[@]} -eq 0 ]]; then
   echo "FAIL: no CloudFront distribution found in synthesized template" >&2
   exit 1
 fi
+
+if [[ ${#DISTRIBUTION_IDS[@]} -gt 1 ]]; then
+  echo "FAIL: expected exactly one CloudFront distribution, found ${#DISTRIBUTION_IDS[@]}: ${DISTRIBUTION_IDS[*]}" >&2
+  exit 1
+fi
+
+DISTRIBUTION_ID="${DISTRIBUTION_IDS[0]}"
 echo "CloudFront distribution: ${DISTRIBUTION_ID}"
 
-DIST=".Resources.${DISTRIBUTION_ID}.Properties.DistributionConfig"
-
 # ── Check 2: Default origin is OAC-protected Lambda Function URL ──────────
-DEFAULT_ORIGIN_ID="$(jq -r "${DIST}.DefaultCacheBehavior.TargetOriginId" "${TEMPLATE_FILE}")"
-echo "Default origin ID: ${DEFAULT_ORIGIN_ID}"
+# shellcheck disable=SC2016 # jq reads $dist from --arg in jq_dist().
+DEFAULT_ORIGIN_ID="$(jq_dist '.Resources[$dist].Properties.DistributionConfig.DefaultCacheBehavior.TargetOriginId // empty')"
+if [[ -z "${DEFAULT_ORIGIN_ID}" ]]; then
+  echo "FAIL: default cache behavior has no TargetOriginId" >&2
+  fail=1
+else
+  echo "Default origin ID: ${DEFAULT_ORIGIN_ID}"
+fi
+
+DEFAULT_ORIGIN_COUNT=0
+if [[ -n "${DEFAULT_ORIGIN_ID}" ]]; then
+  DEFAULT_ORIGIN_COUNT="$(jq -r --arg dist "${DISTRIBUTION_ID}" --arg oid "${DEFAULT_ORIGIN_ID}" '[.Resources[$dist].Properties.DistributionConfig.Origins[]? | select(.Id == $oid)] | length' "${TEMPLATE_FILE}")"
+fi
+if [[ "${DEFAULT_ORIGIN_COUNT}" -eq 0 ]]; then
+  echo "FAIL: default origin '${DEFAULT_ORIGIN_ID}' not found in Origins array" >&2
+  fail=1
+fi
+
+# Verify the default origin is a Custom origin (Lambda Function URL origin), not S3/unknown.
+if [[ "${DEFAULT_ORIGIN_COUNT}" -ne 0 ]]; then
+  DEFAULT_ORIGIN_TYPE="$(origin_field "${DEFAULT_ORIGIN_ID}" 'if .S3OriginConfig then "S3" elif .CustomOriginConfig then "Custom" else "Unknown" end')"
+  echo "  Origin type: ${DEFAULT_ORIGIN_TYPE}"
+  if [[ "${DEFAULT_ORIGIN_TYPE}" != "Custom" ]]; then
+    echo "FAIL: default origin '${DEFAULT_ORIGIN_ID}' is ${DEFAULT_ORIGIN_TYPE}, expected Custom Lambda Function URL origin" >&2
+    fail=1
+  fi
+fi
 
 # Verify the default origin has an OriginAccessControlId (OAC).
-OAC_COUNT="$(jq -r "[${DIST}.Origins[] | select(.Id == \"${DEFAULT_ORIGIN_ID}\") | select(.OriginAccessControlId != null)] | length" "${TEMPLATE_FILE}")"
+OAC_COUNT=0
+if [[ -n "${DEFAULT_ORIGIN_ID}" ]]; then
+  OAC_COUNT="$(jq -r --arg dist "${DISTRIBUTION_ID}" --arg oid "${DEFAULT_ORIGIN_ID}" '[.Resources[$dist].Properties.DistributionConfig.Origins[]? | select(.Id == $oid) | select(.OriginAccessControlId != null)] | length' "${TEMPLATE_FILE}")"
+fi
 if [[ "${OAC_COUNT}" -eq 0 ]]; then
   echo "FAIL: default origin '${DEFAULT_ORIGIN_ID}' does not have OriginAccessControl (OAC required)" >&2
   fail=1
@@ -107,32 +235,91 @@ else
   echo "  OAC: present"
 fi
 
+# Verify the default origin's DomainName is backed by an AWS::Lambda::Url whose
+# AuthType is AWS_IAM. OAC presence alone does not make a Function URL private;
+# a Function URL with AuthType NONE remains public even if CloudFront signs its
+# own origin requests.
+if [[ -n "${DEFAULT_ORIGIN_ID}" ]]; then
+  mapfile -t DEFAULT_LAMBDA_URL_IDS < <(
+    jq -r \
+      --arg dist "${DISTRIBUTION_ID}" \
+      --arg oid "${DEFAULT_ORIGIN_ID}" \
+      'def getatt_refs:
+         .. | objects | select(has("Fn::GetAtt")) | ."Fn::GetAtt" as $g |
+         if (($g | type) == "array" and ($g | length) >= 2) then
+           { logicalId: ($g[0] | tostring), attr: ($g[1] | tostring) }
+         elif (($g | type) == "string") then
+           ($g | split(".") | select(length >= 2) | { logicalId: (.[0] | tostring), attr: (.[1] | tostring) })
+         else
+           empty
+         end;
+       .Resources[$dist].Properties.DistributionConfig.Origins[]?
+       | select(.Id == $oid)
+       | .DomainName
+       | getatt_refs
+       | select(.attr == "FunctionUrl")
+       | .logicalId' \
+      "${TEMPLATE_FILE}" | sort -u
+  )
+
+  if [[ ${#DEFAULT_LAMBDA_URL_IDS[@]} -eq 0 ]]; then
+    echo "FAIL: default origin '${DEFAULT_ORIGIN_ID}' DomainName is not backed by AWS::Lambda::Url.FunctionUrl" >&2
+    fail=1
+  elif [[ ${#DEFAULT_LAMBDA_URL_IDS[@]} -gt 1 ]]; then
+    echo "FAIL: default origin '${DEFAULT_ORIGIN_ID}' references multiple Lambda Function URLs: ${DEFAULT_LAMBDA_URL_IDS[*]}" >&2
+    fail=1
+  else
+    DEFAULT_LAMBDA_URL_ID="${DEFAULT_LAMBDA_URL_IDS[0]}"
+    DEFAULT_LAMBDA_URL_TYPE="$(jq -r --arg id "${DEFAULT_LAMBDA_URL_ID}" '.Resources[$id].Type // empty' "${TEMPLATE_FILE}")"
+    DEFAULT_LAMBDA_URL_AUTH_TYPE="$(jq -r --arg id "${DEFAULT_LAMBDA_URL_ID}" '.Resources[$id].Properties.AuthType // empty' "${TEMPLATE_FILE}")"
+    DEFAULT_LAMBDA_URL_INVOKE_MODE="$(jq -r --arg id "${DEFAULT_LAMBDA_URL_ID}" '.Resources[$id].Properties.InvokeMode // "none"' "${TEMPLATE_FILE}")"
+
+    echo "  Lambda URL: ${DEFAULT_LAMBDA_URL_ID} (AuthType=${DEFAULT_LAMBDA_URL_AUTH_TYPE}, InvokeMode=${DEFAULT_LAMBDA_URL_INVOKE_MODE})"
+
+    if [[ "${DEFAULT_LAMBDA_URL_TYPE}" != "AWS::Lambda::Url" ]]; then
+      echo "FAIL: default origin FunctionUrl reference '${DEFAULT_LAMBDA_URL_ID}' is ${DEFAULT_LAMBDA_URL_TYPE}, expected AWS::Lambda::Url" >&2
+      fail=1
+    fi
+
+    if [[ "${DEFAULT_LAMBDA_URL_AUTH_TYPE}" != "AWS_IAM" ]]; then
+      echo "FAIL: default origin Lambda Function URL '${DEFAULT_LAMBDA_URL_ID}' AuthType '${DEFAULT_LAMBDA_URL_AUTH_TYPE}' is not AWS_IAM" >&2
+      fail=1
+    fi
+  fi
+fi
+
 # Verify the default origin viewer protocol policy.
-DEFAULT_VP="$(jq -r "${DIST}.DefaultCacheBehavior.ViewerProtocolPolicy" "${TEMPLATE_FILE}")"
+# shellcheck disable=SC2016 # jq reads $dist from --arg in jq_dist().
+DEFAULT_VP="$(jq_dist '.Resources[$dist].Properties.DistributionConfig.DefaultCacheBehavior.ViewerProtocolPolicy // empty')"
 echo "  ViewerProtocolPolicy: ${DEFAULT_VP}"
 
 # Verify the default behavior allowed methods.
-DEFAULT_METHODS="$(jq -r "${DIST}.DefaultCacheBehavior.AllowedMethods // [] | join(\",\")" "${TEMPLATE_FILE}")"
+# shellcheck disable=SC2016 # jq reads $dist from --arg in jq_dist().
+DEFAULT_METHODS="$(jq_dist '.Resources[$dist].Properties.DistributionConfig.DefaultCacheBehavior.AllowedMethods // [] | join(",")')"
 echo "  AllowedMethods: ${DEFAULT_METHODS}"
 echo ""
 
 # ── Check 3: /_facetheory/data/* behavior ──────────────────────────────────
-SIDECAR_BEHAVIOR="$(jq -r "[${DIST}.CacheBehaviors[]? | select(.PathPattern == \"_facetheory/data/*\")] | .[0]" "${TEMPLATE_FILE}")"
+SIDECAR_BEHAVIOR="$(jq -c --arg dist "${DISTRIBUTION_ID}" '[.Resources[$dist].Properties.DistributionConfig.CacheBehaviors[]? | select(.PathPattern == "_facetheory/data/*")] | .[0] // empty' "${TEMPLATE_FILE}")"
 SIDECAR_ORIGIN_ID=""
 
 if [[ -z "${SIDECAR_BEHAVIOR}" || "${SIDECAR_BEHAVIOR}" == "null" ]]; then
   echo "FAIL: no CacheBehavior for _facetheory/data/*" >&2
   fail=1
 else
-  SIDECAR_ORIGIN_ID="$(printf '%s' "${SIDECAR_BEHAVIOR}" | jq -r '.TargetOriginId')"
+  SIDECAR_ORIGIN_ID="$(printf '%s' "${SIDECAR_BEHAVIOR}" | jq -r '.TargetOriginId // empty')"
   echo "/_facetheory/data/* → origin: ${SIDECAR_ORIGIN_ID}"
 
   # The sidecar origin should be S3 (check if it's an S3Origin or has S3 config).
-  SIDECAR_ORIGIN_TYPE="$(jq -r "${DIST}.Origins[] | select(.Id == \"${SIDECAR_ORIGIN_ID}\") | if .S3OriginConfig then \"S3\" elif .CustomOriginConfig then \"Custom\" else \"Unknown\" end" "${TEMPLATE_FILE}")"
+  SIDECAR_ORIGIN_TYPE="$(origin_field "${SIDECAR_ORIGIN_ID}" 'if .S3OriginConfig then "S3" elif .CustomOriginConfig then "Custom" else "Unknown" end')"
   echo "  origin type: ${SIDECAR_ORIGIN_TYPE}"
+  if [[ "${SIDECAR_ORIGIN_TYPE}" != "S3" ]]; then
+    echo "FAIL: _facetheory/data/* origin '${SIDECAR_ORIGIN_ID}' is ${SIDECAR_ORIGIN_TYPE}, expected S3" >&2
+    fail=1
+  fi
 
   # Sidecar origin should have OAC.
-  SIDECAR_OAC="$(jq -r "${DIST}.Origins[] | select(.Id == \"${SIDECAR_ORIGIN_ID}\") | .OriginAccessControlId // \"none\"" "${TEMPLATE_FILE}")"
+  SIDECAR_OAC="$(origin_field "${SIDECAR_ORIGIN_ID}" '.OriginAccessControlId // "none"')"
   echo "  OAC: ${SIDECAR_OAC}"
   if [[ "${SIDECAR_OAC}" == "none" ]]; then
     echo "FAIL: _facetheory/data/* origin has no OAC" >&2
@@ -152,19 +339,45 @@ echo ""
 # ── Check 4: Required bearer-auth behaviors ────────────────────────────────
 #
 # Every pattern below must be present in the CloudFront distribution as a
-# CacheBehavior with an exact PathPattern match. The target origin must exist
-# and must NOT carry OriginAccessControl (bearer-auth = AuthType NONE in
-# handler; OAC belongs only on the SSR and sidecar origins).
-#
-# Patterns are sourced from cdk/lib/lesser-host-stack.ts attachBearerBehavior()
-# calls. Missing any required behavior is a FAIL (fail-closed).
+# CacheBehavior with an exact PathPattern match. The target origin must exist,
+# must be the intended named origin, and must NOT carry OriginAccessControl
+# (bearer-auth = AuthType NONE in handler; OAC belongs only on the SSR and
+# sidecar origins).
+
+TRUST_ORIGIN_ID=""
+CONTROL_PLANE_ORIGIN_ID=""
+CONTROL_PLANE_SSE_ORIGIN_ID=""
+
+if TRUST_ORIGIN_ID="$(resolve_origin_by_marker "trust-api" "${TRUST_ORIGIN_MARKER}")"; then
+  echo "Expected trust-api origin: ${TRUST_ORIGIN_ID}"
+else
+  fail=1
+fi
+
+if CONTROL_PLANE_ORIGIN_ID="$(resolve_origin_by_marker "control-plane HTTP API" "${CONTROL_PLANE_ORIGIN_MARKER}")"; then
+  echo "Expected control-plane origin: ${CONTROL_PLANE_ORIGIN_ID}"
+else
+  fail=1
+fi
+
+if CONTROL_PLANE_SSE_ORIGIN_ID="$(resolve_origin_by_marker "control-plane SSE" "${CONTROL_PLANE_SSE_ORIGIN_MARKER}")"; then
+  echo "Expected control-plane SSE origin: ${CONTROL_PLANE_SSE_ORIGIN_ID}"
+else
+  fail=1
+fi
+
+echo ""
 
 check_bearer_auth_behavior() {
   local pattern="$1"
-  local label="$2"
+  local expected_role="$2"
+  local label="$3"
+  local expected_origin_id
+
+  expected_origin_id="$(expected_origin_for_role "${expected_role}")"
 
   local behavior
-  behavior="$(jq -r "[${DIST}.CacheBehaviors[]? | select(.PathPattern == \"${pattern}\")] | .[0]" "${TEMPLATE_FILE}")"
+  behavior="$(jq -c --arg dist "${DISTRIBUTION_ID}" --arg pattern "${pattern}" '[.Resources[$dist].Properties.DistributionConfig.CacheBehaviors[]? | select(.PathPattern == $pattern)] | .[0] // empty' "${TEMPLATE_FILE}")"
 
   if [[ -z "${behavior}" || "${behavior}" == "null" ]]; then
     echo "FAIL: required cache behavior '${pattern}' is missing (${label})" >&2
@@ -173,21 +386,33 @@ check_bearer_auth_behavior() {
   fi
 
   local origin_id
-  origin_id="$(printf '%s' "${behavior}" | jq -r '.TargetOriginId')"
-  echo "${pattern} → origin: ${origin_id}"
+  origin_id="$(printf '%s' "${behavior}" | jq -r '.TargetOriginId // empty')"
+  echo "${pattern} → origin: ${origin_id} (expected ${expected_role}: ${expected_origin_id:-unresolved})"
 
   # Verify the target origin exists in the Origins array.
   local origin_exists
-  origin_exists="$(jq -r "[${DIST}.Origins[] | select(.Id == \"${origin_id}\")] | length" "${TEMPLATE_FILE}")"
+  origin_exists="$(jq -r --arg dist "${DISTRIBUTION_ID}" --arg oid "${origin_id}" '[.Resources[$dist].Properties.DistributionConfig.Origins[]? | select(.Id == $oid)] | length' "${TEMPLATE_FILE}")"
   if [[ "${origin_exists}" -eq 0 ]]; then
     echo "FAIL: origin '${origin_id}' referenced by '${pattern}' not found in Origins array" >&2
     fail=1
     return 0
   fi
 
+  # Pin each required behavior to its intended named origin. This catches
+  # redirects to a different existing non-OAC bearer origin.
+  if [[ -z "${expected_origin_id}" ]]; then
+    echo "FAIL: cannot validate intended origin for '${pattern}' because role '${expected_role}' was not resolved" >&2
+    fail=1
+  elif [[ "${origin_id}" != "${expected_origin_id}" ]]; then
+    echo "FAIL: ${pattern} routes to origin '${origin_id}', expected ${expected_role} origin '${expected_origin_id}' (${label})" >&2
+    fail=1
+  else
+    echo "  intended origin: ${expected_role} (correct)"
+  fi
+
   # Bearer-auth origins must NOT have OAC.
   local oac
-  oac="$(jq -r "${DIST}.Origins[] | select(.Id == \"${origin_id}\") | .OriginAccessControlId // \"none\"" "${TEMPLATE_FILE}")"
+  oac="$(origin_field "${origin_id}" '.OriginAccessControlId // "none"')"
   if [[ "${oac}" != "none" ]]; then
     echo "FAIL: ${pattern} origin '${origin_id}' has OAC (should be AuthType NONE for bearer-auth in handler)" >&2
     fail=1
@@ -200,31 +425,10 @@ check_bearer_auth_behavior() {
 echo "--- Bearer-auth cache behavior verification ---"
 echo ""
 
-# ── Trust API paths (trustOrigin) ──
-check_bearer_auth_behavior "api/v1/previews*"    "trust-api previews"
-check_bearer_auth_behavior "api/v1/renders*"     "trust-api renders"
-check_bearer_auth_behavior "api/v1/trust/*"      "trust-api trust"
-check_bearer_auth_behavior "api/v1/publish/jobs*" "trust-api publish jobs"
-check_bearer_auth_behavior "api/v1/soul/agents/*/update-registration" "trust-api update-registration"
-check_bearer_auth_behavior "api/v1/ai/*"         "trust-api AI"
-check_bearer_auth_behavior "api/v1/budget/debit"  "trust-api budget debit"
-
-# ── Control-plane SSE paths (controlPlaneSseOrigin) ──
-check_bearer_auth_behavior "api/v1/soul/agents/register/*/mint-conversation*" "control-plane SSE mint-conversation (register)"
-check_bearer_auth_behavior "api/v1/soul/agents/*/mint-conversation*"          "control-plane SSE mint-conversation"
-
-# ── Control-plane HTTP API catch-all + auth + setup (controlPlaneOrigin) ──
-check_bearer_auth_behavior "api/*"               "control-plane API catch-all"
-check_bearer_auth_behavior "auth/*"              "control-plane auth"
-check_bearer_auth_behavior "setup/status"        "control-plane setup status"
-check_bearer_auth_behavior "setup/bootstrap/*"   "control-plane setup bootstrap"
-check_bearer_auth_behavior "setup/admin"         "control-plane setup admin"
-check_bearer_auth_behavior "setup/finalize"      "control-plane setup finalize"
-
-# ── Trust API .well-known + attestation paths (trustOrigin) ──
-check_bearer_auth_behavior ".well-known/*"       "trust-api .well-known"
-check_bearer_auth_behavior "attestations"         "trust-api attestations exact"
-check_bearer_auth_behavior "attestations/*"       "trust-api attestations wildcard"
+while IFS='|' read -r pattern expected_role label; do
+  [[ -z "${pattern}" ]] && continue
+  check_bearer_auth_behavior "${pattern}" "${expected_role}" "${label}"
+done <<< "${REQUIRED_BEARER_BEHAVIORS}"
 
 # ── Check 5: OAC enforcement ───────────────────────────────────────────────
 #
@@ -233,7 +437,7 @@ check_bearer_auth_behavior "attestations/*"       "trust-api attestations wildca
 # handler (bearer token, wallet challenge, WebAuthn); OAC would interfere.
 #
 # Allowed OAC carriers:
-#   - Default SSR origin (Function URL, OAC = AWS_IAM fail-closed)
+#   - Default SSR origin (Function URL, AuthType AWS_IAM fail-closed)
 #   - S3 origins (framework-driven by AppTheorySsrSite; e.g. assets bucket,
 #     htmlStoreBucket sidecar)
 #
@@ -241,12 +445,12 @@ check_bearer_auth_behavior "attestations/*"       "trust-api attestations wildca
 # These are bearer-auth origins and must NOT be OAC-signed.
 #
 echo "--- Origin access control enforcement ---"
-ALL_ORIGIN_IDS="$(jq -r "${DIST}.Origins[].Id" "${TEMPLATE_FILE}")"
+mapfile -t ALL_ORIGIN_IDS < <(jq -r --arg dist "${DISTRIBUTION_ID}" '.Resources[$dist].Properties.DistributionConfig.Origins[].Id' "${TEMPLATE_FILE}")
 
-while IFS= read -r oid; do
+for oid in "${ALL_ORIGIN_IDS[@]}"; do
   [[ -z "${oid}" ]] && continue
-  oac="$(jq -r "${DIST}.Origins[] | select(.Id == \"${oid}\") | .OriginAccessControlId // \"none\"" "${TEMPLATE_FILE}")"
-  otype="$(jq -r "${DIST}.Origins[] | select(.Id == \"${oid}\") | if .S3OriginConfig then \"S3\" elif .CustomOriginConfig then \"Custom\" else \"Unknown\" end" "${TEMPLATE_FILE}")"
+  oac="$(origin_field "${oid}" '.OriginAccessControlId // "none"')"
+  otype="$(origin_field "${oid}" 'if .S3OriginConfig then "S3" elif .CustomOriginConfig then "Custom" else "Unknown" end')"
 
   if [[ "${oac}" == "none" ]]; then
     echo "  ${oid} (${otype}): OAC=none"
@@ -276,7 +480,7 @@ while IFS= read -r oid; do
       fail=1
       ;;
   esac
-done <<< "${ALL_ORIGIN_IDS}"
+done
 
 if [[ "${fail}" -ne 0 ]]; then
   echo "" >&2
@@ -285,4 +489,4 @@ if [[ "${fail}" -ne 0 ]]; then
 fi
 
 echo ""
-echo "PASS: CloudFront distribution composition verified (SSR/OAC default, S3 sidecar, 18 bearer-auth behaviors, OAC audit clean)"
+echo "PASS: CloudFront distribution composition verified (SSR Lambda URL AWS_IAM/OAC default, S3 sidecar, ${REQUIRED_BEARER_BEHAVIOR_COUNT} bearer-auth behaviors pinned to intended origins, OAC audit clean)"

--- a/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
+++ b/gov-infra/verifiers/sec/cost-telemetry-redaction.sh
@@ -7,158 +7,714 @@
 #   2. Does not use the deprecated host-local ListCostTelemetryByInstance path.
 #   3. Does not expose PII, cross-tenant fields, tenant content, raw instance
 #      keys, account IDs, table keys (PK/SK), TTL, or raw EntriesJSON storage
-#      payloads in the customer-facing response DTO or error messages.
+#      payloads in the customer-facing response DTO, transitive embedded DTOs,
+#      tests, or error messages.
 #
 # Project 42 M0.4 correction: the accepted data source is the managed Lesser
 # instance metrics endpoint, reached server-side with an instance API key. The
 # SEC-13 proof must therefore gate the secret read and HTTP call, not the old
 # host-local cost telemetry store read.
 #
-# Source: Issue equaltoai/lesser-host#457 and Project 42 M0.4 (#529).
+# LH-25 hardening: scope the ownership ordering check to the
+# handlePortalGetInstanceCost body, scan transitive response DTO structs such as
+# costtelemetry.ReconciledCostEntry/ServiceAttribution, and strip Go comments
+# before treating test source text as proof.
+#
+# Source: Issue equaltoai/lesser-host#457, Project 42 M0.4 (#529), and
+#         issue equaltoai/lesser-host#588.
+#
+# Test hooks:
+#   SEC13_SOURCE_ROOT=/path/to/source-root analyzes that source tree instead of
+#   the repository root. The source root must contain internal/controlplane/*
+#   and internal/costtelemetry/*.
+#   SEC13_SKIP_FIXTURES=1 skips committed negative-fixture regression checks.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${REPO_ROOT}"
+export SEC13_REPO_ROOT="${REPO_ROOT}"
 
-HANDLER_FILE="internal/controlplane/handlers_portal_cost.go"
-METRICS_FILE="internal/controlplane/managed_instance_metrics.go"
-TEST_FILE="internal/controlplane/handlers_portal_cost_internal_test.go"
+python3 - <<'PY'
+from __future__ import annotations
 
-echo "SEC-13: Portal cost redaction + multi-tenant downstream-call ordering"
-echo "Handler file: ${HANDLER_FILE}"
-echo "Metrics file: ${METRICS_FILE}"
-echo "Test file:    ${TEST_FILE}"
-echo ""
+from dataclasses import dataclass
+from pathlib import Path
+import os
+import re
+import sys
 
-FAIL=0
+REPO_ROOT = Path(os.environ["SEC13_REPO_ROOT"]).resolve()
+SOURCE_ROOT = Path(os.environ.get("SEC13_SOURCE_ROOT", ".")).resolve()
+SKIP_FIXTURES = os.environ.get("SEC13_SKIP_FIXTURES", "") == "1"
+FIXTURE_DIR = REPO_ROOT / "gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction"
 
-for file in "${HANDLER_FILE}" "${METRICS_FILE}" "${TEST_FILE}"; do
-  if [[ ! -f "${file}" ]]; then
-    echo "FAIL: required file missing: ${file}" >&2
-    exit 1
-  fi
-done
+HANDLER_FILE = Path("internal/controlplane/handlers_portal_cost.go")
+TEST_FILE = Path("internal/controlplane/handlers_portal_cost_internal_test.go")
+COSTTELEMETRY_DIR = Path("internal/costtelemetry")
 
-non_comment_line() {
-  local pattern="$1"
-  local file="$2"
-  grep -n "${pattern}" "${file}" | grep -v '^\s*[0-9]*:\s*//' | grep -v '^\s*[0-9]*:\s*\*' | head -1 | cut -d: -f1 || true
+FORBIDDEN_JSON_TAGS = {
+    "account_id",
+    "pk",
+    "PK",
+    "sk",
+    "SK",
+    "ttl",
+    "entries_json",
+    "EntriesJSON",
+    "instance_key",
+    "raw_key",
 }
+FORBIDDEN_RESPONSE_TOKENS = [
+    '"account_id"',
+    '"pk"',
+    '"PK"',
+    '"sk"',
+    '"SK"',
+    '"ttl"',
+    '"entries_json"',
+    '"EntriesJSON"',
+    '"instance_key"',
+    '"raw_key"',
+]
+PRIMITIVE_TYPES = {
+    "string",
+    "bool",
+    "byte",
+    "rune",
+    "int",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+    "uintptr",
+    "float32",
+    "float64",
+    "complex64",
+    "complex128",
+    "any",
+    "interface{}",
+    "error",
+}
+ALLOWED_EXTERNAL_TYPES = {("time", "Time")}
 
-echo "Dimension 1: ownership gates secret resolution and managed Lesser HTTP call"
-AUTH_LINE="$(non_comment_line 'requireInstanceAccess' "${HANDLER_FILE}")"
-KEY_LINE="$(non_comment_line 'resolvePortalCostInstanceKey' "${HANDLER_FILE}")"
-FETCH_LINE="$(non_comment_line 'fetchManagedInstanceMetrics' "${HANDLER_FILE}")"
 
-if [[ -z "${AUTH_LINE}" ]]; then
-  echo "FAIL: requireInstanceAccess call not found in handler" >&2
-  FAIL=1
-else
-  echo "Ownership check: requireInstanceAccess at line ${AUTH_LINE}"
-fi
+@dataclass
+class StructDef:
+    package: str
+    name: str
+    path: Path
+    start_line: int
+    end_line: int
+    body: list[tuple[int, str]]
 
-for entry in "secret resolution:${KEY_LINE}:resolvePortalCostInstanceKey" "managed metrics fetch:${FETCH_LINE}:fetchManagedInstanceMetrics"; do
-  label="${entry%%:*}"
-  rest="${entry#*:}"
-  line="${rest%%:*}"
-  symbol="${entry##*:}"
-  if [[ -z "${line}" ]]; then
-    echo "FAIL: ${symbol} call not found in handler" >&2
-    FAIL=1
-    continue
-  fi
-  echo "${label}: ${symbol} at line ${line}"
-  if [[ -n "${AUTH_LINE}" ]] && [[ "${line}" -le "${AUTH_LINE}" ]]; then
-    echo "FAIL: ${symbol} (line ${line}) precedes requireInstanceAccess (line ${AUTH_LINE})" >&2
-    FAIL=1
-  fi
-done
 
-if grep -q 'ListCostTelemetryByInstance' "${HANDLER_FILE}"; then
-  echo "FAIL: handler still reads host-local cost telemetry store" >&2
-  FAIL=1
-else
-  echo "PASS: handler does not use deprecated ListCostTelemetryByInstance path"
-fi
+def display_path(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
 
-echo ""
-echo "Dimension 2a: DTO redaction in handler source"
-HANDLER_CONTENT="$(cat "${HANDLER_FILE}")"
-NON_COMMENT="$(echo "${HANDLER_CONTENT}" | grep -v '^\s*//' | grep -v '^\s*\*' | grep -v '^\s*/\*')"
-DTO_REGION="$(echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostResponse struct/,/^}/p'; echo; echo "${HANDLER_CONTENT}" | sed -n '/^type portalCostDayEntry struct/,/^}/p')"
 
-DTO_FORBIDDEN=(
-  '"account_id"'
-  '"pk"'
-  '"sk"'
-  '"ttl"'
-  '"entries_json"'
-  '"EntriesJSON"'
-  '"instance_key"'
-  '"raw_key"'
-)
+def scrub_go_source(text: str, *, strip_literals: bool) -> str:
+    """Remove Go comments; optionally blank string/rune/raw-string literals.
 
-for forbidden in "${DTO_FORBIDDEN[@]}"; do
-  if echo "${DTO_REGION}" | grep -qF "${forbidden}"; then
-    echo "FAIL: DTO struct contains forbidden json tag ${forbidden}" >&2
-    FAIL=1
-  fi
-done
+    Line count is preserved so evidence line numbers still point at the source.
+    When strip_literals is true, markers in Go strings cannot satisfy source
+    ordering checks. When false, struct tags and test string assertions remain
+    visible while comments are still removed.
+    """
 
-if echo "${NON_COMMENT}" | grep -qF 'EntriesJSON'; then
-  echo "FAIL: handler references raw EntriesJSON on a non-comment line" >&2
-  FAIL=1
-fi
-if echo "${NON_COMMENT}" | grep -qF 'entries_json'; then
-  echo "FAIL: handler references entries_json on a non-comment line" >&2
-  FAIL=1
-fi
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    state = "code"
 
-echo "PASS: DTO struct json tags are clean of forbidden fields"
+    def emit_char(ch: str) -> None:
+        out.append(ch)
 
-echo ""
-echo "Dimension 2b: redaction and fail-closed proof in tests"
-TEST_CONTENT="$(cat "${TEST_FILE}")"
+    def emit_blank(ch: str) -> None:
+        out.append("\n" if ch == "\n" else " ")
 
-if echo "${TEST_CONTENT}" | grep -q 'Bearer "+testRawKey' && echo "${TEST_CONTENT}" | grep -q 'NotContains(t, string(resp.Body), testRawKey)'; then
-  echo "PASS: test proves bearer key is sent upstream and excluded from response"
-else
-  echo "FAIL: missing bearer-auth send plus response redaction proof" >&2
-  FAIL=1
-fi
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
 
-for token in 'account_id' 'PK' 'SK' 'ttl' 'entries_json' 'EntriesJSON' 'instance_key' 'raw_key'; do
-  if ! echo "${TEST_CONTENT}" | grep -q "${token}"; then
-    echo "FAIL: test redaction assertion missing forbidden token ${token}" >&2
-    FAIL=1
-  fi
-done
-if echo "${TEST_CONTENT}" | grep -q 'forbidden := range' && echo "${TEST_CONTENT}" | grep -q 'require.NotContains(t, string(resp.Body), forbidden)'; then
-  echo "PASS: test asserts forbidden response fields are absent"
-else
-  echo "FAIL: test does not assert forbidden response fields are absent" >&2
-  FAIL=1
-fi
+        if state == "code":
+            if ch == "/" and nxt == "/":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "line_comment"
+                continue
+            if ch == "/" and nxt == "*":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "block_comment"
+                continue
+            if ch == '"':
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "double_string"
+                continue
+            if ch == "`":
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "raw_string"
+                continue
+            if ch == "'":
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "rune"
+                continue
+            emit_char(ch)
+            i += 1
+            continue
 
-if echo "${TEST_CONTENT}" | grep -q 'WrongOwnerForbiddenBeforeSecretOrHTTP' && echo "${TEST_CONTENT}" | grep -q 'require.Zero(t, secretReads)' && echo "${TEST_CONTENT}" | grep -q 'require.Zero(t, httpCalls)'; then
-  echo "PASS: forbidden tenant proof skips secret resolution and HTTP call"
-else
-  echo "FAIL: missing wrong-owner proof that secret resolution and HTTP are skipped" >&2
-  FAIL=1
-fi
+        if state == "line_comment":
+            if ch == "\n":
+                emit_char(ch)
+                state = "code"
+            else:
+                emit_blank(ch)
+            i += 1
+            continue
 
-if echo "${TEST_CONTENT}" | grep -q 'Upstream5xxDoesNotLeakKeyOrBody' && echo "${TEST_CONTENT}" | grep -q 'KeyResolverFailureDoesNotLeak'; then
-  echo "PASS: tests cover upstream/key-resolution error redaction"
-else
-  echo "FAIL: missing upstream/key-resolution redaction tests" >&2
-  FAIL=1
-fi
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "code"
+                continue
+            emit_blank(ch)
+            i += 1
+            continue
 
-echo ""
-if [[ "${FAIL}" -ne 0 ]]; then
-  echo "FAIL: SEC-13 portal cost redaction check failed" >&2
-  exit 1
-fi
+        if state == "double_string":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "\\" and i + 1 < n:
+                (emit_blank if strip_literals else emit_char)(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                state = "code"
+            i += 1
+            continue
 
-echo "PASS: SEC-13 portal cost redaction + downstream-call ordering verified"
+        if state == "raw_string":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "`":
+                state = "code"
+            i += 1
+            continue
+
+        if state == "rune":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "\\" and i + 1 < n:
+                (emit_blank if strip_literals else emit_char)(text[i + 1])
+                i += 2
+                continue
+            if ch == "'":
+                state = "code"
+            i += 1
+            continue
+
+        raise AssertionError(f"unexpected lexer state {state}")
+
+    return "".join(out)
+
+
+def brace_delta(code: str) -> int:
+    return code.count("{") - code.count("}")
+
+
+def read_required_file(source_root: Path, path: Path, failures: list[str]) -> str | None:
+    abs_path = source_root / path
+    if not abs_path.is_file():
+        failures.append(f"required file missing: {display_path(abs_path)}")
+        return None
+    return abs_path.read_text(encoding="utf-8")
+
+
+def extract_function_body(
+    source_root: Path,
+    path: Path,
+    receiver: str,
+    function_name: str,
+    failures: list[str],
+) -> tuple[Path, list[dict[str, object]], int, int] | None:
+    abs_path = source_root / path
+    if not abs_path.is_file():
+        failures.append(f"handler file missing: {display_path(abs_path)}")
+        return None
+
+    text = abs_path.read_text(encoding="utf-8")
+    original_lines = text.splitlines()
+    scrubbed_lines = scrub_go_source(text, strip_literals=True).splitlines()
+    max_len = max(len(original_lines), len(scrubbed_lines))
+    original_lines += [""] * (max_len - len(original_lines))
+    scrubbed_lines += [""] * (max_len - len(scrubbed_lines))
+
+    pattern = re.compile(
+        rf"^\s*func\s+\(\s*{re.escape(receiver)}\s+\*Server\s*\)\s+{re.escape(function_name)}\s*\("
+    )
+    start_index = None
+    for idx, code in enumerate(scrubbed_lines):
+        if pattern.search(code):
+            start_index = idx
+            break
+    if start_index is None:
+        failures.append(f"handler function not found: {function_name} in {display_path(abs_path)}")
+        return None
+
+    records: list[dict[str, object]] = []
+    depth = 0
+    body_started = False
+    start_line = start_index + 1
+    end_line = len(scrubbed_lines)
+
+    for idx in range(start_index, len(scrubbed_lines)):
+        code = scrubbed_lines[idx]
+        original = original_lines[idx]
+        if not body_started:
+            if "{" not in code:
+                continue
+            body_started = True
+            depth += brace_delta(code)
+            continue
+
+        depth_before = depth
+        records.append(
+            {
+                "line": idx + 1,
+                "body_line": len(records) + 1,
+                "code": code,
+                "original": original,
+                "depth": depth_before,
+                "delta": brace_delta(code),
+            }
+        )
+        depth += brace_delta(code)
+        if depth <= 0:
+            end_line = idx + 1
+            break
+
+    if not body_started:
+        failures.append(f"handler function has no body: {function_name} in {display_path(abs_path)}")
+        return None
+    if depth != 0:
+        failures.append(f"handler function body did not close: {function_name} in {display_path(abs_path)}:{start_line}")
+        return None
+
+    return abs_path, records, start_line, end_line
+
+
+def find_call(records: list[dict[str, object]], symbol: str) -> list[dict[str, object]]:
+    call_re = re.compile(rf"(^|[^A-Za-z0-9_]){re.escape(symbol)}\s*\(")
+    return [rec for rec in records if call_re.search(str(rec["code"]))]
+
+
+def verify_handler_ordering(source_root: Path, failures: list[str], messages: list[str]) -> None:
+    body = extract_function_body(source_root, HANDLER_FILE, "s", "handlePortalGetInstanceCost", failures)
+    if body is None:
+        return
+
+    handler_path, records, start, end = body
+    messages.append(
+        f"Scoped handler body: handlePortalGetInstanceCost at {display_path(handler_path)}:{start}-{end} "
+        f"({len(records)} body lines)"
+    )
+
+    auth_calls = find_call(records, "requireInstanceAccess")
+    if not auth_calls:
+        failures.append("requireInstanceAccess call not found inside handlePortalGetInstanceCost body")
+        return
+    auth = auth_calls[0]
+    messages.append(
+        f"Ownership check: requireInstanceAccess at handler-body line {auth['body_line']} "
+        f"(file line {auth['line']})"
+    )
+
+    sensitive_hits: list[tuple[dict[str, object], str]] = []
+    for symbol in ("resolvePortalCostInstanceKey", "fetchManagedInstanceMetrics"):
+        calls = find_call(records, symbol)
+        if not calls:
+            failures.append(f"{symbol} call not found inside handlePortalGetInstanceCost body")
+            continue
+        first = calls[0]
+        sensitive_hits.append((first, symbol))
+        messages.append(
+            f"Downstream call: {symbol} at handler-body line {first['body_line']} (file line {first['line']})"
+        )
+
+    if not sensitive_hits:
+        return
+
+    first_sensitive, first_symbol = min(sensitive_hits, key=lambda item: int(item[0]["body_line"]))
+    if int(first_sensitive["body_line"]) <= int(auth["body_line"]):
+        failures.append(
+            f"{first_symbol} (handler-body line {first_sensitive['body_line']}, file line {first_sensitive['line']}) "
+            f"precedes ownership check (handler-body line {auth['body_line']}, file line {auth['line']}) "
+            "inside handlePortalGetInstanceCost"
+        )
+        return
+
+    messages.append(
+        f"PASS: ownership check precedes first secret/HTTP operation {first_symbol} "
+        f"(handler-body line {first_sensitive['body_line']})"
+    )
+
+
+def parse_package(text: str, path: Path, failures: list[str]) -> str | None:
+    match = re.search(r"(?m)^\s*package\s+(\w+)\s*$", text)
+    if not match:
+        failures.append(f"package declaration missing: {display_path(path)}")
+        return None
+    return match.group(1)
+
+
+def parse_import_aliases(text: str) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for match in re.finditer(r'(?m)^\s*(?:(\w+)\s+)?"([^"]+)"', text):
+        explicit, import_path = match.groups()
+        package = import_path.rsplit("/", 1)[-1]
+        alias = explicit or package
+        aliases[alias] = package
+    return aliases
+
+
+def parse_structs_from_file(path: Path, text: str, failures: list[str]) -> dict[tuple[str, str], StructDef]:
+    package = parse_package(text, path, failures)
+    if package is None:
+        return {}
+
+    lines = text.splitlines()
+    code_lines = scrub_go_source(text, strip_literals=False).splitlines()
+    max_len = max(len(lines), len(code_lines))
+    lines += [""] * (max_len - len(lines))
+    code_lines += [""] * (max_len - len(code_lines))
+
+    structs: dict[tuple[str, str], StructDef] = {}
+    type_re = re.compile(r"^\s*type\s+(\w+)\s+struct\s*\{")
+    idx = 0
+    while idx < len(code_lines):
+        code = code_lines[idx]
+        type_match = type_re.search(code)
+        if not type_match:
+            idx += 1
+            continue
+
+        name = type_match.group(1)
+        start_line = idx + 1
+        depth = brace_delta(code)
+        body: list[tuple[int, str]] = []
+        idx += 1
+        while idx < len(code_lines):
+            body_code = code_lines[idx]
+            depth += brace_delta(body_code)
+            if depth <= 0:
+                end_line = idx + 1
+                structs[(package, name)] = StructDef(
+                    package=package,
+                    name=name,
+                    path=path,
+                    start_line=start_line,
+                    end_line=end_line,
+                    body=body,
+                )
+                break
+            body.append((idx + 1, body_code))
+            idx += 1
+        else:
+            failures.append(f"struct {name} in {display_path(path)} does not close")
+            return structs
+        idx += 1
+
+    return structs
+
+
+def type_files(source_root: Path, failures: list[str]) -> list[Path]:
+    files = [source_root / HANDLER_FILE]
+    cost_dir = source_root / COSTTELEMETRY_DIR
+    if not cost_dir.is_dir():
+        failures.append(f"cost telemetry source dir missing: {display_path(cost_dir)}")
+        return files
+    files.extend(sorted(cost_dir.glob("*.go")))
+    return files
+
+
+def clean_field_type(raw_type: str) -> str:
+    t = raw_type.strip()
+    # Remove common type wrappers until a named element type remains.
+    changed = True
+    while changed:
+        changed = False
+        for prefix in ("[]", "*", "..."):
+            if t.startswith(prefix):
+                t = t[len(prefix) :].strip()
+                changed = True
+        if t.startswith("map["):
+            close = t.find("]")
+            if close != -1:
+                t = t[close + 1 :].strip()
+                changed = True
+        if t.startswith("chan "):
+            t = t[5:].strip()
+            changed = True
+        if t.startswith("<-chan "):
+            t = t[7:].strip()
+            changed = True
+    return t
+
+
+def field_type_from_line(line: str) -> str | None:
+    before_tag = line.split("`", 1)[0].strip()
+    if not before_tag or before_tag.startswith("}"):
+        return None
+    # Drop trailing inline punctuation that cannot be part of a type name.
+    before_tag = before_tag.rstrip(",")
+    parts = before_tag.split()
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return parts[0]
+    return parts[-1]
+
+
+def extract_json_tag(line: str) -> str | None:
+    tag_match = re.search(r"`([^`]*)`", line)
+    if not tag_match:
+        return None
+    json_match = re.search(r'json:"([^"]*)"', tag_match.group(1))
+    if not json_match:
+        return None
+    return json_match.group(1).split(",", 1)[0]
+
+
+def resolve_type(
+    current_package: str,
+    raw_type: str | None,
+    import_aliases: dict[str, str],
+) -> tuple[str, str] | None:
+    if raw_type is None:
+        return None
+    t = clean_field_type(raw_type)
+    if not t or t in PRIMITIVE_TYPES:
+        return None
+    if t.startswith("struct{") or t.startswith("func(") or t.startswith("interface{"):
+        return None
+    if "." in t:
+        alias, name = t.split(".", 1)
+        if (alias, name) in ALLOWED_EXTERNAL_TYPES:
+            return None
+        package = import_aliases.get(alias, alias)
+        return package, name
+    return current_package, t
+
+
+def verify_transitive_dto_redaction(source_root: Path, failures: list[str], messages: list[str]) -> None:
+    handler_text = read_required_file(source_root, HANDLER_FILE, failures)
+    if handler_text is None:
+        return
+    handler_abs = source_root / HANDLER_FILE
+    import_aliases = parse_import_aliases(handler_text)
+
+    structs: dict[tuple[str, str], StructDef] = {}
+    for path in type_files(source_root, failures):
+        if not path.is_file():
+            failures.append(f"type source file missing: {display_path(path)}")
+            continue
+        text = path.read_text(encoding="utf-8")
+        structs.update(parse_structs_from_file(path, text, failures))
+
+    visited: set[tuple[str, str]] = set()
+    stack: list[tuple[str, str]] = []
+
+    def scan_struct(package: str, name: str) -> None:
+        key = (package, name)
+        if key in visited:
+            return
+        struct_def = structs.get(key)
+        if struct_def is None:
+            failures.append(f"response DTO references unknown non-allowlisted type {package}.{name}")
+            return
+        visited.add(key)
+        stack.append(key)
+        messages.append(
+            f"DTO scan: {package}.{name} at {display_path(struct_def.path)}:{struct_def.start_line}-{struct_def.end_line}"
+        )
+
+        for line_no, line in struct_def.body:
+            tag_name = extract_json_tag(line)
+            if tag_name and tag_name != "-" and tag_name in FORBIDDEN_JSON_TAGS:
+                failures.append(
+                    f"forbidden json tag {tag_name!r} in transitive response DTO {package}.{name} "
+                    f"at {display_path(struct_def.path)}:{line_no}"
+                )
+            field_type = field_type_from_line(line)
+            resolved = resolve_type(package, field_type, import_aliases)
+            if resolved is None:
+                continue
+            if resolved in structs:
+                scan_struct(*resolved)
+                continue
+            resolved_package, resolved_name = resolved
+            if (resolved_package, resolved_name) in ALLOWED_EXTERNAL_TYPES:
+                continue
+            failures.append(
+                f"response DTO {package}.{name} embeds unknown non-allowlisted type "
+                f"{resolved_package}.{resolved_name} at {display_path(struct_def.path)}:{line_no}"
+            )
+
+        stack.pop()
+
+    scan_struct("controlplane", "portalCostResponse")
+    if not failures:
+        messages.append(
+            "PASS: transitive portalCostResponse DTO graph has no forbidden json tags "
+            f"({', '.join(f'{pkg}.{name}' for pkg, name in sorted(visited))})"
+        )
+
+    # This catches direct raw storage-payload references in handler executable
+    # source even if they are not part of a struct tag.
+    non_comment_handler = scrub_go_source(handler_text, strip_literals=False)
+    for token in ("EntriesJSON", "entries_json"):
+        if token in non_comment_handler:
+            failures.append(f"handler references raw {token} on a non-comment line: {display_path(handler_abs)}")
+
+
+def verify_test_proof(source_root: Path, failures: list[str], messages: list[str]) -> None:
+    test_text = read_required_file(source_root, TEST_FILE, failures)
+    if test_text is None:
+        return
+    test_code = scrub_go_source(test_text, strip_literals=False)
+
+    def has(pattern: str) -> bool:
+        return pattern in test_code
+
+    if has('Bearer "+testRawKey') and has("NotContains(t, string(resp.Body), testRawKey)"):
+        messages.append("PASS: test proves bearer key is sent upstream and excluded from response")
+    else:
+        failures.append("missing bearer-auth send plus response redaction proof")
+
+    for token in FORBIDDEN_RESPONSE_TOKENS:
+        if token not in test_code:
+            failures.append(f"test redaction assertion missing forbidden token {token}")
+    if "forbidden := range" in test_code and "require.NotContains(t, string(resp.Body), forbidden)" in test_code:
+        messages.append("PASS: test asserts forbidden response fields are absent")
+    else:
+        failures.append("test does not assert forbidden response fields are absent")
+
+    if (
+        "WrongOwnerForbiddenBeforeSecretOrHTTP" in test_code
+        and "require.Zero(t, secretReads)" in test_code
+        and "require.Zero(t, httpCalls)" in test_code
+    ):
+        messages.append("PASS: forbidden tenant proof skips secret resolution and HTTP call")
+    else:
+        failures.append("missing wrong-owner proof that secret resolution and HTTP are skipped")
+
+    if "Upstream5xxDoesNotLeakKeyOrBody" in test_code and "KeyResolverFailureDoesNotLeak" in test_code:
+        messages.append("PASS: tests cover upstream/key-resolution error redaction")
+    else:
+        failures.append("missing upstream/key-resolution redaction tests")
+
+    marshal_requirements = [
+        "TestPortalCostResponseJSONOmitsCostTelemetrySensitiveFields",
+        "json.Marshal(body)",
+        "costtelemetry.ReconciledCostEntry",
+        "require.NotContains(t, payload, forbidden)",
+    ]
+    missing_marshal = [token for token in marshal_requirements if token not in test_code]
+    if missing_marshal:
+        failures.append("missing transitive DTO marshal redaction proof tokens: " + ", ".join(missing_marshal))
+    else:
+        messages.append("PASS: test marshals portalCostResponse and asserts transitive DTO redaction")
+
+
+def verify_no_deprecated_store_read(source_root: Path, failures: list[str], messages: list[str]) -> None:
+    handler_text = read_required_file(source_root, HANDLER_FILE, failures)
+    if handler_text is None:
+        return
+    handler_code = scrub_go_source(handler_text, strip_literals=True)
+    if "ListCostTelemetryByInstance" in handler_code:
+        failures.append("handler still reads host-local cost telemetry store")
+    else:
+        messages.append("PASS: handler does not use deprecated ListCostTelemetryByInstance path")
+
+
+def analyze_source(source_root: Path, *, label: str) -> tuple[bool, list[str]]:
+    del label
+    failures: list[str] = []
+    messages: list[str] = []
+
+    verify_handler_ordering(source_root, failures, messages)
+    verify_no_deprecated_store_read(source_root, failures, messages)
+    verify_transitive_dto_redaction(source_root, failures, messages)
+    verify_test_proof(source_root, failures, messages)
+
+    if failures:
+        return False, failures
+    return True, messages
+
+
+def print_result(ok: bool, output: list[str]) -> None:
+    stream = sys.stdout if ok else sys.stderr
+    for message in output:
+        if message.startswith(("PASS:", "FAIL:")):
+            print(message, file=stream)
+        else:
+            print(("PASS: " if ok else "FAIL: ") + message, file=stream)
+
+
+print("SEC-13: Portal cost redaction + multi-tenant downstream-call ordering")
+print(f"Source root: {display_path(SOURCE_ROOT)}")
+print(f"Handler file: {HANDLER_FILE}")
+print(f"Test file:    {TEST_FILE}")
+print("")
+
+ok, output = analyze_source(SOURCE_ROOT, label="source")
+print_result(ok, output)
+
+if not ok:
+    print("FAIL: SEC-13 portal cost redaction check failed", file=sys.stderr)
+    sys.exit(1)
+
+if not SKIP_FIXTURES and SOURCE_ROOT == REPO_ROOT and FIXTURE_DIR.is_dir():
+    print("")
+    print("SEC-13 negative fixture regression checks")
+    expected = [
+        ("fail-decoy-auth-preauth-fetch", "precedes ownership check"),
+        ("fail-forbidden-reconciled-tag", "forbidden json tag 'account_id'"),
+        ("fail-comment-only-test-proof", "missing bearer-auth send plus response redaction proof"),
+    ]
+    for name, expected_fragment in expected:
+        fixture_root = FIXTURE_DIR / name
+        fixture_ok, fixture_output = analyze_source(fixture_root, label=name)
+        joined = "\n".join(fixture_output)
+        if fixture_ok:
+            print(f"FAIL: negative fixture {name} unexpectedly passed", file=sys.stderr)
+            for message in fixture_output:
+                print(message, file=sys.stderr)
+            sys.exit(1)
+        if expected_fragment not in joined:
+            print(
+                f"FAIL: negative fixture {name} failed, but did not emit expected evidence fragment: "
+                f"{expected_fragment}",
+                file=sys.stderr,
+            )
+            for message in fixture_output:
+                print(message, file=sys.stderr)
+            sys.exit(1)
+        print(f"PASS: negative fixture {name} failed closed ({expected_fragment})")
+
+print("")
+print("PASS: SEC-13 portal cost redaction + downstream-call ordering verified")
+PY

--- a/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-bearer-behavior-wrong-origin.json
+++ b/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-bearer-behavior-wrong-origin.json
@@ -1,0 +1,243 @@
+{
+  "Resources": {
+    "HtmlStoreOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "SsrFunctionUrl": {
+      "Properties": {
+        "AuthType": "AWS_IAM",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "WebSsrFn",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Url"
+    },
+    "SsrOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "WebDistribution": {
+      "Properties": {
+        "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "PathPattern": "_facetheory/data/*",
+              "TargetOriginId": "html-store-origin"
+            },
+            {
+              "PathPattern": "resolve*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "health*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/previews*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/renders*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/trust/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "api/v1/publish/jobs*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/update-registration",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/ai/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/budget/debit",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": ".well-known/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/register/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "auth/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "webhooks/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/status",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/bootstrap/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/admin",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/finalize",
+              "TargetOriginId": "control-plane-origin"
+            }
+          ],
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PUT",
+              "PATCH",
+              "POST",
+              "DELETE"
+            ],
+            "TargetOriginId": "ssr-origin",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          },
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Fn::Split": [
+                      "/",
+                      {
+                        "Fn::GetAtt": [
+                          "SsrFunctionUrl",
+                          "FunctionUrl"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Id": "ssr-origin",
+              "OriginAccessControlId": {
+                "Ref": "SsrOriginAccessControl"
+              }
+            },
+            {
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "WebHtmlStoreBucket",
+                  "RegionalDomainName"
+                ]
+              },
+              "Id": "html-store-origin",
+              "OriginAccessControlId": {
+                "Ref": "HtmlStoreOriginAccessControl"
+              },
+              "S3OriginConfig": {}
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "TrustHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "trust-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneSseRestApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "sse-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "control-plane-origin"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::CloudFront::Distribution"
+    }
+  }
+}

--- a/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-default-lambda-url-auth-none.json
+++ b/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-default-lambda-url-auth-none.json
@@ -1,0 +1,243 @@
+{
+  "Resources": {
+    "HtmlStoreOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "SsrFunctionUrl": {
+      "Properties": {
+        "AuthType": "NONE",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "WebSsrFn",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Url"
+    },
+    "SsrOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "WebDistribution": {
+      "Properties": {
+        "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "PathPattern": "_facetheory/data/*",
+              "TargetOriginId": "html-store-origin"
+            },
+            {
+              "PathPattern": "resolve*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "health*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/previews*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/renders*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/trust/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/publish/jobs*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/update-registration",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/ai/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/budget/debit",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": ".well-known/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/register/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "auth/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "webhooks/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/status",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/bootstrap/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/admin",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/finalize",
+              "TargetOriginId": "control-plane-origin"
+            }
+          ],
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PUT",
+              "PATCH",
+              "POST",
+              "DELETE"
+            ],
+            "TargetOriginId": "ssr-origin",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          },
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Fn::Split": [
+                      "/",
+                      {
+                        "Fn::GetAtt": [
+                          "SsrFunctionUrl",
+                          "FunctionUrl"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Id": "ssr-origin",
+              "OriginAccessControlId": {
+                "Ref": "SsrOriginAccessControl"
+              }
+            },
+            {
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "WebHtmlStoreBucket",
+                  "RegionalDomainName"
+                ]
+              },
+              "Id": "html-store-origin",
+              "OriginAccessControlId": {
+                "Ref": "HtmlStoreOriginAccessControl"
+              },
+              "S3OriginConfig": {}
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "TrustHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "trust-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneSseRestApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "sse-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "control-plane-origin"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::CloudFront::Distribution"
+    }
+  }
+}

--- a/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-expanded-required-patterns-missing.json
+++ b/gov-infra/verifiers/sec/fixtures/cloudfront-composition/fail-expanded-required-patterns-missing.json
@@ -1,0 +1,231 @@
+{
+  "Resources": {
+    "HtmlStoreOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "SsrFunctionUrl": {
+      "Properties": {
+        "AuthType": "AWS_IAM",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "WebSsrFn",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Url"
+    },
+    "SsrOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "WebDistribution": {
+      "Properties": {
+        "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "PathPattern": "_facetheory/data/*",
+              "TargetOriginId": "html-store-origin"
+            },
+            {
+              "PathPattern": "api/v1/previews*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/renders*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/trust/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/publish/jobs*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/update-registration",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/ai/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/budget/debit",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": ".well-known/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/register/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "auth/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/status",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/bootstrap/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/admin",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/finalize",
+              "TargetOriginId": "control-plane-origin"
+            }
+          ],
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PUT",
+              "PATCH",
+              "POST",
+              "DELETE"
+            ],
+            "TargetOriginId": "ssr-origin",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          },
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Fn::Split": [
+                      "/",
+                      {
+                        "Fn::GetAtt": [
+                          "SsrFunctionUrl",
+                          "FunctionUrl"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Id": "ssr-origin",
+              "OriginAccessControlId": {
+                "Ref": "SsrOriginAccessControl"
+              }
+            },
+            {
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "WebHtmlStoreBucket",
+                  "RegionalDomainName"
+                ]
+              },
+              "Id": "html-store-origin",
+              "OriginAccessControlId": {
+                "Ref": "HtmlStoreOriginAccessControl"
+              },
+              "S3OriginConfig": {}
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "TrustHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "trust-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneSseRestApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "sse-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "control-plane-origin"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::CloudFront::Distribution"
+    }
+  }
+}

--- a/gov-infra/verifiers/sec/fixtures/cloudfront-composition/pass-current-shape.json
+++ b/gov-infra/verifiers/sec/fixtures/cloudfront-composition/pass-current-shape.json
@@ -1,0 +1,243 @@
+{
+  "Resources": {
+    "HtmlStoreOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "SsrFunctionUrl": {
+      "Properties": {
+        "AuthType": "AWS_IAM",
+        "InvokeMode": "RESPONSE_STREAM",
+        "TargetFunctionArn": {
+          "Fn::GetAtt": [
+            "WebSsrFn",
+            "Arn"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::Url"
+    },
+    "SsrOriginAccessControl": {
+      "Properties": {},
+      "Type": "AWS::CloudFront::OriginAccessControl"
+    },
+    "WebDistribution": {
+      "Properties": {
+        "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+                "OPTIONS"
+              ],
+              "PathPattern": "_facetheory/data/*",
+              "TargetOriginId": "html-store-origin"
+            },
+            {
+              "PathPattern": "resolve*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "health*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/previews*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/renders*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/trust/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/publish/jobs*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/update-registration",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/ai/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/budget/debit",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": ".well-known/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "attestations/*",
+              "TargetOriginId": "trust-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/register/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/v1/soul/agents/*/mint-conversation*",
+              "TargetOriginId": "sse-origin"
+            },
+            {
+              "PathPattern": "api/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "auth/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "webhooks/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/status",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/bootstrap/*",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/admin",
+              "TargetOriginId": "control-plane-origin"
+            },
+            {
+              "PathPattern": "setup/finalize",
+              "TargetOriginId": "control-plane-origin"
+            }
+          ],
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PUT",
+              "PATCH",
+              "POST",
+              "DELETE"
+            ],
+            "TargetOriginId": "ssr-origin",
+            "ViewerProtocolPolicy": "redirect-to-https"
+          },
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Select": [
+                  2,
+                  {
+                    "Fn::Split": [
+                      "/",
+                      {
+                        "Fn::GetAtt": [
+                          "SsrFunctionUrl",
+                          "FunctionUrl"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              },
+              "Id": "ssr-origin",
+              "OriginAccessControlId": {
+                "Ref": "SsrOriginAccessControl"
+              }
+            },
+            {
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "WebHtmlStoreBucket",
+                  "RegionalDomainName"
+                ]
+              },
+              "Id": "html-store-origin",
+              "OriginAccessControlId": {
+                "Ref": "HtmlStoreOriginAccessControl"
+              },
+              "S3OriginConfig": {}
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "TrustHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "trust-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneSseRestApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "sse-origin"
+            },
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only"
+              },
+              "DomainName": {
+                "Fn::Join": [
+                  "",
+                  [
+                    {
+                      "Ref": "ControlPlaneHttpApi"
+                    },
+                    ".execute-api.",
+                    {
+                      "Ref": "AWS::Region"
+                    },
+                    ".amazonaws.com"
+                  ]
+                ]
+              },
+              "Id": "control-plane-origin"
+            }
+          ]
+        }
+      },
+      "Type": "AWS::CloudFront::Distribution"
+    }
+  }
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/controlplane/handlers_portal_cost.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/controlplane/handlers_portal_cost.go
@@ -1,0 +1,41 @@
+//go:build ignore
+
+package controlplane
+
+import (
+	"net/http"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+)
+
+type portalCostResponse struct {
+	InstanceSlug string               `json:"instance_slug"`
+	Days         []portalCostDayEntry `json:"days"`
+	Count        int                  `json:"count"`
+}
+
+type portalCostDayEntry struct {
+	Date     string                              `json:"date"`
+	DayCost  float64                             `json:"day_cost"`
+	Currency string                              `json:"currency"`
+	Entries  []costtelemetry.ReconciledCostEntry `json:"entries"`
+}
+
+func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+	apiKey, keyErr := s.resolvePortalCostInstanceKey(ctx.Context(), inst)
+	if keyErr != nil {
+		return nil, keyErr
+	}
+	metrics, metricsErr := s.fetchManagedInstanceMetrics(ctx.Context(), inst, apiKey, "2026-05-25", "2026-05-26")
+	if metricsErr != nil {
+		return nil, metricsErr
+	}
+	_ = metrics
+	return apptheory.JSON(http.StatusOK, portalCostResponse{InstanceSlug: inst.Slug})
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -1,0 +1,23 @@
+//go:build ignore
+
+package controlplane
+
+import "testing"
+
+func TestHandlePortalGetInstanceCost_CommentsOnlyDoNotProveRedaction(t *testing.T) {
+	// require.Equal(t, "Bearer "+testRawKey, gotAuth)
+	// require.NotContains(t, string(resp.Body), testRawKey)
+	// for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+	// 	require.NotContains(t, string(resp.Body), forbidden)
+	// }
+	// TestHandlePortalGetInstanceCost_WrongOwnerForbiddenBeforeSecretOrHTTP
+	// require.Zero(t, secretReads)
+	// require.Zero(t, httpCalls)
+	// TestHandlePortalGetInstanceCost_Upstream5xxDoesNotLeakKeyOrBody
+	// TestHandlePortalGetInstanceCost_KeyResolverFailureDoesNotLeak
+	// TestPortalCostResponseJSONOmitsCostTelemetrySensitiveFields
+	// json.Marshal(body)
+	// costtelemetry.ReconciledCostEntry
+	// require.NotContains(t, payload, forbidden)
+	_ = t
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/costtelemetry/cloudwatch.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/costtelemetry/cloudwatch.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package costtelemetry
+
+type ServiceAttribution struct {
+	Service    string  `json:"service"`
+	MetricName string  `json:"metric_name"`
+	Stat       string  `json:"stat"`
+	Unit       string  `json:"unit"`
+	Value      float64 `json:"value"`
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/costtelemetry/cost_explorer.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-comment-only-test-proof/internal/costtelemetry/cost_explorer.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package costtelemetry
+
+type ReconciledCostEntry struct {
+	Date     string               `json:"date"`
+	Service  string               `json:"service"`
+	Cost     float64              `json:"cost"`
+	Currency string               `json:"currency"`
+	Metrics  []ServiceAttribution `json:"metrics,omitempty"`
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/controlplane/handlers_portal_cost.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/controlplane/handlers_portal_cost.go
@@ -1,0 +1,51 @@
+//go:build ignore
+
+package controlplane
+
+import (
+	"net/http"
+	"strings"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+)
+
+type portalCostResponse struct {
+	InstanceSlug string               `json:"instance_slug"`
+	Days         []portalCostDayEntry `json:"days"`
+	Count        int                  `json:"count"`
+}
+
+type portalCostDayEntry struct {
+	Date     string                              `json:"date"`
+	DayCost  float64                             `json:"day_cost"`
+	Currency string                              `json:"currency"`
+	Entries  []costtelemetry.ReconciledCostEntry `json:"entries"`
+}
+
+func (s *Server) decoyRequireInstanceAccess(ctx *apptheory.Context) {
+	_, _ = s.requireInstanceAccess(ctx, ctx.Param("slug"))
+}
+
+func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst := &Instance{Slug: strings.ToLower(strings.TrimSpace(ctx.Param("slug")))}
+
+	apiKey, keyErr := s.resolvePortalCostInstanceKey(ctx.Context(), inst)
+	if keyErr != nil {
+		return nil, keyErr
+	}
+
+	authorized, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+
+	metrics, metricsErr := s.fetchManagedInstanceMetrics(ctx.Context(), authorized, apiKey, "2026-05-25", "2026-05-26")
+	if metricsErr != nil {
+		return nil, metricsErr
+	}
+
+	_ = metrics
+	return apptheory.JSON(http.StatusOK, portalCostResponse{InstanceSlug: authorized.Slug})
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -1,0 +1,49 @@
+//go:build ignore
+
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+)
+
+const testRawKey = "lhk_fixture_secret"
+
+func TestHandlePortalGetInstanceCost_SendsBearerAuthAndMapsDailyRows(t *testing.T) {
+	gotAuth := "Bearer " + testRawKey
+	resp := struct{ Body []byte }{Body: []byte(`{"entries":[{"service":"Managed Lesser"}]}`)}
+	require.Equal(t, "Bearer "+testRawKey, gotAuth)
+	require.NotContains(t, string(resp.Body), testRawKey)
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, string(resp.Body), forbidden)
+	}
+}
+
+func TestPortalCostResponseJSONOmitsCostTelemetrySensitiveFields(t *testing.T) {
+	body := portalCostResponse{Days: []portalCostDayEntry{{Entries: []costtelemetry.ReconciledCostEntry{{Service: "Managed Lesser", Metrics: []costtelemetry.ServiceAttribution{{Service: "Lambda"}}}}}}}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	payload := string(raw)
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, payload, forbidden)
+	}
+}
+
+func TestHandlePortalGetInstanceCost_WrongOwnerForbiddenBeforeSecretOrHTTP(t *testing.T) {
+	secretReads := 0
+	httpCalls := 0
+	require.Zero(t, secretReads)
+	require.Zero(t, httpCalls)
+}
+
+func TestHandlePortalGetInstanceCost_Upstream5xxDoesNotLeakKeyOrBody(t *testing.T) {
+	require.NotContains(t, "safe", testRawKey)
+}
+
+func TestHandlePortalGetInstanceCost_KeyResolverFailureDoesNotLeak(t *testing.T) {
+	require.NotContains(t, "safe", testRawKey)
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/costtelemetry/cloudwatch.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/costtelemetry/cloudwatch.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package costtelemetry
+
+type ServiceAttribution struct {
+	Service    string  `json:"service"`
+	MetricName string  `json:"metric_name"`
+	Stat       string  `json:"stat"`
+	Unit       string  `json:"unit"`
+	Value      float64 `json:"value"`
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/costtelemetry/cost_explorer.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-decoy-auth-preauth-fetch/internal/costtelemetry/cost_explorer.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package costtelemetry
+
+type ReconciledCostEntry struct {
+	Date     string               `json:"date"`
+	Service  string               `json:"service"`
+	Cost     float64              `json:"cost"`
+	Currency string               `json:"currency"`
+	Metrics  []ServiceAttribution `json:"metrics,omitempty"`
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/controlplane/handlers_portal_cost.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/controlplane/handlers_portal_cost.go
@@ -1,0 +1,41 @@
+//go:build ignore
+
+package controlplane
+
+import (
+	"net/http"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+)
+
+type portalCostResponse struct {
+	InstanceSlug string               `json:"instance_slug"`
+	Days         []portalCostDayEntry `json:"days"`
+	Count        int                  `json:"count"`
+}
+
+type portalCostDayEntry struct {
+	Date     string                              `json:"date"`
+	DayCost  float64                             `json:"day_cost"`
+	Currency string                              `json:"currency"`
+	Entries  []costtelemetry.ReconciledCostEntry `json:"entries"`
+}
+
+func (s *Server) handlePortalGetInstanceCost(ctx *apptheory.Context) (*apptheory.Response, error) {
+	inst, err := s.requireInstanceAccess(ctx, ctx.Param("slug"))
+	if err != nil {
+		return nil, err
+	}
+	apiKey, keyErr := s.resolvePortalCostInstanceKey(ctx.Context(), inst)
+	if keyErr != nil {
+		return nil, keyErr
+	}
+	metrics, metricsErr := s.fetchManagedInstanceMetrics(ctx.Context(), inst, apiKey, "2026-05-25", "2026-05-26")
+	if metricsErr != nil {
+		return nil, metricsErr
+	}
+	_ = metrics
+	return apptheory.JSON(http.StatusOK, portalCostResponse{InstanceSlug: inst.Slug})
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -1,0 +1,49 @@
+//go:build ignore
+
+package controlplane
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
+)
+
+const testRawKey = "lhk_fixture_secret"
+
+func TestHandlePortalGetInstanceCost_SendsBearerAuthAndMapsDailyRows(t *testing.T) {
+	gotAuth := "Bearer " + testRawKey
+	resp := struct{ Body []byte }{Body: []byte(`{"entries":[{"service":"Managed Lesser"}]}`)}
+	require.Equal(t, "Bearer "+testRawKey, gotAuth)
+	require.NotContains(t, string(resp.Body), testRawKey)
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, string(resp.Body), forbidden)
+	}
+}
+
+func TestPortalCostResponseJSONOmitsCostTelemetrySensitiveFields(t *testing.T) {
+	body := portalCostResponse{Days: []portalCostDayEntry{{Entries: []costtelemetry.ReconciledCostEntry{{Service: "Managed Lesser", Metrics: []costtelemetry.ServiceAttribution{{Service: "Lambda"}}}}}}}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	payload := string(raw)
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, payload, forbidden)
+	}
+}
+
+func TestHandlePortalGetInstanceCost_WrongOwnerForbiddenBeforeSecretOrHTTP(t *testing.T) {
+	secretReads := 0
+	httpCalls := 0
+	require.Zero(t, secretReads)
+	require.Zero(t, httpCalls)
+}
+
+func TestHandlePortalGetInstanceCost_Upstream5xxDoesNotLeakKeyOrBody(t *testing.T) {
+	require.NotContains(t, "safe", testRawKey)
+}
+
+func TestHandlePortalGetInstanceCost_KeyResolverFailureDoesNotLeak(t *testing.T) {
+	require.NotContains(t, "safe", testRawKey)
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/costtelemetry/cloudwatch.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/costtelemetry/cloudwatch.go
@@ -1,0 +1,11 @@
+//go:build ignore
+
+package costtelemetry
+
+type ServiceAttribution struct {
+	Service    string  `json:"service"`
+	MetricName string  `json:"metric_name"`
+	Stat       string  `json:"stat"`
+	Unit       string  `json:"unit"`
+	Value      float64 `json:"value"`
+}

--- a/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/costtelemetry/cost_explorer.go
+++ b/gov-infra/verifiers/sec/fixtures/cost-telemetry-redaction/fail-forbidden-reconciled-tag/internal/costtelemetry/cost_explorer.go
@@ -1,0 +1,12 @@
+//go:build ignore
+
+package costtelemetry
+
+type ReconciledCostEntry struct {
+	Date      string               `json:"date"`
+	Service   string               `json:"service"`
+	AccountID string               `json:"account_id"`
+	Cost      float64              `json:"cost"`
+	Currency  string               `json:"currency"`
+	Metrics   []ServiceAttribution `json:"metrics,omitempty"`
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_drift.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_drift.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	requireOperator(ctx)
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_releases.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_releases.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Response, error) {
+	requireOperator(ctx)
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	requireOperator(ctx)
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/server.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-ignored-error-call/internal/controlplane/server.go
@@ -1,0 +1,10 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func registerOperatorRoutes(app *App, s *Server) {
+	app.Get("/api/v1/operators/releases", s.handleOperatorReleases, apptheory.RequireAuth())
+	app.Get("/api/v1/operators/instances/drift", s.handleOperatorInstancesDrift, apptheory.RequireAuth())
+	app.Post("/api/v1/operators/instances/remediate-mcp-drift", s.handleOperatorRemediateMCPDrift, apptheory.RequireAuth())
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_drift.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_drift.go
@@ -1,0 +1,13 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	x := 0 // requireOperator(ctx)
+	_ = x
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_releases.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_releases.go
@@ -1,0 +1,13 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Response, error) {
+	x := 0 // requireOperator(ctx)
+	_ = x
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -1,0 +1,13 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	x := 0 // requireOperator(ctx)
+	_ = x
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/server.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-inline-comment-marker/internal/controlplane/server.go
@@ -1,0 +1,10 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func registerOperatorRoutes(app *App, s *Server) {
+	app.Get("/api/v1/operators/releases", s.handleOperatorReleases, apptheory.RequireAuth())
+	app.Get("/api/v1/operators/instances/drift", s.handleOperatorInstancesDrift, apptheory.RequireAuth())
+	app.Post("/api/v1/operators/instances/remediate-mcp-drift", s.handleOperatorRemediateMCPDrift, apptheory.RequireAuth())
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_drift.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_drift.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorInstancesDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	_ = "requireOperator(ctx)"
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_releases.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_releases.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorReleases(ctx *apptheory.Context) (*apptheory.Response, error) {
+	_ = "requireOperator(ctx)"
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -1,0 +1,12 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*apptheory.Response, error) {
+	_ = "requireOperator(ctx)"
+	if appErr := requireStoreDB(s); appErr != nil {
+		return nil, appErr
+	}
+	return apptheory.JSON(200, nil)
+}

--- a/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/server.go
+++ b/gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate/fail-string-literal-marker/internal/controlplane/server.go
@@ -1,0 +1,10 @@
+//go:build ignore
+// +build ignore
+
+package controlplane
+
+func registerOperatorRoutes(app *App, s *Server) {
+	app.Get("/api/v1/operators/releases", s.handleOperatorReleases, apptheory.RequireAuth())
+	app.Get("/api/v1/operators/instances/drift", s.handleOperatorInstancesDrift, apptheory.RequireAuth())
+	app.Post("/api/v1/operators/instances/remediate-mcp-drift", s.handleOperatorRemediateMCPDrift, apptheory.RequireAuth())
+}

--- a/gov-infra/verifiers/sec/operator-drift-auth-gate.sh
+++ b/gov-infra/verifiers/sec/operator-drift-auth-gate.sh
@@ -10,16 +10,26 @@
 #   3. POST /api/v1/operators/instances/remediate-mcp-drift → handleOperatorRemediateMCPDrift
 #
 # Full points: all three endpoints have the exact expected method/path/handler
-#   route with apptheory.RequireAuth(), and requireOperator(ctx) appears inside
-#   the expected handler body before any store/fleet read or write operation.
+#   route with apptheory.RequireAuth(), and each expected handler has a
+#   top-level, executable requireOperator(ctx) guard before any store/fleet read
+#   or write operation. The guard must act on the returned error, using the
+#   canonical `if err := requireOperator(ctx); err != nil { return nil, err }`
+#   shape or an equivalent top-level assignment followed by an err != nil
+#   return block before sensitive work.
 # Zero points: any endpoint is missing, routed to the wrong handler, lacks
-#   RequireAuth(), lacks requireOperator(ctx), or performs sensitive work before
-#   requireOperator(ctx).
+#   RequireAuth(), lacks a guarded requireOperator(ctx), has only spoofed
+#   requireOperator(ctx) markers in comments/strings, ignores the returned
+#   error, or performs sensitive work before the operator-role guard.
 #
 # No partial credit.
 #
 # Source: docs/enumerated-changes-web-ui-rework-2026-05-24.md M2.14
-# Issue: equaltoai/lesser-host#440
+# Issue: equaltoai/lesser-host#440; hardened for LH-23 / #587
+#
+# Test hooks:
+#   SEC12_SOURCE_ROOT=/path/to/source-root analyzes that source tree instead of
+#   the repository root. The source root must contain internal/controlplane/*.
+#   SEC12_SKIP_FIXTURES=1 skips committed negative-fixture regression checks.
 
 set -euo pipefail
 
@@ -28,8 +38,14 @@ cd "${REPO_ROOT}"
 
 python3 - <<'PY'
 from pathlib import Path
+import os
 import re
 import sys
+
+REPO_ROOT = Path.cwd()
+SOURCE_ROOT = Path(os.environ.get("SEC12_SOURCE_ROOT", ".")).resolve()
+SKIP_FIXTURES = os.environ.get("SEC12_SKIP_FIXTURES", "") == "1"
+FIXTURE_DIR = REPO_ROOT / "gov-infra/verifiers/sec/fixtures/operator-drift-auth-gate"
 
 ROUTES_FILE = Path("internal/controlplane/server.go")
 ENDPOINTS = [
@@ -67,111 +83,412 @@ ENDPOINTS = [
     },
 ]
 
+GUARD_IF_RE = re.compile(
+    r"^\s*if\s+([A-Za-z_]\w*)\s*:=\s*requireOperator\s*\(\s*ctx\s*\)\s*;\s*\1\s*!=\s*nil\s*\{"
+)
+ASSIGN_RE = re.compile(r"^\s*([A-Za-z_]\w*)\s*:=\s*requireOperator\s*\(\s*ctx\s*\)\s*$")
+ERR_IF_RE_TEMPLATE = r"^\s*if\s+{err}\s*!=\s*nil\s*\{{"
+CALL_RE = re.compile(r"\brequireOperator\s*\(\s*ctx\s*\)")
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def scrub_go_source(text: str, *, strip_literals: bool) -> str:
+    """Remove Go comments; optionally blank Go string/rune literals.
+
+    The verifier must not accept requireOperator(ctx) markers after `//` or
+    inside Go strings/raw strings/runes. This lexer preserves line numbers and
+    enough column shape for source evidence while blanking non-executable text.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    state = "code"
+
+    def emit_char(ch: str) -> None:
+        out.append(ch)
+
+    def emit_blank(ch: str) -> None:
+        out.append("\n" if ch == "\n" else " ")
+
+    while i < n:
+        ch = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+
+        if state == "code":
+            if ch == "/" and nxt == "/":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "line_comment"
+                continue
+            if ch == "/" and nxt == "*":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "block_comment"
+                continue
+            if ch == '"':
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "double_string"
+                continue
+            if ch == "`":
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "raw_string"
+                continue
+            if ch == "'":
+                (emit_blank if strip_literals else emit_char)(ch)
+                i += 1
+                state = "rune"
+                continue
+            emit_char(ch)
+            i += 1
+            continue
+
+        if state == "line_comment":
+            if ch == "\n":
+                emit_char(ch)
+                state = "code"
+            else:
+                emit_blank(ch)
+            i += 1
+            continue
+
+        if state == "block_comment":
+            if ch == "*" and nxt == "/":
+                emit_blank(ch)
+                emit_blank(nxt)
+                i += 2
+                state = "code"
+                continue
+            emit_blank(ch)
+            i += 1
+            continue
+
+        if state == "double_string":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "\\" and i + 1 < n:
+                (emit_blank if strip_literals else emit_char)(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                state = "code"
+            i += 1
+            continue
+
+        if state == "raw_string":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "`":
+                state = "code"
+            i += 1
+            continue
+
+        if state == "rune":
+            (emit_blank if strip_literals else emit_char)(ch)
+            if ch == "\\" and i + 1 < n:
+                (emit_blank if strip_literals else emit_char)(text[i + 1])
+                i += 2
+                continue
+            if ch == "'":
+                state = "code"
+            i += 1
+            continue
+
+        raise AssertionError(f"unexpected lexer state {state}")
+
+    return "".join(out)
+
+
+def executable_lines(text: str, *, strip_literals: bool):
+    scrubbed = scrub_go_source(text, strip_literals=strip_literals)
+    original_lines = text.splitlines()
+    scrubbed_lines = scrubbed.splitlines()
+    # Pad in case the file ends with trailing newlines represented differently.
+    max_len = max(len(original_lines), len(scrubbed_lines))
+    original_lines += [""] * (max_len - len(original_lines))
+    scrubbed_lines += [""] * (max_len - len(scrubbed_lines))
+    for idx, (code, original) in enumerate(zip(scrubbed_lines, original_lines), start=1):
+        if code.strip() == "":
+            continue
+        yield idx, code, original
+
+
+def brace_delta(code: str) -> int:
+    return code.count("{") - code.count("}")
+
+
+def find_function_body(source_root: Path, path: Path, handler: str, failures: list[str]):
+    abs_path = source_root / path
+    if not abs_path.is_file():
+        failures.append(f"handler file missing for {handler}: {display_path(abs_path)}")
+        return None
+
+    text = abs_path.read_text(encoding="utf-8")
+    original_lines = text.splitlines()
+    scrubbed_lines = scrub_go_source(text, strip_literals=True).splitlines()
+    max_len = max(len(original_lines), len(scrubbed_lines))
+    original_lines += [""] * (max_len - len(original_lines))
+    scrubbed_lines += [""] * (max_len - len(scrubbed_lines))
+
+    pattern = re.compile(rf"^\s*func\s+\([^)]*\)\s+{re.escape(handler)}\s*\(")
+    start_index = None
+    for idx, code in enumerate(scrubbed_lines):
+        if pattern.search(code):
+            start_index = idx
+            break
+    if start_index is None:
+        failures.append(f"handler function not found: {handler} in {display_path(abs_path)}")
+        return None
+
+    records: list[dict[str, object]] = []
+    depth = 0
+    body_started = False
+    start_line = start_index + 1
+    end_line = len(scrubbed_lines)
+
+    for idx in range(start_index, len(scrubbed_lines)):
+        code = scrubbed_lines[idx]
+        original = original_lines[idx]
+        if not body_started:
+            if "{" not in code:
+                continue
+            body_started = True
+            depth += brace_delta(code)
+            continue
+
+        depth_before = depth
+        records.append(
+            {
+                "line": idx + 1,
+                "code": code,
+                "original": original,
+                "depth": depth_before,
+                "delta": brace_delta(code),
+            }
+        )
+        depth += brace_delta(code)
+        if depth <= 0:
+            end_line = idx + 1
+            break
+
+    if not body_started:
+        failures.append(f"handler function has no body: {handler} in {display_path(abs_path)}")
+        return None
+    if depth != 0:
+        failures.append(f"handler function body did not close: {handler} in {display_path(abs_path)}:{start_line}")
+        return None
+
+    return abs_path, records, start_line, end_line
+
+
+def block_returns_error(records: list[dict[str, object]], guard_pos: int, err_name: str) -> bool:
+    return_re = re.compile(rf"\breturn\s+nil\s*,\s*{re.escape(err_name)}\b")
+    guard = records[guard_pos]
+    guard_line = str(guard["code"])
+    if return_re.search(guard_line):
+        return True
+
+    for later in records[guard_pos + 1 :]:
+        depth = int(later["depth"])
+        if depth <= int(guard["depth"]):
+            break
+        if return_re.search(str(later["code"])):
+            return True
+    return False
+
+
+def find_later_err_guard(records: list[dict[str, object]], assign_pos: int, err_name: str, before_line: int):
+    err_if_re = re.compile(ERR_IF_RE_TEMPLATE.format(err=re.escape(err_name)))
+    assign_depth = int(records[assign_pos]["depth"])
+    for pos in range(assign_pos + 1, len(records)):
+        rec = records[pos]
+        line_no = int(rec["line"])
+        if line_no >= before_line:
+            return None
+        if int(rec["depth"]) != assign_depth:
+            continue
+        if err_if_re.search(str(rec["code"])) and block_returns_error(records, pos, err_name):
+            return rec
+    return None
+
+
+def find_authorizing_guard(records: list[dict[str, object]], first_sensitive_line: int):
+    invalid_call_before_sensitive = None
+
+    for pos, rec in enumerate(records):
+        line_no = int(rec["line"])
+        if line_no >= first_sensitive_line:
+            break
+        code = str(rec["code"])
+        if CALL_RE.search(code) and int(rec["depth"]) != 1:
+            invalid_call_before_sensitive = invalid_call_before_sensitive or (
+                line_no,
+                "requireOperator(ctx) is not a top-level handler statement",
+            )
+            continue
+        if int(rec["depth"]) != 1:
+            continue
+
+        guarded = GUARD_IF_RE.search(code)
+        if guarded:
+            err_name = guarded.group(1)
+            if block_returns_error(records, pos, err_name):
+                return (line_no, f"if {err_name} := requireOperator(ctx); {err_name} != nil {{ ... return nil, {err_name} }}"), None
+            invalid_call_before_sensitive = invalid_call_before_sensitive or (
+                line_no,
+                "requireOperator(ctx) guard does not return the checked error",
+            )
+            continue
+
+        assigned = ASSIGN_RE.search(code)
+        if assigned:
+            err_name = assigned.group(1)
+            err_guard = find_later_err_guard(records, pos, err_name, first_sensitive_line)
+            if err_guard is not None:
+                return (line_no, f"{err_name} := requireOperator(ctx) with later {err_name} != nil return guard"), None
+            invalid_call_before_sensitive = invalid_call_before_sensitive or (
+                line_no,
+                "requireOperator(ctx) assignment is not followed by err != nil return guard before sensitive work",
+            )
+            continue
+
+        if CALL_RE.search(code):
+            invalid_call_before_sensitive = invalid_call_before_sensitive or (
+                line_no,
+                "requireOperator(ctx) call is not in an accepted guarded error-handling form",
+            )
+
+    return None, invalid_call_before_sensitive
+
+
+def analyze_source(source_root: Path, *, label: str) -> tuple[bool, list[str]]:
+    messages: list[str] = []
+    failures: list[str] = []
+    routes_abs = source_root / ROUTES_FILE
+
+    if not routes_abs.is_file():
+        failures.append(f"routes file missing: {display_path(routes_abs)}")
+        return False, failures
+
+    route_text = routes_abs.read_text(encoding="utf-8")
+    route_lines = list(executable_lines(route_text, strip_literals=False))
+
+    for ep in ENDPOINTS:
+        method = ep["method"]
+        path = ep["path"]
+        handler = ep["handler"]
+        route_re = re.compile(
+            rf'app\.{method}\(\s*"{re.escape(path)}"\s*,\s*s\.{handler}\s*,\s*apptheory\.RequireAuth\(\)\s*\)'
+        )
+        exact_matches = [(idx, original) for idx, code, original in route_lines if route_re.search(code)]
+        if exact_matches:
+            idx, _line = exact_matches[0]
+            messages.append(f"PASS: {method.upper()} {path} line {idx}: expected handler {handler} + RequireAuth()")
+        else:
+            nearby = [
+                f"line {idx}: {original.strip()}"
+                for idx, code, original in route_lines
+                if f'"{path}"' in code
+            ]
+            detail = "; ".join(nearby) if nearby else "route not found"
+            failures.append(
+                f"{method.upper()} {path}: expected s.{handler} with apptheory.RequireAuth(); found {detail}"
+            )
+
+        body = find_function_body(source_root, ep["file"], handler, failures)
+        if body is None:
+            continue
+        handler_file, records, start, end = body
+
+        sensitive_hits: list[tuple[int, str, str]] = []
+        for rec in records:
+            code = str(rec["code"])
+            if code.strip() == "":
+                continue
+            for token in ep["sensitive"]:
+                if token in code:
+                    sensitive_hits.append((int(rec["line"]), token, str(rec["original"]).strip()))
+                    break
+        if not sensitive_hits:
+            failures.append(f"{handler}: no sensitive operation tokens found to order-check")
+            continue
+
+        first_sensitive = min(sensitive_hits, key=lambda item: item[0])
+        guard, invalid_call = find_authorizing_guard(records, first_sensitive[0])
+        if guard is None:
+            if invalid_call is not None:
+                call_line, reason = invalid_call
+                failures.append(
+                    f"{handler}: {reason} at {display_path(handler_file)}:{call_line}; first sensitive operation "
+                    f"{first_sensitive[1]} line {first_sensitive[0]} ({first_sensitive[2]})"
+                )
+            else:
+                failures.append(
+                    f"{handler}: guarded requireOperator(ctx) not found before first sensitive operation "
+                    f"{first_sensitive[1]} line {first_sensitive[0]} ({first_sensitive[2]}) "
+                    f"inside {display_path(handler_file)}:{start}-{end}"
+                )
+            continue
+
+        guard_line, guard_shape = guard
+        messages.append(
+            f"PASS: {handler}: guarded requireOperator(ctx) line {guard_line} ({guard_shape}) precedes first sensitive operation "
+            f"{first_sensitive[1]} line {first_sensitive[0]}"
+        )
+
+    if failures:
+        return False, failures
+    return True, messages
+
+
 print("SEC-12: Operator drift/release/remediation auth gate")
+print(f"Source root: {display_path(SOURCE_ROOT)}")
 print(f"Routes file: {ROUTES_FILE}")
 print("")
 
-if not ROUTES_FILE.is_file():
-    print(f"FAIL: routes file missing: {ROUTES_FILE}", file=sys.stderr)
-    sys.exit(1)
+ok, output = analyze_source(SOURCE_ROOT, label="source")
+for message in output:
+    stream = sys.stdout if ok else sys.stderr
+    print(("PASS" if ok else "FAIL") + f": source: {message}" if not message.startswith(("PASS:", "FAIL:")) else message, file=stream)
 
-failures: list[str] = []
-route_lines = ROUTES_FILE.read_text(encoding="utf-8").splitlines()
-
-
-def code_lines(lines: list[str]):
-    for idx, line in enumerate(lines, start=1):
-        stripped = line.strip()
-        if stripped.startswith("//") or stripped.startswith("/*") or stripped.startswith("*"):
-            continue
-        yield idx, line
-
-
-def find_function_body(path: Path, handler: str):
-    if not path.is_file():
-        failures.append(f"handler file missing for {handler}: {path}")
-        return None
-    lines = path.read_text(encoding="utf-8").splitlines()
-    start = None
-    pattern = re.compile(rf"^func\s+\([^)]*\)\s+{re.escape(handler)}\s*\(")
-    for idx, line in enumerate(lines, start=1):
-        if pattern.search(line):
-            start = idx
-            break
-    if start is None:
-        failures.append(f"handler function not found: {handler} in {path}")
-        return None
-    end = len(lines) + 1
-    for idx in range(start + 1, len(lines) + 1):
-        if re.match(r"^func\s", lines[idx - 1]):
-            end = idx
-            break
-    return path, lines, start, end
-
-for ep in ENDPOINTS:
-    method = ep["method"]
-    path = ep["path"]
-    handler = ep["handler"]
-    route_re = re.compile(
-        rf'app\.{method}\(\s*"{re.escape(path)}"\s*,\s*s\.{handler}\s*,\s*apptheory\.RequireAuth\(\)\s*\)'
-    )
-    exact_matches = [(idx, line) for idx, line in code_lines(route_lines) if route_re.search(line)]
-    if exact_matches:
-        idx, line = exact_matches[0]
-        print(f"PASS: {method.upper()} {path} line {idx}: expected handler {handler} + RequireAuth()")
-    else:
-        nearby = [
-            f"line {idx}: {line.strip()}"
-            for idx, line in code_lines(route_lines)
-            if f'"{path}"' in line
-        ]
-        detail = "; ".join(nearby) if nearby else "route not found"
-        failures.append(
-            f"{method.upper()} {path}: expected s.{handler} with apptheory.RequireAuth(); found {detail}"
-        )
-
-    body = find_function_body(ep["file"], handler)
-    if body is None:
-        continue
-    handler_file, lines, start, end = body
-    body_code = list(code_lines(lines[start - 1 : end - 1]))
-    # code_lines returns slice-relative line numbers; convert to absolute.
-    body_code = [(start + rel_idx - 1, line) for rel_idx, line in body_code]
-
-    require_lines = [idx for idx, line in body_code if "requireOperator(ctx)" in line]
-    if not require_lines:
-        failures.append(f"{handler}: requireOperator(ctx) not found inside {handler_file}:{start}-{end - 1}")
-        continue
-    require_line = require_lines[0]
-
-    sensitive_hits: list[tuple[int, str, str]] = []
-    for idx, line in body_code:
-        for token in ep["sensitive"]:
-            if token in line:
-                sensitive_hits.append((idx, token, line.strip()))
-                break
-    sensitive_hits = [hit for hit in sensitive_hits if hit[0] != require_line]
-    if not sensitive_hits:
-        failures.append(f"{handler}: no sensitive operation tokens found to order-check")
-        continue
-    first_sensitive = min(sensitive_hits, key=lambda item: item[0])
-    if require_line < first_sensitive[0]:
-        print(
-            f"PASS: {handler}: requireOperator(ctx) line {require_line} precedes first sensitive operation "
-            f"{first_sensitive[1]} line {first_sensitive[0]}"
-        )
-    else:
-        failures.append(
-            f"{handler}: requireOperator(ctx) line {require_line} does not precede first sensitive operation "
-            f"{first_sensitive[1]} line {first_sensitive[0]} ({first_sensitive[2]})"
-        )
-
-print("")
-if failures:
-    for failure in failures:
-        print(f"FAIL: {failure}", file=sys.stderr)
+if not ok:
     print("FAIL: one or more operator endpoints lack auth/role protection", file=sys.stderr)
     sys.exit(1)
 
-print("PASS: all three operator endpoints protected by exact route RequireAuth() + pre-read requireOperator(ctx)")
+if not SKIP_FIXTURES and SOURCE_ROOT == REPO_ROOT and FIXTURE_DIR.is_dir():
+    print("")
+    print("SEC-12 negative fixture regression checks")
+    expected = [
+        ("fail-string-literal-marker", "guarded requireOperator(ctx) not found"),
+        ("fail-inline-comment-marker", "guarded requireOperator(ctx) not found"),
+        ("fail-ignored-error-call", "not in an accepted guarded error-handling form"),
+    ]
+    for name, expected_fragment in expected:
+        fixture_root = FIXTURE_DIR / name
+        fixture_ok, fixture_output = analyze_source(fixture_root, label=name)
+        joined = "\n".join(fixture_output)
+        if fixture_ok:
+            print(f"FAIL: negative fixture {name} unexpectedly passed", file=sys.stderr)
+            for message in fixture_output:
+                print(message, file=sys.stderr)
+            sys.exit(1)
+        if expected_fragment not in joined:
+            print(
+                f"FAIL: negative fixture {name} failed, but did not emit expected evidence fragment: {expected_fragment}",
+                file=sys.stderr,
+            )
+            for message in fixture_output:
+                print(message, file=sys.stderr)
+            sys.exit(1)
+        print(f"PASS: negative fixture {name} failed closed ({expected_fragment})")
+
+print("")
+print("PASS: all three operator endpoints protected by exact route RequireAuth() + guarded pre-read requireOperator(ctx)")
 PY

--- a/gov-infra/verifiers/sec/portal-stack-state-tenant-scoping.sh
+++ b/gov-infra/verifiers/sec/portal-stack-state-tenant-scoping.sh
@@ -43,58 +43,274 @@ if [[ ! -f "${HANDLER_FILE}" ]]; then
   exit 1
 fi
 
-# ── Step 2: requireInstanceAccess must be called ─────────────────────────
-if ! grep -q 'requireInstanceAccess' "${HANDLER_FILE}"; then
-  echo "FAIL: requireInstanceAccess call not found in handler" >&2
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+HANDLER_BODY_FILE="${TMP_DIR}/handlePortalGetInstanceStack.body.go"
+HANDLER_CODE_FILE="${TMP_DIR}/handlePortalGetInstanceStack.body.code.go"
+
+# ── Step 2: Extract only handlePortalGetInstanceStack's body ─────────────
+extract_handler_body() {
+  local source_file="$1"
+  local body_file="$2"
+
+  awk '
+    function strip_go_non_code(line,    i, c, n, out) {
+      out = ""
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+
+        if (block_comment) {
+          if (c == "*" && substr(line, i + 1, 1) == "/") {
+            block_comment = 0
+            i++
+          }
+          continue
+        }
+
+        if (raw_string) {
+          if (c == "`") {
+            raw_string = 0
+          }
+          continue
+        }
+
+        if (double_string) {
+          if (c == "\\") {
+            i++
+            continue
+          }
+          if (c == "\"") {
+            double_string = 0
+          }
+          continue
+        }
+
+        if (rune_literal) {
+          if (c == "\\") {
+            i++
+            continue
+          }
+          if (c == "'\''") {
+            rune_literal = 0
+          }
+          continue
+        }
+
+        if (c == "/" && substr(line, i + 1, 1) == "/") {
+          break
+        }
+        if (c == "/" && substr(line, i + 1, 1) == "*") {
+          block_comment = 1
+          i++
+          continue
+        }
+        if (c == "`") {
+          raw_string = 1
+          continue
+        }
+        if (c == "\"") {
+          double_string = 1
+          continue
+        }
+        if (c == "'\''") {
+          rune_literal = 1
+          continue
+        }
+
+        out = out c
+      }
+      return out
+    }
+
+    function count_char(text, needle,    i, total) {
+      total = 0
+      for (i = 1; i <= length(text); i++) {
+        if (substr(text, i, 1) == needle) {
+          total++
+        }
+      }
+      return total
+    }
+
+    $0 ~ /^func[[:space:]]+\(s \*Server\)[[:space:]]+handlePortalGetInstanceStack[[:space:]]*\(/ {
+      in_handler = 1
+    }
+
+    in_handler {
+      print
+      code = strip_go_non_code($0)
+      opens = count_char(code, "{")
+      closes = count_char(code, "}")
+      if (opens > 0) {
+        opened = 1
+      }
+      depth += opens - closes
+      if (opened && depth == 0) {
+        completed = 1
+        exit
+      }
+    }
+
+    END {
+      if (!in_handler) {
+        print "FAIL: handlePortalGetInstanceStack function not found" > "/dev/stderr"
+        exit 2
+      }
+      if (!completed) {
+        print "FAIL: handlePortalGetInstanceStack closing brace not found" > "/dev/stderr"
+        exit 3
+      }
+    }
+  ' "${source_file}" >"${body_file}"
+}
+
+strip_non_code_lines() {
+  local body_file="$1"
+  local code_file="$2"
+
+  awk '
+    function strip_go_non_code(line,    i, c, n, out) {
+      out = ""
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+
+        if (block_comment) {
+          if (c == "*" && substr(line, i + 1, 1) == "/") {
+            block_comment = 0
+            i++
+          }
+          continue
+        }
+
+        if (raw_string) {
+          if (c == "`") {
+            raw_string = 0
+          }
+          continue
+        }
+
+        if (double_string) {
+          if (c == "\\") {
+            i++
+            continue
+          }
+          if (c == "\"") {
+            double_string = 0
+          }
+          continue
+        }
+
+        if (rune_literal) {
+          if (c == "\\") {
+            i++
+            continue
+          }
+          if (c == "'\''") {
+            rune_literal = 0
+          }
+          continue
+        }
+
+        if (c == "/" && substr(line, i + 1, 1) == "/") {
+          break
+        }
+        if (c == "/" && substr(line, i + 1, 1) == "*") {
+          block_comment = 1
+          i++
+          continue
+        }
+        if (c == "`") {
+          raw_string = 1
+          continue
+        }
+        if (c == "\"") {
+          double_string = 1
+          continue
+        }
+        if (c == "'\''") {
+          rune_literal = 1
+          continue
+        }
+
+        out = out c
+      }
+      return out
+    }
+
+    { print strip_go_non_code($0) }
+  ' "${body_file}" >"${code_file}"
+}
+
+extract_handler_body "${HANDLER_FILE}" "${HANDLER_BODY_FILE}"
+strip_non_code_lines "${HANDLER_BODY_FILE}" "${HANDLER_CODE_FILE}"
+
+echo "Scoped handler body: handlePortalGetInstanceStack ($(wc -l <"${HANDLER_BODY_FILE}") lines)"
+
+# ── Step 3: requireInstanceAccess must be an in-body call ────────────────
+mapfile -t AUTH_LINES < <(grep -nE '(^|[^[:alnum:]_])requireInstanceAccess[[:space:]]*\(' "${HANDLER_CODE_FILE}" | cut -d: -f1)
+if [[ "${#AUTH_LINES[@]}" -eq 0 ]]; then
+  echo "FAIL: requireInstanceAccess call not found in handlePortalGetInstanceStack body" >&2
   exit 1
 fi
 
-# Exclude comment lines (//...) to avoid matching the function-level doc comment.
-AUTH_LINE="$(grep -n 'requireInstanceAccess' "${HANDLER_FILE}" | grep -v '^\s*[0-9]*:\s*//' | head -1 | cut -d: -f1)"
-echo "Ownership check: requireInstanceAccess at line ${AUTH_LINE}"
+AUTH_LINE="${AUTH_LINES[0]}"
+echo "Ownership check: requireInstanceAccess call at handler-body line ${AUTH_LINE}"
+if [[ "${#AUTH_LINES[@]}" -gt 1 ]]; then
+  echo "Additional requireInstanceAccess calls at handler-body lines: ${AUTH_LINES[*]:1}"
+fi
 
-# ── Step 3: Find stack-state DB read calls ───────────────────────────────
+# ── Step 4: Find stack-state DB read calls in the handler body ───────────
 # These are the function calls (not definitions) that perform stack-state
-# database reads. We exclude lines that start with "func" to avoid matching
-# the function definitions themselves, and instead match only the call sites
-# inside handlePortalGetInstanceStack.
+# database reads. Matching uses the comment/string-stripped handler body so
+# mentions outside executable code cannot satisfy the verifier.
 
 # categorizeLatestUpdateJobs queries update jobs via GSI1.
-CAT_LINE="$(grep -n 'categorizeLatestUpdateJobs(' "${HANDLER_FILE}" | grep -v 'func' | head -1 | cut -d: -f1 || true)"
+mapfile -t CAT_LINES < <(grep -nE '(^|[^[:alnum:]_])categorizeLatestUpdateJobs[[:space:]]*\(' "${HANDLER_CODE_FILE}" | cut -d: -f1)
 # loadProvisionJobFallback loads the initial provision job from the store.
-PROV_LINE="$(grep -n 'loadProvisionJobFallback(' "${HANDLER_FILE}" | grep -v 'func' | head -1 | cut -d: -f1 || true)"
+mapfile -t PROV_LINES < <(grep -nE '(^|[^[:alnum:]_])loadProvisionJobFallback[[:space:]]*\(' "${HANDLER_CODE_FILE}" | cut -d: -f1)
 
-# ── Step 4: Emit evidence ────────────────────────────────────────────────
+# ── Step 5: Emit evidence ────────────────────────────────────────────────
 echo ""
 echo "Stack-state read call sites:"
-if [[ -n "${CAT_LINE}" ]]; then
-  echo "  categorizeLatestUpdateJobs call at line ${CAT_LINE}"
+if [[ "${#CAT_LINES[@]}" -gt 0 ]]; then
+  for line in "${CAT_LINES[@]}"; do
+    echo "  categorizeLatestUpdateJobs call at handler-body line ${line}"
+  done
 else
   echo "  categorizeLatestUpdateJobs call: NOT FOUND"
 fi
-if [[ -n "${PROV_LINE}" ]]; then
-  echo "  loadProvisionJobFallback call at line ${PROV_LINE}"
+if [[ "${#PROV_LINES[@]}" -gt 0 ]]; then
+  for line in "${PROV_LINES[@]}"; do
+    echo "  loadProvisionJobFallback call at handler-body line ${line}"
+  done
 else
   echo "  loadProvisionJobFallback call: NOT FOUND"
 fi
 
-if [[ -z "${CAT_LINE}" ]] && [[ -z "${PROV_LINE}" ]]; then
-  echo "FAIL: no stack-state read calls found in handler" >&2
+if [[ "${#CAT_LINES[@]}" -eq 0 ]] && [[ "${#PROV_LINES[@]}" -eq 0 ]]; then
+  echo "FAIL: no stack-state read calls found in handlePortalGetInstanceStack body" >&2
   exit 1
 fi
 
-# ── Step 5: Ownership check must precede all stack-state reads ───────────
+# ── Step 6: Ownership check must precede all stack-state reads ───────────
 FAIL=0
 
-if [[ -n "${CAT_LINE}" ]] && [[ "${CAT_LINE}" -le "${AUTH_LINE}" ]]; then
-  echo "FAIL: categorizeLatestUpdateJobs call (line ${CAT_LINE}) precedes ownership check (line ${AUTH_LINE})" >&2
-  FAIL=1
-fi
+for line in "${CAT_LINES[@]}"; do
+  if [[ "${line}" -le "${AUTH_LINE}" ]]; then
+    echo "FAIL: categorizeLatestUpdateJobs call (handler-body line ${line}) precedes ownership check (handler-body line ${AUTH_LINE})" >&2
+    FAIL=1
+  fi
+done
 
-if [[ -n "${PROV_LINE}" ]] && [[ "${PROV_LINE}" -le "${AUTH_LINE}" ]]; then
-  echo "FAIL: loadProvisionJobFallback call (line ${PROV_LINE}) precedes ownership check (line ${AUTH_LINE})" >&2
-  FAIL=1
-fi
+for line in "${PROV_LINES[@]}"; do
+  if [[ "${line}" -le "${AUTH_LINE}" ]]; then
+    echo "FAIL: loadProvisionJobFallback call (handler-body line ${line}) precedes ownership check (handler-body line ${AUTH_LINE})" >&2
+    FAIL=1
+  fi
+done
 
 if [[ "${FAIL}" -ne 0 ]]; then
   echo ""
@@ -103,4 +319,4 @@ if [[ "${FAIL}" -ne 0 ]]; then
 fi
 
 echo ""
-echo "PASS: ownership check (line ${AUTH_LINE}) precedes all stack-state reads"
+echo "PASS: ownership check (handler-body line ${AUTH_LINE}) precedes all stack-state reads"

--- a/internal/controlplane/handlers_portal_cost_internal_test.go
+++ b/internal/controlplane/handlers_portal_cost_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/costtelemetry"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
@@ -137,8 +138,48 @@ func TestHandlePortalGetInstanceCost_SendsBearerAuthAndMapsDailyRows(t *testing.
 	require.InDelta(t, 0.12, body.Days[0].Entries[0].Cost, 0.000001)
 	require.NotEmpty(t, body.Days[0].Entries[0].Metrics)
 	require.NotContains(t, string(resp.Body), testRawKey)
-	for _, forbidden := range []string{`"account_id"`, `"PK"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
 		require.NotContains(t, string(resp.Body), forbidden)
+	}
+}
+
+func TestPortalCostResponseJSONOmitsCostTelemetrySensitiveFields(t *testing.T) {
+	t.Parallel()
+
+	body := portalCostResponse{
+		InstanceSlug: testCostSlug1,
+		FromDate:     testCostDate1,
+		ToDate:       testCostDate2,
+		Days: []portalCostDayEntry{
+			{
+				Date:     testCostDate1,
+				DayCost:  0.12,
+				Currency: "USD",
+				Entries: []costtelemetry.ReconciledCostEntry{
+					{
+						Date:     testCostDate1,
+						Service:  "Managed Lesser",
+						Cost:     0.12,
+						Currency: "USD",
+						Metrics: []costtelemetry.ServiceAttribution{
+							{Service: "Lambda", MetricName: "Invocations", Stat: "Sum", Unit: "Count", Value: 42},
+						},
+					},
+				},
+			},
+		},
+		Count:     1,
+		TotalCost: 0.12,
+		Currency:  "USD",
+	}
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+	payload := string(raw)
+	require.Contains(t, payload, `"entries"`)
+	require.Contains(t, payload, `"metrics"`)
+	for _, forbidden := range []string{`"account_id"`, `"pk"`, `"PK"`, `"sk"`, `"SK"`, `"ttl"`, `"entries_json"`, `"EntriesJSON"`, `"instance_key"`, `"raw_key"`} {
+		require.NotContains(t, payload, forbidden)
 	}
 }
 


### PR DESCRIPTION
## Project 43 — lesser-host M2 release (dedicated → main)

Milestone **Codex 2026-05-30 M2 — Governance verifier soundness**. Merges the M2 remediation work on `project-43-security-remediation` into `main`. **Release gate: awaiting Aron's approval — do not auto-merge.**

### Included (6/6 merged to dedicated; each GPG-verified, gov-rubric 40/0/0, Arch-reviewed)
| Finding | PR | Summary |
|---|---|---|
| LH-12 | #611 | SEC-8 CloudFront verifier hardening |
| LH-17 | #612 | CMP-4 denylist verifier |
| LH-20 | #613 | DOC-5 T* parity verifier |
| LH-21 | #614 | SEC-11 verifier scoped to handler body |
| LH-23 | #615 | SEC-12 operator-drift auth-gate: rejects inline-comment / string-literal / ignored-error spoofs via Go comment/literal lexing + brace-depth top-level guard ordering |
| LH-25 | #616 | SEC-13 cost-telemetry-redaction: function-body-scoped ordering, transitive ReconciledCostEntry redaction scan, comment-stripped test proof + Go marshal test |

All six belong to the **governance-verifier-soundness cluster**: the verifiers were syntactic/whole-file greps that could false-pass unsafe future changes; each is now function-body-scoped, comment/literal-aware, and backed by negative-control fixtures (`//go:build ignore`) proving the false-pass scenarios are rejected. `gov-verify-rubric.sh` is 40/0/0 on real code.

### CI status on the dedicated branch
Each finding merged with full CI green (gov-rubric 40/0/0, go-test, golangci-lint, cdk-synth, contract-verify, contracts-compile, slither, web-build). A 1-commit `main`→dedicated sync is being applied so this PR merges conflict-free.

### Scope
lesser-host M2 only. M3 (LH-06/09/11/22) and M4 (LH-18/19/26/27/28) will follow as separate release units after this lands on `main` (per release sequencing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
