### PR TITLE
[Project 43] lesser-host M3 — Replay, consent & provisioning integrity (release → main)

### DIFF
--- a/internal/controlplane/audit.go
+++ b/internal/controlplane/audit.go
@@ -24,7 +24,7 @@ func (s *Server) tryWriteAuditLog(ctx *apptheory.Context, entry *models.AuditLog
 	}
 	applyAuditSourceProvenance(ctx, entry)
 
-	s.tryWriteAuditLogWithContext(ctx.Context(), entry)
+	_ = s.tryWriteAuditLogWithContext(ctx.Context(), entry)
 }
 
 func applyAuditSourceProvenance(ctx *apptheory.Context, entry *models.AuditLogEntry) {
@@ -38,20 +38,35 @@ func applyAuditSourceProvenance(ctx *apptheory.Context, entry *models.AuditLogEn
 	entry.SourceValid = source.Valid
 }
 
-func (s *Server) tryWriteAuditLogWithContext(ctx context.Context, entry *models.AuditLogEntry) {
+func (s *Server) tryWriteAuditLogWithContext(ctx context.Context, entry *models.AuditLogEntry) bool {
 	if s == nil || s.store == nil || s.store.DB == nil || entry == nil {
-		return
+		return true
 	}
 
-	_ = entry.UpdateKeys()
-	if err := s.store.DB.WithContext(ctx).Model(entry).Create(); err != nil {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := entry.UpdateKeys(); err != nil {
 		log.Printf(
-			"controlplane: audit log write failed action=%q actor=%q target=%q request_id=%q: %v",
+			"controlplane: audit log write failed audit_persisted=false action=%q actor=%q target=%q request_id=%q: %v",
 			strings.TrimSpace(entry.Action),
 			strings.TrimSpace(entry.Actor),
 			strings.TrimSpace(entry.Target),
 			strings.TrimSpace(entry.RequestID),
 			err,
 		)
+		return false
 	}
+	if err := s.store.DB.WithContext(ctx).Model(entry).Create(); err != nil {
+		log.Printf(
+			"controlplane: audit log write failed audit_persisted=false action=%q actor=%q target=%q request_id=%q: %v",
+			strings.TrimSpace(entry.Action),
+			strings.TrimSpace(entry.Actor),
+			strings.TrimSpace(entry.Target),
+			strings.TrimSpace(entry.RequestID),
+			err,
+		)
+		return false
+	}
+	return true
 }

--- a/internal/controlplane/audit_internal_test.go
+++ b/internal/controlplane/audit_internal_test.go
@@ -1,10 +1,21 @@
 package controlplane
 
 import (
+	"bytes"
+	"context"
+	"errors"
+	"log"
+	"os"
+	"strings"
 	"testing"
+	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
+	"github.com/stretchr/testify/mock"
+
+	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -46,5 +57,54 @@ func TestApplyAuditSourceProvenanceUnknownForHeaderOnlyContext(t *testing.T) {
 
 	if entry.SourceValid || entry.SourceIP != "" || entry.SourceProvider != commMetricUnknown || entry.SourceProvenance != commMetricUnknown {
 		t.Fatalf("expected unknown source fields, got %#v", entry)
+	}
+}
+
+func TestTryWriteAuditLogWithContextSurfacesCreateError(t *testing.T) {
+	db := ttmocks.NewMockExtendedDB()
+	qAudit := new(ttmocks.MockQuery)
+	createErr := errors.New("boom")
+
+	db.On("WithContext", mock.Anything).Return(db).Once()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Once()
+	qAudit.On("Create").Return(createErr).Once()
+
+	s := &Server{store: store.New(db)}
+	entry := &models.AuditLogEntry{
+		Actor:     "alice",
+		Action:    "operator.fleet.remediate_mcp_drift",
+		Target:    "fleet:mcp-remediation:count=1:hash=0123456789abcdef",
+		RequestID: "rid-create-error",
+		CreatedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	var buf bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&buf)
+	t.Cleanup(func() {
+		if previousOutput != nil {
+			log.SetOutput(previousOutput)
+			return
+		}
+		log.SetOutput(os.Stderr)
+	})
+
+	persisted := s.tryWriteAuditLogWithContext(context.Background(), entry)
+	if persisted {
+		t.Fatalf("expected audit_persisted=false for Create error")
+	}
+
+	line := buf.String()
+	for _, want := range []string{
+		"audit_persisted=false",
+		`action="operator.fleet.remediate_mcp_drift"`,
+		`actor="alice"`,
+		`target="fleet:mcp-remediation:count=1:hash=0123456789abcdef"`,
+		`request_id="rid-create-error"`,
+		"boom",
+	} {
+		if !strings.Contains(line, want) {
+			t.Fatalf("expected log to contain %q, got %q", want, line)
+		}
 	}
 }

--- a/internal/controlplane/handlers_operator_endpoints_internal_test.go
+++ b/internal/controlplane/handlers_operator_endpoints_internal_test.go
@@ -1,7 +1,9 @@
 package controlplane
 
 import (
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -145,6 +147,21 @@ func makeInstance(slug, lesserVer, bodyVer string, bodyUpdateAt, mcpWiredAt time
 		McpWiredAt:         mcpWiredAt,
 		UpdatedAt:          bodyUpdateAt,
 	}
+}
+
+func expectedRemediationAuditTarget(slugs []string) string {
+	sum := sha256.Sum256([]byte(strings.Join(slugs, ",")))
+	return fmt.Sprintf("fleet:mcp-remediation:count=%d:hash=%s", len(slugs), fmt.Sprintf("%x", sum)[:16])
+}
+
+func makeMaxLengthFleetAuditInputs(count int) ([]string, []string) {
+	slugs := make([]string, 0, count)
+	jobIDs := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		slugs = append(slugs, fmt.Sprintf("lh22-%058d", i))
+		jobIDs = append(jobIDs, fmt.Sprintf("job%019d", i))
+	}
+	return slugs, jobIDs
 }
 
 func instanceWithProvisionJob(slug, lesserVer, provisionJobID string, updatedAt time.Time) *models.Instance {
@@ -833,11 +850,10 @@ func TestHandleOperatorRemediateMCPDrift_VersionFromDeployedBody(t *testing.T) {
 		"MCP remediation must wire against deployed current_body, not config target v0.4.0")
 }
 
-// TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList is the Blocker 3
-// regression: the audit record must include the affected slug list, not just a
-// count. Pre-rework, the audit Target was "fleet:mcp-remediation:N-slugs";
-// post-rework, it must be "fleet:mcp-remediation:slugs=slug1,slug2;jobs=job1,job2".
-func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
+// TestHandleOperatorRemediateMCPDrift_AuditDetailsIncludeSlugList is the
+// regression: the audit record must keep the full affected slug/job lists in
+// non-key Details while Target stays bounded for DynamoDB PK safety.
+func TestHandleOperatorRemediateMCPDrift_AuditDetailsIncludeSlugList(t *testing.T) {
 	t.Parallel()
 
 	tdb := newOperatorEndpointTestDB()
@@ -963,10 +979,186 @@ func TestHandleOperatorRemediateMCPDrift_AuditIncludesSlugList(t *testing.T) {
 
 	audits := createdAuditLogs(t, tdb)
 	require.Len(t, audits, 1)
-	require.Contains(t, audits[0].Target, "slugs=ws-audit-1,ws-audit-2")
-	require.Contains(t, audits[0].Target, ";jobs=")
+	require.Equal(t, expectedRemediationAuditTarget([]string{"ws-audit-1", "ws-audit-2"}), audits[0].Target)
+	require.NotContains(t, audits[0].Target, "ws-audit-1")
+	require.NotContains(t, audits[0].Target, "ws-audit-2")
+	require.NotContains(t, audits[0].Target, "slugs=")
+	require.NotContains(t, audits[0].Target, ";jobs=")
+	require.Contains(t, audits[0].Details, "slugs=ws-audit-1,ws-audit-2")
+	require.Contains(t, audits[0].Details, ";jobs=")
 	for _, id := range body.CreatedJobIDs {
-		require.Contains(t, audits[0].Target, id)
+		require.Contains(t, audits[0].Details, id)
+	}
+}
+
+func TestEmitRemediationAudit_BoundsTargetAndPreservesLargeDetails(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	slugs, jobIDs := makeMaxLengthFleetAuditInputs(200)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	ctx := operatorAuthenticatedCtx()
+	err := s.emitRemediationAudit(ctx, slugs, jobIDs, now, "alice")
+	require.NoError(t, err)
+	tdb.qAudit.AssertCalled(t, "Create")
+
+	audits := createdAuditLogs(t, tdb)
+	require.Len(t, audits, 1)
+	audit := audits[0]
+	require.Equal(t, expectedRemediationAuditTarget(slugs), audit.Target)
+	require.Equal(t, "slugs="+strings.Join(slugs, ",")+";jobs="+strings.Join(jobIDs, ","), audit.Details)
+	require.Less(t, len(audit.PK), 2048)
+	require.LessOrEqual(t, len(audit.PK), 1024)
+	require.NotContains(t, audit.Target, slugs[0])
+	require.NotContains(t, audit.Target, slugs[len(slugs)-1])
+	require.NotContains(t, audit.Target, jobIDs[0])
+	require.NotContains(t, audit.Target, jobIDs[len(jobIDs)-1])
+}
+
+func TestEmitRemediationAudit_RoundTripByExactTarget(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qAudit := new(ttmocks.MockQuery)
+	slugs := []string{"roundtrip-a", "roundtrip-b"}
+	jobIDs := []string{"job-roundtrip-a", "job-roundtrip-b"}
+	target := expectedRemediationAuditTarget(slugs)
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	var created *models.AuditLogEntry
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(qAudit).Run(func(args mock.Arguments) {
+		entry, ok := args.Get(0).(*models.AuditLogEntry)
+		if !ok || strings.TrimSpace(entry.Action) == "" {
+			return
+		}
+		copyEntry := *entry
+		created = &copyEntry
+	}).Maybe()
+	qAudit.On("Create").Return(nil).Once()
+	qAudit.On("Where", "PK", "=", "AUDIT#"+target).Return(qAudit).Once()
+	qAudit.On("Where", "SK", "BEGINS_WITH", "EVENT#").Return(qAudit).Once()
+	qAudit.On("Limit", 200).Return(qAudit).Once()
+	qAudit.On("All", mock.AnythingOfType("*[]*models.AuditLogEntry")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.AuditLogEntry](t, args, 0)
+		require.NotNil(t, created)
+		*dest = []*models.AuditLogEntry{created}
+	}).Once()
+
+	s := &Server{store: store.New(db)}
+	ctx := operatorAuthenticatedCtx()
+	require.NoError(t, s.emitRemediationAudit(ctx, slugs, jobIDs, now, "alice"))
+
+	items, appErr := s.listOperatorAuditLogEntries(ctx, operatorAuditLogFilters{Target: target, Limit: 200})
+	require.Nil(t, appErr)
+	require.Len(t, items, 1)
+	require.Equal(t, target, items[0].Target)
+	require.Equal(t, "slugs=roundtrip-a,roundtrip-b;jobs=job-roundtrip-a,job-roundtrip-b", items[0].Details)
+}
+
+func TestEmitRemediationAudit_EmptyFleet(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+
+	require.NoError(t, s.emitRemediationAudit(operatorAuthenticatedCtx(), nil, nil, now, "alice"))
+
+	audits := createdAuditLogs(t, tdb)
+	require.Len(t, audits, 1)
+	require.Equal(t, expectedRemediationAuditTarget(nil), audits[0].Target)
+	require.Equal(t, "slugs=;jobs=", audits[0].Details)
+	require.Less(t, len(audits[0].PK), 2048)
+}
+
+func TestHandleOperatorRemediateMCPDrift_LargeFleetPersistsOneAuditRecord(t *testing.T) {
+	t.Parallel()
+
+	tdb := newOperatorEndpointTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{
+		ManagedLesserBodyDefaultVersion: "v0.3.0",
+		ManagedInstanceRoleName:         "ManagedInstanceRole",
+	}}
+
+	now := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	slugs, _ := makeMaxLengthFleetAuditInputs(200)
+	instances := make([]*models.Instance, 0, len(slugs))
+	for _, slug := range slugs {
+		instances = append(instances, &models.Instance{
+			Slug:               slug,
+			Owner:              "alice",
+			Status:             models.InstanceStatusActive,
+			LesserBodyVersion:  "v0.3.0",
+			LesserBodyUpdateAt: now,
+			McpWiredAt:         now,
+			UpdatedAt:          now,
+			HostedAccountID:    "123456789012",
+			HostedRegion:       "us-east-1",
+			HostedBaseDomain:   slug + ".greater.website",
+			LesserVersion:      "v1.4.2",
+		})
+	}
+	tdb.qInstance.On("All", mock.AnythingOfType("*[]*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.Instance](t, args, 0)
+		*dest = instances
+	}).Once()
+
+	for _, slug := range slugs {
+		slug := slug
+		tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+			*dest = []*models.UpdateJob{
+				{
+					ID: "body-" + slug, InstanceSlug: slug, Status: models.UpdateJobStatusOK,
+					BodyOnly: true, LesserBodyVersion: "v0.3.0", UpdatedAt: now.Add(-1 * time.Hour),
+				},
+				{
+					ID: "mcp-" + slug, InstanceSlug: slug, Status: models.UpdateJobStatusOK,
+					MCPOnly: true, LesserBodyVersion: "v0.2.9", UpdatedAt: now.Add(-2 * time.Hour),
+				},
+			}
+		}).Once()
+	}
+	tdb.qUpdate.On("All", mock.AnythingOfType("*[]*models.UpdateJob")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.UpdateJob](t, args, 0)
+		*dest = []*models.UpdateJob{}
+	}).Once()
+
+	for _, slug := range slugs {
+		slug := slug
+		tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+			dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+			*dest = models.Instance{
+				Slug: slug, Owner: "alice", Status: models.InstanceStatusActive,
+				LesserBodyVersion: "v0.3.0", HostedAccountID: "123456789012",
+				HostedRegion: "us-east-1", HostedBaseDomain: slug + ".greater.website",
+				LesserHostInstanceKeySecretARN: "", LesserVersion: "v1.4.2",
+			}
+		}).Once()
+	}
+
+	ctx := operatorAuthenticatedCtx()
+	resp, err := s.handleOperatorRemediateMCPDrift(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 200, resp.Status)
+
+	var body remediateMCPDriftResponse
+	require.NoError(t, json.Unmarshal(resp.Body, &body))
+	require.Len(t, body.CreatedJobIDs, len(slugs))
+	require.Equal(t, len(slugs), body.Created)
+	require.Equal(t, 0, body.Skipped)
+	tdb.qAudit.AssertNumberOfCalls(t, "Create", 1)
+
+	audits := createdAuditLogs(t, tdb)
+	require.Len(t, audits, 1)
+	require.Equal(t, expectedRemediationAuditTarget(slugs), audits[0].Target)
+	require.Contains(t, audits[0].Details, "slugs="+strings.Join(slugs, ","))
+	require.Contains(t, audits[0].Details, ";jobs=")
+	for _, id := range body.CreatedJobIDs {
+		require.Contains(t, audits[0].Details, id)
 	}
 }
 

--- a/internal/controlplane/handlers_operator_remediate_mcp.go
+++ b/internal/controlplane/handlers_operator_remediate_mcp.go
@@ -1,6 +1,8 @@
 package controlplane
 
 import (
+	"context"
+	"crypto/sha256"
 	"fmt"
 	"net/http"
 	"strings"
@@ -98,7 +100,9 @@ func (s *Server) handleOperatorRemediateMCPDrift(ctx *apptheory.Context) (*appth
 
 	// Emit operator audit event AFTER remediation so we can include the
 	// affected slug list and created job IDs.
-	s.emitRemediationAudit(ctx, remediatedSlugs, createdJobIDs, now, actor)
+	if auditErr := s.emitRemediationAudit(ctx, remediatedSlugs, createdJobIDs, now, actor); auditErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to persist remediation audit log"}
+	}
 
 	return apptheory.JSON(http.StatusOK, remediateMCPDriftResponse{
 		CreatedJobIDs: createdJobIDs,
@@ -223,35 +227,54 @@ func (s *Server) createRemediationMCPJob(
 	return job, nil
 }
 
-// emitRemediationAudit writes an operator audit event for MCP remediation.
-// The audit record includes the affected slug list and created job IDs using
-// existing AuditLogEntry fields — no tenant content or secrets are logged.
+// emitRemediationAudit writes an operator audit event for MCP remediation after
+// remediation finishes. The key-bearing Target is bounded and deterministic;
+// the full affected slug list and created job IDs are carried in Details.
 func (s *Server) emitRemediationAudit(
 	ctx *apptheory.Context,
 	slugs []string,
 	jobIDs []string,
 	now time.Time,
 	actor string,
-) {
+) error {
 	if s == nil || s.store == nil || s.store.DB == nil {
-		return
+		return nil
 	}
 
-	target := fmt.Sprintf("fleet:mcp-remediation:%d-slugs", len(slugs))
-	if len(slugs) > 0 {
-		target = fmt.Sprintf("fleet:mcp-remediation:slugs=%s", strings.Join(slugs, ","))
-	}
-	if len(jobIDs) > 0 {
-		target += fmt.Sprintf(";jobs=%s", strings.Join(jobIDs, ","))
+	joinedSlugs := strings.Join(slugs, ",")
+	sum := sha256.Sum256([]byte(joinedSlugs))
+	hash := fmt.Sprintf("%x", sum)[:16]
+	target := fmt.Sprintf("fleet:mcp-remediation:count=%d:hash=%s", len(slugs), hash)
+	details := fmt.Sprintf("slugs=%s;jobs=%s", joinedSlugs, strings.Join(jobIDs, ","))
+
+	requestID := ""
+	if ctx != nil {
+		requestID = strings.TrimSpace(ctx.RequestID)
 	}
 
 	audit := &models.AuditLogEntry{
 		Actor:     actor,
 		Action:    "operator.fleet.remediate_mcp_drift",
 		Target:    target,
-		RequestID: strings.TrimSpace(ctx.RequestID),
+		Details:   details,
+		RequestID: requestID,
 		CreatedAt: now,
 	}
-	_ = audit.UpdateKeys()
-	s.tryWriteAuditLog(ctx, audit)
+	if strings.TrimSpace(audit.Actor) == "" && ctx != nil {
+		audit.Actor = strings.TrimSpace(ctx.AuthIdentity)
+	}
+	if strings.TrimSpace(audit.RequestID) == "" && ctx != nil {
+		audit.RequestID = strings.TrimSpace(ctx.RequestID)
+	}
+	if ctx != nil {
+		applyAuditSourceProvenance(ctx, audit)
+		if s.tryWriteAuditLogWithContext(ctx.Context(), audit) {
+			return nil
+		}
+		return fmt.Errorf("remediation audit log was not persisted")
+	}
+	if s.tryWriteAuditLogWithContext(context.Background(), audit) {
+		return nil
+	}
+	return fmt.Errorf("remediation audit log was not persisted")
 }

--- a/internal/controlplane/handlers_soul_lifecycle.go
+++ b/internal/controlplane/handlers_soul_lifecycle.go
@@ -59,6 +59,10 @@ const (
 	soulContinuitySummaryArchived           = "Archived"
 	soulContinuitySummarySuccessionDeclared = "Succession declared"
 	soulContinuitySummarySuccessionReceived = "Succession received"
+
+	soulLifecycleChallengeTTL                       = 5 * time.Minute
+	soulLifecycleChallengePurposeArchiveAgent       = "archive_agent"
+	soulLifecycleChallengePurposeDesignateSuccessor = "designate_successor"
 )
 
 // --- Handlers ---
@@ -104,6 +108,11 @@ func (s *Server) handleSoulArchiveAgentBegin(ctx *apptheory.Context) (*apptheory
 
 	digest, appErr := computeSoulContinuityEntryDigest(models.SoulContinuityEntryTypeArchived, timestamp, summary, "", references, continuityNonce)
 	if appErr != nil {
+		return nil, appErr
+	}
+
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", now)
+	if appErr := s.persistSoulLifecycleChallenge(ctx, challenge); appErr != nil {
 		return nil, appErr
 	}
 
@@ -153,6 +162,10 @@ func (s *Server) handleSoulArchiveAgent(ctx *apptheory.Context) (*apptheory.Resp
 	}
 
 	now := time.Now().UTC()
+	challenge, appErr := s.loadSoulLifecycleChallenge(ctx, agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", now)
+	if appErr != nil {
+		return nil, appErr
+	}
 
 	// Verify archive continuity signature (EIP-191 over keccak256(JCS(unsignedEntry))).
 	continuitySummary, continuityRefs := soulArchiveContinuityPayload(agentIDHex)
@@ -192,13 +205,14 @@ func (s *Server) handleSoulArchiveAgent(ctx *apptheory.Context) (*apptheory.Resp
 	_ = audit.UpdateKeys()
 
 	if err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+		tx.Delete(challenge, tabletheory.IfExists(), tabletheory.Condition("TTL", ">", now.Unix()))
 		tx.Update(identity, []string{"Status", "LifecycleStatus", "LifecycleReason", "UpdatedAt"}, tabletheory.IfExists())
 		tx.Create(continuity)
 		tx.Put(audit)
 		return nil
 	}); err != nil {
 		if theoryErrors.IsConditionFailed(err) {
-			return nil, &apptheory.AppError{Code: "app.not_found", Message: "agent not found"}
+			return nil, invalidSoulLifecycleChallengeError()
 		}
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to archive agent"}
 	}
@@ -242,8 +256,13 @@ func (s *Server) handleSoulDesignateSuccessorBegin(ctx *apptheory.Context) (*app
 	if nonceErr != nil {
 		return nil, nonceErr
 	}
-	beginResp, appErr := buildSoulDesignateSuccessorBeginResponse(agentIDHex, successorIDHex, canonicalSoulSignedTimestamp(time.Now().UTC()), continuityNonce)
+	now := time.Now().UTC()
+	beginResp, appErr := buildSoulDesignateSuccessorBeginResponse(agentIDHex, successorIDHex, canonicalSoulSignedTimestamp(now), continuityNonce)
 	if appErr != nil {
+		return nil, appErr
+	}
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeDesignateSuccessor, successorIDHex, now)
+	if appErr := s.persistSoulLifecycleChallenge(ctx, challenge); appErr != nil {
 		return nil, appErr
 	}
 	return apptheory.JSON(http.StatusOK, beginResp)
@@ -280,28 +299,20 @@ func (s *Server) handleSoulDesignateSuccessor(ctx *apptheory.Context) (*apptheor
 		return nil, appErr
 	}
 
+	now := time.Now().UTC()
+	challenge, appErr := s.loadSoulLifecycleChallenge(ctx, agentIDHex, continuityNonce, soulLifecycleChallengePurposeDesignateSuccessor, successorIDHex, now)
+	if appErr != nil {
+		return nil, appErr
+	}
+
 	successorIdentity, appErr := s.loadSoulActiveSuccessorIdentity(ctx, identity, agentIDHex, successorIDHex)
 	if appErr != nil {
 		return nil, appErr
 	}
 
-	now := time.Now().UTC()
-
 	declaredSummary, declaredRefs, receivedSummary, receivedRefs := soulSuccessionContinuityPayloads(agentIDHex, successorIDHex)
-	declaredDigest, appErr := computeSoulContinuityEntryDigest(models.SoulContinuityEntryTypeSuccessionDeclared, timestampCanonical, declaredSummary, "", declaredRefs, continuityNonce)
-	if appErr != nil {
+	if appErr := verifySoulDesignateSuccessorContinuitySignatures(identity.Wallet, successorIdentity.Wallet, timestampCanonical, continuityNonce, declaredSummary, declaredRefs, receivedSummary, receivedRefs, predSig, succSig); appErr != nil {
 		return nil, appErr
-	}
-	if sigErr := verifyEthereumSignatureBytesNonMalleable(identity.Wallet, declaredDigest, predSig); sigErr != nil {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid predecessor continuity signature"}
-	}
-
-	receivedDigest, appErr := computeSoulContinuityEntryDigest(models.SoulContinuityEntryTypeSuccessionReceived, timestampCanonical, receivedSummary, "", receivedRefs, continuityNonce)
-	if appErr != nil {
-		return nil, appErr
-	}
-	if sigErr := verifyEthereumSignatureBytesNonMalleable(successorIdentity.Wallet, receivedDigest, succSig); sigErr != nil {
-		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "invalid successor continuity signature"}
 	}
 
 	identity.Status = models.SoulAgentStatusSucceeded
@@ -346,6 +357,7 @@ func (s *Server) handleSoulDesignateSuccessor(ctx *apptheory.Context) (*apptheor
 	_ = audit.UpdateKeys()
 
 	if err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+		tx.Delete(challenge, tabletheory.IfExists(), tabletheory.Condition("TTL", ">", now.Unix()))
 		tx.Update(identity, []string{"Status", "LifecycleStatus", "LifecycleReason", "SuccessorAgentID", "UpdatedAt"}, tabletheory.IfExists())
 		tx.Update(successorIdentity, []string{"PredecessorAgentID", "UpdatedAt"}, tabletheory.IfExists())
 		tx.Create(predContinuity)
@@ -354,7 +366,7 @@ func (s *Server) handleSoulDesignateSuccessor(ctx *apptheory.Context) (*apptheor
 		return nil
 	}); err != nil {
 		if theoryErrors.IsConditionFailed(err) {
-			return nil, &apptheory.AppError{Code: "app.not_found", Message: "agent not found"}
+			return nil, invalidSoulLifecycleChallengeError()
 		}
 		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to designate successor"}
 	}
@@ -386,6 +398,122 @@ func validateSoulLifecycleMutableStatus(identity *models.SoulAgentIdentity, acti
 		return nil
 	}
 	return &apptheory.AppError{Code: "app.conflict", Message: fmt.Sprintf("only active or self-suspended agents can %s", strings.TrimSpace(action))}
+}
+
+func verifySoulDesignateSuccessorContinuitySignatures(predecessorWallet string, successorWallet string, timestampCanonical string, continuityNonce string, declaredSummary string, declaredRefs []string, receivedSummary string, receivedRefs []string, predSig string, succSig string) *apptheory.AppError {
+	declaredDigest, appErr := computeSoulContinuityEntryDigest(models.SoulContinuityEntryTypeSuccessionDeclared, timestampCanonical, declaredSummary, "", declaredRefs, continuityNonce)
+	if appErr != nil {
+		return appErr
+	}
+	if sigErr := verifyEthereumSignatureBytesNonMalleable(predecessorWallet, declaredDigest, predSig); sigErr != nil {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid predecessor continuity signature"}
+	}
+
+	receivedDigest, appErr := computeSoulContinuityEntryDigest(models.SoulContinuityEntryTypeSuccessionReceived, timestampCanonical, receivedSummary, "", receivedRefs, continuityNonce)
+	if appErr != nil {
+		return appErr
+	}
+	if sigErr := verifyEthereumSignatureBytesNonMalleable(successorWallet, receivedDigest, succSig); sigErr != nil {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "invalid successor continuity signature"}
+	}
+	return nil
+}
+
+func newSoulLifecycleChallenge(agentIDHex string, nonce string, purpose string, successorIDHex string, now time.Time) *models.SoulLifecycleChallenge {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	challenge := &models.SoulLifecycleChallenge{
+		AgentID:          agentIDHex,
+		Nonce:            nonce,
+		Purpose:          purpose,
+		SuccessorAgentID: successorIDHex,
+		IssuedAt:         now.UTC(),
+		ExpiresAt:        now.UTC().Add(soulLifecycleChallengeTTL),
+	}
+	_ = challenge.UpdateKeys()
+	return challenge
+}
+
+func (s *Server) persistSoulLifecycleChallenge(ctx *apptheory.Context, challenge *models.SoulLifecycleChallenge) *apptheory.AppError {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil || challenge == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+		tx.Create(challenge)
+		return nil
+	}); err != nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to issue lifecycle challenge"}
+	}
+	return nil
+}
+
+func (s *Server) loadSoulLifecycleChallenge(ctx *apptheory.Context, agentIDHex string, nonce string, purpose string, successorIDHex string, now time.Time) (*models.SoulLifecycleChallenge, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	agentIDHex = strings.ToLower(strings.TrimSpace(agentIDHex))
+	nonce = strings.TrimSpace(nonce)
+	if agentIDHex == "" || nonce == "" {
+		return nil, invalidSoulLifecycleChallengeError()
+	}
+
+	key := &models.SoulLifecycleChallenge{
+		AgentID: agentIDHex,
+		Nonce:   nonce,
+	}
+	_ = key.UpdateKeys()
+
+	var challenge models.SoulLifecycleChallenge
+	err := s.store.DB.WithContext(ctx.Context()).
+		Model(&models.SoulLifecycleChallenge{}).
+		Where("PK", "=", key.PK).
+		Where("SK", "=", key.SK).
+		ConsistentRead().
+		Limit(1).
+		First(&challenge)
+	if theoryErrors.IsNotFound(err) {
+		return nil, invalidSoulLifecycleChallengeError()
+	}
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to load lifecycle challenge"}
+	}
+	if appErr := validateSoulLifecycleChallenge(&challenge, agentIDHex, nonce, purpose, successorIDHex, now); appErr != nil {
+		return nil, appErr
+	}
+	return &challenge, nil
+}
+
+func validateSoulLifecycleChallenge(challenge *models.SoulLifecycleChallenge, agentIDHex string, nonce string, purpose string, successorIDHex string, now time.Time) *apptheory.AppError {
+	if challenge == nil {
+		return invalidSoulLifecycleChallengeError()
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	agentIDHex = strings.ToLower(strings.TrimSpace(agentIDHex))
+	nonce = strings.TrimSpace(nonce)
+	purpose = strings.ToLower(strings.TrimSpace(purpose))
+	successorIDHex = strings.ToLower(strings.TrimSpace(successorIDHex))
+
+	if strings.ToLower(strings.TrimSpace(challenge.AgentID)) != agentIDHex ||
+		strings.TrimSpace(challenge.Nonce) != nonce ||
+		strings.ToLower(strings.TrimSpace(challenge.Purpose)) != purpose {
+		return invalidSoulLifecycleChallengeError()
+	}
+	if purpose == soulLifecycleChallengePurposeDesignateSuccessor &&
+		strings.ToLower(strings.TrimSpace(challenge.SuccessorAgentID)) != successorIDHex {
+		return invalidSoulLifecycleChallengeError()
+	}
+	if challenge.ExpiresAt.IsZero() || !now.Before(challenge.ExpiresAt.UTC()) {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "continuity_nonce expired"}
+	}
+	_ = challenge.UpdateKeys()
+	return nil
+}
+
+func invalidSoulLifecycleChallengeError() *apptheory.AppError {
+	return &apptheory.AppError{Code: "app.bad_request", Message: "invalid continuity_nonce"}
 }
 
 func parseSoulArchiveRequestBody(ctx *apptheory.Context) (reason string, parsedTS time.Time, timestampCanonical string, sig string, continuityNonce string, appErr *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_lifecycle_begin_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_begin_more_internal_test.go
@@ -25,6 +25,7 @@ func TestHandleSoulArchiveAgentBegin_MorePaths(t *testing.T) {
 		t.Parallel()
 
 		tdb := newSoulLifecycleTestDB()
+		expectSoulLifecycleChallengeCreate(t, tdb, agentIDHex, soulLifecycleChallengePurposeArchiveAgent, "")
 		s := &Server{
 			store: store.New(tdb.db),
 			cfg: config.Config{
@@ -130,6 +131,7 @@ func TestHandleSoulDesignateSuccessorBegin_MorePaths(t *testing.T) {
 		t.Parallel()
 
 		tdb := newSoulLifecycleTestDB()
+		expectSoulLifecycleChallengeCreate(t, tdb, agentIDHex, soulLifecycleChallengePurposeDesignateSuccessor, successorIDHex)
 		s := &Server{
 			store: store.New(tdb.db),
 			cfg: config.Config{

--- a/internal/controlplane/handlers_soul_lifecycle_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_internal_test.go
@@ -127,6 +127,7 @@ type soulLifecycleTestDB struct {
 	qChannelIdx *ttmocks.MockQuery
 	qENS        *ttmocks.MockQuery
 	qContinuity *ttmocks.MockQuery
+	qChallenge  *ttmocks.MockQuery
 	qDispute    *ttmocks.MockQuery
 }
 
@@ -152,6 +153,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 	qChannelTypeIdx := new(ttmocks.MockQuery)
 	qENSResolution := new(ttmocks.MockQuery)
 	qContinuity := new(ttmocks.MockQuery)
+	qChallenge := new(ttmocks.MockQuery)
 	qDispute := new(ttmocks.MockQuery)
 
 	db.On("WithContext", mock.Anything).Return(db).Maybe()
@@ -175,6 +177,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 	db.On("Model", mock.AnythingOfType("*models.SoulChannelAgentIndex")).Return(qChannelTypeIdx).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(qENSResolution).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentContinuity")).Return(qContinuity).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.SoulLifecycleChallenge")).Return(qChallenge).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentDispute")).Return(qDispute).Maybe()
 
 	for _, q := range []*ttmocks.MockQuery{
@@ -198,11 +201,13 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 		qChannelTypeIdx,
 		qENSResolution,
 		qContinuity,
+		qChallenge,
 		qDispute,
 	} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Index", mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()
+		q.On("ConsistentRead").Return(q).Maybe()
 		q.On("Cursor", mock.Anything).Return(q).Maybe()
 		q.On("OrderBy", mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("IfExists").Return(q).Maybe()
@@ -237,6 +242,7 @@ func newSoulLifecycleTestDB() soulLifecycleTestDB {
 		qChannelIdx: qChannelTypeIdx,
 		qENS:        qENSResolution,
 		qContinuity: qContinuity,
+		qChallenge:  qChallenge,
 		qDispute:    qDispute,
 	}
 }

--- a/internal/controlplane/handlers_soul_lifecycle_transitions_internal_test.go
+++ b/internal/controlplane/handlers_soul_lifecycle_transitions_internal_test.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"crypto/ecdsa"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -12,6 +13,8 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
 	"github.com/stretchr/testify/mock"
@@ -39,6 +42,8 @@ func TestHandleSoulArchiveAgent_ArchivesAndWritesAudit(t *testing.T) {
 
 	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	continuityNonce := "test-archive-nonce"
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", time.Now().UTC())
+	expectSoulLifecycleChallengeLookup(t, tdb, challenge)
 	digest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeArchived,
 		timestamp,
@@ -56,6 +61,7 @@ func TestHandleSoulArchiveAgent_ArchivesAndWritesAudit(t *testing.T) {
 	}
 	sigHex := "0x" + hex.EncodeToString(sig)
 
+	expectSoulLifecycleChallengeDelete(t, tb, agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "")
 	expectArchiveIdentityUpdate(t, tb)
 	expectArchiveContinuityCreate(t, tb, agentIDHex, sigHex, timestamp)
 	tb.On("Put", mock.Anything, mock.Anything).Return(tb).Once()
@@ -112,6 +118,8 @@ func TestHandleSoulDesignateSuccessor_SucceedsAndCreatesEntries(t *testing.T) {
 
 	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	continuityNonce := "test-succession-nonce"
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeDesignateSuccessor, successorIDHex, time.Now().UTC())
+	expectSoulLifecycleChallengeLookup(t, tdb, challenge)
 	declaredDigest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeSuccessionDeclared,
 		timestamp,
@@ -146,6 +154,7 @@ func TestHandleSoulDesignateSuccessor_SucceedsAndCreatesEntries(t *testing.T) {
 	}
 	receivedSigHex := "0x" + hex.EncodeToString(receivedSigBytes)
 
+	expectSoulLifecycleChallengeDelete(t, tb, agentIDHex, continuityNonce, soulLifecycleChallengePurposeDesignateSuccessor, successorIDHex)
 	expectSuccessorUpdates(t, tb, agentIDHex, successorIDHex)
 	createKinds := expectSuccessorContinuityCreates(t, tb, agentIDHex, successorIDHex, declaredSigHex, receivedSigHex, timestamp)
 
@@ -191,6 +200,110 @@ func prepareSoulLifecycleTransitionServer(t *testing.T, tdb soulLifecycleTestDB)
 	tdb.db.TransactWriteBuilder = tb
 	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 	return tb
+}
+
+func expectSoulLifecycleChallengeLookup(t *testing.T, tdb soulLifecycleTestDB, challenge *models.SoulLifecycleChallenge) {
+	t.Helper()
+	tdb.qChallenge.On("First", mock.AnythingOfType("*models.SoulLifecycleChallenge")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulLifecycleChallenge](t, args, 0)
+		*dest = *challenge
+	}).Once()
+}
+
+func expectSoulLifecycleChallengeNotFound(tdb soulLifecycleTestDB) {
+	tdb.qChallenge.On("First", mock.AnythingOfType("*models.SoulLifecycleChallenge")).Return(theoryErrors.ErrItemNotFound).Once()
+}
+
+func expectSoulLifecycleChallengeCreate(t *testing.T, tdb soulLifecycleTestDB, agentIDHex string, purpose string, successorIDHex string) *ttmocks.MockTransactionBuilder {
+	t.Helper()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tdb.db.TransactWriteBuilder = tb
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("Create", mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		challenge := testutil.RequireMockArg[*models.SoulLifecycleChallenge](t, args, 0)
+		if challenge.AgentID != strings.ToLower(strings.TrimSpace(agentIDHex)) {
+			t.Fatalf("expected challenge agent id %q, got %q", strings.ToLower(strings.TrimSpace(agentIDHex)), challenge.AgentID)
+		}
+		if challenge.Purpose != strings.ToLower(strings.TrimSpace(purpose)) {
+			t.Fatalf("expected challenge purpose %q, got %q", strings.ToLower(strings.TrimSpace(purpose)), challenge.Purpose)
+		}
+		if challenge.SuccessorAgentID != strings.ToLower(strings.TrimSpace(successorIDHex)) {
+			t.Fatalf("expected challenge successor %q, got %q", strings.ToLower(strings.TrimSpace(successorIDHex)), challenge.SuccessorAgentID)
+		}
+		if strings.TrimSpace(challenge.Nonce) == "" {
+			t.Fatalf("expected issued nonce")
+		}
+		if challenge.ExpiresAt.Sub(challenge.IssuedAt) != soulLifecycleChallengeTTL {
+			t.Fatalf("expected ttl %s, got %s", soulLifecycleChallengeTTL, challenge.ExpiresAt.Sub(challenge.IssuedAt))
+		}
+	})
+	return tb
+}
+
+func expectSoulLifecycleChallengeDelete(t *testing.T, tb *ttmocks.MockTransactionBuilder, agentIDHex string, nonce string, purpose string, successorIDHex string) {
+	t.Helper()
+	tb.On("Delete", mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		challenge := testutil.RequireMockArg[*models.SoulLifecycleChallenge](t, args, 0)
+		if challenge.AgentID != strings.ToLower(strings.TrimSpace(agentIDHex)) {
+			t.Fatalf("expected challenge agent id %q, got %q", strings.ToLower(strings.TrimSpace(agentIDHex)), challenge.AgentID)
+		}
+		if challenge.Nonce != strings.TrimSpace(nonce) {
+			t.Fatalf("expected challenge nonce %q, got %q", strings.TrimSpace(nonce), challenge.Nonce)
+		}
+		if challenge.Purpose != strings.ToLower(strings.TrimSpace(purpose)) {
+			t.Fatalf("expected challenge purpose %q, got %q", strings.ToLower(strings.TrimSpace(purpose)), challenge.Purpose)
+		}
+		if challenge.SuccessorAgentID != strings.ToLower(strings.TrimSpace(successorIDHex)) {
+			t.Fatalf("expected challenge successor %q, got %q", strings.ToLower(strings.TrimSpace(successorIDHex)), challenge.SuccessorAgentID)
+		}
+
+		conditions, ok := args.Get(1).([]core.TransactCondition)
+		if !ok {
+			t.Fatalf("expected transactional delete conditions, got %T", args.Get(1))
+		}
+		if len(conditions) != 2 {
+			t.Fatalf("expected IfExists + TTL conditions, got %#v", conditions)
+		}
+		if conditions[0].Kind != core.TransactConditionKindPrimaryKeyExists {
+			t.Fatalf("expected primary-key-exists condition, got %#v", conditions[0])
+		}
+		if conditions[1].Kind != core.TransactConditionKindField || conditions[1].Field != "TTL" || conditions[1].Operator != ">" {
+			t.Fatalf("expected TTL freshness condition, got %#v", conditions[1])
+		}
+	})
+}
+
+func signSoulArchiveContinuityForTest(t *testing.T, privateKey *ecdsa.PrivateKey, agentIDHex string, timestamp string, continuityNonce string) string {
+	t.Helper()
+	digest, appErr := computeSoulContinuityEntryDigest(
+		models.SoulContinuityEntryTypeArchived,
+		timestamp,
+		"Archived",
+		"",
+		[]string{"agent:" + agentIDHex},
+		continuityNonce,
+	)
+	if appErr != nil {
+		t.Fatalf("digest: %v", appErr)
+	}
+	sig, sigErr := crypto.Sign(accounts.TextHash(digest), privateKey)
+	if sigErr != nil {
+		t.Fatalf("sign: %v", sigErr)
+	}
+	return "0x" + hex.EncodeToString(sig)
+}
+
+func newSoulArchiveCompletionContext(agentIDHex string, timestamp string, sigHex string, continuityNonce string) *apptheory.Context {
+	ctx := &apptheory.Context{
+		RequestID:    "r-lh06",
+		AuthIdentity: "alice",
+		Params:       map[string]string{"agentId": agentIDHex},
+		Request: apptheory.Request{
+			Body: []byte(`{"reason":"done","timestamp":"` + timestamp + `","signature":"` + sigHex + `","continuity_nonce":"` + continuityNonce + `"}`),
+		},
+	}
+	ctx.Set(ctxKeyOperatorRole, models.RoleOperator)
+	return ctx
 }
 
 func seedSoulLifecycleTransitionAccess(t *testing.T, tdb soulLifecycleTestDB, agentIDHex string, wallet string) {
@@ -475,6 +588,8 @@ func TestHandleSoulArchiveAgent_TransactionFailureReturnsInternalError(t *testin
 
 	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
 	continuityNonce := "test-archive-nonce-2"
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", time.Now().UTC())
+	expectSoulLifecycleChallengeLookup(t, tdb, challenge)
 	digest, appErr := computeSoulContinuityEntryDigest(
 		models.SoulContinuityEntryTypeArchived,
 		timestamp,
@@ -512,6 +627,124 @@ func TestHandleSoulArchiveAgent_TransactionFailureReturnsInternalError(t *testin
 	}
 	if appErr.Code != appErrCodeInternal {
 		t.Fatalf("expected %s, got %s", appErrCodeInternal, appErr.Code)
+	}
+}
+
+func TestHandleSoulArchiveAgent_RejectsConsumedNonceReplay(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+	tb := prepareSoulLifecycleTransitionServer(t, tdb)
+
+	agentIDHex := soulLifecycleTestAgentIDHex
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
+	continuityNonce := "replayed-archive-nonce"
+	sigHex := signSoulArchiveContinuityForTest(t, key, agentIDHex, timestamp, continuityNonce)
+
+	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, wallet)
+	challenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", time.Now().UTC())
+	expectSoulLifecycleChallengeLookup(t, tdb, challenge)
+	expectSoulLifecycleChallengeDelete(t, tb, agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "")
+	expectArchiveIdentityUpdate(t, tb)
+	expectArchiveContinuityCreate(t, tb, agentIDHex, sigHex, timestamp)
+	tb.On("Put", mock.Anything, mock.Anything).Return(tb).Once()
+
+	firstCtx := newSoulArchiveCompletionContext(agentIDHex, timestamp, sigHex, continuityNonce)
+	resp, callErr := newSoulLifecycleTransitionServer(tdb).handleSoulArchiveAgent(firstCtx)
+	if callErr != nil {
+		t.Fatalf("first archive completion unexpected err: %v", callErr)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected first completion 200, got %d", resp.Status)
+	}
+
+	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, wallet)
+	expectSoulLifecycleChallengeNotFound(tdb)
+
+	secondCtx := newSoulArchiveCompletionContext(agentIDHex, timestamp, sigHex, continuityNonce)
+	_, callErr = newSoulLifecycleTransitionServer(tdb).handleSoulArchiveAgent(secondCtx)
+	if callErr == nil {
+		t.Fatalf("expected replayed continuity_nonce to be rejected")
+	}
+	appErr, ok := callErr.(*apptheory.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", callErr)
+	}
+	if appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected %s, got %s", appErrCodeBadRequest, appErr.Code)
+	}
+}
+
+func TestHandleSoulArchiveAgent_RejectsUnknownNonce(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+
+	agentIDHex := soulLifecycleTestAgentIDHex
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
+	continuityNonce := "never-issued-archive-nonce"
+	sigHex := signSoulArchiveContinuityForTest(t, key, agentIDHex, timestamp, continuityNonce)
+
+	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, wallet)
+	expectSoulLifecycleChallengeNotFound(tdb)
+
+	ctx := newSoulArchiveCompletionContext(agentIDHex, timestamp, sigHex, continuityNonce)
+	_, callErr := newSoulLifecycleTransitionServer(tdb).handleSoulArchiveAgent(ctx)
+	if callErr == nil {
+		t.Fatalf("expected unknown continuity_nonce to be rejected")
+	}
+	appErr, ok := callErr.(*apptheory.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", callErr)
+	}
+	if appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected %s, got %s", appErrCodeBadRequest, appErr.Code)
+	}
+}
+
+func TestHandleSoulArchiveAgent_RejectsExpiredNonce(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	key, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	wallet := strings.ToLower(crypto.PubkeyToAddress(key.PublicKey).Hex())
+
+	agentIDHex := soulLifecycleTestAgentIDHex
+	timestamp := canonicalSoulSignedTimestamp(time.Now().Add(-time.Minute).UTC())
+	continuityNonce := "expired-archive-nonce"
+	sigHex := signSoulArchiveContinuityForTest(t, key, agentIDHex, timestamp, continuityNonce)
+
+	seedSoulLifecycleTransitionAccess(t, tdb, agentIDHex, wallet)
+	expiredChallenge := newSoulLifecycleChallenge(agentIDHex, continuityNonce, soulLifecycleChallengePurposeArchiveAgent, "", time.Now().Add(-10*time.Minute).UTC())
+	expectSoulLifecycleChallengeLookup(t, tdb, expiredChallenge)
+
+	ctx := newSoulArchiveCompletionContext(agentIDHex, timestamp, sigHex, continuityNonce)
+	_, callErr := newSoulLifecycleTransitionServer(tdb).handleSoulArchiveAgent(ctx)
+	if callErr == nil {
+		t.Fatalf("expected expired continuity_nonce to be rejected")
+	}
+	appErr, ok := callErr.(*apptheory.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", callErr)
+	}
+	if appErr.Code != appErrCodeBadRequest {
+		t.Fatalf("expected %s, got %s", appErrCodeBadRequest, appErr.Code)
+	}
+	if !strings.Contains(appErr.Message, "expired") {
+		t.Fatalf("expected expired nonce message, got %q", appErr.Message)
 	}
 }
 

--- a/internal/provisionworker/deploy_start_consent_persistence_internal_test.go
+++ b/internal/provisionworker/deploy_start_consent_persistence_internal_test.go
@@ -1,0 +1,300 @@
+package provisionworker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+	cbtypes "github.com/aws/aws-sdk-go-v2/service/codebuild/types"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/store"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+const (
+	deployStartConsentTestMessage   = `{"slug":"slug","expires_at":"2026-06-01T00:00:00Z"}`
+	deployStartConsentTestSignature = "0xconsent"
+)
+
+func TestAdvanceProvisionDeployStart_ConsentRetryAndReroutePersistsStripPlaintextOnly(t *testing.T) {
+	now := time.Unix(1_000, 0).UTC()
+	message := deployStartConsentTestMessage
+	signature := deployStartConsentTestSignature
+	keyHex, encrypted := encryptedProvisionConsent(t, message, signature)
+
+	t.Run("load_instance_error_retry", func(t *testing.T) {
+		st, db := newConsentPersistTestStore()
+		mockBranchInstanceLookup(t, db, nil, errors.New("boom"))
+		builder := expectProvisionJobPersist(t, db)
+		srv := consentPersistDeployStartServer(st, keyHex, nil)
+		job := deployStartConsentJob(encrypted, now)
+		job.MaxAttempts = 3
+
+		delay, done, err := srv.advanceProvisionDeployStart(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Positive(t, delay)
+		require.Equal(t, int64(1), job.Attempts)
+
+		assertPersistedConsentPlaintextClearedEncryptedPreserved(t, builder, encrypted)
+	})
+
+	t.Run("instance_config_reroute", func(t *testing.T) {
+		st, db := newConsentPersistTestStore()
+		mockBranchInstanceLookup(t, db, deployStartConsentInstance(""), nil)
+		builder := expectProvisionJobPersist(t, db)
+		srv := consentPersistDeployStartServer(st, keyHex, nil)
+		job := deployStartConsentJob(encrypted, now)
+
+		delay, done, err := srv.advanceProvisionDeployStart(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Zero(t, delay)
+		require.Equal(t, provisionStepInstanceConfig, job.Step)
+
+		assertPersistedConsentPlaintextClearedEncryptedPreserved(t, builder, encrypted)
+	})
+
+	t.Run("deploy_start_error_retry", func(t *testing.T) {
+		st, db := newConsentPersistTestStore()
+		mockBranchInstanceLookup(t, db, deployStartConsentInstance("arn:aws:secretsmanager:us-east-1:123456789012:secret:test"), nil)
+		builder := expectProvisionJobPersist(t, db)
+		cb := &fakeCodebuild{startErr: errors.New("codebuild unavailable")}
+		srv := consentPersistDeployStartServer(st, keyHex, cb)
+		job := deployStartConsentJob(encrypted, now)
+		job.MaxAttempts = 3
+
+		delay, done, err := srv.advanceProvisionDeployStart(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Positive(t, delay)
+		require.Equal(t, int64(1), job.Attempts)
+		require.Len(t, cb.startInputs, 1)
+		assertStartBuildConsentEnv(t, cb.startInputs[0], message, signature)
+
+		assertPersistedConsentPlaintextClearedEncryptedPreserved(t, builder, encrypted)
+	})
+}
+
+func TestAdvanceProvisionDeployStart_ConsentTerminalFailuresClearAllArtifacts(t *testing.T) {
+	now := time.Unix(2_000, 0).UTC()
+	message := deployStartConsentTestMessage
+	signature := deployStartConsentTestSignature
+	keyHex, encrypted := encryptedProvisionConsent(t, message, signature)
+
+	t.Run("instance_not_found", func(t *testing.T) {
+		st, db := newConsentPersistTestStore()
+		mockBranchInstanceLookup(t, db, nil, theoryErrors.ErrItemNotFound)
+		builder := expectProvisionJobPersist(t, db)
+		srv := consentPersistDeployStartServer(st, keyHex, nil)
+		job := deployStartConsentJob(encrypted, now)
+
+		delay, done, err := srv.advanceProvisionDeployStart(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Zero(t, delay)
+		require.Equal(t, models.ProvisionJobStatusError, job.Status)
+		require.Equal(t, "instance_not_found", job.ErrorCode)
+
+		assertPersistedConsentArtifactsCleared(t, builder)
+	})
+
+	t.Run("deploy_start_failed_at_max_attempts", func(t *testing.T) {
+		st, db := newConsentPersistTestStore()
+		mockBranchInstanceLookup(t, db, deployStartConsentInstance("arn:aws:secretsmanager:us-east-1:123456789012:secret:test"), nil)
+		builder := expectProvisionJobPersist(t, db)
+		cb := &fakeCodebuild{startErr: errors.New("codebuild unavailable")}
+		srv := consentPersistDeployStartServer(st, keyHex, cb)
+		job := deployStartConsentJob(encrypted, now)
+		job.MaxAttempts = 2
+		job.Attempts = 1
+
+		delay, done, err := srv.advanceProvisionDeployStart(context.Background(), job, "req", now)
+		require.NoError(t, err)
+		require.False(t, done)
+		require.Zero(t, delay)
+		require.Equal(t, models.ProvisionJobStatusError, job.Status)
+		require.Equal(t, "deploy_start_failed", job.ErrorCode)
+		require.Len(t, cb.startInputs, 1)
+		assertStartBuildConsentEnv(t, cb.startInputs[0], message, signature)
+
+		assertPersistedConsentArtifactsCleared(t, builder)
+	})
+}
+
+func TestAdvanceProvisionDeployStart_RetryPreservesEncryptedConsentForRedecrypt(t *testing.T) {
+	now := time.Unix(3_000, 0).UTC()
+	message := deployStartConsentTestMessage
+	signature := deployStartConsentTestSignature
+	keyHex, encrypted := encryptedProvisionConsent(t, message, signature)
+	job := deployStartConsentJob(encrypted, now)
+	job.MaxAttempts = 3
+
+	retryStore, retryDB := newConsentPersistTestStore()
+	mockBranchInstanceLookup(t, retryDB, nil, errors.New("temporary instance lookup failure"))
+	retryBuilder := expectProvisionJobPersist(t, retryDB)
+	retrySrv := consentPersistDeployStartServer(retryStore, keyHex, nil)
+
+	delay, done, err := retrySrv.advanceProvisionDeployStart(context.Background(), job, "req-retry", now)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Positive(t, delay)
+	assertPersistedConsentPlaintextClearedEncryptedPreserved(t, retryBuilder, encrypted)
+	require.Empty(t, job.ConsentMessage)
+	require.Empty(t, job.ConsentSignature)
+	require.Equal(t, encrypted, job.ConsentEncrypted)
+
+	successStore, successDB := newConsentPersistTestStore()
+	mockBranchInstanceLookup(t, successDB, deployStartConsentInstance("arn:aws:secretsmanager:us-east-1:123456789012:secret:test"), nil)
+	successBuilder := expectProvisionJobPersist(t, successDB)
+	cb := &fakeCodebuild{startOut: &codebuild.StartBuildOutput{Build: &cbtypes.Build{Id: aws.String("run-success")}}}
+	successSrv := consentPersistDeployStartServer(successStore, keyHex, cb)
+
+	delay, done, err = successSrv.advanceProvisionDeployStart(context.Background(), job, "req-success", now.Add(time.Second))
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, provisionDefaultPollDelay, delay)
+	require.Equal(t, "run-success", job.RunID)
+	require.Len(t, cb.startInputs, 1)
+	assertStartBuildConsentEnv(t, cb.startInputs[0], message, signature)
+	assertPersistedConsentArtifactsCleared(t, successBuilder)
+}
+
+func encryptedProvisionConsent(t *testing.T, message string, signature string) (string, string) {
+	t.Helper()
+
+	key := generateTestKey(t)
+	packed, err := PackConsent(message, signature)
+	require.NoError(t, err)
+	encrypted, err := EncryptConsent(string(packed), key)
+	require.NoError(t, err)
+	return hex.EncodeToString(key), encrypted
+}
+
+func deployStartConsentJob(encrypted string, now time.Time) *models.ProvisionJob {
+	return &models.ProvisionJob{
+		ID:                 "job-1",
+		InstanceSlug:       "slug",
+		Status:             models.ProvisionJobStatusRunning,
+		Step:               provisionStepDeployStart,
+		MaxAttempts:        2,
+		AccountID:          "123456789012",
+		AccountRoleName:    "lesser-host-instance",
+		Region:             "us-east-1",
+		BaseDomain:         "slug.example.com",
+		Stage:              "lab",
+		LesserVersion:      "v1.2.6",
+		AdminUsername:      "admin",
+		AdminWalletAddr:    "0x0000000000000000000000000000000000000003",
+		AdminWalletChainID: 1,
+		ConsentEncrypted:   encrypted,
+		ConsentExpiresAt:   now.Add(time.Hour),
+		CreatedAt:          now.Add(-time.Minute),
+		UpdatedAt:          now.Add(-time.Minute),
+		ExpiresAt:          now.Add(time.Hour),
+	}
+}
+
+func deployStartConsentInstance(secretARN string) *models.Instance {
+	return &models.Instance{
+		Slug:                           "slug",
+		HostedAccountID:                "123456789012",
+		HostedRegion:                   "us-east-1",
+		HostedBaseDomain:               "slug.example.com",
+		LesserHostInstanceKeySecretARN: secretARN,
+		LesserHostBaseURL:              "https://lab.lesser.host",
+		LesserHostAttestationsURL:      "https://lab.lesser.host",
+	}
+}
+
+func consentPersistDeployStartServer(st *store.Store, keyHex string, cb *fakeCodebuild) *Server {
+	return &Server{
+		cfg: config.Config{
+			Stage:                                   "lab",
+			WebAuthnRPID:                            "lesser.host",
+			ManagedProvisionConsentEncryptionKeyHex: keyHex,
+			ManagedProvisionRunnerProjectName:       "proj",
+			ManagedLesserGitHubOwner:                "equaltoai",
+			ManagedLesserGitHubRepo:                 "lesser",
+			ManagedLesserBodyGitHubOwner:            "equaltoai",
+			ManagedLesserBodyGitHubRepo:             "lesser-body",
+			ManagedLesserBodyDefaultVersion:         "v0.2.3",
+			ManagedInstanceRoleName:                 "lesser-host-instance",
+			ArtifactBucketName:                      "bucket",
+		},
+		store: st,
+		cb:    cb,
+	}
+}
+
+func newConsentPersistTestStore() (*store.Store, *ttmocks.MockExtendedDB) {
+	db := ttmocks.NewMockExtendedDBStrict()
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	return store.New(db), db
+}
+
+func expectProvisionJobPersist(t *testing.T, db *ttmocks.MockExtendedDB) *recordingTransactionBuilder {
+	t.Helper()
+
+	builder := &recordingTransactionBuilder{}
+	db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once().Run(func(args mock.Arguments) {
+		fn := testutil.RequireMockArg[func(core.TransactionBuilder) error](t, args, 1)
+		require.NoError(t, fn(builder))
+	})
+	return builder
+}
+
+func assertPersistedConsentPlaintextClearedEncryptedPreserved(t *testing.T, builder *recordingTransactionBuilder, encrypted string) {
+	t.Helper()
+
+	persisted := persistedProvisionJob(t, builder)
+	require.Empty(t, persisted.ConsentMessage)
+	require.Empty(t, persisted.ConsentSignature)
+	require.Equal(t, encrypted, persisted.ConsentEncrypted)
+}
+
+func assertPersistedConsentArtifactsCleared(t *testing.T, builder *recordingTransactionBuilder) {
+	t.Helper()
+
+	persisted := persistedProvisionJob(t, builder)
+	require.Empty(t, persisted.ConsentMessage)
+	require.Empty(t, persisted.ConsentSignature)
+	require.Empty(t, persisted.ConsentEncrypted)
+}
+
+func persistedProvisionJob(t *testing.T, builder *recordingTransactionBuilder) *models.ProvisionJob {
+	t.Helper()
+
+	for _, model := range builder.putModels {
+		if job, ok := model.(*models.ProvisionJob); ok && job != nil {
+			return job
+		}
+	}
+	t.Fatalf("expected a persisted ProvisionJob, got %#v", builder.putModels)
+	return nil
+}
+
+func assertStartBuildConsentEnv(t *testing.T, in *codebuild.StartBuildInput, message string, signature string) {
+	t.Helper()
+
+	env := map[string]string{}
+	for _, item := range in.EnvironmentVariablesOverride {
+		env[aws.ToString(item.Name)] = aws.ToString(item.Value)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(env["CONSENT_MESSAGE_B64"])
+	require.NoError(t, err)
+	require.Equal(t, message, string(decoded))
+	require.Equal(t, signature, env["CONSENT_SIGNATURE"])
+}

--- a/internal/provisionworker/server.go
+++ b/internal/provisionworker/server.go
@@ -511,6 +511,7 @@ func (s *Server) failJob(ctx context.Context, job *models.ProvisionJob, requestI
 	job.ErrorMessage = strings.TrimSpace(msg)
 	job.RequestID = strings.TrimSpace(requestID)
 	job.UpdatedAt = now
+	clearProvisionJobConsentArtifacts(job)
 	_ = job.UpdateKeys()
 
 	updateInst := &models.Instance{Slug: strings.TrimSpace(job.InstanceSlug)}
@@ -1646,13 +1647,20 @@ func clearProvisionJobConsentArtifacts(job *models.ProvisionJob) {
 	if job == nil {
 		return
 	}
+	clearProvisionJobConsentPlaintext(job)
+	job.ConsentEncrypted = ""
+}
+
+func clearProvisionJobConsentPlaintext(job *models.ProvisionJob) {
+	if job == nil {
+		return
+	}
 	if strings.TrimSpace(job.ConsentMessageHash) == "" && job.ConsentMessage != "" {
 		sum := sha256.Sum256([]byte(job.ConsentMessage))
 		job.ConsentMessageHash = hex.EncodeToString(sum[:])
 	}
 	job.ConsentMessage = ""
 	job.ConsentSignature = ""
-	job.ConsentEncrypted = ""
 }
 
 func (s *Server) advanceProvisionDeployWait(ctx context.Context, job *models.ProvisionJob, requestID string, now time.Time) (time.Duration, bool, error) {
@@ -1946,6 +1954,7 @@ func (s *Server) persistJobAndInstance(ctx context.Context, job *models.Provisio
 
 	job.RequestID = strings.TrimSpace(requestID)
 	job.UpdatedAt = now
+	clearProvisionJobConsentPlaintext(job)
 	_ = job.UpdateKeys()
 
 	return s.persistModelAndInstance(ctx, job, strings.TrimSpace(job.InstanceSlug), instanceUpdate)

--- a/internal/provisionworker/update_jobs_concurrency_internal_test.go
+++ b/internal/provisionworker/update_jobs_concurrency_internal_test.go
@@ -23,6 +23,7 @@ import (
 
 type recordingTransactionBuilder struct {
 	putCount               int
+	putModels              []any
 	updateWithBuilderCalls []recordingUpdateWithBuilderCall
 }
 
@@ -33,8 +34,14 @@ type recordingUpdateWithBuilderCall struct {
 
 const updateJobUpdatedAtField = "UpdatedAt"
 
-func (r *recordingTransactionBuilder) Put(_ any, _ ...core.TransactCondition) core.TransactionBuilder {
+func (r *recordingTransactionBuilder) Put(model any, _ ...core.TransactCondition) core.TransactionBuilder {
 	r.putCount++
+	if job, ok := model.(*models.ProvisionJob); ok && job != nil {
+		jobCopy := *job
+		r.putModels = append(r.putModels, &jobCopy)
+		return r
+	}
+	r.putModels = append(r.putModels, model)
 	return r
 }
 

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -75,6 +75,7 @@ func LambdaInit() (DB, error) {
 		&models.SoulAgentValidationChallenge{},
 		&models.SoulAgentPromotionLifecycleEvent{},
 		&models.SoulAgentContinuity{},
+		&models.SoulLifecycleChallenge{},
 		&models.SoulAgentMintConversation{},
 		&models.SoulAgentValidationRecord{},
 		&models.SoulCommMessageStatus{},

--- a/internal/store/models/audit_log_entry.go
+++ b/internal/store/models/audit_log_entry.go
@@ -6,6 +6,8 @@ import (
 	"time"
 )
 
+const auditLogPartitionKeyMaxBytes = 1024
+
 // AuditLogEntry records an operator action for auditing.
 type AuditLogEntry struct {
 	_ struct{} `theorydb:"naming:camelCase"`
@@ -17,6 +19,7 @@ type AuditLogEntry struct {
 	Actor     string    `theorydb:"attr:actor" json:"actor"`
 	Action    string    `theorydb:"attr:action" json:"action"`
 	Target    string    `theorydb:"attr:target" json:"target"`
+	Details   string    `theorydb:"attr:details,omitempty" json:"details,omitempty"`
 	RequestID string    `theorydb:"attr:requestID" json:"request_id"`
 	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
 
@@ -50,7 +53,12 @@ func (a *AuditLogEntry) UpdateKeys() error {
 		a.ID = fmt.Sprintf("%d", createdAt.UnixNano())
 	}
 	target := strings.TrimSpace(a.Target)
-	a.PK = fmt.Sprintf("AUDIT#%s", target)
+	pk := fmt.Sprintf("AUDIT#%s", target)
+	if len(pk) > auditLogPartitionKeyMaxBytes {
+		a.PK = ""
+		return fmt.Errorf("audit log target too long: partition key length %d exceeds %d bytes", len(pk), auditLogPartitionKeyMaxBytes)
+	}
+	a.PK = pk
 	a.SK = fmt.Sprintf("EVENT#%s#%s", createdAt.Format(time.RFC3339Nano), a.ID)
 	return nil
 }

--- a/internal/store/models/audit_log_entry_internal_test.go
+++ b/internal/store/models/audit_log_entry_internal_test.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAuditLogEntryUpdateKeysRejectsOversizedTarget(t *testing.T) {
+	entry := &AuditLogEntry{
+		Target:    strings.Repeat("x", auditLogPartitionKeyMaxBytes),
+		CreatedAt: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC),
+	}
+
+	err := entry.UpdateKeys()
+	if err == nil {
+		t.Fatalf("expected oversized target error")
+	}
+	if entry.PK != "" {
+		t.Fatalf("oversized target must not emit a PK, got %q", entry.PK)
+	}
+	if strings.Contains(entry.PK, strings.Repeat("x", 64)) {
+		t.Fatalf("oversized target leaked into PK: %q", entry.PK)
+	}
+}

--- a/internal/store/models/contracts_more_test.go
+++ b/internal/store/models/contracts_more_test.go
@@ -43,6 +43,7 @@ func TestModelContracts_TableNameAndKeyAccessors(t *testing.T) {
 		User{},
 		ProvisionJob{},
 		RenderArtifact{},
+		SoulLifecycleChallenge{},
 		SetupSession{},
 		SoulCommSendIdempotency{},
 		SoulX402InvocationGrant{},
@@ -110,6 +111,18 @@ func TestModelContracts_TableNameAndKeyAccessors(t *testing.T) {
 	require.NoError(t, ra.BeforeCreate())
 	require.NotEmpty(t, ra.GetPK())
 	require.NotEmpty(t, ra.GetSK())
+
+	lifecycleChallenge := &SoulLifecycleChallenge{
+		AgentID:   " 0xABC ",
+		Nonce:     " lifecycle-nonce ",
+		Purpose:   " Archive_Agent ",
+		IssuedAt:  time.Now().UTC(),
+		ExpiresAt: time.Now().Add(5 * time.Minute).UTC(),
+	}
+	require.NoError(t, lifecycleChallenge.BeforeCreate())
+	require.Equal(t, "SOUL#AGENT#0xabc", lifecycleChallenge.GetPK())
+	require.Equal(t, "LIFECYCLE_CHALLENGE#lifecycle-nonce", lifecycleChallenge.GetSK())
+	require.Equal(t, lifecycleChallenge.ExpiresAt.Unix(), lifecycleChallenge.TTL)
 
 	x402Grant := &SoulX402InvocationGrant{
 		GrantID:                         "x402-grant-id",

--- a/internal/store/models/soul_lifecycle_challenge.go
+++ b/internal/store/models/soul_lifecycle_challenge.go
@@ -1,0 +1,72 @@
+package models
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+// SoulLifecycleChallenge stores a short-lived, single-use lifecycle nonce issued
+// by archive/successor begin endpoints.
+type SoulLifecycleChallenge struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	AgentID          string    `theorydb:"attr:agentId" json:"agent_id"`
+	Nonce            string    `theorydb:"attr:nonce" json:"nonce"`
+	Purpose          string    `theorydb:"attr:purpose" json:"purpose"`
+	SuccessorAgentID string    `theorydb:"attr:successorAgentId" json:"successor_agent_id,omitempty"`
+	IssuedAt         time.Time `theorydb:"attr:issuedAt" json:"issued_at"`
+	ExpiresAt        time.Time `theorydb:"attr:expiresAt" json:"expires_at"`
+}
+
+// TableName returns the database table name for SoulLifecycleChallenge.
+func (SoulLifecycleChallenge) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating SoulLifecycleChallenge.
+func (c *SoulLifecycleChallenge) BeforeCreate() error {
+	if c.IssuedAt.IsZero() {
+		c.IssuedAt = time.Now().UTC()
+	}
+	if c.ExpiresAt.IsZero() {
+		c.ExpiresAt = c.IssuedAt.Add(5 * time.Minute)
+	}
+	if err := c.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", c.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("nonce", c.Nonce); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("purpose", c.Purpose); err != nil {
+		return err
+	}
+	return nil
+}
+
+// UpdateKeys updates the database keys and TTL for SoulLifecycleChallenge.
+func (c *SoulLifecycleChallenge) UpdateKeys() error {
+	c.AgentID = strings.ToLower(strings.TrimSpace(c.AgentID))
+	c.Nonce = strings.TrimSpace(c.Nonce)
+	c.Purpose = strings.ToLower(strings.TrimSpace(c.Purpose))
+	c.SuccessorAgentID = strings.ToLower(strings.TrimSpace(c.SuccessorAgentID))
+	c.IssuedAt = c.IssuedAt.UTC()
+	c.ExpiresAt = c.ExpiresAt.UTC()
+	c.PK = fmt.Sprintf("SOUL#AGENT#%s", c.AgentID)
+	c.SK = fmt.Sprintf("LIFECYCLE_CHALLENGE#%s", c.Nonce)
+	if !c.ExpiresAt.IsZero() {
+		c.TTL = c.ExpiresAt.Unix()
+	}
+	return nil
+}
+
+// GetPK returns the partition key for SoulLifecycleChallenge.
+func (c *SoulLifecycleChallenge) GetPK() string { return c.PK }
+
+// GetSK returns the sort key for SoulLifecycleChallenge.
+func (c *SoulLifecycleChallenge) GetSK() string { return c.SK }

--- a/scripts/soul-email-m2-migration/main.go
+++ b/scripts/soul-email-m2-migration/main.go
@@ -53,9 +53,9 @@ var (
 
 // errMigaduMailboxAlreadyExists is a sentinel returned by defaultMigaduCreateMailbox
 // when the Migadu API responds with HTTP 409 Conflict, meaning a mailbox with the
-// same local part already exists. The caller should treat this as a non-fatal
-// signal: the mailbox exists (possibly from a prior migration run) and forwarding
-// may still be created or already be in place.
+// same local part already exists. Callers must treat this as a fail-closed error:
+// without a verified ownership/state read, the migration must not add forwarding
+// to a mailbox it did not create.
 var errMigaduMailboxAlreadyExists = errors.New("migadu mailbox already exists")
 
 type migrationConfig struct {
@@ -689,7 +689,7 @@ func (defaultMigaduClient) EnsureMailboxAndForwarding(ctx context.Context, input
 	if input.DisplayName == "" {
 		input.DisplayName = input.LocalPart
 	}
-	if err := defaultMigaduCreateMailbox(ctx, creds, input.LocalPart, input.DisplayName, password); err != nil && !errors.Is(err, errMigaduMailboxAlreadyExists) {
+	if err := defaultMigaduCreateMailbox(ctx, creds, input.LocalPart, input.DisplayName, password); err != nil {
 		return err
 	}
 	return defaultMigaduCreateForwarding(ctx, creds, input.LocalPart, input.ForwardingAddress)

--- a/scripts/soul-email-m2-migration/main_test.go
+++ b/scripts/soul-email-m2-migration/main_test.go
@@ -420,11 +420,9 @@ func TestDefaultMigaduClientEnsuresMailboxAndForwarding(t *testing.T) {
 	}
 }
 
-func TestDefaultMigaduClient_MailboxAlreadyExistsProceedsToForwarding(t *testing.T) {
-	// CSR-008: When Migadu returns 409 Conflict on mailbox creation, the
-	// migration must not fail; it must proceed to create the forwarding
-	// (which is the essential operation) and complete successfully.
-	server := newMigaduConflictMailboxTestServer(t)
+func TestDefaultMigaduClientMailboxConflictFailsClosedWithoutForwarding(t *testing.T) {
+	var paths []string
+	server := newMigaduConflictMailboxTestServer(t, &paths)
 	defer server.Close()
 
 	oldCredsLoader := migaduCredsLoader
@@ -450,19 +448,26 @@ func TestDefaultMigaduClient_MailboxAlreadyExistsProceedsToForwarding(t *testing
 		LocalPart:         testNewLocalPart,
 		ForwardingAddress: testForwardingAddr,
 	})
-	if err != nil {
-		t.Fatalf("expected mailbox-already-exists to be non-fatal, got: %v", err)
+	if !errors.Is(err, errMigaduMailboxAlreadyExists) {
+		t.Fatalf("expected mailbox conflict to fail closed, got: %v", err)
+	}
+	got := strings.Join(paths, ",")
+	if got != "POST "+testMailboxesPath {
+		t.Fatalf("expected mailbox POST only and no forwarding POST on 409, got %q", got)
 	}
 }
 
-func newMigaduConflictMailboxTestServer(t *testing.T) *httptest.Server {
+func newMigaduConflictMailboxTestServer(t *testing.T, paths *[]string) *httptest.Server {
 	t.Helper()
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		*paths = append(*paths, r.Method+" "+r.URL.Path)
+		assertMigaduTestAuth(t, r)
 		switch r.URL.Path {
 		case testMailboxesPath:
+			assertMigaduMailboxRequest(t, r)
 			w.WriteHeader(http.StatusConflict)
 		case "/domains/lessersoul.ai/mailboxes/" + testNewLocalPart + "/forwardings":
-			w.WriteHeader(http.StatusCreated)
+			t.Fatalf("forwarding POST must not be issued after unverified mailbox conflict")
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}


### PR DESCRIPTION
## Project 43 — lesser-host M3 release (dedicated → main)

Milestone **Codex 2026-05-30 M3 — Replay, consent & provisioning integrity**. Merges the M3 remediation work on `project-43-security-remediation` into `main`. **Release gate: awaiting Aron's approval — do not auto-merge.**

Branch is **8 ahead / 0 behind main** (clean linear ancestry — conflict-free; no sync needed). M2 was already released to main (#617); M3 accumulated on top after a fast-forward.

### Included (4/4 merged to dedicated; each GPG-verified, gov-rubric 40/0/0, full CI green, Arch Tier-1 reviewed)
| Finding | Sev | PR | Summary |
|---|---|---|---|
| LH-06 | MED | #618 | Lifecycle signature replay: continuity nonce is now a single-use server-issued challenge (SoulLifecycleChallenge persisted at /begin, atomically consumed via conditional delete in the SAME TransactWrite as the status mutation) |
| LH-09 | MED | #619 | Provisioning consent re-persisted as plaintext on error paths: clearProvisionJobConsentPlaintext chokepoint in persistJobAndInstance strips plaintext on every worker persist while PRESERVING ConsentEncrypted for retry; failJob clears all three (retry-safe) |
| LH-11 | MED | #620 | Migadu mailbox 409 accepted before forwarding: fail closed on mailbox-create 409, matching the canonical deps_migadu.go policy |
| LH-22 | LOW | #621 | Bulk MCP remediation audit-PK overflow: bounded count/hash Target (shaped in emitRemediationAudit), full lists in non-key Details, verbatim AUDIT#<target> + length guard, audit-write failure surfaced (no silent 200) |

### Closeout verification (Arch, Tier-1, on dedicated HEAD `1b05aab2`)
- All 4 fix commits are ancestors of the dedicated branch (LH-06 a7bceed, LH-09 a043b89, LH-11 97fe60d, LH-22 33802f8).
- Tree-wide conflict-marker scan: **clean**.
- 8 ahead / 0 behind main → linear ancestry, no merge divergence to mis-resolve.
- LH-06 atomicity, LH-09 retry-safety, and LH-22 read/write-PK-symmetry were each Tier-1 verified in their PR diffs (the LH-22 fix-locus + symmetry constraint came from an Arch pre-flight that corrected the finding's own suggested approach).

### Scope
lesser-host M3 only. M4 findings (LH-18/19/26/27/28) can be scheduled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
