### PR TITLE
fix(soul): fail closed legacy ENS aliases

### DIFF
--- a/docs/adr/0007-hosted-identity-and-ens-invariants.md
+++ b/docs/adr/0007-hosted-identity-and-ens-invariants.md
@@ -50,6 +50,10 @@ artifacts MUST NOT advertise legacy bare names such as `<name>.lessersoul.eth` a
 Existing bare names, aliases, examples, or receipts may exist as legacy migration inputs. Later backfill/canary work must
 treat them as compatibility material, not as the target shape.
 
+Legacy bare managed ENS names (`<name>.lessersoul.eth`) fail closed on current public discovery, ENS search, and the
+ENS gateway. They are not public/gateway aliases for canonical instance-scoped names unless a future governance-reviewed
+change adds explicit bounded alias records and tests.
+
 ### 3. ENS chain and resolver selection are independent from SoulRegistry chain selection
 
 ENS gateway chain/resolver configuration is its own stage-owned concern:
@@ -171,6 +175,8 @@ Later Project 44 milestones should use this checklist as their done/rollback/evi
 - [ ] No SoulRegistry readiness/mint requirement blocks hosted identity, ENS publication, channel policy, or x402 grant
       eligibility.
 - [ ] Consumer-facing schema examples and generated contract snapshots are updated where the public shape changes.
+- [ ] Legacy bare managed ENS names fail closed on public discovery/search and gateway resolution; migration-only
+      replacement behavior remains bounded to known legacy managed channels.
 
 ### M4 — Resolver deployment/runbooks
 

--- a/internal/controlplane/handlers_soul_discovery_v3.go
+++ b/internal/controlplane/handlers_soul_discovery_v3.go
@@ -194,6 +194,9 @@ func soulPublicENSChannelFromModel(c *models.SoulAgentChannel) *soulPublicENSCha
 	if c == nil || strings.TrimSpace(c.Identifier) == "" {
 		return nil
 	}
+	if soul.IsLegacyBareManagedENSName(c.Identifier) {
+		return nil
+	}
 	return &soulPublicENSChannel{
 		Name:            strings.TrimSpace(c.Identifier),
 		ResolverAddress: strings.TrimSpace(c.ENSResolverAddress),
@@ -349,12 +352,9 @@ func (s *Server) handleSoulPublicResolveENSName(ctx *apptheory.Context) (*appthe
 		return nil, &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 	}
 
-	raw, _ := url.PathUnescape(strings.TrimSpace(ctx.Param("ensName")))
-	if raw == "" {
-		return nil, &apptheory.AppError{Code: appErrCodeBadRequest, Message: "ensName is required"}
-	}
-	if !soulENSNameRegex.MatchString(strings.ToLower(raw)) {
-		return nil, &apptheory.AppError{Code: appErrCodeBadRequest, Message: "ensName is invalid"}
+	raw, appErr := normalizeSoulPublicResolveENSName(ctx.Param("ensName"))
+	if appErr != nil {
+		return nil, appErr
 	}
 
 	key := &models.SoulAgentENSResolution{ENSName: raw}
@@ -396,6 +396,20 @@ func (s *Server) handleSoulPublicResolveENSName(ctx *apptheory.Context) (*appthe
 	}
 	s.setSoulPublicHeaders(ctx, resp, "public, max-age=60")
 	return resp, nil
+}
+
+func normalizeSoulPublicResolveENSName(rawParam string) (string, *apptheory.AppError) {
+	raw, _ := url.PathUnescape(strings.TrimSpace(rawParam))
+	if raw == "" {
+		return "", &apptheory.AppError{Code: appErrCodeBadRequest, Message: "ensName is required"}
+	}
+	if !soulENSNameRegex.MatchString(strings.ToLower(raw)) {
+		return "", &apptheory.AppError{Code: appErrCodeBadRequest, Message: "ensName is invalid"}
+	}
+	if soul.IsLegacyBareManagedENSName(raw) {
+		return "", &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+	}
+	return raw, nil
 }
 
 func (s *Server) handleSoulPublicResolveEmail(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -594,6 +608,9 @@ func (s *Server) requirePublicResolvableSoulChannel(ctx *apptheory.Context, agen
 			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 		}
 	case models.SoulChannelTypeENS:
+		if soul.IsLegacyBareManagedENSName(identifier) || soul.IsLegacyBareManagedENSName(chCopy.Identifier) {
+			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
+		}
 		if chCopy.Status != models.SoulChannelStatusActive {
 			return &apptheory.AppError{Code: "app.not_found", Message: "not found"}
 		}

--- a/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
+++ b/internal/controlplane/handlers_soul_discovery_v3_internal_test.go
@@ -40,18 +40,33 @@ func TestSoulPublicDiscoveryV3ENSChannelFromModel(t *testing.T) {
 	if got := soulPublicENSChannelFromModel(&models.SoulAgentChannel{Identifier: " "}); got != nil {
 		t.Fatalf("expected nil ENS channel for blank identifier, got %#v", got)
 	}
+	if got := soulPublicENSChannelFromModel(&models.SoulAgentChannel{Identifier: "agent.lessersoul.eth"}); got != nil {
+		t.Fatalf("expected nil ENS channel for legacy bare managed name, got %#v", got)
+	}
 
 	got := soulPublicENSChannelFromModel(&models.SoulAgentChannel{
-		Identifier:         " agent.lessersoul.eth ",
+		Identifier:         " agent.inst1.lessersoul.eth ",
 		ENSResolverAddress: " 0xresolver ",
 		ENSChain:           " base ",
 	})
 	if got == nil {
 		t.Fatalf("expected ENS channel")
 	}
-	if got.Name != "agent.lessersoul.eth" || got.ResolverAddress != "0xresolver" || got.Chain != "base" {
+	if got.Name != "agent.inst1.lessersoul.eth" || got.ResolverAddress != "0xresolver" || got.Chain != "base" {
 		t.Fatalf("unexpected ENS channel: %#v", got)
 	}
+}
+
+func TestHandleSoulPublicResolveENSName_LegacyBareManagedNameFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db), cfg: config.Config{SoulEnabled: true}}
+	ctx := &apptheory.Context{Params: map[string]string{"ensName": "agent.lessersoul.eth"}}
+
+	_, err := s.handleSoulPublicResolveENSName(ctx)
+	requireAppErrorCode(t, err, "app.not_found")
+	tdb.qENS.AssertNotCalled(t, "First", mock.Anything)
 }
 
 func TestSoulPublicDiscoveryV3EmailChannelFromModel(t *testing.T) {
@@ -372,8 +387,8 @@ func TestHandleSoulPublicResolveLookup_DiscoveryV3(t *testing.T) {
 				"ensName",
 				" ",
 				"agent.example.com",
-				"agent.lessersoul.eth",
-				"Agent%2Elessersoul.eth",
+				"agent.inst1.lessersoul.eth",
+				"Agent%2Einst1%2Elessersoul.eth",
 				func(s *Server, ctx *apptheory.Context) (*apptheory.Response, error) {
 					return s.handleSoulPublicResolveENSName(ctx)
 				},
@@ -618,7 +633,7 @@ func discoverySuccessSetup(setup discoveryResolveSetup, localID string) discover
 			*dest = models.SoulAgentChannel{
 				AgentID:     agentID,
 				ChannelType: models.SoulChannelTypeENS,
-				Identifier:  "agent.lessersoul.eth",
+				Identifier:  "agent.inst1.lessersoul.eth",
 				Status:      models.SoulChannelStatusActive,
 			}
 		}).Twice()
@@ -628,7 +643,7 @@ func discoverySuccessSetup(setup discoveryResolveSetup, localID string) discover
 func discoveryENSResolveSetup(t *testing.T, tdb *soulPublicTestDB, agentID string) {
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 }
 

--- a/internal/controlplane/handlers_soul_public.go
+++ b/internal/controlplane/handlers_soul_public.go
@@ -940,6 +940,9 @@ func (s *Server) searchSoulAgentsByENS(ctx context.Context, params soulPublicSea
 	if ensName == "" {
 		return nil, false, "", &apptheory.AppError{Code: "app.bad_request", Message: "ens is required"}
 	}
+	if soul.IsLegacyBareManagedENSName(ensName) {
+		return []soulSearchResult{}, false, "", nil
+	}
 
 	key := &models.SoulAgentENSResolution{ENSName: ensName}
 	_ = key.UpdateKeys()

--- a/internal/controlplane/handlers_soul_public_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_internal_test.go
@@ -508,7 +508,7 @@ func newSoulPublicAvatarTestServer(t *testing.T) (*Server, soulPublicAvatarExpec
 	tdb := newSoulPublicTestDB()
 	expected := soulPublicAvatarExpectations{
 		agentID:          "0x" + strings.Repeat("12", 32),
-		ensName:          "agent-bot.lessersoul.eth",
+		ensName:          "agent-bot.inst1.lessersoul.eth",
 		registryAddr:     common.HexToAddress("0x0000000000000000000000000000000000000abc"),
 		renderers:        [3]common.Address{common.HexToAddress("0x0000000000000000000000000000000000000100"), common.HexToAddress("0x0000000000000000000000000000000000000101"), common.HexToAddress("0x0000000000000000000000000000000000000102")},
 		images:           [3]string{encodeSoulPublicAvatarSVG("<svg>blob</svg>"), encodeSoulPublicAvatarSVG("<svg>geometry</svg>"), encodeSoulPublicAvatarSVG("<svg>sigil</svg>")},
@@ -1533,7 +1533,7 @@ func TestHandleSoulPublicSearch_ENS(t *testing.T) {
 
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent-bob.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent-bob.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
@@ -1541,7 +1541,7 @@ func TestHandleSoulPublicSearch_ENS(t *testing.T) {
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: testDomainExampleCom, LocalID: "agent-bob", Status: models.SoulAgentStatusActive}
 	}).Once()
 
-	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"ens": {"agent-bob.lessersoul.eth"}}}}
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"ens": {"agent-bob.inst1.lessersoul.eth"}}}}
 	resp, err := s.handleSoulPublicSearch(ctx)
 	if err != nil || resp.Status != http.StatusOK {
 		t.Fatalf("unexpected: resp=%#v err=%v", resp, err)

--- a/internal/controlplane/handlers_soul_public_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_more_internal_test.go
@@ -95,7 +95,17 @@ func TestSearchSoulAgentsByENS_ResolutionNotFoundReturnsEmpty(t *testing.T) {
 	tdb := newSoulPublicTestDB()
 	s := &Server{store: store.New(tdb.db)}
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(theoryErrors.ErrItemNotFound).Once()
+	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"}, "")
+}
+
+func TestSearchSoulAgentsByENS_LegacyBareManagedNameFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	tdb := newSoulPublicTestDB()
+	s := &Server{store: store.New(tdb.db)}
+
 	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{ENSName: "agent.lessersoul.eth"}, "")
+	tdb.qENS.AssertNotCalled(t, "First", mock.Anything)
 }
 
 func TestSearchSoulAgentsByENS_StatusDefaultsToActiveOnly(t *testing.T) {
@@ -109,7 +119,7 @@ func TestSearchSoulAgentsByENS_StatusDefaultsToActiveOnly(t *testing.T) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: "agent-a", Status: models.SoulAgentStatusSuspended}
 	}).Once()
-	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{ENSName: "agent.lessersoul.eth"}, "")
+	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"}, "")
 }
 
 func TestSearchSoulAgentsByENS_BoundaryFilterExcludesAgent(t *testing.T) {
@@ -122,7 +132,7 @@ func TestSearchSoulAgentsByENS_BoundaryFilterExcludesAgent(t *testing.T) {
 	mockSoulPublicENSIdentity(t, &tdb, agentID)
 	tdb.qBoundIdx.On("First", mock.AnythingOfType("*models.SoulBoundaryKeywordAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{
-		ENSName:    "agent.lessersoul.eth",
+		ENSName:    "agent.inst1.lessersoul.eth",
 		Boundary:   "finance",
 		Channels:   []string{"email"},
 		Limit:      1,
@@ -144,7 +154,7 @@ func TestSearchSoulAgentsByENS_ChannelFilterExcludesAgent(t *testing.T) {
 	}).Once()
 	tdb.qChanIdx.On("First", mock.AnythingOfType("*models.SoulChannelAgentIndex")).Return(theoryErrors.ErrItemNotFound).Once()
 	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{
-		ENSName:  "agent.lessersoul.eth",
+		ENSName:  "agent.inst1.lessersoul.eth",
 		Boundary: "finance",
 		Channels: []string{"email"},
 	}, "")
@@ -167,7 +177,7 @@ func TestSearchSoulAgentsByENS_BoundaryAndChannelFiltersIncludeAgent(t *testing.
 		*dest = models.SoulChannelAgentIndex{AgentID: agentID, Domain: "example.com", LocalID: "agent-b", ChannelType: "email"}
 	}).Once()
 	assertSoulPublicENSSearchResults(t, s, soulPublicSearchParams{
-		ENSName:  "agent.lessersoul.eth",
+		ENSName:  "agent.inst1.lessersoul.eth",
 		Boundary: "finance",
 		Channels: []string{"email"},
 	}, agentID)
@@ -239,7 +249,7 @@ func mockSoulPublicENSResolution(t *testing.T, tdb *soulPublicTestDB, agentID st
 	t.Helper()
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 }
 
@@ -689,14 +699,14 @@ func TestSearchSoulAgentsByENS_SupportsRFC3339StatusOverride(t *testing.T) {
 	agentID := "0x" + strings.Repeat("dd", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: "agent-d", Status: models.SoulAgentStatusActive, LifecycleStatus: ""}
 	}).Once()
 
-	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth", Status: models.SoulAgentStatusActive})
+	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth", Status: models.SoulAgentStatusActive})
 	if appErr != nil || len(results) != 1 {
 		t.Fatalf("expected status override to match identity status, got results=%#v err=%v", results, appErr)
 	}
@@ -791,14 +801,14 @@ func TestSearchSoulAgentsByENS_ReturnsInternalOnIdentityNil(t *testing.T) {
 	agentID := "0x" + strings.Repeat("ee", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{}
 	}).Once()
 
-	results, hasMore, nextCursor, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth"})
+	results, hasMore, nextCursor, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"})
 	if appErr != nil || hasMore || nextCursor != "" || len(results) != 0 {
 		t.Fatalf("expected empty non-active result, got results=%#v hasMore=%v nextCursor=%q err=%v", results, hasMore, nextCursor, appErr)
 	}
@@ -979,11 +989,11 @@ func TestSearchSoulAgentsByENS_IdentityNotFoundReturnsEmpty(t *testing.T) {
 	agentID := "0x" + strings.Repeat("ab", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(theoryErrors.ErrItemNotFound).Once()
 
-	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth"})
+	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"})
 	if appErr != nil || len(results) != 0 {
 		t.Fatalf("expected identity not found to return empty, got results=%#v err=%v", results, appErr)
 	}
@@ -996,7 +1006,7 @@ func TestSearchSoulAgentsByENS_ResolutionError(t *testing.T) {
 	s := &Server{store: store.New(tdb.db)}
 
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(errors.New("boom")).Once()
-	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth"})
+	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"})
 	if appErr == nil || appErr.Code != appErrCodeInternal {
 		t.Fatalf("expected internal error, got %#v", appErr)
 	}
@@ -1011,7 +1021,7 @@ func TestSearchSoulAgentsByENS_ChannelIndexError(t *testing.T) {
 	agentID := "0x" + strings.Repeat("bc", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
@@ -1019,7 +1029,7 @@ func TestSearchSoulAgentsByENS_ChannelIndexError(t *testing.T) {
 	}).Once()
 	tdb.qChanIdx.On("First", mock.AnythingOfType("*models.SoulChannelAgentIndex")).Return(errors.New("boom")).Once()
 
-	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth", Channels: []string{"email"}})
+	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth", Channels: []string{"email"}})
 	if appErr == nil || appErr.Code != appErrCodeInternal {
 		t.Fatalf("expected internal error for channel index, got %#v", appErr)
 	}
@@ -1034,7 +1044,7 @@ func TestSearchSoulAgentsByENS_BoundaryIndexError(t *testing.T) {
 	agentID := "0x" + strings.Repeat("cd", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
@@ -1042,7 +1052,7 @@ func TestSearchSoulAgentsByENS_BoundaryIndexError(t *testing.T) {
 	}).Once()
 	tdb.qBoundIdx.On("First", mock.AnythingOfType("*models.SoulBoundaryKeywordAgentIndex")).Return(errors.New("boom")).Once()
 
-	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth", Boundary: "finance"})
+	_, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth", Boundary: "finance"})
 	if appErr == nil || appErr.Code != appErrCodeInternal {
 		t.Fatalf("expected internal error for boundary index, got %#v", appErr)
 	}
@@ -1057,14 +1067,14 @@ func TestSearchSoulAgentsByENS_StatusMismatchExplicit(t *testing.T) {
 	agentID := "0x" + strings.Repeat("de", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: "agent-de", Status: models.SoulAgentStatusActive}
 	}).Once()
 
-	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth", Status: models.SoulAgentStatusSuspended})
+	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth", Status: models.SoulAgentStatusSuspended})
 	if appErr != nil || len(results) != 0 {
 		t.Fatalf("expected explicit status mismatch to return empty, got results=%#v err=%v", results, appErr)
 	}
@@ -1078,10 +1088,10 @@ func TestSearchSoulAgentsByENS_ResolutionEmptyAgentID(t *testing.T) {
 
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: " "}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: " "}
 	}).Once()
 
-	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.lessersoul.eth"})
+	results, _, _, appErr := s.searchSoulAgentsByENS(context.Background(), soulPublicSearchParams{ENSName: "agent.inst1.lessersoul.eth"})
 	if appErr != nil || len(results) != 0 {
 		t.Fatalf("expected empty agent id resolution to return empty, got results=%#v err=%v", results, appErr)
 	}
@@ -1133,14 +1143,14 @@ func TestHandleSoulPublicSearch_UsesENSBranch(t *testing.T) {
 	agentID := "0x" + strings.Repeat("aa", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
 		*dest = models.SoulAgentIdentity{AgentID: agentID, Domain: "example.com", LocalID: "agent-a", Status: models.SoulAgentStatusActive}
 	}).Once()
 
-	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"ens": {"agent.lessersoul.eth"}}}}
+	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"ens": {"agent.inst1.lessersoul.eth"}}}}
 	resp, err := s.handleSoulPublicSearch(ctx)
 	if err != nil || resp.Status != http.StatusOK {
 		t.Fatalf("unexpected: resp=%#v err=%v", resp, err)
@@ -1156,7 +1166,7 @@ func TestHandleSoulPublicSearch_ENSBranchRespectsPrincipalFilter(t *testing.T) {
 	agentID := "0x" + strings.Repeat("aa", 32)
 	tdb.qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-		*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: agentID}
+		*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: agentID}
 	}).Once()
 	tdb.qID.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(nil).Run(func(args mock.Arguments) {
 		dest := testutil.RequireMockArg[*models.SoulAgentIdentity](t, args, 0)
@@ -1170,7 +1180,7 @@ func TestHandleSoulPublicSearch_ENSBranchRespectsPrincipalFilter(t *testing.T) {
 	}).Once()
 
 	ctx := &apptheory.Context{Request: apptheory.Request{Query: map[string][]string{
-		"ens":       {"agent.lessersoul.eth"},
+		"ens":       {"agent.inst1.lessersoul.eth"},
 		"principal": {"0x00000000000000000000000000000000000000bb"},
 	}}}
 	resp, err := s.handleSoulPublicSearch(ctx)

--- a/internal/controlplane/handlers_soul_public_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_public_more_internal_test.go
@@ -1155,6 +1155,13 @@ func TestHandleSoulPublicSearch_UsesENSBranch(t *testing.T) {
 	if err != nil || resp.Status != http.StatusOK {
 		t.Fatalf("unexpected: resp=%#v err=%v", resp, err)
 	}
+	var out soulSearchResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Count != 1 || len(out.Results) != 1 || out.Results[0].AgentID != agentID {
+		t.Fatalf("expected instance-scoped ENS search result for %s, got %#v", agentID, out)
+	}
 }
 
 func TestHandleSoulPublicSearch_ENSBranchRespectsPrincipalFilter(t *testing.T) {

--- a/internal/controlplane/soul_public_agent_view.go
+++ b/internal/controlplane/soul_public_agent_view.go
@@ -164,7 +164,11 @@ func (s *Server) loadSoulPublicAgentENSName(ctx context.Context, agentIDHex stri
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(ens.Identifier), nil
+	ensName := strings.TrimSpace(ens.Identifier)
+	if soul.IsLegacyBareManagedENSName(ensName) {
+		return "", nil
+	}
+	return ensName, nil
 }
 
 func (s *Server) loadSoulPublicAgentAvatar(ctx context.Context, identity *models.SoulAgentIdentity) (*soulPublicAvatarView, error) {

--- a/internal/soul/managed_identity.go
+++ b/internal/soul/managed_identity.go
@@ -77,3 +77,23 @@ func LegacyBareManagedENSNameForMigration(name string) (string, error) {
 	}
 	return fmt.Sprintf("%s.%s", handle, ManagedENSRootName), nil
 }
+
+// IsLegacyBareManagedENSName reports whether name is the pre-instance-scoped
+// managed ENS shape:
+//
+//	<name>.lessersoul.eth
+//
+// This helper is intentionally for fail-closed compatibility checks and
+// migration guardrails. It must not be used to route legacy bare names as
+// current public channels or gateway aliases for the canonical
+// <name>.<instance-slug>.lessersoul.eth name.
+func IsLegacyBareManagedENSName(name string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(name))
+	normalized = strings.TrimSuffix(normalized, ".")
+	labels := strings.Split(normalized, ".")
+	if len(labels) != 3 || strings.Join(labels[1:], ".") != ManagedENSRootName {
+		return false
+	}
+	_, err := ValidateManagedHandle(labels[0])
+	return err == nil
+}

--- a/internal/soul/managed_identity_test.go
+++ b/internal/soul/managed_identity_test.go
@@ -132,3 +132,36 @@ func TestLegacyBareManagedENSNameForMigration(t *testing.T) {
 		t.Fatal("expected legacy helper to preserve managed handle validation")
 	}
 }
+
+func TestIsLegacyBareManagedENSName(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{
+		"agent-alice.lessersoul.eth",
+		"Agent-Alice.LesserSoul.ETH.",
+	} {
+		name := name
+		t.Run("legacy_"+name, func(t *testing.T) {
+			t.Parallel()
+			if !IsLegacyBareManagedENSName(name) {
+				t.Fatalf("IsLegacyBareManagedENSName(%q) = false, want true", name)
+			}
+		})
+	}
+
+	for _, name := range []string{
+		"agent-alice.simulacrum.lessersoul.eth",
+		"agent-alice.eth",
+		"bad_handle.lessersoul.eth",
+		"agent.lessersoul.ai",
+		"",
+	} {
+		name := name
+		t.Run("not_legacy_"+name, func(t *testing.T) {
+			t.Parallel()
+			if IsLegacyBareManagedENSName(name) {
+				t.Fatalf("IsLegacyBareManagedENSName(%q) = true, want false", name)
+			}
+		})
+	}
+}

--- a/internal/trust/handlers_ens_gateway.go
+++ b/internal/trust/handlers_ens_gateway.go
@@ -19,6 +19,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 
 	"github.com/equaltoai/lesser-host/internal/httpx"
+	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
@@ -409,12 +410,9 @@ func (s *Server) loadENSGatewayMaterial(ctx context.Context, ensName string) (en
 	if ensName == "" {
 		return ensGatewayMaterial{}, false, nil
 	}
-
 	now := time.Now().UTC()
-	if s.ensCache != nil {
-		if material, ok, hit := s.ensCache.get(ensName, now); hit {
-			return material, ok, nil
-		}
+	if material, ok, hit := s.cachedENSGatewayMaterialOrLegacyMiss(ensName, now); hit {
+		return material, ok, nil
 	}
 
 	key := &models.SoulAgentENSResolution{ENSName: ensName}
@@ -485,6 +483,18 @@ func (s *Server) loadENSGatewayMaterial(ctx context.Context, ensName string) (en
 
 	s.cacheENSGatewayMaterial(ensName, material, true, now)
 	return material, true, nil
+}
+
+func (s *Server) cachedENSGatewayMaterialOrLegacyMiss(ensName string, now time.Time) (ensGatewayMaterial, bool, bool) {
+	if soul.IsLegacyBareManagedENSName(ensName) {
+		s.cacheENSGatewayMaterial(ensName, ensGatewayMaterial{}, false, now)
+		return ensGatewayMaterial{}, false, true
+	}
+	if s.ensCache == nil {
+		return ensGatewayMaterial{}, false, false
+	}
+	material, ok, hit := s.ensCache.get(ensName, now)
+	return material, ok, hit
 }
 
 func (s *Server) cacheENSGatewayMaterial(ensName string, material ensGatewayMaterial, ok bool, now time.Time) {

--- a/internal/trust/handlers_ens_gateway_internal_test.go
+++ b/internal/trust/handlers_ens_gateway_internal_test.go
@@ -274,7 +274,7 @@ func TestHandleENSGatewayResolve_Addr_SignsAndEncodes(t *testing.T) {
 
 	signerAddr := testENSGatewaySignerAddress(t)
 
-	ensName := "agent-bob.lessersoul.eth"
+	ensName := "agent-bob.inst1.lessersoul.eth"
 	agentID := "0x8db124b1d48e366002db4e61cc1501eeb8561e1ef06fd6f9abf9f984501d13ab"
 	wallet := "0x000000000000000000000000000000000000beef"
 
@@ -358,7 +358,7 @@ func TestHandleENSGatewayResolve_Addr_SignsAndEncodes(t *testing.T) {
 func TestHandleENSGatewayResolve_Text_StatusResolvesDeterministically(t *testing.T) {
 	t.Parallel()
 
-	ensName := "agent-alice.lessersoul.eth"
+	ensName := "agent-alice.inst1.lessersoul.eth"
 	agentID := "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 	qENS := new(ttmocks.MockQuery)
@@ -417,7 +417,7 @@ func TestHandleENSGatewayResolve_Text_StatusResolvesDeterministically(t *testing
 func TestAnswerENSQuery_Branches(t *testing.T) {
 	t.Parallel()
 
-	ensName := "agent-query.lessersoul.eth"
+	ensName := "agent-query.inst1.lessersoul.eth"
 	node := ensNameHash(ensName)
 
 	t.Run("inner data too short", func(t *testing.T) {
@@ -437,7 +437,7 @@ func TestAnswerENSQuery_Branches(t *testing.T) {
 	t.Run("addr node mismatch", func(t *testing.T) {
 		t.Parallel()
 
-		args, err := ensAddrInputs.Pack(ensNameHash("someone-else.lessersoul.eth"))
+		args, err := ensAddrInputs.Pack(ensNameHash("someone-else.inst1.lessersoul.eth"))
 		require.NoError(t, err)
 		_, err = (&Server{}).answerENSQuery(context.Background(), ensName, node, buildENSGatewayInnerCall(t, ensAddrSelector, args))
 		requireENSGatewayError(t, err, "ccip.bad_request", 400)
@@ -520,7 +520,7 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 	t.Run("nil store errors", func(t *testing.T) {
 		t.Parallel()
 
-		_, ok, err := (&Server{}).loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		_, ok, err := (&Server{}).loadENSGatewayMaterial(context.Background(), "agent.inst1.lessersoul.eth")
 		require.Error(t, err)
 		require.False(t, ok)
 	})
@@ -544,12 +544,12 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 
 		srv := NewServer(config.Config{ENSGatewaySignatureTTLSeconds: 5}, store.New(db))
 
-		first, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		first, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.inst1.lessersoul.eth")
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Equal(t, ensGatewayMaterial{}, first)
 
-		second, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		second, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.inst1.lessersoul.eth")
 		require.NoError(t, err)
 		require.False(t, ok)
 		require.Equal(t, ensGatewayMaterial{}, second)
@@ -562,11 +562,11 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 		db := newTestDBWithModelQueries(modelQueryPair{model: &models.SoulAgentENSResolution{}, query: qENS})
 		qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-			*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: " "}
+			*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: " "}
 		}).Once()
 
 		srv := NewServer(config.Config{}, store.New(db))
-		_, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		_, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.inst1.lessersoul.eth")
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
@@ -583,12 +583,12 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 
 		qENS.On("First", mock.AnythingOfType("*models.SoulAgentENSResolution")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentENSResolution](t, args, 0)
-			*dest = models.SoulAgentENSResolution{ENSName: "agent.lessersoul.eth", AgentID: "0xabc"}
+			*dest = models.SoulAgentENSResolution{ENSName: "agent.inst1.lessersoul.eth", AgentID: "0xabc"}
 		}).Once()
 		qIdentity.On("First", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(theoryErrors.ErrItemNotFound).Once()
 
 		srv := NewServer(config.Config{}, store.New(db))
-		_, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.lessersoul.eth")
+		_, ok, err := srv.loadENSGatewayMaterial(context.Background(), "agent.inst1.lessersoul.eth")
 		require.NoError(t, err)
 		require.False(t, ok)
 	})
@@ -596,7 +596,7 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 	t.Run("success caches material and successor", func(t *testing.T) {
 		t.Parallel()
 
-		ensName := "agent.lessersoul.eth"
+		ensName := "agent.inst1.lessersoul.eth"
 		agentID := "0xabc"
 		successorID := "0xdef"
 
@@ -634,7 +634,7 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 		}).Once()
 		qChannel.On("First", mock.AnythingOfType("*models.SoulAgentChannel")).Return(nil).Run(func(args mock.Arguments) {
 			dest := testutil.RequireMockArg[*models.SoulAgentChannel](t, args, 0)
-			*dest = models.SoulAgentChannel{Identifier: " Next.Lessersoul.eth. "}
+			*dest = models.SoulAgentChannel{Identifier: " Next.Inst1.Lessersoul.eth. "}
 		}).Once()
 
 		srv := NewServer(config.Config{}, store.New(db))
@@ -652,7 +652,7 @@ func TestLoadENSGatewayMaterial_CacheAndFallbacks(t *testing.T) {
 		require.Equal(t, "hello world", first.Description)
 		require.Equal(t, successorID, first.SuccessorAgentID)
 		require.True(t, first.SuccessorENSOK)
-		require.Equal(t, "next.lessersoul.eth", first.SuccessorENSName)
+		require.Equal(t, "next.inst1.lessersoul.eth", first.SuccessorENSName)
 
 		second, ok, err := srv.loadENSGatewayMaterial(context.Background(), ensName)
 		require.NoError(t, err)
@@ -816,7 +816,7 @@ func TestENSTextValueAndCacheHelpers(t *testing.T) {
 		Description:      longDescription,
 		Status:           " active ",
 		SuccessorAgentID: " successor ",
-		SuccessorENSName: " next.lessersoul.eth ",
+		SuccessorENSName: " next.inst1.lessersoul.eth ",
 		SuccessorENSOK:   true,
 	}
 
@@ -827,7 +827,7 @@ func TestENSTextValueAndCacheHelpers(t *testing.T) {
 	require.Equal(t, "hello@example.com", ensTextValue(material, "email", context.Background()))
 	require.Equal(t, "+15551234567", ensTextValue(material, "phone", context.Background()))
 	require.Equal(t, "active", ensTextValue(material, "soul.status", context.Background()))
-	require.Equal(t, "next.lessersoul.eth", ensTextValue(material, "soul.successor", context.Background()))
+	require.Equal(t, "next.inst1.lessersoul.eth", ensTextValue(material, "soul.successor", context.Background()))
 	require.Len(t, ensTextValue(material, "description", context.Background()), 256)
 	require.Empty(t, ensTextValue(ensGatewayMaterial{SuccessorAgentID: "successor"}, "soul.successor", context.Background()))
 	require.Empty(t, ensTextValue(material, "unknown", context.Background()))

--- a/internal/trust/handlers_ens_gateway_more_internal_test.go
+++ b/internal/trust/handlers_ens_gateway_more_internal_test.go
@@ -32,7 +32,7 @@ type ensGatewayTestDB struct {
 	qChannel *ttmocks.MockQuery
 }
 
-const ensGatewaySuccessorName = "next.lessersoul.eth"
+const ensGatewaySuccessorName = "next.inst1.lessersoul.eth"
 
 func newENSGatewayTestDB() ensGatewayTestDB {
 	qRes := new(ttmocks.MockQuery)
@@ -199,6 +199,16 @@ func TestLoadENSGatewayMaterialAndSuccessorLookup(t *testing.T) {
 	})
 }
 
+func TestLoadENSGatewayMaterial_LegacyBareManagedNameFailsClosed(t *testing.T) {
+	t.Parallel()
+
+	s := NewServer(config.Config{}, store.New(ttmocks.NewMockExtendedDB()))
+	got, ok, err := s.loadENSGatewayMaterial(context.Background(), "Agent.Lessersoul.eth.")
+	if err != nil || ok || got != (ensGatewayMaterial{}) {
+		t.Fatalf("expected legacy bare managed name to fail closed, got material=%#v ok=%v err=%v", got, ok, err)
+	}
+}
+
 func mustManagedENSNameForGatewayTest(t testing.TB, name string, instanceSlug string) string {
 	t.Helper()
 	ensName, err := soul.ManagedENSName(name, instanceSlug)
@@ -213,8 +223,8 @@ func newENSGatewayAnswerTestServer(addr common.Address) (*Server, common.Hash, [
 		store:    store.New(newTestDBWithModelQueries()),
 		ensCache: &ensGatewayCache{},
 	}
-	s.cacheENSGatewayMaterial("agent.lessersoul.eth", ensGatewayMaterial{
-		ENSName:          "agent.lessersoul.eth",
+	s.cacheENSGatewayMaterial("agent.inst1.lessersoul.eth", ensGatewayMaterial{
+		ENSName:          "agent.inst1.lessersoul.eth",
 		AgentID:          "0xabc",
 		Wallet:           addr.Hex(),
 		Status:           models.SoulAgentStatusActive,
@@ -226,7 +236,7 @@ func newENSGatewayAnswerTestServer(addr common.Address) (*Server, common.Hash, [
 		SuccessorENSOK:   true,
 	}, true, time.Now().UTC())
 
-	node := ensNameHash("agent.lessersoul.eth")
+	node := ensNameHash("agent.inst1.lessersoul.eth")
 	var nodeBytes [32]byte
 	copy(nodeBytes[:], node[:])
 	return s, node, nodeBytes
@@ -239,7 +249,7 @@ func TestAnswerENSQuery_AddrAndCoin(t *testing.T) {
 	s, node, nodeBytes := newENSGatewayAnswerTestServer(addr)
 
 	addrArgs, _ := ensAddrInputs.Pack(nodeBytes)
-	addrOut, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensAddrSelector...), addrArgs...))
+	addrOut, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensAddrSelector...), addrArgs...))
 	if err != nil {
 		t.Fatalf("addr query: %v", err)
 	}
@@ -253,7 +263,7 @@ func TestAnswerENSQuery_AddrAndCoin(t *testing.T) {
 	}
 
 	coinArgs, _ := ensAddrCoinInputs.Pack(nodeBytes, big.NewInt(60))
-	coinOut, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensAddrCoinSelector...), coinArgs...))
+	coinOut, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensAddrCoinSelector...), coinArgs...))
 	if err != nil {
 		t.Fatalf("coin query: %v", err)
 	}
@@ -267,7 +277,7 @@ func TestAnswerENSQuery_AddrAndCoin(t *testing.T) {
 	}
 
 	coinArgsUnsupported, _ := ensAddrCoinInputs.Pack(nodeBytes, big.NewInt(0))
-	coinOutUnsupported, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensAddrCoinSelector...), coinArgsUnsupported...))
+	coinOutUnsupported, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensAddrCoinSelector...), coinArgsUnsupported...))
 	if err != nil {
 		t.Fatalf("unsupported coin query: %v", err)
 	}
@@ -287,7 +297,7 @@ func TestAnswerENSQuery_TextAndContenthash(t *testing.T) {
 	s, node, nodeBytes := newENSGatewayAnswerTestServer(common.HexToAddress("0x0000000000000000000000000000000000001234"))
 
 	textArgs, _ := ensTextInputs.Pack(nodeBytes, "soul.successor")
-	textOut, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensTextSelector...), textArgs...))
+	textOut, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensTextSelector...), textArgs...))
 	if err != nil {
 		t.Fatalf("text query: %v", err)
 	}
@@ -301,7 +311,7 @@ func TestAnswerENSQuery_TextAndContenthash(t *testing.T) {
 	}
 
 	contentArgs, _ := ensContenthashInputs.Pack(nodeBytes)
-	contentOut, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensContenthashSelector...), contentArgs...))
+	contentOut, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensContenthashSelector...), contentArgs...))
 	if err != nil {
 		t.Fatalf("contenthash query: %v", err)
 	}
@@ -320,15 +330,15 @@ func TestAnswerENSQuery_Validation(t *testing.T) {
 
 	s, node, nodeBytes := newENSGatewayAnswerTestServer(common.HexToAddress("0x0000000000000000000000000000000000001234"))
 	addrArgs, _ := ensAddrInputs.Pack(nodeBytes)
-	if _, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, []byte{0x01, 0x02, 0x03}); err == nil {
+	if _, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, []byte{0x01, 0x02, 0x03}); err == nil {
 		t.Fatalf("expected invalid inner resolver data error")
 	}
 
 	badNodeArgs, _ := ensAddrInputs.Pack([32]byte{})
-	if _, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append(append([]byte(nil), ensAddrSelector...), badNodeArgs...)); err == nil {
+	if _, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append(append([]byte(nil), ensAddrSelector...), badNodeArgs...)); err == nil {
 		t.Fatalf("expected node mismatch error")
 	}
-	if _, err := s.answerENSQuery(context.Background(), "agent.lessersoul.eth", node, append([]byte{0xff, 0xee, 0xdd, 0xcc}, addrArgs...)); err == nil {
+	if _, err := s.answerENSQuery(context.Background(), "agent.inst1.lessersoul.eth", node, append([]byte{0xff, 0xee, 0xdd, 0xcc}, addrArgs...)); err == nil {
 		t.Fatalf("expected unsupported query error")
 	}
 }
@@ -336,14 +346,14 @@ func TestAnswerENSQuery_Validation(t *testing.T) {
 func TestParseENSGatewayRequestAndResolveHandler(t *testing.T) {
 	t.Parallel()
 
-	node := ensNameHash("agent.lessersoul.eth")
+	node := ensNameHash("agent.inst1.lessersoul.eth")
 	var nodeBytes [32]byte
 	copy(nodeBytes[:], node[:])
 
 	innerArgs, _ := ensAddrInputs.Pack(nodeBytes)
 	innerData := append(append([]byte(nil), ensAddrSelector...), innerArgs...)
 
-	callData, encodedName, parsedInner, err := parseENSGatewayRequest("agent.lessersoul.eth", hexutil.Encode(innerData))
+	callData, encodedName, parsedInner, err := parseENSGatewayRequest("agent.inst1.lessersoul.eth", hexutil.Encode(innerData))
 	if err != nil {
 		t.Fatalf("parse compatibility request: %v", err)
 	}
@@ -377,15 +387,15 @@ func TestParseENSGatewayRequestAndResolveHandler(t *testing.T) {
 		store:    store.New(newTestDBWithModelQueries()),
 		ensCache: &ensGatewayCache{},
 	}
-	s.cacheENSGatewayMaterial("agent.lessersoul.eth", ensGatewayMaterial{
-		ENSName: "agent.lessersoul.eth",
+	s.cacheENSGatewayMaterial("agent.inst1.lessersoul.eth", ensGatewayMaterial{
+		ENSName: "agent.inst1.lessersoul.eth",
 		Wallet:  common.HexToAddress("0x0000000000000000000000000000000000001234").Hex(),
 	}, true, time.Now().UTC())
 
 	resp, err := s.handleENSGatewayResolve(&apptheory.Context{
 		Request: apptheory.Request{Query: map[string][]string{
 			"sender": {resolverAddr},
-			"name":   {"agent.lessersoul.eth"},
+			"name":   {"agent.inst1.lessersoul.eth"},
 			"data":   {hexutil.Encode(innerData)},
 		}},
 	})

--- a/internal/trust/handlers_ens_gateway_more_internal_test.go
+++ b/internal/trust/handlers_ens_gateway_more_internal_test.go
@@ -407,18 +407,27 @@ func TestParseENSGatewayRequestAndResolveHandler(t *testing.T) {
 	}
 
 	var out ensGatewayResolveJSON
-	if err := json.Unmarshal(resp.Body, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if unmarshalErr := json.Unmarshal(resp.Body, &out); unmarshalErr != nil {
+		t.Fatalf("unmarshal: %v", unmarshalErr)
 	}
 	if !strings.HasPrefix(out.Data, "0x") {
 		t.Fatalf("expected hex-encoded data, got %q", out.Data)
 	}
 
-	if _, err := s.handleENSGatewayResolve(&apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"sender": {"not-hex"}, "data": {hexutil.Encode(innerData)}}}}); err == nil {
-		t.Fatalf("expected invalid sender error")
-	}
-	if _, err := s.handleENSGatewayResolve(&apptheory.Context{Request: apptheory.Request{Query: map[string][]string{"sender": {"0x000000000000000000000000000000000000cafe"}, "data": {hexutil.Encode(innerData)}}}}); err == nil {
-		t.Fatalf("expected unsupported sender error")
+	requireENSGatewayResolveErrorCode(t, s, map[string][]string{"sender": {"not-hex"}, "data": {hexutil.Encode(innerData)}}, "ccip.bad_request")
+	requireENSGatewayResolveErrorCode(t, s, map[string][]string{
+		"sender": {"0x000000000000000000000000000000000000cafe"},
+		"name":   {"agent.inst1.lessersoul.eth"},
+		"data":   {hexutil.Encode(innerData)},
+	}, "ccip.sender_unsupported")
+}
+
+func requireENSGatewayResolveErrorCode(t *testing.T, s *Server, query map[string][]string, want string) {
+	t.Helper()
+
+	_, err := s.handleENSGatewayResolve(&apptheory.Context{Request: apptheory.Request{Query: query}})
+	if appErr, ok := err.(*apptheory.AppTheoryError); !ok || appErr.Code != want {
+		t.Fatalf("expected ENS gateway error %q, got %#v", want, err)
 	}
 }
 


### PR DESCRIPTION
## Milestone
Project 44 M3 tail — legacy ENS alias decision + public/gateway material coverage.

## Classification
Soul-registry / public discovery / ENS gateway test coverage. No Solidity, on-chain, provisioning, trust-API instance-auth, CSP, dependency, or deployment changes.

## Surfaces affected
- Managed ENS name helpers (`internal/soul`)
- Soul public discovery / public ENS search (`internal/controlplane`)
- ENS gateway material lookup (`internal/trust`)
- ADR/runbook evidence for hosted identity + ENS invariants
- Tests for public discovery/search and gateway material

## Legacy behavior chosen (#657)
Low-overhead no-alias/fail-closed path: legacy bare managed ENS names (`<name>.lessersoul.eth`) are migration-only compatibility material. They are not treated as current public channels, ENS search targets, public resolve targets, or ENS gateway aliases for canonical `<name>.<instance-slug>.lessersoul.eth` names.

Existing migration replacement behavior for known legacy managed ENS channels is preserved through the bounded migration helper; no broad alias model or shared runtime routing was added.

## #658 coverage added/confirmed
- Tightened public ENS search fixtures to canonical instance-scoped names.
- Tightened public discovery / channel fixtures to canonical instance-scoped names.
- Tightened ENS gateway addr/text/contenthash/successor fixtures to canonical instance-scoped names.
- Added explicit assertion that public ENS search returns the instance-scoped result.
- Added explicit assertion that the ENS gateway rejects a wrong resolver sender while resolving an instance-scoped name.
- Added fail-closed tests for legacy bare managed names across public resolve/search/channel material and gateway material.

## Specialist walk: soul registry
- Solidity contracts: none.
- On-chain Go code / RPC mutation: none.
- Off-chain state: no new model; only read-time fail-closed behavior and test fixture tightening.
- Safe-ready payloads / mint-signer: untouched.
- Namespace coordination: not required; host implementation/ADR clarification only.

## Multi-tenant isolation impact
No tenant data access or cross-tenant behavior added. This change narrows public/gateway resolution for legacy bare names.

## On-chain impact
None. No AWS, Sepolia, mainnet, ENS manager, backfill, or deployment actions.

## Consumer release verification impact
None. No provisioning or managed release ingestion changes.

## Trust API / CSP impact
ENS gateway public behavior is narrowed for legacy bare managed names. Instance-auth and CSP are untouched.

## Validation
- `git diff --check origin/main...HEAD`
- `gofmt` on changed Go files; `gofmt -l` empty
- `go test ./internal/soul ./internal/controlplane ./internal/trust`
- `go test ./...`
- `go vet ./...`
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (40 pass / 0 fail / 0 blocked)
- `git worktree list --porcelain` shows only the normal checkout

## Rollout
No lab/live deploys in this PR. After merge, normal lab soak before any live deployment remains required.

Closes #657
Closes #658
