### PR TITLE
Promote staging→main: P49 M1.1 host durable hosted-genesis contract lock

### DIFF
--- a/docs/contracts/README.md
+++ b/docs/contracts/README.md
@@ -5,6 +5,8 @@ from `lesser-host` APIs (for example, `greater-components`).
 
 - `openapi.yaml` — OpenAPI snapshot for build-time client/type generation. Do not serve this file at runtime.
 - `soul-mint-conversation-sse.json` — machine-readable SSE companion contract for the soul mint-conversation stream.
+- `hosted-genesis-conversation.md` — Host-owned durable async hosted-genesis status contract for the Lesser
+  instance-key path.
 - `../spec/v3/` — JSON Schema + fixtures for lesser-soul v3 protocol surfaces implemented by `lesser-host`.
 
 ## Canonical generation process
@@ -31,7 +33,11 @@ npm run verify:lesser-host-contracts
   `docs/contracts/openapi.yaml`
 - required instance-key bootstrap write routes, the `soul_instance.*` error envelope, hosted/off-chain finalize response
   schema, or server-side instance-key auth semantics are missing from `docs/contracts/openapi.yaml`
-- the SSE companion contract is missing required events or routes
+- the Lesser-used instance-key registration mint-conversation route is still documented as SSE-only instead of
+  JSON-authoritative durable status
+- the hosted-genesis durable conversation schema or example payloads are missing required status/evidence cases
+- the SSE companion contract is missing required portal/native Host UI events or incorrectly claims the Lesser
+  instance-key route as authoritative SSE
 - the checked-in generated adapter does not match a fresh regeneration
 
 CI and the governance rubric both run this verification so contract drift fails closed.
@@ -40,6 +46,11 @@ The instance-key bootstrap route family under `/api/v1/soul/instance/agents/regi
 server-side contract. Its bearer token is the managed InstanceKey (`sha256(raw_key)` stored by Host); it is not a
 portal/control-plane session-token or browser credential contract. Greater Components syncs the generated adapter before
 Simulacrum consumes these capabilities.
+
+For hosted genesis, `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation` and `GET
+/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}` are JSON-authoritative durable status
+routes. `HTTP 200` / `HTTP 202` is transport success only; downstream consumers must poll/read the durable
+HostConversation status and require `declaration_ready` plus `produced_declarations` before publish.
 
 Release automation packages these artifacts as GitHub Release assets on every `v*` tag.
 

--- a/docs/contracts/hosted-genesis-conversation.md
+++ b/docs/contracts/hosted-genesis-conversation.md
@@ -1,0 +1,82 @@
+# Hosted genesis durable conversation contract
+
+Project 49 locks the Host-owned durable async contract for Lesser-driven hosted/off-chain soul genesis. The observed
+failure this contract fixes was a transport-success response (`HTTP 200` plus a request id) while Host persisted the
+conversation as `in_progress` with no declarations and Lesser could not persist a `host_conversation_id`.
+
+This document is a contract artifact for Host, Lesser, Greater, and Sim. M1.1 only locks names and examples; it does
+not implement the M2 async worker/queue.
+
+## Authoritative Lesser route family
+
+The Lesser server calls Host with `instanceKeyAuth`; the browser never receives raw Host credentials or Host
+control-plane session tokens.
+
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation`
+  - JSON-authoritative for Lesser.
+  - Creates or appends a hosted-genesis turn and returns the current durable status envelope.
+  - `HTTP 200` or `HTTP 202` is **transport success only**. It is not terminal completion.
+  - Lesser must persist `conversation.conversation_id` as soon as it appears, even when `conversation.status` is
+    `in_progress`.
+- `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
+  - Durable status read.
+  - Source of truth for polling, resume, declaration readiness, and typed failure recovery.
+
+SSE may remain available for portal/native Host UI routes, but SSE is not the authoritative completion mechanism for
+the Lesser instance-key path.
+
+## HostConversation envelope
+
+Machine-readable schema:
+
+- `docs/spec/v3/schemas/hosted-genesis.conversation.response.schema.json`
+
+Examples:
+
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.in-progress.example.json`
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.completed-declaration-ready.example.json`
+- `docs/spec/v3/fixtures/hosted-genesis.conversation.failed.example.json`
+
+Field names locked for M1.1:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `registration_id` | yes | Host registration id for the active hosted genesis attempt. |
+| `conversation_id` | yes | Host durable conversation id. Persist early and use for polling/resume. |
+| `agent_id` | yes | Host Soul registry agent id. |
+| `status` | yes | One of the locked status names below. |
+| `latest_turn_id` | no | Opaque Host id for the most recent durable turn. |
+| `message_count` | yes | Count of durable turns/messages Host has accepted into this conversation. |
+| `produced_declarations` | only `declaration_ready` | Terminal declaration evidence. Publish is forbidden without it. |
+| `failure` | only `failed` | Typed bounded recovery instructions. |
+| `request_id` | yes | Host request id for the snapshot; safe for correlation/log lookup. |
+| `trace_ids` | no | Client-safe correlation/idempotency ids, never raw transcripts or credential material. |
+
+Locked status enum:
+
+- `created`
+- `in_progress`
+- `assistant_turn_ready`
+- `declaration_extraction_pending`
+- `declaration_ready`
+- `failed`
+
+The current implementation's legacy `completed` state maps to the locked `declaration_ready` contract status when and
+only when valid `produced_declarations` are present. Downstream M1.2/M1.3 consumers should project
+`declaration_ready`, not infer terminal success from transport status or from the legacy word `completed`.
+
+## Invariants
+
+1. Transport is not state. SSE, JSON, and HTTP status codes only deliver state; durable Host records are the source of
+   truth.
+2. `HTTP 200` and `HTTP 202` are not terminal. Terminal publish readiness requires `status=declaration_ready` plus
+   valid `produced_declarations`.
+3. `conversation_id` is persisted early. Lesser persists it before returning control to a browser or retry loop.
+4. Publish requires declaration evidence. Lesser, Greater, and Sim fail closed without active-conversation
+   `produced_declarations`.
+5. Recovery is typed and bounded. `failure.recovery.action` is one of `refresh_state`, `retry_same_step`,
+   `restart_soul_bootstrap`, or `operator_action`.
+6. Idempotency is cross-boundary. `idempotency_key` and `correlation_id` are accepted on POST and echoed through
+   `trace_ids` when available; callers must keep them client-safe.
+7. Human-visible evidence is compact. Responses carry ids, status, typed recovery, and declaration summary/evidence; they
+   do not expose raw Host credentials or require raw LLM transcripts.

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -1031,6 +1031,40 @@ components:
           type: string
           minLength: 1
 
+    SoulHostedGenesisMintConversationRequest:
+      type: object
+      additionalProperties: false
+      required: [message]
+      description: |
+        JSON-authoritative Host ↔ Lesser request for creating or appending a hosted-genesis mint-conversation turn.
+        `conversation_id` is supplied when Lesser is resuming or appending to a persisted Host conversation. The optional
+        `idempotency_key` and `correlation_id` are client-safe cross-boundary identifiers; they must not contain raw Host
+        credentials, browser bearer tokens, raw LLM transcripts, or tenant user content.
+      properties:
+        model:
+          type: string
+          minLength: 1
+        conversation_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: "^[A-Za-z0-9._:-]{1,128}$"
+        message:
+          type: string
+          minLength: 1
+        idempotency_key:
+          type: string
+          minLength: 1
+          maxLength: 128
+          pattern: "^[A-Za-z0-9._:-]{1,128}$"
+        correlation_id:
+          type: string
+          minLength: 1
+          maxLength: 128
+
+    SoulHostedGenesisConversationResponse:
+      $ref: "../spec/v3/schemas/hosted-genesis.conversation.response.schema.json"
+
     SoulMintConversation:
       type: object
       additionalProperties: false
@@ -2769,13 +2803,21 @@ paths:
 
   /api/v1/soul/instance/agents/register/{id}/mint-conversation:
     post:
-      operationId: soulInstanceStartRegistrationMintConversationSSE
-      summary: Start or continue an instance-key registration mint conversation over SSE
+      operationId: soulInstanceStartRegistrationMintConversation
+      summary: Start or continue an instance-key registration mint conversation with durable JSON status
       description: |
-        Streams the assistant response using `text/event-stream` for a registration owned by the authenticated managed
-        instance. The bearer token is the managed InstanceKey and Host enforces the registration's domain boundary before
-        streaming. Canonical SSE event names and payload schemas are published in
-        `docs/contracts/soul-mint-conversation-sse.json`.
+        JSON-authoritative server-to-server route for Lesser. It creates or appends a hosted-genesis turn for a
+        registration owned by the authenticated managed instance and returns a durable HostConversation status envelope.
+        The bearer token is the managed InstanceKey (`sha256(raw_key)` stored by Host) and Host enforces the
+        registration's domain boundary before returning any conversation id or status.
+
+        HTTP `200` or `202` means transport/request acceptance only; it is not terminal completion. Lesser must persist
+        `conversation_id` immediately, then poll `GET
+        /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}` until the durable status is
+        `declaration_ready` (terminal declaration evidence present) or `failed` (typed bounded recovery). SSE remains an
+        optional portal/native Host UI delivery mechanism on the non-instance routes, but it is not the authoritative
+        completion mechanism for this Lesser path.
+      x-authoritative-completion: durable-json
       security:
         - instanceKeyAuth: []
       parameters:
@@ -2790,17 +2832,24 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SoulMintConversationSSEInput"
+              $ref: "#/components/schemas/SoulHostedGenesisMintConversationRequest"
       responses:
         "200":
-          description: SSE stream of mint-conversation events
+          description: |
+            Request accepted or replayed and the current durable HostConversation status is available. This is transport
+            success only; inspect `conversation.status` before advancing workflow state.
           content:
-            text/event-stream:
+            application/json:
               schema:
-                type: string
-          x-sse-contract:
-            file: "./soul-mint-conversation-sse.json"
-            version: "1"
+                $ref: "#/components/schemas/SoulHostedGenesisConversationResponse"
+        "202":
+          description: |
+            Request accepted and asynchronous hosted-genesis work is in progress. This is transport success only; Lesser
+            must poll the durable status read using the returned `conversation.conversation_id`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulHostedGenesisConversationResponse"
         "400":
           description: Invalid request
           content:
@@ -2841,10 +2890,12 @@ paths:
   /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}:
     get:
       operationId: soulInstanceGetRegistrationMintConversation
-      summary: Get an instance-key registration mint-conversation record
+      summary: Read durable hosted-genesis mint-conversation status
       description: |
-        Server-to-server route for managed Lesser instances. Returns the bounded private conversation record for a
-        registration inside the authenticated instance boundary.
+        JSON-authoritative durable status read for managed Lesser instances. Returns the current HostConversation status
+        envelope for a registration inside the authenticated instance boundary. This route is the polling/resume source
+        of truth for hosted genesis; it returns terminal declaration evidence only when `conversation.status` is
+        `declaration_ready`, and returns typed failure/recovery when `conversation.status` is `failed`.
       security:
         - instanceKeyAuth: []
       parameters:
@@ -2864,11 +2915,11 @@ paths:
             pattern: "^[A-Za-z0-9._:-]{1,128}$"
       responses:
         "200":
-          description: OK
+          description: Current durable HostConversation status. HTTP 200 is transport success only.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SoulInstanceMintConversationResponse"
+                $ref: "#/components/schemas/SoulHostedGenesisConversationResponse"
         "400":
           description: Invalid request
           content:

--- a/docs/contracts/soul-mint-conversation-sse.json
+++ b/docs/contracts/soul-mint-conversation-sse.json
@@ -4,9 +4,9 @@
   "contentType": "text/event-stream",
   "routes": [
     "/api/v1/soul/agents/register/{id}/mint-conversation",
-    "/api/v1/soul/agents/{agentId}/mint-conversation",
-    "/api/v1/soul/instance/agents/register/{id}/mint-conversation"
+    "/api/v1/soul/agents/{agentId}/mint-conversation"
   ],
+  "scope": "Optional portal/native Host UI streaming companion. The Lesser instance-key route /api/v1/soul/instance/agents/register/{id}/mint-conversation is JSON-authoritative durable status and is intentionally not part of this SSE companion.",
   "request": {
     "contentType": "application/json",
     "schema": {

--- a/docs/soul-agent-first-client-contract.md
+++ b/docs/soul-agent-first-client-contract.md
@@ -11,6 +11,8 @@ For machine-readable schemas, also use:
 
 - `docs/contracts/openapi.yaml`
 - `docs/contracts/soul-mint-conversation-sse.json`
+- `docs/contracts/hosted-genesis-conversation.md`
+- `docs/spec/v3/schemas/hosted-genesis.conversation.response.schema.json`
 - `web/src/lib/api/soul.ts`
 
 ## Scope
@@ -127,8 +129,10 @@ with `instanceKeyAuth`, where the presented raw bearer key is hashed and matched
 They must scope every write to the authenticated managed instance slug/domain and must keep `lesser-host` as the source
 of canonical registration/signing material.
 
-Until that route family exists, the control-plane session routes below are fallback/operator tooling, not the canonical
-human-facing `/l/*` creation route.
+Project 49 locks the durable async hosted-genesis status contract for that route family. Lesser must treat the
+instance-key mint-conversation path as JSON-authoritative durable state: `HTTP 200` / `HTTP 202` is transport success
+only, `conversation_id` is persisted early, and publish readiness requires `status=declaration_ready` plus
+`produced_declarations`. See `docs/contracts/hosted-genesis-conversation.md`.
 
 ## Canonical Resources
 
@@ -144,7 +148,8 @@ These are the resources an agent-first client should treat as canonical:
   - list per-agent events with `GET /api/v1/soul/agents/{agentId}/promotion/events`
 - `SoulAgentMintConversation`
   - review conversation record
-  - streamed creation via SSE
+  - portal/native Host UI streamed creation via SSE on non-instance routes
+  - Lesser instance-key hosted genesis via durable JSON HostConversation status
   - explicit completion + finalize steps
 
 Clients should use `SoulAgentPromotion` for current state and `SoulAgentPromotionLifecycleEvent` for notifications,
@@ -153,8 +158,7 @@ timelines, and “what changed” UI.
 ## Route Families
 
 The route families in this section are control-plane session routes unless explicitly marked `instanceKeyAuth`.
-Project 44 M1 (#706) is responsible for adding the scoped instance-key write route family required by the production
-Simulacrum flow.
+Project 49 makes the Lesser production mint-conversation path durable JSON rather than SSE-authoritative.
 
 There are two equivalent route families during the review/finalize phase:
 
@@ -165,7 +169,17 @@ There are two equivalent route families during the review/finalize phase:
 
 The client should prefer the agent-scoped form once `agentId` is known and stored.
 
-There is also a narrow instance-key read family for Lesser-mediated private self-scope reads:
+There is also a scoped instance-key registration bootstrap family for Lesser-mediated hosted genesis:
+
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation`
+- `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
+
+These routes are **not** portal/session routes. They require `instanceKeyAuth` using strict `sha256(raw bearer)` lookup,
+do not accept the legacy plaintext key-id fallback, and enforce that the authenticated instance owns the managed domain
+for the requested registration. The POST route returns a durable HostConversation status envelope, not an authoritative
+SSE completion stream. The GET route is the durable status read used for polling/resume/completion.
+
+There is also a narrow instance-key agent read family for Lesser-mediated private self-scope reads:
 
 - `GET /api/v1/soul/instance/agents/{agentId}/mint-conversations`
 - `GET /api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}`
@@ -174,8 +188,9 @@ These routes are **not** portal/session routes. They require `instanceKeyAuth` u
 do not accept the legacy plaintext key-id fallback, and enforce that the authenticated instance owns the managed domain
 for the requested agent identity. The list route returns compact metadata only and never includes `messages` or
 `produced_declarations`; the explicit single-conversation route may return the bounded full private record for the
-requested conversation. Instance keys do not gain access to mint start, complete, finalize preflight, finalize begin, or
-finalize mutation routes. Bounds are part of the contract: list defaults to `limit=20` and rejects values above `50`,
+requested conversation. Instance keys do not gain access to general portal/control-plane mint start, complete, finalize
+preflight, finalize begin, or finalize mutation routes beyond the explicitly documented registration bootstrap family.
+Bounds are part of the contract: list defaults to `limit=20` and rejects values above `50`,
 conversation IDs are opaque safe path values up to `128` characters, list responses are capped at `1 MiB`, single
 responses are capped at `2 MiB`, oversize responses fail with `413 soul_mint.response_too_large` rather than silent
 truncation, and rate limiting returns `429 soul_mint.rate_limited` with `Retry-After` when available.
@@ -280,12 +295,25 @@ This step may happen before hosted finalize or later as an upgrade. It is not re
 
 ### 5. Start or continue review
 
+For the Lesser instance-key hosted-genesis path:
+
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation`
+- `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
+
+The POST response and GET status read are durable JSON HostConversation envelopes. `HTTP 200` / `HTTP 202` is transport
+success only. Lesser must persist `conversation_id` immediately, project `in_progress` and
+`declaration_extraction_pending` as progress, and only advance to publish when the status read returns
+`declaration_ready` with `produced_declarations`.
+
+For portal/native Host UI routes:
+
 - registration-scoped:
   - `POST /api/v1/soul/agents/register/{id}/mint-conversation`
 - agent-scoped:
   - `POST /api/v1/soul/agents/{agentId}/mint-conversation`
 
-This endpoint streams the assistant response over SSE and updates the durable conversation record.
+These endpoints stream the assistant response over SSE and update the durable conversation record. SSE is delivery, not
+the authoritative completion mechanism for Lesser.
 
 Important behavior:
 

--- a/docs/spec/v3/README.md
+++ b/docs/spec/v3/README.md
@@ -6,9 +6,11 @@ surfaces implemented by `lesser-host`.
 - `schemas/` — JSON Schema (draft 2020-12)
 - `fixtures/` — example payloads intended for cross-repo consumption (`lesser`, `lesser-body`)
 
-The instance-key bootstrap schemas (`soul-instance-bootstrap.*`) are the Host ↔ Lesser server-side contract for
-managed-instance soul creation. They describe server-held instance-key calls only; they do not establish a browser-held
-Host credential path.
+The instance-key bootstrap schemas (`soul-instance-bootstrap.*`) and hosted-genesis durable conversation schema
+(`hosted-genesis.conversation.response.schema.json`) are the Host ↔ Lesser server-side contract for managed-instance
+soul creation. They describe server-held instance-key calls only; they do not establish a browser-held Host credential
+path. The hosted-genesis examples lock `in_progress`, terminal `declaration_ready` with produced declarations, and
+`failed` with typed bounded recovery.
 
 Managed `@lessersoul.ai` email examples use the Project 37 current-channel form
 `<agent-local-id>.<instance-slug>@lessersoul.ai`. Bare `<agent-local-id>@lessersoul.ai`

--- a/docs/spec/v3/fixtures/hosted-genesis.conversation.completed-declaration-ready.example.json
+++ b/docs/spec/v3/fixtures/hosted-genesis.conversation.completed-declaration-ready.example.json
@@ -1,0 +1,58 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_02",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "declaration_ready",
+    "latest_turn_id": "turn_01jzhostedgenesis_assistant",
+    "message_count": 2,
+    "produced_declarations": {
+      "declaration_id": "decl_01jzhostedgenesis",
+      "declaration_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "produced_at": "2026-06-18T13:12:30Z",
+      "declarations": {
+        "selfDescription": {
+          "summary": "Demo hosted soul for a managed Lesser drone.",
+          "version": "v2"
+        },
+        "capabilities": [
+          {
+            "id": "chat",
+            "statement": "Can answer operator questions using its configured Lesser tools."
+          }
+        ],
+        "boundaries": [
+          {
+            "id": "no-credential-disclosure",
+            "category": "security",
+            "statement": "Will not disclose raw credentials, seed phrases, or Instance API keys."
+          }
+        ],
+        "transparency": {
+          "authority_model": "instance_trust",
+          "anchor_state": "hosted_offchain"
+        }
+      },
+      "evidence": {
+        "source": "host_conversation",
+        "registration_id": "reg_01jzhostedgenesis",
+        "conversation_id": "conv_01jzhostedgenesis",
+        "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+        "message_count": 2,
+        "model": "openai:gpt-5.4",
+        "request_id": "req_hosted_genesis_02"
+      }
+    },
+    "request_id": "req_hosted_genesis_02",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_02",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-01"
+    },
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:12:30Z",
+    "completed_at": "2026-06-18T13:12:30Z"
+  }
+}

--- a/docs/spec/v3/fixtures/hosted-genesis.conversation.failed.example.json
+++ b/docs/spec/v3/fixtures/hosted-genesis.conversation.failed.example.json
@@ -1,0 +1,32 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_03",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "failed",
+    "latest_turn_id": "turn_01jzhostedgenesis_user",
+    "message_count": 1,
+    "failure": {
+      "code": "llm_unavailable",
+      "message": "Assistant turn failed before declaration extraction.",
+      "retryable": true,
+      "recovery": {
+        "action": "retry_same_step",
+        "max_attempts": 3,
+        "retry_after_seconds": 30,
+        "reason": "provider_unavailable"
+      }
+    },
+    "request_id": "req_hosted_genesis_03",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_03",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-02"
+    },
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:11:00Z",
+    "completed_at": "2026-06-18T13:11:00Z"
+  }
+}

--- a/docs/spec/v3/fixtures/hosted-genesis.conversation.in-progress.example.json
+++ b/docs/spec/v3/fixtures/hosted-genesis.conversation.in-progress.example.json
@@ -1,0 +1,21 @@
+{
+  "version": "1",
+  "request_id": "req_hosted_genesis_01",
+  "conversation": {
+    "registration_id": "reg_01jzhostedgenesis",
+    "conversation_id": "conv_01jzhostedgenesis",
+    "agent_id": "0x2222222222222222222222222222222222222222222222222222222222222222",
+    "status": "in_progress",
+    "latest_turn_id": "turn_01jzhostedgenesis_user",
+    "message_count": 1,
+    "request_id": "req_hosted_genesis_01",
+    "trace_ids": {
+      "host_request_id": "req_hosted_genesis_01",
+      "correlation_id": "lesser-bootstrap-01",
+      "idempotency_key": "idem-hosted-genesis-01"
+    },
+    "poll_after_seconds": 2,
+    "created_at": "2026-06-18T13:10:00Z",
+    "updated_at": "2026-06-18T13:10:01Z"
+  }
+}

--- a/docs/spec/v3/schemas/hosted-genesis.conversation.response.schema.json
+++ b/docs/spec/v3/schemas/hosted-genesis.conversation.response.schema.json
@@ -1,0 +1,148 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lesser.host/spec/v3/schemas/hosted-genesis.conversation.response.schema.json",
+  "title": "Hosted genesis durable conversation response",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "request_id", "conversation"],
+  "$defs": {
+    "status": {
+      "type": "string",
+      "enum": [
+        "created",
+        "in_progress",
+        "assistant_turn_ready",
+        "declaration_extraction_pending",
+        "declaration_ready",
+        "failed"
+      ]
+    },
+    "trace_ids": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "host_request_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "correlation_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "idempotency_key": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "lesser_request_id": { "type": "string", "minLength": 1, "maxLength": 128 }
+      }
+    },
+    "declarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selfDescription", "capabilities", "boundaries", "transparency"],
+      "properties": {
+        "selfDescription": {
+          "type": "object",
+          "additionalProperties": true,
+          "minProperties": 1
+        },
+        "capabilities": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "boundaries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "transparency": {
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "produced_declarations": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["declaration_id", "declaration_hash", "produced_at", "declarations", "evidence"],
+      "properties": {
+        "declaration_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "declaration_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+        "produced_at": { "type": "string", "format": "date-time" },
+        "declarations": { "$ref": "#/$defs/declarations" },
+        "evidence": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source", "registration_id", "conversation_id", "agent_id", "message_count", "request_id"],
+          "properties": {
+            "source": { "type": "string", "const": "host_conversation" },
+            "registration_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+            "conversation_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+            "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+            "message_count": { "type": "integer", "minimum": 1 },
+            "model": { "type": "string", "minLength": 1 },
+            "request_id": { "type": "string", "minLength": 1, "maxLength": 128 }
+          }
+        }
+      }
+    },
+    "failure": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["code", "message", "retryable", "recovery"],
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "llm_unavailable",
+            "assistant_turn_failed",
+            "declaration_extraction_failed",
+            "invalid_completion_state",
+            "missing_produced_declarations",
+            "invalid_produced_declarations",
+            "tenant_boundary_violation",
+            "operator_action_required"
+          ]
+        },
+        "message": { "type": "string", "minLength": 1, "maxLength": 512 },
+        "retryable": { "type": "boolean" },
+        "recovery": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["action"],
+          "properties": {
+            "action": {
+              "type": "string",
+              "enum": ["refresh_state", "retry_same_step", "restart_soul_bootstrap", "operator_action"]
+            },
+            "max_attempts": { "type": "integer", "minimum": 1, "maximum": 10 },
+            "retry_after_seconds": { "type": "integer", "minimum": 1, "maximum": 3600 },
+            "reason": { "type": "string", "minLength": 1, "maxLength": 128 }
+          }
+        }
+      }
+    },
+    "conversation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["registration_id", "conversation_id", "agent_id", "status", "message_count", "request_id"],
+      "properties": {
+        "registration_id": { "type": "string", "minLength": 1, "maxLength": 256 },
+        "conversation_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "agent_id": { "type": "string", "pattern": "^0x[0-9a-fA-F]{64}$" },
+        "status": { "$ref": "#/$defs/status" },
+        "latest_turn_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "message_count": { "type": "integer", "minimum": 0 },
+        "produced_declarations": { "$ref": "#/$defs/produced_declarations" },
+        "failure": { "$ref": "#/$defs/failure" },
+        "request_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+        "trace_ids": { "$ref": "#/$defs/trace_ids" },
+        "poll_after_seconds": { "type": "integer", "minimum": 1, "maximum": 3600 },
+        "created_at": { "type": "string", "format": "date-time" },
+        "updated_at": { "type": "string", "format": "date-time" },
+        "completed_at": { "type": "string", "format": "date-time" }
+      }
+    }
+  },
+  "properties": {
+    "version": { "type": "string", "const": "1" },
+    "request_id": { "type": "string", "minLength": 1, "maxLength": 128 },
+    "conversation": { "$ref": "#/$defs/conversation" }
+  }
+}

--- a/web/scripts/verify-lesser-host-contracts.mjs
+++ b/web/scripts/verify-lesser-host-contracts.mjs
@@ -67,6 +67,8 @@ const requiredSchemas = [
   'SoulAgentRegistrationVerifyRequest',
   'SoulAgentRegistrationVerifyResponse',
   'SoulMintConversationSSEInput',
+  'SoulHostedGenesisMintConversationRequest',
+  'SoulHostedGenesisConversationResponse',
   'SoulMintConversation',
   'SoulMintConversationCompleteRequest',
   'SoulAgentMintConversationsResponse',
@@ -96,6 +98,10 @@ const requiredSseEvents = [
 ];
 
 const requiredSpecV3Files = [
+  path.join(specV3SchemasDir, 'hosted-genesis.conversation.response.schema.json'),
+  path.join(specV3FixturesDir, 'hosted-genesis.conversation.in-progress.example.json'),
+  path.join(specV3FixturesDir, 'hosted-genesis.conversation.completed-declaration-ready.example.json'),
+  path.join(specV3FixturesDir, 'hosted-genesis.conversation.failed.example.json'),
   path.join(specV3SchemasDir, 'soul-instance-bootstrap.error.schema.json'),
   path.join(specV3SchemasDir, 'soul-instance-bootstrap.finalize.response.schema.json'),
   path.join(specV3FixturesDir, 'soul-instance-bootstrap.error.boundary-violation.example.json'),
@@ -123,6 +129,10 @@ function assert(condition, message) {
   }
 }
 
+function jsonSchemaRef(operation, status, contentType) {
+  return operation?.responses?.[status]?.content?.[contentType]?.schema?.$ref ?? '';
+}
+
 function verifyOpenApiSurface() {
   const openapi = parseYaml(readFileSync(openapiPath, 'utf8'));
 
@@ -142,9 +152,41 @@ function verifyOpenApiSurface() {
     openapi.paths['/api/v1/soul/agents/{agentId}/mint-conversation']?.post?.responses?.['200']?.content?.['text/event-stream'],
     'agent-scoped mint-conversation route must publish a text/event-stream response'
   );
+
+  const instancePost =
+    openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation']?.post;
+  const instanceGet =
+    openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}']?.get;
+  assert(instancePost, 'missing instance-key registration mint-conversation POST operation');
+  assert(instanceGet, 'missing instance-key registration mint-conversation GET operation');
   assert(
-    openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation']?.post?.responses?.['200']?.content?.['text/event-stream'],
-    'instance-key registration mint-conversation route must publish a text/event-stream response'
+    instancePost.operationId === 'soulInstanceStartRegistrationMintConversation',
+    'instance-key registration mint-conversation POST must not be locked to an SSE operation id'
+  );
+  assert(
+    instancePost['x-authoritative-completion'] === 'durable-json',
+    'instance-key registration mint-conversation POST must declare durable JSON authoritative completion'
+  );
+  assert(
+    !instancePost?.responses?.['200']?.content?.['text/event-stream'],
+    'instance-key registration mint-conversation POST must not be documented as text/event-stream authoritative'
+  );
+  assert(
+    jsonSchemaRef(instancePost, '200', 'application/json') === '#/components/schemas/SoulHostedGenesisConversationResponse',
+    'instance-key registration mint-conversation POST 200 must return SoulHostedGenesisConversationResponse JSON'
+  );
+  assert(
+    jsonSchemaRef(instancePost, '202', 'application/json') === '#/components/schemas/SoulHostedGenesisConversationResponse',
+    'instance-key registration mint-conversation POST 202 must return SoulHostedGenesisConversationResponse JSON'
+  );
+  assert(
+    jsonSchemaRef(instanceGet, '200', 'application/json') === '#/components/schemas/SoulHostedGenesisConversationResponse',
+    'instance-key registration mint-conversation GET must return SoulHostedGenesisConversationResponse JSON'
+  );
+  assert(
+    instancePost?.requestBody?.content?.['application/json']?.schema?.$ref ===
+      '#/components/schemas/SoulHostedGenesisMintConversationRequest',
+    'instance-key registration mint-conversation POST must use the hosted-genesis JSON request schema'
   );
 
   for (const route of requiredInstanceBootstrapPaths) {
@@ -200,15 +242,89 @@ function verifySseCompanionSurface() {
 
   for (const route of [
     '/api/v1/soul/agents/register/{id}/mint-conversation',
-    '/api/v1/soul/agents/{agentId}/mint-conversation',
-    '/api/v1/soul/instance/agents/register/{id}/mint-conversation'
+    '/api/v1/soul/agents/{agentId}/mint-conversation'
   ]) {
     assert(sseContract.routes.includes(route), `SSE companion contract missing route: ${route}`);
   }
+  assert(
+    !sseContract.routes.includes('/api/v1/soul/instance/agents/register/{id}/mint-conversation'),
+    'SSE companion contract must not claim the Lesser instance-key mint-conversation route'
+  );
 
   for (const eventName of requiredSseEvents) {
     assert(sseContract?.events?.[eventName]?.schema, `SSE companion contract missing event schema: ${eventName}`);
   }
+}
+
+function assertHostedGenesisConversationExample(file, expectedStatus) {
+  const payload = JSON.parse(readFileSync(path.join(specV3FixturesDir, file), 'utf8'));
+  assert(payload?.version === '1', `${file} must declare version=1`);
+  assert(typeof payload?.request_id === 'string' && payload.request_id.length > 0, `${file} must include request_id`);
+
+  const conversation = payload?.conversation;
+  assert(conversation, `${file} must include conversation`);
+  for (const field of ['registration_id', 'conversation_id', 'agent_id', 'status', 'message_count', 'request_id']) {
+    assert(conversation[field] !== undefined && conversation[field] !== '', `${file} conversation missing ${field}`);
+  }
+  assert(conversation.status === expectedStatus, `${file} expected status=${expectedStatus}, got ${conversation.status}`);
+  assert(conversation.request_id === payload.request_id, `${file} conversation.request_id must match top-level request_id`);
+  assert(!('messages' in conversation), `${file} must not expose raw conversation messages`);
+
+  if (expectedStatus === 'declaration_ready') {
+    const produced = conversation.produced_declarations;
+    assert(produced, `${file} declaration_ready must include produced_declarations`);
+    assert(/^sha256:[0-9a-f]{64}$/.test(produced.declaration_hash ?? ''), `${file} must include declaration_hash evidence`);
+    for (const field of ['selfDescription', 'capabilities', 'boundaries', 'transparency']) {
+      assert(produced.declarations?.[field] !== undefined, `${file} produced_declarations missing ${field}`);
+    }
+    assert(produced.evidence?.conversation_id === conversation.conversation_id, `${file} evidence must bind conversation_id`);
+    assert(produced.evidence?.registration_id === conversation.registration_id, `${file} evidence must bind registration_id`);
+    assert(produced.evidence?.agent_id === conversation.agent_id, `${file} evidence must bind agent_id`);
+  } else {
+    assert(
+      !('produced_declarations' in conversation),
+      `${file} must not include produced_declarations before declaration_ready`
+    );
+  }
+
+  if (expectedStatus === 'failed') {
+    const failure = conversation.failure;
+    assert(failure?.code, `${file} failed status must include failure.code`);
+    assert(['refresh_state', 'retry_same_step', 'restart_soul_bootstrap', 'operator_action'].includes(failure?.recovery?.action), `${file} failed status must include typed recovery.action`);
+  } else {
+    assert(!('failure' in conversation), `${file} must not include failure outside failed status`);
+  }
+}
+
+function verifyHostedGenesisConversationSurface() {
+  const schema = JSON.parse(readFileSync(path.join(specV3SchemasDir, 'hosted-genesis.conversation.response.schema.json'), 'utf8'));
+  const statusEnum = schema?.$defs?.status?.enum ?? [];
+  for (const status of [
+    'created',
+    'in_progress',
+    'assistant_turn_ready',
+    'declaration_extraction_pending',
+    'declaration_ready',
+    'failed'
+  ]) {
+    assert(statusEnum.includes(status), `hosted-genesis conversation schema missing status: ${status}`);
+  }
+  assert(!statusEnum.includes('completed'), 'hosted-genesis contract must use declaration_ready instead of legacy completed');
+  const requiredFields = schema?.$defs?.conversation?.required ?? [];
+  for (const field of ['registration_id', 'conversation_id', 'agent_id', 'status', 'message_count', 'request_id']) {
+    assert(requiredFields.includes(field), `hosted-genesis conversation schema missing required field: ${field}`);
+  }
+  const recoveryActions = schema?.$defs?.failure?.properties?.recovery?.properties?.action?.enum ?? [];
+  for (const action of ['refresh_state', 'retry_same_step', 'restart_soul_bootstrap', 'operator_action']) {
+    assert(recoveryActions.includes(action), `hosted-genesis failure recovery missing action: ${action}`);
+  }
+
+  assertHostedGenesisConversationExample('hosted-genesis.conversation.in-progress.example.json', 'in_progress');
+  assertHostedGenesisConversationExample(
+    'hosted-genesis.conversation.completed-declaration-ready.example.json',
+    'declaration_ready'
+  );
+  assertHostedGenesisConversationExample('hosted-genesis.conversation.failed.example.json', 'failed');
 }
 
 function verifySpecV3BootstrapSurface() {
@@ -310,6 +426,7 @@ function verifyGeneratedAdapter() {
 
 verifyOpenApiSurface();
 verifySseCompanionSurface();
+verifyHostedGenesisConversationSurface();
 verifySpecV3BootstrapSurface();
 verifyGeneratedAdapter();
 

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -457,13 +457,20 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Start or continue an instance-key registration mint conversation over SSE
-         * @description Streams the assistant response using `text/event-stream` for a registration owned by the authenticated managed
-         *     instance. The bearer token is the managed InstanceKey and Host enforces the registration's domain boundary before
-         *     streaming. Canonical SSE event names and payload schemas are published in
-         *     `docs/contracts/soul-mint-conversation-sse.json`.
+         * Start or continue an instance-key registration mint conversation with durable JSON status
+         * @description JSON-authoritative server-to-server route for Lesser. It creates or appends a hosted-genesis turn for a
+         *     registration owned by the authenticated managed instance and returns a durable HostConversation status envelope.
+         *     The bearer token is the managed InstanceKey (`sha256(raw_key)` stored by Host) and Host enforces the
+         *     registration's domain boundary before returning any conversation id or status.
+         *
+         *     HTTP `200` or `202` means transport/request acceptance only; it is not terminal completion. Lesser must persist
+         *     `conversation_id` immediately, then poll `GET
+         *     /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}` until the durable status is
+         *     `declaration_ready` (terminal declaration evidence present) or `failed` (typed bounded recovery). SSE remains an
+         *     optional portal/native Host UI delivery mechanism on the non-instance routes, but it is not the authoritative
+         *     completion mechanism for this Lesser path.
          */
-        post: operations["soulInstanceStartRegistrationMintConversationSSE"];
+        post: operations["soulInstanceStartRegistrationMintConversation"];
         delete?: never;
         options?: never;
         head?: never;
@@ -478,9 +485,11 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get an instance-key registration mint-conversation record
-         * @description Server-to-server route for managed Lesser instances. Returns the bounded private conversation record for a
-         *     registration inside the authenticated instance boundary.
+         * Read durable hosted-genesis mint-conversation status
+         * @description JSON-authoritative durable status read for managed Lesser instances. Returns the current HostConversation status
+         *     envelope for a registration inside the authenticated instance boundary. This route is the polling/resume source
+         *     of truth for hosted genesis; it returns terminal declaration evidence only when `conversation.status` is
+         *     `declaration_ready`, and returns typed failure/recovery when `conversation.status` is `failed`.
          */
         get: operations["soulInstanceGetRegistrationMintConversation"];
         put?: never;
@@ -1491,6 +1500,20 @@ export interface components {
             conversation_id?: string;
             message: string;
         };
+        /**
+         * @description JSON-authoritative Host ↔ Lesser request for creating or appending a hosted-genesis mint-conversation turn.
+         *     `conversation_id` is supplied when Lesser is resuming or appending to a persisted Host conversation. The optional
+         *     `idempotency_key` and `correlation_id` are client-safe cross-boundary identifiers; they must not contain raw Host
+         *     credentials, browser bearer tokens, raw LLM transcripts, or tenant user content.
+         */
+        SoulHostedGenesisMintConversationRequest: {
+            model?: string;
+            conversation_id?: string;
+            message: string;
+            idempotency_key?: string;
+            correlation_id?: string;
+        };
+        SoulHostedGenesisConversationResponse: components["schemas"]["hosted-genesis.conversation.response.schema"];
         SoulMintConversation: {
             agent_id: string;
             conversation_id: string;
@@ -1988,6 +2011,157 @@ export interface components {
                     [key: string]: unknown;
                 };
                 request_id?: string;
+            };
+        };
+        declarations: {
+            selfDescription: {
+                [key: string]: unknown;
+            };
+            capabilities: {
+                [key: string]: unknown;
+            }[];
+            boundaries: {
+                [key: string]: unknown;
+            }[];
+            transparency: {
+                [key: string]: unknown;
+            };
+        };
+        /** @enum {string} */
+        status: "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "failed";
+        produced_declarations: {
+            declaration_id: string;
+            declaration_hash: string;
+            /** Format: date-time */
+            produced_at: string;
+            declarations: components["schemas"]["declarations"];
+            evidence: {
+                /** @constant */
+                source: "host_conversation";
+                registration_id: string;
+                conversation_id: string;
+                agent_id: string;
+                message_count: number;
+                model?: string;
+                request_id: string;
+            };
+        };
+        failure: {
+            /** @enum {string} */
+            code: "llm_unavailable" | "assistant_turn_failed" | "declaration_extraction_failed" | "invalid_completion_state" | "missing_produced_declarations" | "invalid_produced_declarations" | "tenant_boundary_violation" | "operator_action_required";
+            message: string;
+            retryable: boolean;
+            recovery: {
+                /** @enum {string} */
+                action: "refresh_state" | "retry_same_step" | "restart_soul_bootstrap" | "operator_action";
+                max_attempts?: number;
+                retry_after_seconds?: number;
+                reason?: string;
+            };
+        };
+        trace_ids: {
+            host_request_id?: string;
+            correlation_id?: string;
+            idempotency_key?: string;
+            lesser_request_id?: string;
+        };
+        conversation: {
+            registration_id: string;
+            conversation_id: string;
+            agent_id: string;
+            status: components["schemas"]["status"];
+            latest_turn_id?: string;
+            message_count: number;
+            produced_declarations?: components["schemas"]["produced_declarations"];
+            failure?: components["schemas"]["failure"];
+            request_id: string;
+            trace_ids?: components["schemas"]["trace_ids"];
+            poll_after_seconds?: number;
+            /** Format: date-time */
+            created_at?: string;
+            /** Format: date-time */
+            updated_at?: string;
+            /** Format: date-time */
+            completed_at?: string;
+        };
+        /** Hosted genesis durable conversation response */
+        "hosted-genesis.conversation.response.schema": {
+            /** @constant */
+            version: "1";
+            request_id: string;
+            conversation: components["schemas"]["conversation"];
+            $defs: {
+                /** @enum {string} */
+                status: "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "failed";
+                trace_ids: {
+                    host_request_id?: string;
+                    correlation_id?: string;
+                    idempotency_key?: string;
+                    lesser_request_id?: string;
+                };
+                declarations: {
+                    selfDescription: {
+                        [key: string]: unknown;
+                    };
+                    capabilities: {
+                        [key: string]: unknown;
+                    }[];
+                    boundaries: {
+                        [key: string]: unknown;
+                    }[];
+                    transparency: {
+                        [key: string]: unknown;
+                    };
+                };
+                produced_declarations: {
+                    declaration_id: string;
+                    declaration_hash: string;
+                    /** Format: date-time */
+                    produced_at: string;
+                    declarations: components["schemas"]["declarations"];
+                    evidence: {
+                        /** @constant */
+                        source: "host_conversation";
+                        registration_id: string;
+                        conversation_id: string;
+                        agent_id: string;
+                        message_count: number;
+                        model?: string;
+                        request_id: string;
+                    };
+                };
+                failure: {
+                    /** @enum {string} */
+                    code: "llm_unavailable" | "assistant_turn_failed" | "declaration_extraction_failed" | "invalid_completion_state" | "missing_produced_declarations" | "invalid_produced_declarations" | "tenant_boundary_violation" | "operator_action_required";
+                    message: string;
+                    retryable: boolean;
+                    recovery: {
+                        /** @enum {string} */
+                        action: "refresh_state" | "retry_same_step" | "restart_soul_bootstrap" | "operator_action";
+                        max_attempts?: number;
+                        retry_after_seconds?: number;
+                        reason?: string;
+                    };
+                };
+                conversation: {
+                    registration_id: string;
+                    conversation_id: string;
+                    agent_id: string;
+                    status: components["schemas"]["status"];
+                    latest_turn_id?: string;
+                    message_count: number;
+                    produced_declarations?: components["schemas"]["produced_declarations"];
+                    failure?: components["schemas"]["failure"];
+                    request_id: string;
+                    trace_ids?: components["schemas"]["trace_ids"];
+                    poll_after_seconds?: number;
+                    /** Format: date-time */
+                    created_at?: string;
+                    /** Format: date-time */
+                    updated_at?: string;
+                    /** Format: date-time */
+                    completed_at?: string;
+                };
             };
         };
         /**
@@ -4132,7 +4306,7 @@ export interface operations {
             };
         };
     };
-    soulInstanceStartRegistrationMintConversationSSE: {
+    soulInstanceStartRegistrationMintConversation: {
         parameters: {
             query?: never;
             header?: never;
@@ -4143,17 +4317,32 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SoulMintConversationSSEInput"];
+                "application/json": components["schemas"]["SoulHostedGenesisMintConversationRequest"];
             };
         };
         responses: {
-            /** @description SSE stream of mint-conversation events */
+            /**
+             * @description Request accepted or replayed and the current durable HostConversation status is available. This is transport
+             *     success only; inspect `conversation.status` before advancing workflow state.
+             */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "text/event-stream": string;
+                    "application/json": components["schemas"]["hosted-genesis.conversation.response.schema"];
+                };
+            };
+            /**
+             * @description Request accepted and asynchronous hosted-genesis work is in progress. This is transport success only; Lesser
+             *     must poll the durable status read using the returned `conversation.conversation_id`.
+             */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["hosted-genesis.conversation.response.schema"];
                 };
             };
             /** @description Invalid request */
@@ -4224,13 +4413,13 @@ export interface operations {
         };
         requestBody?: never;
         responses: {
-            /** @description OK */
+            /** @description Current durable HostConversation status. HTTP 200 is transport success only. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SoulInstanceMintConversationResponse"];
+                    "application/json": components["schemas"]["hosted-genesis.conversation.response.schema"];
                 };
             };
             /** @description Invalid request */


### PR DESCRIPTION
Staging→main promotion (operator-merged).

Promotes lesser-host **staging** (`9e2fd00`) to **main**. Content: P49 **M1.1** — lock Host durable hosted-genesis JSON/status contract (#745, closes #730). CI green.

NOTE: **M2** (durable async conversation API, #738/#731-#735) is in progress and will land on staging shortly; once merged it will appear in this same promotion PR. You may merge now to promote M1.1, or wait for M2 to accrue. Prepared by factory; merge to main is operator-owned.