### PR TITLE
feat(soul): enforce managed handle ENS names

### DIFF
--- a/docs/adr/0007-hosted-identity-and-ens-invariants.md
+++ b/docs/adr/0007-hosted-identity-and-ens-invariants.md
@@ -123,9 +123,8 @@ Findings:
 - `docs/ens-offchain-resolver.md` describes the resolver contract and current mainnet-oriented deployment shape. Later
   Project 44 resolver/runbook work must extend it for the lab Sepolia and live mainnet split; M0 intentionally performs
   no deploy or resolver mutation.
-- `docs/contracts/openapi.yaml` and v3 fixtures still contain legacy bare ENS examples such as
-  `agent-bob.lessersoul.eth`. Later implementation milestones must update public schema examples and generated
-  consumers when the canonical instance-scoped form is implemented.
+- Project 44 M2 updates the v3 fixture examples to the canonical instance-scoped managed ENS form. Any remaining bare
+  `lessersoul.eth` examples are legacy, resolver-specific, or non-managed fixtures unless called out separately.
 
 No behavior changes are made by this audit.
 

--- a/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
+++ b/docs/spec/v3/fixtures/communication-inbound-notification.sms.example.json
@@ -4,7 +4,7 @@
   "from": {
     "number": "+15550142",
     "soulAgentId": "0x1111111111111111111111111111111111111111111111111111111111111111",
-    "displayName": "agent-alice.lessersoul.eth"
+    "displayName": "agent-alice.simulacrum.lessersoul.eth"
   },
   "to": {
     "address": "agent-bob.simulacrum@lessersoul.ai",

--- a/docs/spec/v3/fixtures/soul-agent-channels.response.example.json
+++ b/docs/spec/v3/fixtures/soul-agent-channels.response.example.json
@@ -2,7 +2,7 @@
   "agentId": "0x2222222222222222222222222222222222222222222222222222222222222222",
   "channels": {
     "ens": {
-      "name": "agent-bob.lessersoul.eth",
+      "name": "agent-bob.simulacrum.lessersoul.eth",
       "resolverAddress": "0x1111111111111111111111111111111111111111",
       "chain": "mainnet"
     },
@@ -44,4 +44,3 @@
   },
   "updatedAt": "2026-03-04T12:00:00Z"
 }
-

--- a/internal/controlplane/handlers_portal_auth.go
+++ b/internal/controlplane/handlers_portal_auth.go
@@ -11,6 +11,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -265,6 +266,12 @@ func (s *Server) ensurePortalWalletUser(
 	displayName string,
 	now time.Time,
 ) (models.User, error) {
+	normalizedUsername, err := soul.ValidateManagedHandle(username)
+	if err != nil || normalizedUsername == "" {
+		return models.User{}, &apptheory.AppError{Code: "app.bad_request", Message: "username is invalid"}
+	}
+	username = normalizedUsername
+
 	user, found, err := s.getUserProfile(ctx, username)
 	if err != nil {
 		return models.User{}, err

--- a/internal/controlplane/handlers_provisioning_consent.go
+++ b/internal/controlplane/handlers_provisioning_consent.go
@@ -12,6 +12,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -60,14 +61,14 @@ func normalizeControlPlaneStage(stage string) string {
 
 func normalizeProvisionAdminUsername(slug, adminUsername string) (string, *apptheory.AppError) {
 	slug = strings.ToLower(strings.TrimSpace(slug))
-	adminUsername = strings.ToLower(strings.TrimSpace(adminUsername))
-	if adminUsername == "" {
+	if strings.TrimSpace(adminUsername) == "" {
 		adminUsername = slug
 	}
-	if adminUsername == "" || !instanceSlugRE.MatchString(adminUsername) {
+	normalized, err := soul.ValidateManagedHandle(adminUsername)
+	if err != nil || normalized == "" {
 		return "", &apptheory.AppError{Code: "app.bad_request", Message: "invalid admin_username"}
 	}
-	return adminUsername, nil
+	return normalized, nil
 }
 
 func normalizeLinkedWalletAddress(cred *models.WalletCredential) (string, *apptheory.AppError) {

--- a/internal/controlplane/handlers_provisioning_consent_internal_test.go
+++ b/internal/controlplane/handlers_provisioning_consent_internal_test.go
@@ -118,6 +118,39 @@ func TestManagedProvisionBaseDomain_NormalizesInput(t *testing.T) {
 	}
 }
 
+func TestNormalizeProvisionAdminUsername_UsesManagedHandleGrammar(t *testing.T) {
+	t.Parallel()
+
+	got, appErr := normalizeProvisionAdminUsername(testCostSlug1, "")
+	if appErr != nil || got != testCostSlug1 {
+		t.Fatalf("expected slug default, got %q appErr=%v", got, appErr)
+	}
+	got, appErr = normalizeProvisionAdminUsername(testCostSlug1, provisionTestAgentLocalID)
+	if appErr != nil || got != provisionTestAgentLocalID {
+		t.Fatalf("expected clean admin username, got %q appErr=%v", got, appErr)
+	}
+
+	for _, raw := range []string{
+		"Agent-Alice",
+		"agent_alice",
+		"agent.alice",
+		" agent-alice ",
+		"agent@alice",
+		"agent%2falice",
+		"agent/alice",
+		"-agent",
+		"agent-",
+	} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if got, appErr := normalizeProvisionAdminUsername(testCostSlug1, raw); appErr == nil || appErr.Code != appErrCodeBadRequest {
+				t.Fatalf("normalizeProvisionAdminUsername(%q) = %q, expected bad_request", raw, got)
+			}
+		})
+	}
+}
+
 func TestHandlePortalProvisionConsentChallenge_CreatesChallenge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_setup.go
+++ b/internal/controlplane/handlers_setup.go
@@ -10,6 +10,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -445,16 +446,20 @@ func parseSetupCreateAdminRequestInput(ctx *apptheory.Context) (setupCreateAdmin
 		return setupCreateAdminRequest{}, &apptheory.AppError{Code: "app.bad_request", Message: "invalid request"}
 	}
 
-	req.Username = strings.TrimSpace(req.Username)
 	req.DisplayName = strings.TrimSpace(req.DisplayName)
 	req.Wallet.ChallengeID = strings.TrimSpace(req.Wallet.ChallengeID)
 	req.Wallet.Address = strings.TrimSpace(req.Wallet.Address)
 	req.Wallet.Signature = strings.TrimSpace(req.Wallet.Signature)
 	req.Wallet.Message = strings.TrimSpace(req.Wallet.Message)
 
-	if req.Username == "" {
+	username, err := soul.ValidateManagedHandle(req.Username)
+	if strings.TrimSpace(req.Username) == "" {
 		return setupCreateAdminRequest{}, &apptheory.AppError{Code: "app.bad_request", Message: "username is required"}
 	}
+	if err != nil {
+		return setupCreateAdminRequest{}, &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
+	}
+	req.Username = username
 	if strings.EqualFold(req.Username, setupBootstrapUser) {
 		return setupCreateAdminRequest{}, &apptheory.AppError{Code: "app.bad_request", Message: "username is reserved"}
 	}

--- a/internal/controlplane/handlers_setup_internal_test.go
+++ b/internal/controlplane/handlers_setup_internal_test.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -51,13 +52,38 @@ func TestParseSetupCreateAdminRequestInput(t *testing.T) {
 		t.Fatalf("expected reserved username error")
 	}
 
-	ctx.Request.Body = []byte(`{"username":" alice ","displayName":" Alice ","wallet":{"challengeId":" c ","address":" a ","signature":" s ","message":" m "}}`)
+	ctx.Request.Body = []byte(`{"username":"alice","displayName":" Alice ","wallet":{"challengeId":" c ","address":" a ","signature":" s ","message":" m "}}`)
 	req, appErr := parseSetupCreateAdminRequestInput(ctx)
 	if appErr != nil {
 		t.Fatalf("parseSetupCreateAdminRequestInput: %v", appErr)
 	}
 	if req.Username != testUsernameAlice || req.DisplayName != "Alice" || req.Wallet.ChallengeID != "c" {
 		t.Fatalf("unexpected request: %#v", req)
+	}
+}
+
+func TestParseSetupCreateAdminRequestInput_RejectsUnsafeManagedUsernames(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		" Alice ",
+		"Agent-Alice",
+		"agent_alice",
+		"agent.alice",
+		"agent@alice",
+		"agent%2falice",
+		"agent/alice",
+		"-agent",
+		"agent-",
+	} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			body := fmt.Sprintf(`{"username":%q,"wallet":{"challengeId":"c","address":"a","signature":"s","message":"m"}}`, raw)
+			if _, appErr := parseSetupCreateAdminRequestInput(&apptheory.Context{Request: apptheory.Request{Body: []byte(body)}}); appErr == nil || appErr.Code != appErrCodeBadRequest {
+				t.Fatalf("parseSetupCreateAdminRequestInput(%q) expected bad_request, got %v", raw, appErr)
+			}
+		})
 	}
 }
 

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -511,7 +511,7 @@ func (s *Server) resolveSoulProvisionEmailAddress(ctx context.Context, identity 
 	if identity == nil {
 		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
-	canonicalLocal, err := soul.NormalizeLocalAgentID(identity.LocalID)
+	canonicalLocal, err := soul.ValidateManagedHandle(identity.LocalID)
 	if err != nil || canonicalLocal == "" {
 		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
 	}
@@ -523,8 +523,35 @@ func (s *Server) resolveSoulProvisionEmailAddress(ctx context.Context, identity 
 }
 
 func (s *Server) resolveSoulProvisionEmailInstanceSlug(ctx context.Context, identity *models.SoulAgentIdentity) (string, *apptheory.AppError) {
+	return s.resolveSoulManagedIdentityInstanceSlug(ctx, identity, "managed email")
+}
+
+func (s *Server) resolveSoulProvisionENSName(ctx context.Context, identity *models.SoulAgentIdentity) (string, *apptheory.AppError) {
+	if identity == nil {
+		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	canonicalLocal, err := soul.ValidateManagedHandle(identity.LocalID)
+	if err != nil || canonicalLocal == "" {
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
+	}
+	instanceSlug, appErr := s.resolveSoulManagedIdentityInstanceSlug(ctx, identity, "managed identity")
+	if appErr != nil {
+		return "", appErr
+	}
+	ensName, err := soul.ManagedENSName(canonicalLocal, instanceSlug)
+	if err != nil {
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "managed ens name is invalid"}
+	}
+	return ensName, nil
+}
+
+func (s *Server) resolveSoulManagedIdentityInstanceSlug(ctx context.Context, identity *models.SoulAgentIdentity, surface string) (string, *apptheory.AppError) {
 	if s == nil || identity == nil {
 		return "", &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	surface = strings.TrimSpace(surface)
+	if surface == "" {
+		surface = "managed identity"
 	}
 	normalizedDomain, err := domains.NormalizeDomain(identity.Domain)
 	if err != nil {
@@ -533,29 +560,29 @@ func (s *Server) resolveSoulProvisionEmailInstanceSlug(ctx context.Context, iden
 
 	domain, loadErr := s.loadManagedStageAwareDomain(ctx, normalizedDomain)
 	if theoryErrors.IsNotFound(loadErr) {
-		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not registered for managed email"}
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not registered for " + surface}
 	}
 	if loadErr != nil {
 		return "", &apptheory.AppError{Code: "app.internal", Message: "failed to load agent domain"}
 	}
 	if domain == nil || !domainIsVerifiedOrActive(domain.Status) {
-		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not verified for managed email"}
+		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain is not verified for " + surface}
 	}
 
-	instanceSlug := strings.ToLower(strings.TrimSpace(domain.InstanceSlug))
-	if !instanceSlugRE.MatchString(instanceSlug) {
+	instanceSlug, err := soul.ValidateManagedInstanceSlug(domain.InstanceSlug)
+	if err != nil {
 		return "", &apptheory.AppError{Code: "app.conflict", Message: "agent domain instance slug is invalid"}
 	}
 	return instanceSlug, nil
 }
 
 func buildSoulProvisionManagedEmailAddress(agentLocalID string, instanceSlug string, requestedLocalPart string) (soulProvisionManagedEmailAddress, *apptheory.AppError) {
-	canonicalLocal, err := soul.NormalizeLocalAgentID(agentLocalID)
+	canonicalLocal, err := soul.ValidateManagedHandle(agentLocalID)
 	if err != nil || canonicalLocal == "" {
 		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent local id is invalid"}
 	}
-	slug := strings.ToLower(strings.TrimSpace(instanceSlug))
-	if !instanceSlugRE.MatchString(slug) {
+	slug, err := soul.ValidateManagedInstanceSlug(instanceSlug)
+	if err != nil {
 		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "agent domain instance slug is invalid"}
 	}
 
@@ -564,14 +591,18 @@ func buildSoulProvisionManagedEmailAddress(agentLocalID string, instanceSlug str
 		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "email local_part exceeds 64-octet SMTP limit"}
 	}
 
-	if requested := strings.TrimSpace(requestedLocalPart); requested != "" {
-		requestedNorm, err := soul.NormalizeLocalAgentID(requested)
-		if err != nil {
-			return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.bad_request", Message: "local_part is invalid"}
-		}
-		if requestedNorm != providerLocalPart {
+	if requestedLocalPart != strings.TrimSpace(requestedLocalPart) {
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.bad_request", Message: "local_part is invalid"}
+	}
+	if requested := requestedLocalPart; requested != "" {
+		if requested != providerLocalPart {
 			return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: soulEmailProvisionErrDerivedLocalPartReq}
 		}
+	}
+
+	ensName, err := soul.ManagedENSName(canonicalLocal, slug)
+	if err != nil {
+		return soulProvisionManagedEmailAddress{}, &apptheory.AppError{Code: "app.conflict", Message: "managed ens name is invalid"}
 	}
 
 	return soulProvisionManagedEmailAddress{
@@ -579,7 +610,7 @@ func buildSoulProvisionManagedEmailAddress(agentLocalID string, instanceSlug str
 		InstanceSlug:      slug,
 		ProviderLocalPart: providerLocalPart,
 		Address:           providerLocalPart + "@" + soulManagedEmailDomain,
-		ENSName:           soulCanonicalENSName(canonicalLocal),
+		ENSName:           ensName,
 	}, nil
 }
 

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -29,7 +29,7 @@ const (
 	provisionTestInstanceSlug     = "inst1"
 	provisionTestEmailLocalPart   = provisionTestAgentLocalID + "." + provisionTestInstanceSlug
 	provisionTestEmailAddress     = provisionTestEmailLocalPart + "@lessersoul.ai"
-	provisionTestEmailENSName     = provisionTestAgentLocalID + ".lessersoul.eth"
+	provisionTestEmailENSName     = provisionTestAgentLocalID + "." + provisionTestInstanceSlug + ".lessersoul.eth"
 	provisionTestAgentDomain      = "example.com"
 	provisionTestStageAlias       = "dev.simulacrum.greater.website"
 	provisionTestStageBaseDomain  = "simulacrum.greater.website"
@@ -169,18 +169,43 @@ func TestBuildSoulProvisionManagedEmailAddress_DerivesInstanceScopedAddress(t *t
 		got.ENSName != provisionTestEmailENSName {
 		t.Fatalf("unexpected resolved address: %#v", got)
 	}
+
+	got, appErr = buildSoulProvisionManagedEmailAddress(provisionTestAgentLocalID, provisionTestInstanceSlug, provisionTestEmailLocalPart)
+	if appErr != nil {
+		t.Fatalf("expected exact local_part success, got %v", appErr)
+	}
+	if got.ProviderLocalPart != provisionTestEmailLocalPart {
+		t.Fatalf("unexpected exact local_part result: %#v", got)
+	}
 }
 
-func TestBuildSoulProvisionManagedEmailAddress_AllowsDotsAndSameLocalIDAcrossInstances(t *testing.T) {
+func TestBuildSoulProvisionManagedEmailAddress_RejectsAmbiguousHandleCharacters(t *testing.T) {
 	t.Parallel()
 
-	got, appErr := buildSoulProvisionManagedEmailAddress("Agent.With.Dot", "simulacrum", "agent.with.dot.simulacrum")
-	if appErr != nil {
-		t.Fatalf("expected dotted local id success, got %v", appErr)
+	invalid := []string{
+		"Agent-With-Uppercase",
+		"agent_with_underscore",
+		"agent.with.dot",
+		"agent with space",
+		"agent%2falice",
+		"agent/alice",
+		"@agent",
+		"-agent",
+		"agent-",
 	}
-	if got.ProviderLocalPart != "agent.with.dot.simulacrum" || got.Address != "agent.with.dot.simulacrum@lessersoul.ai" {
-		t.Fatalf("unexpected dotted address: %#v", got)
+	for _, raw := range invalid {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, appErr := buildSoulProvisionManagedEmailAddress(raw, "simulacrum", ""); appErr == nil || appErr.Code != appErrCodeConflict {
+				t.Fatalf("expected invalid local id conflict for %q, got %v", raw, appErr)
+			}
+		})
 	}
+}
+
+func TestBuildSoulProvisionManagedEmailAddress_DerivesDistinctAddressesAcrossInstances(t *testing.T) {
+	t.Parallel()
 
 	a, appErr := buildSoulProvisionManagedEmailAddress("pilot", "simulacrum", "")
 	if appErr != nil {
@@ -247,7 +272,7 @@ func TestResolveSoulProvisionEmailAddress_ExactVanityDomain(t *testing.T) {
 	s := &Server{store: store.New(db)}
 	got, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{
 		Domain:  "agents.example.com",
-		LocalID: "Pilot",
+		LocalID: "pilot",
 	}, "")
 	if appErr != nil {
 		t.Fatalf("expected exact vanity resolution, got %v", appErr)
@@ -282,7 +307,7 @@ func TestResolveSoulProvisionEmailAddress_ManagedStagePrimaryAlias(t *testing.T)
 	s := &Server{store: store.New(db), cfg: config.Config{Stage: "lab"}}
 	got, appErr := s.resolveSoulProvisionEmailAddress(context.Background(), &models.SoulAgentIdentity{
 		Domain:  provisionTestStageAlias,
-		LocalID: "Pilot",
+		LocalID: "pilot",
 	}, "")
 	if appErr != nil {
 		t.Fatalf("expected managed stage alias resolution, got %v", appErr)

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -83,10 +83,14 @@ func (s *Server) handleSoulBeginProvisionPhoneChannel(ctx *apptheory.Context) (*
 	now := time.Now().UTC()
 	expectedVersion := identity.SelfDescriptionVersion
 	nextVersion := expectedVersion + 1
+	ensName, appErr := s.resolveSoulProvisionENSName(ctx.Context(), identity)
+	if appErr != nil {
+		return nil, appErr
+	}
 
 	regMap, _, digest, appErr := s.buildSoulProvisionPhoneRegistration(ctx.Context(), baseReg, baseVersion, agentIDHex, identity, soulProvisionPhoneBuildInput{
 		PhoneNumber:        desired,
-		ENSName:            strings.TrimSpace(identity.LocalID) + ".lessersoul.eth",
+		ENSName:            ensName,
 		IssuedAt:           now,
 		ExpectedPrev:       expectedVersion,
 		NextVersion:        nextVersion,
@@ -172,10 +176,14 @@ func (s *Server) prepareSoulProvisionPhoneChannel(
 	if appErr != nil {
 		return nil, nil, appErr
 	}
+	ensName, appErr := s.resolveSoulProvisionENSName(ctx, identity)
+	if appErr != nil {
+		return nil, nil, appErr
+	}
 
 	regMap, regV3, digest, appErr := s.buildSoulProvisionPhoneRegistration(ctx, baseReg, baseVersion, agentIDHex, identity, soulProvisionPhoneBuildInput{
 		PhoneNumber:        number,
-		ENSName:            strings.TrimSpace(identity.LocalID) + ".lessersoul.eth",
+		ENSName:            ensName,
 		IssuedAt:           issuedAt.UTC(),
 		ExpectedPrev:       expectedVersion,
 		NextVersion:        expectedVersion + 1,
@@ -356,20 +364,22 @@ func (s *Server) finalizeSoulDeprovisionPhoneChannel(ctx *apptheory.Context, age
 	}
 
 	// Best-effort: clear phone field from ENS resolution record (if it exists).
-	ensName := strings.TrimSpace(identity.LocalID) + ".lessersoul.eth"
-	res := &models.SoulAgentENSResolution{ENSName: ensName}
-	_ = res.UpdateKeys()
-	var existing models.SoulAgentENSResolution
-	loadResolutionErr := s.store.DB.WithContext(ctx.Context()).
-		Model(&models.SoulAgentENSResolution{}).
-		Where("PK", "=", res.PK).
-		Where("SK", "=", res.SK).
-		First(&existing)
-	if loadResolutionErr == nil {
-		existing.Phone = ""
-		existing.UpdatedAt = now
-		_ = existing.UpdateKeys()
-		_ = s.store.DB.WithContext(ctx.Context()).Model(&existing).CreateOrUpdate()
+	ensName, appErr := s.resolveSoulProvisionENSName(ctx.Context(), identity)
+	if appErr == nil {
+		res := &models.SoulAgentENSResolution{ENSName: ensName}
+		_ = res.UpdateKeys()
+		var existing models.SoulAgentENSResolution
+		loadResolutionErr := s.store.DB.WithContext(ctx.Context()).
+			Model(&models.SoulAgentENSResolution{}).
+			Where("PK", "=", res.PK).
+			Where("SK", "=", res.SK).
+			First(&existing)
+		if loadResolutionErr == nil {
+			existing.Phone = ""
+			existing.UpdatedAt = now
+			_ = existing.UpdateKeys()
+			_ = s.store.DB.WithContext(ctx.Context()).Model(&existing).CreateOrUpdate()
+		}
 	}
 
 	_ = s.store.DB.WithContext(ctx.Context()).Model(&models.AuditLogEntry{

--- a/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
@@ -19,12 +19,23 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
 )
 
 const provisionPhoneInternalError = "internal error"
+const provisionPhoneTestInstanceSlug = "inst1"
+
+func mustProvisionPhoneENSName(t testing.TB, localID string) string {
+	t.Helper()
+	ensName, err := soul.ManagedENSName(localID, provisionPhoneTestInstanceSlug)
+	if err != nil {
+		t.Fatalf("ManagedENSName(%q, %q): %v", localID, provisionPhoneTestInstanceSlug, err)
+	}
+	return ensName
+}
 
 func testProvisionPhoneIdentity() *models.SoulAgentIdentity {
 	identity := testMintConversationIdentity()
@@ -142,15 +153,15 @@ func seedProvisionPhoneAccess(t *testing.T, tdb soulLifecycleTestDB, identities 
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
 		*dest = models.Domain{
 			Domain:       "example.com",
-			InstanceSlug: "inst1",
+			InstanceSlug: provisionPhoneTestInstanceSlug,
 			Status:       models.DomainStatusVerified,
 		}
-	}).Times(len(identities))
+	}).Maybe()
 
 	tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
-		*dest = models.Instance{Slug: "inst1", Owner: "admin"}
-	}).Times(len(identities))
+		*dest = models.Instance{Slug: provisionPhoneTestInstanceSlug, Owner: "admin"}
+	}).Maybe()
 
 	callIdx := 0
 	tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
@@ -198,7 +209,7 @@ func signProvisionPhoneRequest(
 		identity,
 		soulProvisionPhoneBuildInput{
 			PhoneNumber:        number,
-			ENSName:            strings.TrimSpace(identity.LocalID) + ".lessersoul.eth",
+			ENSName:            mustProvisionPhoneENSName(t, identity.LocalID),
 			IssuedAt:           issuedAt,
 			ExpectedPrev:       identity.SelfDescriptionVersion,
 			NextVersion:        identity.SelfDescriptionVersion + 1,
@@ -696,7 +707,7 @@ func TestHandleSoulDeprovisionPhoneChannel_SuccessReleasesProviderNumberAndClear
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
 		*dest = models.SoulAgentENSResolution{
-			ENSName: "agent-bot.lessersoul.eth",
+			ENSName: mustProvisionPhoneENSName(t, "agent-bot"),
 			AgentID: identity.AgentID,
 			Phone:   "+15551234567",
 		}

--- a/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
@@ -108,11 +108,11 @@ func seedProvisionPhoneE2EAccess(t *testing.T, fixture *provisionPhoneE2EFixture
 	fixture.tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
 		*dest = models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}
-	}).Times(3)
+	}).Maybe()
 	fixture.tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
 		*dest = models.Instance{Slug: "inst1", Owner: "admin"}
-	}).Times(3)
+	}).Maybe()
 
 	identityCalls := 0
 	fixture.tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
@@ -245,6 +245,10 @@ func assertProvisionPhonePublished(t *testing.T, fixture *provisionPhoneE2EFixtu
 	if !ok || phoneAny == nil || strings.TrimSpace(extractStringField(phoneAny, "number")) != "+15551234567" {
 		t.Fatalf("expected channels.phone.number to be published, got %#v", chAny["phone"])
 	}
+	ensAny, ok := chAny["ens"].(map[string]any)
+	if !ok || ensAny == nil || strings.TrimSpace(extractStringField(ensAny, "name")) != mustProvisionPhoneENSName(t, "agent-alice") {
+		t.Fatalf("expected canonical channels.ens.name to be published, got %#v", chAny["ens"])
+	}
 }
 
 func assertProvisionPhoneIdempotent(t *testing.T, fixture *provisionPhoneE2EFixture, confirmBody []byte) {
@@ -297,11 +301,11 @@ func TestHandleSoulDeprovisionPhoneChannel_SuccessAndIdempotent(t *testing.T) {
 		tdb.qDomain.On("First", mock.AnythingOfType("*models.Domain")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.Domain](t, args, 0)
 			*dest = models.Domain{Domain: "example.com", InstanceSlug: "inst1", Status: models.DomainStatusVerified}
-		}).Once()
+		}).Twice()
 		tdb.qInstance.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
 			*dest = models.Instance{Slug: "inst1", Owner: "admin"}
-		}).Once()
+		}).Twice()
 		tdb.qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 			*dest = models.SoulAgentIdentity{
@@ -323,7 +327,7 @@ func TestHandleSoulDeprovisionPhoneChannel_SuccessAndIdempotent(t *testing.T) {
 		}).Once()
 		tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-			*dest = models.SoulAgentENSResolution{ENSName: "agent-alice.lessersoul.eth", Phone: "+15551234567"}
+			*dest = models.SoulAgentENSResolution{ENSName: mustProvisionPhoneENSName(t, "agent-alice"), Phone: "+15551234567"}
 		}).Once()
 
 		ctx := &apptheory.Context{

--- a/internal/controlplane/handlers_soul_registry.go
+++ b/internal/controlplane/handlers_soul_registry.go
@@ -330,7 +330,7 @@ func (s *Server) handleSoulAgentRegistrationBegin(ctx *apptheory.Context) (*appt
 		return nil, appErr
 	}
 
-	rawLocal := strings.TrimSpace(req.LocalID)
+	rawLocal := req.LocalID
 	local, appErr := normalizeSoulRegistrationBeginLocalID(rawLocal)
 	if appErr != nil {
 		return nil, appErr
@@ -454,8 +454,7 @@ func (s *Server) normalizeSoulRegistrationBeginDomain(ctx *apptheory.Context, ra
 }
 
 func normalizeSoulRegistrationBeginLocalID(rawLocal string) (string, *apptheory.AppError) {
-	rawLocal = strings.TrimSpace(rawLocal)
-	local, err := soul.NormalizeLocalAgentID(rawLocal)
+	local, err := soul.ValidateManagedHandle(rawLocal)
 	if err != nil {
 		return "", &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
 	}

--- a/internal/controlplane/handlers_soul_registry_internal_test.go
+++ b/internal/controlplane/handlers_soul_registry_internal_test.go
@@ -279,6 +279,36 @@ func assertSoulAgentRegistrationHTTPSProof(t *testing.T, httpsBodyRaw string, to
 	}
 }
 
+func TestNormalizeSoulRegistrationBeginLocalID_RejectsUnsafeManagedHandles(t *testing.T) {
+	t.Parallel()
+
+	valid, appErr := normalizeSoulRegistrationBeginLocalID("agent-alice")
+	if appErr != nil || valid != "agent-alice" {
+		t.Fatalf("expected clean handle success, got valid=%q appErr=%v", valid, appErr)
+	}
+
+	for _, raw := range []string{
+		"Agent-Alice",
+		"soul_researcher",
+		"agent.alice",
+		"agent..alice",
+		" agent-alice ",
+		"agent@alice",
+		"agent%2falice",
+		"agent/alice",
+		"-agent",
+		"agent-",
+	} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if got, appErr := normalizeSoulRegistrationBeginLocalID(raw); appErr == nil || appErr.Code != appErrCodeBadRequest {
+				t.Fatalf("normalizeSoulRegistrationBeginLocalID(%q) = %q, expected bad_request", raw, got)
+			}
+		})
+	}
+}
+
 func TestHandleSoulAgentRegistrationBegin_StructuredCapabilities_Success(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -887,14 +887,6 @@ func trustedManagedSoulChannelForIndex(ch *models.SoulAgentChannel) bool {
 	}
 }
 
-func soulCanonicalENSName(localID string) string {
-	localID = strings.TrimSpace(localID)
-	if localID == "" {
-		return ""
-	}
-	return localID + ".lessersoul.eth"
-}
-
 func (s *Server) ensureSoulEmailAgentIndex(ctx context.Context, idx *models.SoulEmailAgentIndex) *apptheory.AppError {
 	if idx == nil {
 		return nil
@@ -1295,7 +1287,7 @@ func validateSoulUpdateRegistrationIdentityFields(reg map[string]any, agentIDHex
 	if bodyLocal == "" {
 		bodyLocal = extractStringField(reg, "local_id")
 	}
-	localNorm, err := soul.NormalizeLocalAgentID(bodyLocal)
+	localNorm, err := soul.ValidateManagedHandle(bodyLocal)
 	if err != nil {
 		return &apptheory.AppError{Code: "app.bad_request", Message: err.Error()}
 	}

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -98,7 +98,7 @@ func TestValidateSoulUpdateRegistrationIdentityFields_UsesFallbackKeysAndRejects
 	if appErr := validateSoulUpdateRegistrationIdentityFields(map[string]any{
 		"agent_id": soulLifecycleTestAgentIDHex,
 		"domain":   "EXAMPLE.COM",
-		"local_id": "@Agent-Alice/",
+		"local_id": "agent-alice",
 	}, soulLifecycleTestAgentIDHex, identity); appErr != nil {
 		t.Fatalf("expected fallback field names to validate, got %v", appErr)
 	}
@@ -133,7 +133,16 @@ func TestValidateSoulUpdateRegistrationIdentityFields_UsesFallbackKeysAndRejects
 				"domain":  "example.com",
 				"localId": "bad/local",
 			},
-			message: "local_id must not contain /, :, or @",
+			message: "managed handle must be 3-63 lowercase letters, digits, or hyphens and start/end with a letter or digit",
+		},
+		{
+			name: "ambiguous local id",
+			reg: map[string]any{
+				"agentId": soulLifecycleTestAgentIDHex,
+				"domain":  "example.com",
+				"localId": "agent.alice",
+			},
+			message: "managed handle must be 3-63 lowercase letters, digits, or hyphens and start/end with a letter or digit",
 		},
 		{
 			name: "localId mismatch",

--- a/internal/soul/managed_identity.go
+++ b/internal/soul/managed_identity.go
@@ -1,0 +1,66 @@
+package soul
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const ManagedENSRootName = "lessersoul.eth"
+
+var managedHandleRE = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$`)
+
+// managedInstanceSlugRE intentionally mirrors controlplane.instanceSlugRE.
+var managedInstanceSlugRE = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{1,61}[a-z0-9])?$`)
+
+// ValidateManagedHandle validates future managed identity handles shared across
+// ENS labels, ActivityPub paths/handles, email local-part derivation, and URL
+// paths.
+//
+// Grammar: 3-63 ASCII lowercase letters, digits, or hyphens; the first and last
+// character must be alphanumeric. The validator intentionally does not
+// lowercase, trim, strip "@", or otherwise translate input.
+func ValidateManagedHandle(raw string) (string, error) {
+	handle := strings.TrimSpace(raw)
+	if handle == "" {
+		return "", errors.New("managed handle is required")
+	}
+	if raw != handle {
+		return "", errors.New("managed handle must not contain leading or trailing whitespace")
+	}
+	if !managedHandleRE.MatchString(handle) {
+		return "", errors.New("managed handle must be 3-63 lowercase letters, digits, or hyphens and start/end with a letter or digit")
+	}
+	return handle, nil
+}
+
+// ValidateManagedInstanceSlug applies the managed-instance slug grammar used by
+// host's provisioning paths. It intentionally mirrors the existing instance slug
+// rule without adding a migration-time translation layer.
+func ValidateManagedInstanceSlug(raw string) (string, error) {
+	slug := strings.ToLower(strings.TrimSpace(raw))
+	if slug == "" {
+		return "", errors.New("managed instance slug is required")
+	}
+	if !managedInstanceSlugRE.MatchString(slug) {
+		return "", errors.New("managed instance slug must be lowercase letters, digits, or hyphens and start/end with a letter or digit")
+	}
+	return slug, nil
+}
+
+// ManagedENSName derives the canonical managed ENS name for a hosted identity.
+// The canonical form is exactly:
+//
+//	<name>.<instance-slug>.lessersoul.eth
+func ManagedENSName(name string, instanceSlug string) (string, error) {
+	handle, err := ValidateManagedHandle(name)
+	if err != nil {
+		return "", err
+	}
+	slug, err := ValidateManagedInstanceSlug(instanceSlug)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s.%s", handle, slug, ManagedENSRootName), nil
+}

--- a/internal/soul/managed_identity_test.go
+++ b/internal/soul/managed_identity_test.go
@@ -1,0 +1,118 @@
+package soul
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateManagedHandle_Grammar(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{
+		"abc",
+		"agent-alice",
+		"agent0",
+		"a0-b1-c2",
+		strings.Repeat("a", 63),
+	}
+	for _, raw := range valid {
+		raw := raw
+		t.Run("valid_"+raw, func(t *testing.T) {
+			t.Parallel()
+			got, err := ValidateManagedHandle(raw)
+			if err != nil {
+				t.Fatalf("ValidateManagedHandle(%q) unexpected err: %v", raw, err)
+			}
+			if got != raw {
+				t.Fatalf("ValidateManagedHandle(%q) = %q, want unchanged input", raw, got)
+			}
+		})
+	}
+
+	invalid := []string{
+		"",
+		"a",
+		"ab",
+		strings.Repeat("a", 64),
+		"Agent-Alice",
+		"soul_researcher",
+		"agent.alice",
+		"agent..alice",
+		" agent-alice",
+		"agent-alice ",
+		"agent alice",
+		"@agent-alice",
+		"agent@alice",
+		"agent%2falice",
+		"agent/alice",
+		"-agent",
+		"agent-",
+	}
+	for _, raw := range invalid {
+		raw := raw
+		t.Run("invalid_"+strings.ReplaceAll(raw, "/", "_"), func(t *testing.T) {
+			t.Parallel()
+			if got, err := ValidateManagedHandle(raw); err == nil {
+				t.Fatalf("ValidateManagedHandle(%q) = %q, expected err", raw, got)
+			}
+		})
+	}
+}
+
+func TestValidateManagedInstanceSlug_MirrorsInstanceSlugRule(t *testing.T) {
+	t.Parallel()
+
+	got, err := ValidateManagedInstanceSlug(" Simulacrum ")
+	if err != nil {
+		t.Fatalf("ValidateManagedInstanceSlug unexpected err: %v", err)
+	}
+	if got != "simulacrum" {
+		t.Fatalf("ValidateManagedInstanceSlug got %q", got)
+	}
+	got, err = ValidateManagedInstanceSlug("x")
+	if err != nil {
+		t.Fatalf("ValidateManagedInstanceSlug one-character slug unexpected err: %v", err)
+	}
+	if got != "x" {
+		t.Fatalf("ValidateManagedInstanceSlug one-character slug got %q", got)
+	}
+
+	for _, raw := range []string{"bad_slug", "bad.slug", "-bad", "bad-", "ab", strings.Repeat("a", 64)} {
+		raw := raw
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ValidateManagedInstanceSlug(raw); err == nil {
+				t.Fatalf("ValidateManagedInstanceSlug(%q) expected err", raw)
+			}
+		})
+	}
+}
+
+func TestManagedENSName_CanonicalInstanceScopedForm(t *testing.T) {
+	t.Parallel()
+
+	got, err := ManagedENSName("agent-alice", "simulacrum")
+	if err != nil {
+		t.Fatalf("ManagedENSName unexpected err: %v", err)
+	}
+	if got != "agent-alice.simulacrum.lessersoul.eth" {
+		t.Fatalf("ManagedENSName got %q", got)
+	}
+
+	for _, tc := range []struct {
+		name string
+		slug string
+	}{
+		{name: "Agent-Alice", slug: "simulacrum"},
+		{name: "agent.alice", slug: "simulacrum"},
+		{name: "agent-alice", slug: "bad_slug"},
+	} {
+		tc := tc
+		t.Run(tc.name+"_"+tc.slug, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ManagedENSName(tc.name, tc.slug); err == nil {
+				t.Fatalf("ManagedENSName(%q, %q) expected err", tc.name, tc.slug)
+			}
+		})
+	}
+}

--- a/internal/soul/registration_v2.go
+++ b/internal/soul/registration_v2.go
@@ -180,7 +180,7 @@ func validateRegistrationIdentity(agentID string, domain string, localID string,
 		return errors.New("domain is invalid")
 	}
 
-	normalizedLocalID, err := NormalizeLocalAgentID(localID)
+	normalizedLocalID, err := ValidateManagedHandle(localID)
 	if err != nil || normalizedLocalID == "" {
 		return errors.New("localId is invalid")
 	}

--- a/internal/soul/registration_v2_test.go
+++ b/internal/soul/registration_v2_test.go
@@ -151,6 +151,8 @@ func TestRegistrationFileV2_ParseAndValidate(t *testing.T) {
 		{name: "bad agent id", mut: func(r *RegistrationFileV2) { r.AgentID = "0x1234" }},
 		{name: "bad domain", mut: func(r *RegistrationFileV2) { r.Domain = "bad domain" }},
 		{name: "bad local id", mut: func(r *RegistrationFileV2) { r.LocalID = "@" }},
+		{name: "ambiguous local id dot", mut: func(r *RegistrationFileV2) { r.LocalID = "agent.bot" }},
+		{name: "ambiguous local id uppercase", mut: func(r *RegistrationFileV2) { r.LocalID = "Agent-Bot" }},
 		{name: "bad wallet", mut: func(r *RegistrationFileV2) { r.Wallet = "not-an-address" }},
 		{name: "bad principal", mut: func(r *RegistrationFileV2) { r.Principal.Type = "robot" }},
 		{name: "bad self description", mut: func(r *RegistrationFileV2) { r.SelfDescription.Purpose = "short" }},

--- a/scripts/soul-email-m0-inventory/main.go
+++ b/scripts/soul-email-m0-inventory/main.go
@@ -694,12 +694,12 @@ func getItem(ctx context.Context, client dynamoClient, tableName, pk, sk string)
 }
 
 func buildProposedManagedAddress(agentLocalID, instanceSlug string) (proposedEmailInventory, error) {
-	localID, err := soul.NormalizeLocalAgentID(agentLocalID)
+	localID, err := soul.ValidateManagedHandle(agentLocalID)
 	if err != nil || localID == "" {
 		return proposedEmailInventory{}, errors.New("invalid_agent_local_id")
 	}
-	instanceSlug = strings.ToLower(strings.TrimSpace(instanceSlug))
-	if !managedInstanceSlugRE.MatchString(instanceSlug) {
+	instanceSlug, err = soul.ValidateManagedInstanceSlug(instanceSlug)
+	if err != nil || !managedInstanceSlugRE.MatchString(instanceSlug) {
 		return proposedEmailInventory{}, errors.New("invalid_instance_slug")
 	}
 	localPart := localID + "." + instanceSlug

--- a/scripts/soul-email-m0-inventory/main_test.go
+++ b/scripts/soul-email-m0-inventory/main_test.go
@@ -24,14 +24,14 @@ const (
 func TestBuildProposedManagedAddress(t *testing.T) {
 	t.Parallel()
 
-	got, err := buildProposedManagedAddress(" Agent.With.Dot ", "Simulacrum")
+	got, err := buildProposedManagedAddress("agent-bot", "Simulacrum")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if got.LocalPart != "agent.with.dot.simulacrum" || got.Address != "agent.with.dot.simulacrum@lessersoul.ai" {
+	if got.LocalPart != "agent-bot.simulacrum" || got.Address != "agent-bot.simulacrum@lessersoul.ai" {
 		t.Fatalf("unexpected proposed address: %#v", got)
 	}
-	if got.LocalPartLength != len("agent.with.dot.simulacrum") || got.Overflow {
+	if got.LocalPartLength != len("agent-bot.simulacrum") || got.Overflow {
 		t.Fatalf("unexpected proposed length/overflow: %#v", got)
 	}
 }
@@ -41,6 +41,9 @@ func TestBuildProposedManagedAddressRejectsInvalidSlugAndOverflow(t *testing.T) 
 
 	if _, err := buildProposedManagedAddress("agent", "bad_slug"); err == nil || err.Error() != "invalid_instance_slug" {
 		t.Fatalf("expected invalid_instance_slug, got %v", err)
+	}
+	if _, err := buildProposedManagedAddress("agent.with.dot", "slug"); err == nil || err.Error() != "invalid_agent_local_id" {
+		t.Fatalf("expected invalid_agent_local_id, got %v", err)
 	}
 
 	got, err := buildProposedManagedAddress("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", "slug")


### PR DESCRIPTION
## Milestone
Project 44 M2 — enforce shared URL-safe handles and derive instance-scoped managed ENS names.

## Classification
Soul registry / provisioning / managed identity hardening / trust-surface naming consistency.

## Surfaces affected
- Shared managed handle validation in `internal/soul`.
- Soul registration/update validation ingress for future agent local IDs.
- Setup, portal wallet auto-create, and managed provisioning admin username ingress for future user names.
- Managed email and phone provisioning ENS derivation.
- Managed ENS examples in v3 spec fixtures and Project 44 ADR notes.

## Specialist walks referenced
- Soul registry: naming/ENS derivation only; no Solidity, Safe payload, mint-signer, Sepolia, mainnet, resolver, or backfill action.
- Provisioning / managed-update / release verification: admin username/provisioning channel validation only; per-slug isolation unchanged; no release-verification path changes.
- Trust API / CSP / instance-auth: no auth/CSP changes; remaining bare `.lessersoul.eth` references are root config, resolver/legacy tests, docs, or fixtures.
- Governance rubric: no verifier or pack changes; local gov verifier passed.

## Multi-tenant isolation impact
No cross-tenant reads/writes or tenant data ingestion. Instance slug lookups remain scoped to the agent domain being provisioned.

## On-chain impact
None. This PR does not change contracts, deploy contracts, mutate ENS resolvers, run Sepolia/mainnet transactions, or backfill persisted state.

## Consumer impact
Future managed user/agent handles with ambiguous/shared-unsafe characters are rejected before entering hosted identity surfaces. Existing clean lowercase/digit/hyphen names remain valid without migration-time translation.

## Tasks
- [x] #649 Add a shared managed handle validator.
- [x] #650 Wire validation into relevant creation/update/provisioning boundaries.
- [x] #651 Add one canonical instance-scoped ENS helper.
- [x] #652 Replace managed `.lessersoul.eth` derivations with the canonical helper.
- [x] #653 Update ENS fixtures and negative handle tests.

## Validation
- [x] `git diff --check origin/main...HEAD`
- [x] `git ls-files '*.go' | xargs gofmt -l` (empty)
- [x] `go test ./internal/controlplane ./internal/soul ./scripts/soul-email-m0-inventory`
- [x] `go test ./...`
- [x] `go vet ./...`
- [x] `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS 40/0/0
- [x] `rg "\.lessersoul\.eth|lessersoul\.eth" internal cmd scripts --glob '!**/*_test.go' --glob '!**/node_modules/**' --glob '!cdk/**'` — only root config and canonical helper remain.

## Stage rollout plan (handoff after merge)
- [ ] Merged to `main` after required review and CI.
- [ ] Deploy to `lab` via `theory app up --stage lab --execute` when operator-authorized.
- [ ] Lab soak: exercise soul registration/update validation and managed email/phone provisioning derivation against test identities.
- [ ] Deploy to `live` only after lab soak and explicit operator authorization.
- [ ] Post-deploy monitor control-plane errors and managed provisioning/channel provisioning failures.

## Cross-repo coordination
No sibling-repo code changes. M2 is host-side naming/derivation hardening only.

Closes #636
Closes #649
Closes #650
Closes #651
Closes #652
Closes #653
