### PR TITLE
feat(soul): sync managed ENS gateway material

### DIFF
--- a/internal/controlplane/constants.go
+++ b/internal/controlplane/constants.go
@@ -19,4 +19,7 @@ const (
 	appErrCodeConflict     = "app.conflict"
 
 	cacheControlNoStore = "no-store"
+
+	ensGatewayChainMainnet = "mainnet"
+	ensGatewayChainSepolia = "sepolia"
 )

--- a/internal/controlplane/handlers_soul_boundaries_coverage_internal_test.go
+++ b/internal/controlplane/handlers_soul_boundaries_coverage_internal_test.go
@@ -75,6 +75,7 @@ func seedBoundaryPortalAccess(t *testing.T, tdb soulLifecycleTestDB, agentIDHex 
 			UpdatedAt:              time.Now().UTC(),
 		}
 	}).Maybe()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Maybe()
 }
 
 func mustGenerateBoundaryWallet(t *testing.T) (*ecdsa.PrivateKey, string) {

--- a/internal/controlplane/handlers_soul_channels_email_provision.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision.go
@@ -352,7 +352,7 @@ func (s *Server) buildSoulProvisionEmailRegistration(ctx context.Context, base m
 	reg["changeSummary"] = "Provision email channel"
 	setProvisionSelfAttestation(reg, input.SelfAttestationHex)
 	ch := cloneProvisionChannels(reg)
-	ensureProvisionENSChannel(ch, input.ENSName)
+	s.ensureProvisionENSChannel(ch, input.ENSName)
 	ch["email"] = map[string]any{
 		"address":      strings.TrimSpace(input.EmailAddress),
 		"capabilities": []any{"receive", "send"},
@@ -422,14 +422,89 @@ func cloneProvisionChannels(reg map[string]any) map[string]any {
 	return out
 }
 
-func ensureProvisionENSChannel(channels map[string]any, ensName string) {
-	if _, ok := channels["ens"]; ok || strings.TrimSpace(ensName) == "" {
+func (s *Server) ensureProvisionENSChannel(channels map[string]any, ensName string) {
+	ensName = strings.TrimSpace(ensName)
+	if ensName == "" {
 		return
 	}
-	channels["ens"] = map[string]any{
-		"name":  strings.TrimSpace(ensName),
-		"chain": "mainnet",
+	existing, ok := channels["ens"]
+	if ok && !shouldReplaceProvisionENSChannel(existing, ensName) {
+		return
 	}
+	channels["ens"] = s.buildProvisionENSChannel(ensName)
+}
+
+func (s *Server) buildProvisionENSChannel(ensName string) map[string]any {
+	out := map[string]any{
+		"name": strings.TrimSpace(ensName),
+	}
+	if chain := s.provisionENSChainName(); chain != "" {
+		out["chain"] = chain
+	}
+	if s != nil {
+		if resolver := strings.TrimSpace(s.cfg.ENSGatewayResolverAddress); resolver != "" {
+			out["resolverAddress"] = resolver
+		}
+	}
+	return out
+}
+
+func (s *Server) provisionENSChainName() string {
+	if s == nil {
+		return ""
+	}
+	if chain := strings.ToLower(strings.TrimSpace(s.cfg.ENSGatewayChainName)); chain != "" {
+		return chain
+	}
+	switch s.cfg.ENSGatewayChainID {
+	case 1:
+		return ensGatewayChainMainnet
+	case 11155111:
+		return ensGatewayChainSepolia
+	}
+	switch strings.ToLower(strings.TrimSpace(s.cfg.Stage)) {
+	case defaultControlPlaneStage:
+		return ensGatewayChainSepolia
+	case "live":
+		return ensGatewayChainMainnet
+	default:
+		return ""
+	}
+}
+
+func shouldReplaceProvisionENSChannel(existing any, desiredName string) bool {
+	existingName := provisionENSChannelName(existing)
+	if strings.TrimSpace(existingName) == "" {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(existingName), strings.TrimSpace(desiredName)) {
+		return true
+	}
+	return isLegacyBareManagedProvisionENSName(existingName, desiredName)
+}
+
+func provisionENSChannelName(existing any) string {
+	switch m := existing.(type) {
+	case map[string]any:
+		return extractStringField(m, "name")
+	case map[string]string:
+		return strings.TrimSpace(m["name"])
+	default:
+		return ""
+	}
+}
+
+func isLegacyBareManagedProvisionENSName(existingName string, desiredName string) bool {
+	desiredName = strings.ToLower(strings.TrimSpace(desiredName))
+	labels := strings.Split(desiredName, ".")
+	if len(labels) != 4 || strings.Join(labels[2:], ".") != soul.ManagedENSRootName {
+		return false
+	}
+	legacy, err := soul.LegacyBareManagedENSNameForMigration(labels[0])
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(existingName), legacy)
 }
 
 func parseSoulProvisionRegistrationV3(reg map[string]any) (*soul.RegistrationFileV3, *apptheory.AppError) {

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -530,7 +530,7 @@ func seedProvisionEmailE2EAccess(t *testing.T, fixture *provisionEmailE2EFixture
 	fixture.tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	fixture.tdb.qEmailIdx.On("First", mock.AnythingOfType("*models.SoulEmailAgentIndex")).Return(theoryErrors.ErrItemNotFound).Times(3)
-	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Twice()
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)

--- a/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_email_provision_internal_test.go
@@ -220,6 +220,53 @@ func TestBuildSoulProvisionManagedEmailAddress_DerivesDistinctAddressesAcrossIns
 	}
 }
 
+func TestBuildSoulProvisionEmailRegistration_UpdatesOnlyManagedENSChannel(t *testing.T) {
+	t.Parallel()
+
+	fixture := newProvisionEmailE2EFixture(t)
+	s := fixture.server
+	now := time.Date(2026, time.March, 5, 12, 0, 0, 0, time.UTC)
+
+	legacyBase := testProvisionManagedChannelBaseRegistration(fixture.agentIDHex, fixture.wallet, fixture.principalDeclaration, fixture.principalSigHex)
+	legacyBase["channels"] = map[string]any{
+		"ens": map[string]any{
+			"name":  provisionTestAgentLocalID + ".lessersoul.eth",
+			"chain": "mainnet",
+		},
+	}
+	legacyReg, _, _, appErr := s.buildSoulProvisionEmailRegistration(context.Background(), legacyBase, "2", fixture.agentIDHex, &models.SoulAgentIdentity{LocalID: provisionTestAgentLocalID}, soulProvisionEmailBuildInput{
+		EmailAddress: provisionTestEmailAddress,
+		ENSName:      provisionTestEmailENSName,
+		IssuedAt:     now,
+		ExpectedPrev: 3,
+		NextVersion:  4,
+	})
+	if appErr != nil {
+		t.Fatalf("legacy build unexpected appErr: %v", appErr)
+	}
+	assertProvisionENSChannelMetadata(t, legacyReg, provisionTestEmailENSName, "sepolia", "0x0000000000000000000000000000000000000002")
+
+	externalBase := testProvisionManagedChannelBaseRegistration(fixture.agentIDHex, fixture.wallet, fixture.principalDeclaration, fixture.principalSigHex)
+	externalBase["channels"] = map[string]any{
+		"ens": map[string]any{
+			"name":            "external.eth",
+			"chain":           "mainnet",
+			"resolverAddress": "0x00000000000000000000000000000000000000ee",
+		},
+	}
+	externalReg, _, _, appErr := s.buildSoulProvisionEmailRegistration(context.Background(), externalBase, "2", fixture.agentIDHex, &models.SoulAgentIdentity{LocalID: provisionTestAgentLocalID}, soulProvisionEmailBuildInput{
+		EmailAddress: provisionTestEmailAddress,
+		ENSName:      provisionTestEmailENSName,
+		IssuedAt:     now,
+		ExpectedPrev: 3,
+		NextVersion:  4,
+	})
+	if appErr != nil {
+		t.Fatalf("external build unexpected appErr: %v", appErr)
+	}
+	assertProvisionENSChannelMetadata(t, externalReg, "external.eth", "mainnet", "0x00000000000000000000000000000000000000ee")
+}
+
 func TestBuildSoulProvisionManagedEmailAddress_RejectsOverflowAndInvalidSlug(t *testing.T) {
 	t.Parallel()
 
@@ -403,6 +450,8 @@ func newProvisionEmailE2EFixture(t *testing.T) *provisionEmailE2EFixture {
 			SoulSupportedCapabilities:   []string{"social"},
 			PublicBaseURL:               "https://lab.lesser.host",
 			SoulEmailInboundDomain:      "inbound.lessersoul.ai",
+			ENSGatewayChainName:         "sepolia",
+			ENSGatewayResolverAddress:   "0x0000000000000000000000000000000000000002",
 			Stage:                       "lab",
 		},
 		soulPacks: fixture.packs,
@@ -522,6 +571,7 @@ func runProvisionEmailBegin(t *testing.T, fixture *provisionEmailE2EFixture) sou
 	if beginOut.ENSName != provisionTestEmailENSName {
 		t.Fatalf("begin expected ens %s, got %q", provisionTestEmailENSName, beginOut.ENSName)
 	}
+	assertProvisionENSChannelMetadata(t, beginOut.Registration, provisionTestEmailENSName, "sepolia", "0x0000000000000000000000000000000000000002")
 	return beginOut
 }
 
@@ -601,6 +651,28 @@ func assertProvisionEmailPublished(t *testing.T, fixture *provisionEmailE2EFixtu
 	}
 	if strings.TrimSpace(extractStringField(emailAny, "address")) != provisionTestEmailAddress {
 		t.Fatalf("expected published channels.email.address %s, got %#v", provisionTestEmailAddress, emailAny["address"])
+	}
+	assertProvisionENSChannelMetadata(t, published, provisionTestEmailENSName, "sepolia", "0x0000000000000000000000000000000000000002")
+}
+
+func assertProvisionENSChannelMetadata(t *testing.T, reg map[string]any, wantName string, wantChain string, wantResolver string) {
+	t.Helper()
+	chAny, ok := reg["channels"].(map[string]any)
+	if !ok || chAny == nil {
+		t.Fatalf("expected registration channels object, got %#v", reg["channels"])
+	}
+	ensAny, ok := chAny["ens"].(map[string]any)
+	if !ok || ensAny == nil {
+		t.Fatalf("expected channels.ens object, got %#v", chAny["ens"])
+	}
+	if got := strings.TrimSpace(extractStringField(ensAny, "name")); got != wantName {
+		t.Fatalf("expected channels.ens.name %q, got %q", wantName, got)
+	}
+	if got := strings.TrimSpace(extractStringField(ensAny, "chain")); got != wantChain {
+		t.Fatalf("expected channels.ens.chain %q, got %q", wantChain, got)
+	}
+	if got := strings.TrimSpace(extractStringField(ensAny, "resolverAddress")); got != wantResolver {
+		t.Fatalf("expected channels.ens.resolverAddress %q, got %q", wantResolver, got)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_channels_phone_provision.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision.go
@@ -416,7 +416,7 @@ func (s *Server) buildSoulProvisionPhoneRegistration(ctx context.Context, base m
 	reg["changeSummary"] = "Provision phone channel"
 	setProvisionSelfAttestation(reg, input.SelfAttestationHex)
 	ch := cloneProvisionChannels(reg)
-	ensureProvisionENSChannel(ch, input.ENSName)
+	s.ensureProvisionENSChannel(ch, input.ENSName)
 	ch["phone"] = map[string]any{
 		"number":       strings.TrimSpace(input.PhoneNumber),
 		"provider":     "telnyx",

--- a/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
@@ -107,6 +107,8 @@ func newProvisionPhoneServer(tdb soulLifecycleTestDB, packs soulPackStore) *Serv
 			SoulPackBucketName:          "bucket",
 			SoulSupportedCapabilities:   []string{"social"},
 			PublicBaseURL:               "https://lab.lesser.host",
+			ENSGatewayChainName:         "sepolia",
+			ENSGatewayResolverAddress:   "0x0000000000000000000000000000000000000002",
 			Stage:                       "lab",
 		},
 	}
@@ -394,6 +396,7 @@ func TestHandleSoulBeginProvisionPhoneChannel_SearchSuccessBuildsProvisionalRegi
 	if !ok || channels["phone"] == nil {
 		t.Fatalf("expected phone channel in registration: %#v", out.Registration)
 	}
+	assertProvisionENSChannelMetadata(t, out.Registration, mustProvisionPhoneENSName(t, "agent-bot"), "sepolia", "0x0000000000000000000000000000000000000002")
 }
 
 func TestHandleSoulProvisionPhoneChannel_ExpectedVersionIsRequired(t *testing.T) {
@@ -609,6 +612,7 @@ func assertProvisionPhonePublishedRegistration(t *testing.T, packs *fakeSoulPack
 	if !ok || strings.TrimSpace(extractStringField(phone, "number")) != "+15551234567" {
 		t.Fatalf("expected published phone number, got %#v", channels["phone"])
 	}
+	assertProvisionENSChannelMetadata(t, published, mustProvisionPhoneENSName(t, "agent-bot"), "sepolia", "0x0000000000000000000000000000000000000002")
 }
 
 func TestHandleSoulDeprovisionPhoneChannel_MissingPhoneChannelIsIdempotent(t *testing.T) {

--- a/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go
@@ -486,7 +486,7 @@ func TestHandleSoulProvisionPhoneChannel_SuccessPublishesRegistrationAndRecordsP
 	seedProvisionPhoneRegistration(t, packs, identity)
 
 	tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Twice()
-	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Twice()
 	tdb.qVersion.On("First", mock.AnythingOfType("*models.SoulAgentVersion")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Maybe()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)

--- a/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
@@ -77,6 +77,8 @@ func newProvisionPhoneE2EFixture(t *testing.T) *provisionPhoneE2EFixture {
 			SoulRegistryContractAddress: "0x0000000000000000000000000000000000000001",
 			SoulPackBucketName:          "bucket",
 			PublicBaseURL:               "https://lab.lesser.host",
+			ENSGatewayChainName:         "sepolia",
+			ENSGatewayResolverAddress:   "0x0000000000000000000000000000000000000002",
 			Stage:                       "lab",
 		},
 		soulPacks: fixture.packs,
@@ -249,6 +251,7 @@ func assertProvisionPhonePublished(t *testing.T, fixture *provisionPhoneE2EFixtu
 	if !ok || ensAny == nil || strings.TrimSpace(extractStringField(ensAny, "name")) != mustProvisionPhoneENSName(t, "agent-alice") {
 		t.Fatalf("expected canonical channels.ens.name to be published, got %#v", chAny["ens"])
 	}
+	assertProvisionENSChannelMetadata(t, published, mustProvisionPhoneENSName(t, "agent-alice"), "sepolia", "0x0000000000000000000000000000000000000002")
 }
 
 func assertProvisionPhoneIdempotent(t *testing.T, fixture *provisionPhoneE2EFixture, confirmBody []byte) {

--- a/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go
@@ -141,7 +141,7 @@ func seedProvisionPhoneE2EAccess(t *testing.T, fixture *provisionPhoneE2EFixture
 	fixture.tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
 
 	fixture.tdb.qPhoneIdx.On("First", mock.AnythingOfType("*models.SoulPhoneAgentIndex")).Return(theoryErrors.ErrItemNotFound).Twice()
-	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	fixture.tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Twice()
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
 	fixture.tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)

--- a/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
+++ b/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
@@ -167,6 +167,10 @@ func TestHandleSoulPublicGetAgentChannels_DiscoveryV3ENSAndPhone(t *testing.T) {
 	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
 
 	agentID := "0x" + strings.Repeat("44", 32)
+	canonicalENSName, err := soul.ManagedENSName("agent-caro", "inst1")
+	if err != nil {
+		t.Fatalf("ManagedENSName: %v", err)
+	}
 	identityUpdated := time.Date(2026, 3, 4, 9, 0, 0, 0, time.UTC)
 	ensUpdated := identityUpdated.Add(30 * time.Minute)
 	phoneUpdated := identityUpdated.Add(2 * time.Hour)
@@ -188,9 +192,9 @@ func TestHandleSoulPublicGetAgentChannels_DiscoveryV3ENSAndPhone(t *testing.T) {
 		*dest = models.SoulAgentChannel{
 			AgentID:            agentID,
 			ChannelType:        models.SoulChannelTypeENS,
-			Identifier:         "agent-caro.lessersoul.eth",
+			Identifier:         canonicalENSName,
 			ENSResolverAddress: "0xresolver",
-			ENSChain:           "base",
+			ENSChain:           "sepolia",
 			UpdatedAt:          ensUpdated,
 		}
 	}).Once()
@@ -228,7 +232,7 @@ func TestHandleSoulPublicGetAgentChannels_DiscoveryV3ENSAndPhone(t *testing.T) {
 	if out.AgentID != agentID {
 		t.Fatalf("expected agentId %q, got %q", agentID, out.AgentID)
 	}
-	if out.Channels.ENS == nil || out.Channels.ENS.Name != "agent-caro.lessersoul.eth" {
+	if out.Channels.ENS == nil || out.Channels.ENS.Name != canonicalENSName || out.Channels.ENS.Chain != "sepolia" {
 		t.Fatalf("unexpected ENS channel: %#v", out.Channels.ENS)
 	}
 	if out.Channels.Email != nil {

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -527,16 +527,45 @@ func (s *Server) buildSoulV3ENSSync(agentIDHex string, identity *models.SoulAgen
 		return nil, nil
 	}
 	ens := regV3.Channels.ENS
+	ensName := strings.TrimSpace(ens.Name)
 	desired := &models.SoulAgentChannel{
 		AgentID:            agentIDHex,
 		ChannelType:        models.SoulChannelTypeENS,
-		Identifier:         strings.TrimSpace(ens.Name),
+		Identifier:         ensName,
 		ENSResolverAddress: strings.TrimSpace(ens.ResolverAddress),
 		ENSChain:           strings.TrimSpace(ens.Chain),
 		Status:             models.SoulChannelStatusActive,
 		UpdatedAt:          now,
 	}
-	return desired, nil
+	resolution := &models.SoulAgentENSResolution{
+		ENSName:             ensName,
+		AgentID:             agentIDHex,
+		Wallet:              firstNonEmpty(identity.Wallet, regV3.Wallet),
+		LocalID:             firstNonEmpty(identity.LocalID, regV3.LocalID),
+		Domain:              firstNonEmpty(identity.Domain, regV3.Domain),
+		SoulRegistrationURI: s.currentSoulRegistrationURI(agentIDHex),
+		MCPEndpoint:         strings.TrimSpace(regV3.Endpoints.MCP),
+		ActivityPubURI:      strings.TrimSpace(regV3.Endpoints.ActivityPub),
+		Email:               emailAddress,
+		Phone:               phoneNumber,
+		Description:         strings.TrimSpace(regV3.SelfDescription.Purpose),
+		Status:              firstNonEmpty(regV3.Lifecycle.Status, identity.LifecycleStatus, identity.Status),
+		UpdatedAt:           now,
+	}
+	if createdAt, ok := parseRFC3339Loose(regV3.Created); ok {
+		resolution.CreatedAt = createdAt
+	}
+	if resolution.CreatedAt.IsZero() {
+		resolution.CreatedAt = now
+	}
+	return desired, resolution
+}
+
+func (s *Server) currentSoulRegistrationURI(agentIDHex string) string {
+	if s == nil || strings.TrimSpace(s.cfg.SoulPackBucketName) == "" || strings.TrimSpace(agentIDHex) == "" {
+		return ""
+	}
+	return fmt.Sprintf("s3://%s/%s", strings.TrimSpace(s.cfg.SoulPackBucketName), soulRegistrationS3Key(agentIDHex))
 }
 
 func buildSoulV3EmailSync(agentIDHex string, regV3 *soul.RegistrationFileV3, now time.Time) (*models.SoulAgentChannel, *models.SoulEmailAgentIndex) {

--- a/internal/controlplane/handlers_soul_update_registration.go
+++ b/internal/controlplane/handlers_soul_update_registration.go
@@ -639,6 +639,11 @@ func (s *Server) syncSoulV3Channel(
 			return appErr
 		}
 	}
+	if channelType == models.SoulChannelTypeENS && desiredENS != nil {
+		if appErr := s.preflightSoulENSResolutionAssignable(ctx, desiredENS); appErr != nil {
+			return appErr
+		}
+	}
 	if appErr := s.cleanupSoulV3ChannelIndexes(ctx, agentIDHex, channelType, identity, existing, desired); appErr != nil {
 		return appErr
 	}
@@ -1054,6 +1059,33 @@ func (s *Server) ensureSoulENSResolution(ctx context.Context, idx *models.SoulAg
 			return &apptheory.AppError{Code: "app.conflict", Message: "ens name is already provisioned"}
 		}
 		return &apptheory.AppError{Code: "app.internal", Message: "failed to update ens resolution"}
+	}
+	return nil
+}
+
+func (s *Server) preflightSoulENSResolutionAssignable(ctx context.Context, idx *models.SoulAgentENSResolution) *apptheory.AppError {
+	if idx == nil {
+		return nil
+	}
+	probe := *idx
+	_ = probe.UpdateKeys()
+	if strings.TrimSpace(probe.ENSName) == "" || strings.TrimSpace(probe.AgentID) == "" {
+		return &apptheory.AppError{Code: "app.bad_request", Message: "ens resolution is invalid"}
+	}
+	var existing models.SoulAgentENSResolution
+	err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulAgentENSResolution{}).
+		Where("PK", "=", probe.PK).
+		Where("SK", "=", probe.SK).
+		First(&existing)
+	if err == nil {
+		if strings.EqualFold(strings.TrimSpace(existing.AgentID), strings.TrimSpace(probe.AgentID)) {
+			return nil
+		}
+		return &apptheory.AppError{Code: "app.conflict", Message: "ens name is already provisioned"}
+	}
+	if !theoryErrors.IsNotFound(err) {
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to validate ens resolution"}
 	}
 	return nil
 }

--- a/internal/controlplane/handlers_soul_update_registration_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_internal_test.go
@@ -267,6 +267,7 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 
 	// v3 sync reads existing channel records by SK.
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
 	if err != nil {

--- a/internal/controlplane/handlers_soul_update_registration_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_internal_test.go
@@ -267,7 +267,7 @@ func TestHandleSoulAgentUpdateRegistration_V3_FirstVersion_AllowsNullPreviousVer
 
 	// v3 sync reads existing channel records by SK.
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
-	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Twice()
 
 	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
 	if err != nil {

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -429,7 +429,7 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
-	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Twice()
 
 	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
 	if err != nil {
@@ -907,6 +907,7 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 			Identifier:  "old-agent.lessersoul.eth",
 		}
 	}).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
 		*dest = models.SoulAgentENSResolution{ENSName: "old-agent.lessersoul.eth", AgentID: identity.AgentID}
@@ -1048,6 +1049,70 @@ func TestSyncSoulV3StateFromRegistration_RejectsManagedChannelIdentifierChange(t
 	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "managed channel must be deprovisioned before changing identifier" {
 		t.Fatalf("expected managed channel conflict, got %v", appErr)
 	}
+}
+
+func TestSyncSoulV3Channel_PreflightsENSConflictBeforeCleanupAndUpsert(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulLifecycleTestDB()
+	s := &Server{store: store.New(tdb.db)}
+	identity := &models.SoulAgentIdentity{
+		AgentID: soulLifecycleTestAgentIDHex,
+		Domain:  "example.com",
+		LocalID: "agent-alice",
+	}
+	oldENSName := "old-agent.lessersoul.eth"
+	desiredENSName := "foreign-agent.lessersoul.eth"
+
+	oldResolutionKey := &models.SoulAgentENSResolution{ENSName: oldENSName, AgentID: identity.AgentID}
+	_ = oldResolutionKey.UpdateKeys()
+	desiredResolution := &models.SoulAgentENSResolution{ENSName: desiredENSName, AgentID: identity.AgentID}
+	_ = desiredResolution.UpdateKeys()
+
+	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
+		*dest = models.SoulAgentChannel{
+			AgentID:     identity.AgentID,
+			ChannelType: models.SoulChannelTypeENS,
+			Identifier:  oldENSName,
+			Status:      models.SoulChannelStatusActive,
+		}
+	}).Once()
+
+	tdb.qENS.ExpectedCalls = nil
+	var ensPK string
+	tdb.qENS.On("Where", "PK", "=", mock.Anything).Return(tdb.qENS).Run(func(args mock.Arguments) {
+		ensPK, _ = args.Get(2).(string)
+	}).Maybe()
+	tdb.qENS.On("Where", "SK", "=", "RESOLUTION").Return(tdb.qENS).Maybe()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
+		switch ensPK {
+		case desiredResolution.PK:
+			*dest = models.SoulAgentENSResolution{ENSName: desiredENSName, AgentID: "0xother"}
+		case oldResolutionKey.PK:
+			*dest = models.SoulAgentENSResolution{ENSName: oldENSName, AgentID: identity.AgentID}
+		default:
+			t.Fatalf("unexpected ENS resolution lookup PK %q", ensPK)
+		}
+	}).Once()
+
+	desiredChannel := &models.SoulAgentChannel{
+		AgentID:     identity.AgentID,
+		ChannelType: models.SoulChannelTypeENS,
+		Identifier:  desiredENSName,
+		Status:      models.SoulChannelStatusActive,
+	}
+	appErr := s.syncSoulV3Channel(context.Background(), identity.AgentID, identity, models.SoulChannelTypeENS, desiredChannel, nil, nil, desiredResolution)
+	if appErr == nil || appErr.Code != appErrCodeConflict || appErr.Message != "ens name is already provisioned" {
+		t.Fatalf("expected ENS ownership conflict, got %v", appErr)
+	}
+
+	tdb.qENS.AssertNumberOfCalls(t, "First", 1)
+	tdb.qENS.AssertNotCalled(t, "Delete")
+	tdb.qENS.AssertNotCalled(t, "Create")
+	tdb.qENS.AssertNotCalled(t, "CreateOrUpdate")
+	tdb.qChannel.AssertNotCalled(t, "CreateOrUpdate")
 }
 
 func TestSyncSoulV3StateFromRegistration_AllowsProject37LegacyEmailMigration(t *testing.T) {

--- a/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_update_registration_more_internal_test.go
@@ -429,6 +429,7 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}).Once()
 	tdb.qCapIdx.On("First", mock.AnythingOfType("*models.SoulCapabilityAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(theoryErrors.ErrItemNotFound).Times(3)
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 
 	parsedABI, err := abi.JSON(strings.NewReader(soul.SoulRegistryABI))
 	if err != nil {
@@ -560,8 +561,8 @@ func TestUpdateSoulAgentRegistrationForInstance_V3_SyncsENSWithoutS3Key(t *testi
 	}
 
 	summary := collectSyncV3StateModels(tdb.db.Calls, agentIDHex)
-	if len(summary.ensNames) != 0 {
-		t.Fatalf("expected self-asserted ENS resolution to remain unindexed, got %v", summary.ensNames)
+	if !summary.ensNames["agent-alice.lessersoul.eth"] {
+		t.Fatalf("expected self-asserted ENS resolution material, got %v", summary.ensNames)
 	}
 }
 
@@ -882,9 +883,13 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 	tdb := newSoulLifecycleTestDB()
 	s := &Server{
 		store: store.New(tdb.db),
-		cfg:   config.Config{WebAuthnRPID: "portal.example"},
+		cfg:   config.Config{SoulPackBucketName: "bucket", WebAuthnRPID: "portal.example"},
 	}
 	now := time.Date(2026, time.March, 5, 13, 14, 15, 0, time.UTC)
+	canonicalENSName, err := soul.ManagedENSName("agent-alice", "inst1")
+	if err != nil {
+		t.Fatalf("ManagedENSName: %v", err)
+	}
 	rep := 0.8
 	identity := &models.SoulAgentIdentity{
 		AgentID:         soulLifecycleTestAgentIDHex,
@@ -906,6 +911,7 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
 		*dest = models.SoulAgentENSResolution{ENSName: "old-agent.lessersoul.eth", AgentID: identity.AgentID}
 	}).Once()
+	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
 	tdb.qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
 		*dest = models.SoulAgentChannel{
@@ -939,11 +945,19 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 	}).Once()
 
 	regV3 := &soul.RegistrationFileV3{
+		Version: "3",
+		AgentID: identity.AgentID,
+		Domain:  identity.Domain,
+		LocalID: identity.LocalID,
+		Wallet:  identity.Wallet,
+		SelfDescription: soul.SelfDescriptionV2{
+			Purpose: "I summarize documents for humans.",
+		},
 		Channels: &soul.ChannelsV3{
 			ENS: &soul.ENSChannelV3{
-				Name:            "agent-alice.lessersoul.eth",
+				Name:            canonicalENSName,
 				ResolverAddress: "0x0000000000000000000000000000000000000002",
-				Chain:           "mainnet",
+				Chain:           "sepolia",
 			},
 			Phone: &soul.PhoneChannelV3{
 				Number:       "+15557654321",
@@ -979,6 +993,11 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 			MCP:         "https://example.com/mcp",
 			ActivityPub: "https://example.com/activitypub",
 		},
+		Lifecycle: soul.LifecycleV2{
+			Status: models.SoulAgentStatusActive,
+		},
+		Created: "2026-03-01T00:00:00Z",
+		Updated: "2026-03-05T13:14:15Z",
 	}
 
 	if appErr := s.syncSoulV3StateFromRegistration(context.Background(), identity.AgentID, identity, regV3, now); appErr != nil {
@@ -989,7 +1008,8 @@ func TestSyncSoulV3StateFromRegistration_PreservesManagedFieldsAndCleansUpIndexe
 
 	assertSyncV3PhoneModel(t, summary.phoneModel, now)
 	assertSyncV3PrefsModel(t, summary.prefsModel, rep)
-	assertSyncV3Indexes(t, summary)
+	assertSyncV3Indexes(t, summary, canonicalENSName)
+	assertSyncV3ENSResolution(t, summary.ensResolution, canonicalENSName, identity, now)
 }
 
 func TestSyncSoulV3StateFromRegistration_RejectsManagedChannelIdentifierChange(t *testing.T) {
@@ -1512,6 +1532,7 @@ func collectCapabilityClaimLevels(calls []mock.Call) map[string]string {
 type syncV3StateModels struct {
 	phoneModel        *models.SoulAgentChannel
 	prefsModel        *models.SoulAgentContactPreferences
+	ensResolution     *models.SoulAgentENSResolution
 	ensNames          map[string]bool
 	emailIndexSeen    bool
 	phoneIndexes      map[string]bool
@@ -1544,6 +1565,9 @@ func recordSyncV3StateModel(summary *syncV3StateModels, model any, agentID strin
 	case *models.SoulAgentENSResolution:
 		if strings.TrimSpace(v.ENSName) != "" {
 			summary.ensNames[v.ENSName] = true
+		}
+		if v.AgentID == agentID && strings.TrimSpace(v.SoulRegistrationURI) != "" {
+			summary.ensResolution = v
 		}
 	case *models.SoulEmailAgentIndex:
 		if v.Email == "old-agent@example.com" {
@@ -1601,10 +1625,10 @@ func assertSyncV3PrefsModel(t *testing.T, prefsModel *models.SoulAgentContactPre
 	}
 }
 
-func assertSyncV3Indexes(t *testing.T, summary syncV3StateModels) {
+func assertSyncV3Indexes(t *testing.T, summary syncV3StateModels, canonicalENSName string) {
 	t.Helper()
-	if !summary.ensNames["old-agent.lessersoul.eth"] || summary.ensNames["agent-alice.lessersoul.eth"] {
-		t.Fatalf("expected old ENS cleanup without self-asserted ENS upsert, got %v", summary.ensNames)
+	if !summary.ensNames["old-agent.lessersoul.eth"] || !summary.ensNames[canonicalENSName] {
+		t.Fatalf("expected old ENS cleanup and canonical ENS upsert, got %v", summary.ensNames)
 	}
 	if !summary.emailIndexSeen {
 		t.Fatalf("expected old email index cleanup")
@@ -1614,5 +1638,43 @@ func assertSyncV3Indexes(t *testing.T, summary syncV3StateModels) {
 	}
 	if !summary.channelIndexTypes[models.SoulChannelTypeEmail] || summary.channelIndexTypes[models.SoulChannelTypePhone] {
 		t.Fatalf("expected only removed email channel index cleanup, got %v", summary.channelIndexTypes)
+	}
+}
+
+func assertSyncV3ENSResolution(t *testing.T, resolution *models.SoulAgentENSResolution, canonicalENSName string, identity *models.SoulAgentIdentity, now time.Time) {
+	t.Helper()
+	if resolution == nil {
+		t.Fatalf("expected canonical ENS resolution material")
+	}
+	if resolution.ENSName != canonicalENSName || resolution.AgentID != identity.AgentID {
+		t.Fatalf("unexpected ENS resolution identity: %#v", resolution)
+	}
+	assertSyncV3ENSResolutionIdentity(t, resolution, identity)
+	assertSyncV3ENSResolutionMaterial(t, resolution, now)
+}
+
+func assertSyncV3ENSResolutionIdentity(t *testing.T, resolution *models.SoulAgentENSResolution, identity *models.SoulAgentIdentity) {
+	t.Helper()
+	if resolution.Wallet != identity.Wallet || resolution.LocalID != identity.LocalID || resolution.Domain != identity.Domain {
+		t.Fatalf("expected identity fields in ENS resolution, got %#v", resolution)
+	}
+	if resolution.SoulRegistrationURI != "s3://bucket/"+soulRegistrationS3Key(identity.AgentID) {
+		t.Fatalf("unexpected registration URI: %q", resolution.SoulRegistrationURI)
+	}
+}
+
+func assertSyncV3ENSResolutionMaterial(t *testing.T, resolution *models.SoulAgentENSResolution, now time.Time) {
+	t.Helper()
+	if resolution.MCPEndpoint != "https://example.com/mcp" || resolution.ActivityPubURI != "https://example.com/activitypub" {
+		t.Fatalf("unexpected endpoint material: %#v", resolution)
+	}
+	if resolution.Phone != "+15557654321" || resolution.Email != "" {
+		t.Fatalf("unexpected contact material: %#v", resolution)
+	}
+	if resolution.Description != "I summarize documents for humans." || resolution.Status != models.SoulAgentStatusActive {
+		t.Fatalf("unexpected text/status material: %#v", resolution)
+	}
+	if !resolution.CreatedAt.Equal(time.Date(2026, time.March, 1, 0, 0, 0, 0, time.UTC)) || !resolution.UpdatedAt.Equal(now) {
+		t.Fatalf("unexpected ENS resolution timestamps: created=%v updated=%v", resolution.CreatedAt, resolution.UpdatedAt)
 	}
 }

--- a/internal/soul/managed_identity.go
+++ b/internal/soul/managed_identity.go
@@ -64,3 +64,16 @@ func ManagedENSName(name string, instanceSlug string) (string, error) {
 	}
 	return fmt.Sprintf("%s.%s.%s", handle, slug, ManagedENSRootName), nil
 }
+
+// LegacyBareManagedENSNameForMigration derives the pre-instance-scoped managed
+// ENS name that host emitted before managed ENS names included the instance
+// slug. It exists only so migration paths can recognize and replace known
+// legacy managed state without treating arbitrary external ENS channels as
+// host-managed.
+func LegacyBareManagedENSNameForMigration(name string) (string, error) {
+	handle, err := ValidateManagedHandle(name)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s", handle, ManagedENSRootName), nil
+}

--- a/internal/soul/managed_identity_test.go
+++ b/internal/soul/managed_identity_test.go
@@ -116,3 +116,19 @@ func TestManagedENSName_CanonicalInstanceScopedForm(t *testing.T) {
 		})
 	}
 }
+
+func TestLegacyBareManagedENSNameForMigration(t *testing.T) {
+	t.Parallel()
+
+	got, err := LegacyBareManagedENSNameForMigration("agent-alice")
+	if err != nil {
+		t.Fatalf("LegacyBareManagedENSNameForMigration unexpected err: %v", err)
+	}
+	if got != "agent-alice.lessersoul.eth" {
+		t.Fatalf("LegacyBareManagedENSNameForMigration got %q", got)
+	}
+
+	if _, err := LegacyBareManagedENSNameForMigration("Agent-Alice"); err == nil {
+		t.Fatal("expected legacy helper to preserve managed handle validation")
+	}
+}

--- a/internal/trust/handlers_ens_gateway_more_internal_test.go
+++ b/internal/trust/handlers_ens_gateway_more_internal_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
@@ -132,6 +133,7 @@ func TestLoadENSGatewayMaterialAndSuccessorLookup(t *testing.T) {
 	t.Run("success_and_cache_hit", func(t *testing.T) {
 		t.Parallel()
 
+		ensName := mustManagedENSNameForGatewayTest(t, "agent", "inst1")
 		tdb := newENSGatewayTestDB()
 		s := &Server{
 			cfg:      config.Config{SoulEnabled: true, ENSGatewaySignatureTTLSeconds: 15},
@@ -142,7 +144,7 @@ func TestLoadENSGatewayMaterialAndSuccessorLookup(t *testing.T) {
 		tdb.qRes.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
 			*dest = models.SoulAgentENSResolution{
-				ENSName:             "agent.lessersoul.eth",
+				ENSName:             ensName,
 				AgentID:             agentID,
 				SoulRegistrationURI: "s3://bucket/reg.json",
 				MCPEndpoint:         "https://example.com/mcp",
@@ -167,15 +169,15 @@ func TestLoadENSGatewayMaterialAndSuccessorLookup(t *testing.T) {
 			*dest = models.SoulAgentChannel{AgentID: successorID, ChannelType: models.SoulChannelTypeENS, Identifier: ensGatewaySuccessorName}
 		}).Once()
 
-		got, ok, err := s.loadENSGatewayMaterial(context.Background(), "Agent.Lessersoul.ETH")
+		got, ok, err := s.loadENSGatewayMaterial(context.Background(), "Agent.Inst1.Lessersoul.ETH")
 		if err != nil || !ok {
 			t.Fatalf("loadENSGatewayMaterial err=%v ok=%v", err, ok)
 		}
-		if got.ENSName != "agent.lessersoul.eth" || got.SuccessorENSName != ensGatewaySuccessorName || !got.SuccessorENSOK {
+		if got.ENSName != ensName || got.SuccessorENSName != ensGatewaySuccessorName || !got.SuccessorENSOK {
 			t.Fatalf("unexpected material: %#v", got)
 		}
 
-		cached, ok, err := s.loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		cached, ok, err := s.loadENSGatewayMaterial(context.Background(), ensName)
 		if err != nil || !ok || cached.AgentID != agentID {
 			t.Fatalf("expected cache hit, got material=%#v ok=%v err=%v", cached, ok, err)
 		}
@@ -195,6 +197,15 @@ func TestLoadENSGatewayMaterialAndSuccessorLookup(t *testing.T) {
 			t.Fatalf("unexpected blank successor result: name=%q ok=%v err=%v", name, ok, err)
 		}
 	})
+}
+
+func mustManagedENSNameForGatewayTest(t testing.TB, name string, instanceSlug string) string {
+	t.Helper()
+	ensName, err := soul.ManagedENSName(name, instanceSlug)
+	if err != nil {
+		t.Fatalf("ManagedENSName(%q, %q): %v", name, instanceSlug, err)
+	}
+	return ensName
 }
 
 func newENSGatewayAnswerTestServer(addr common.Address) (*Server, common.Hash, [32]byte) {


### PR DESCRIPTION
## Summary
- Emit canonical instance-scoped managed ENS channel metadata in generated v3 email and phone provisioning registrations.
- Use stage-aware ENS gateway chain/resolver config for managed provisioning metadata.
- Preserve arbitrary existing ENS channels while replacing current canonical or known legacy bare managed names.
- Materialize `SoulAgentENSResolution` records during v3 registration sync so the ENS gateway can resolve canonical managed names from host state.

## Changed files
- `internal/controlplane/constants.go`
- `internal/controlplane/handlers_soul_channels_email_provision.go`
- `internal/controlplane/handlers_soul_channels_email_provision_internal_test.go`
- `internal/controlplane/handlers_soul_channels_phone_provision.go`
- `internal/controlplane/handlers_soul_channels_phone_provision_internal_test.go`
- `internal/controlplane/handlers_soul_channels_phone_provision_more_internal_test.go`
- `internal/controlplane/handlers_soul_update_registration.go`
- `internal/controlplane/handlers_soul_update_registration_internal_test.go`
- `internal/controlplane/handlers_soul_update_registration_more_internal_test.go`
- `internal/controlplane/handlers_soul_boundaries_coverage_internal_test.go`
- `internal/controlplane/handlers_soul_discovery_v3_internal_test.go`
- `internal/soul/managed_identity.go`
- `internal/soul/managed_identity_test.go`
- `internal/trust/handlers_ens_gateway_more_internal_test.go`

## Validation evidence
- `git diff --check origin/main...HEAD` — pass
- `gofmt -l <changed Go files>` — empty
- `go test ./internal/soul ./internal/controlplane ./internal/trust` — pass
- `go test ./...` — pass
- `go vet ./...` — pass
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — pass (40 pass, 0 fail, 0 blocked; 2026-06-01T21:13:58Z run)
- `git status --short --branch` — clean on `codex/project44-m3-ens-sync-gateway`
- `git worktree list --porcelain` — only the normal checkout

## Caveats / deferred work
- No production, lab/live deploy, AWS, Sepolia, mainnet, backfill, or on-chain actions were run.
- ENS gateway material is populated by the v3 sync path; existing records need that path or a separately approved backfill before they appear in gateway lookup state.
- Legacy bare managed ENS replacement is limited to the known prior `<local>.lessersoul.eth` shape; arbitrary external ENS channels remain preserved.
- Generated validation artifacts were cleaned from the working tree after local validation.

Closes #637 #654 #655 #656