### PR TITLE
Promote staging→main: P49 M2 durable async hosted-genesis conversation API

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -155,10 +155,25 @@ export class LesserHostStack extends cdk.Stack {
 		safetyDLQ.applyRemovalPolicy(removalPolicy);
 		const safetyQueue = new sqs.Queue(this, 'SafetyQueue', {
 			queueName: `${namePrefix}-safety-queue`,
+			visibilityTimeout: cdk.Duration.minutes(3),
 			deadLetterQueue: { queue: safetyDLQ, maxReceiveCount: 3 },
 			encryption: sqs.QueueEncryption.SQS_MANAGED,
 		});
 		safetyQueue.applyRemovalPolicy(removalPolicy);
+
+		const hostedGenesisDLQ = new sqs.Queue(this, 'HostedGenesisDLQ', {
+			queueName: `${namePrefix}-hosted-genesis-dlq`,
+			retentionPeriod: cdk.Duration.days(14),
+			encryption: sqs.QueueEncryption.SQS_MANAGED,
+		});
+		hostedGenesisDLQ.applyRemovalPolicy(removalPolicy);
+		const hostedGenesisQueue = new sqs.Queue(this, 'HostedGenesisQueue', {
+			queueName: `${namePrefix}-hosted-genesis-queue`,
+			visibilityTimeout: cdk.Duration.minutes(3),
+			deadLetterQueue: { queue: hostedGenesisDLQ, maxReceiveCount: 3 },
+			encryption: sqs.QueueEncryption.SQS_MANAGED,
+		});
+		hostedGenesisQueue.applyRemovalPolicy(removalPolicy);
 
 		const provisionDLQ = new sqs.Queue(this, 'ProvisionDLQ', {
 			queueName: `${namePrefix}-provision-dlq`,
@@ -204,6 +219,15 @@ export class LesserHostStack extends cdk.Stack {
 		new cloudwatch.Alarm(this, 'SafetyDLQAlarm', {
 			alarmName: `${namePrefix}-safety-dlq-visible`,
 			metric: safetyDLQ.metricApproximateNumberOfMessagesVisible({ period: dlqAlarmPeriod }),
+			threshold: dlqAlarmThreshold,
+			comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
+			evaluationPeriods: 1,
+			datapointsToAlarm: 1,
+			treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+		});
+		new cloudwatch.Alarm(this, 'HostedGenesisDLQAlarm', {
+			alarmName: `${namePrefix}-hosted-genesis-dlq-visible`,
+			metric: hostedGenesisDLQ.metricApproximateNumberOfMessagesVisible({ period: dlqAlarmPeriod }),
 			threshold: dlqAlarmThreshold,
 			comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
 			evaluationPeriods: 1,
@@ -462,6 +486,7 @@ export class LesserHostStack extends cdk.Stack {
 			SAFETY_QUEUE_URL: safetyQueue.queueUrl,
 			PROVISION_QUEUE_URL: provisionQueue.queueUrl,
 			COMM_QUEUE_URL: commQueue.queueUrl,
+			HOSTED_GENESIS_QUEUE_URL: hostedGenesisQueue.queueUrl,
 			SOUL_COMM_MAILBOX_BUCKET_NAME: soulCommMailboxBucket.bucketName,
 			SOUL_COMM_MAILBOX_RETENTION_DAYS: String(soulCommMailboxRetentionDays),
 			BOOTSTRAP_WALLET_ADDRESS: bootstrapWalletAddress,
@@ -562,9 +587,10 @@ export class LesserHostStack extends cdk.Stack {
 			ARTIFACT_BUCKET_NAME: artifactsBucket.bucketName,
 			PREVIEW_QUEUE_URL: previewQueue.queueUrl,
 			SAFETY_QUEUE_URL: safetyQueue.queueUrl,
+			HOSTED_GENESIS_QUEUE_URL: hostedGenesisQueue.queueUrl,
 			ATTESTATION_SIGNING_KEY_ID: attestationSigningKey.keyId,
 			ATTESTATION_PUBLIC_KEY_IDS: attestationSigningKey.keyId,
-		});
+		}, { timeoutSeconds: 120 });
 
 		const soulReputationWorkerFn = this.goLambda(
 			'SoulReputationWorker',
@@ -671,6 +697,8 @@ export class LesserHostStack extends cdk.Stack {
 		safetyQueue.grantSendMessages(controlPlaneFn);
 		safetyQueue.grantSendMessages(trustFn);
 		safetyQueue.grantConsumeMessages(aiWorkerFn);
+		hostedGenesisQueue.grantSendMessages(controlPlaneFn);
+		hostedGenesisQueue.grantConsumeMessages(aiWorkerFn);
 		provisionQueue.grantSendMessages(controlPlaneFn);
 		provisionQueue.grantConsumeMessages(provisionWorkerFn);
 		provisionQueue.grantSendMessages(provisionWorkerFn);
@@ -787,6 +815,7 @@ export class LesserHostStack extends cdk.Stack {
 
 		renderWorkerFn.addEventSource(new lambdaEventSources.SqsEventSource(previewQueue, { batchSize: 1 }));
 		aiWorkerFn.addEventSource(new lambdaEventSources.SqsEventSource(safetyQueue, { batchSize: 5 }));
+		aiWorkerFn.addEventSource(new lambdaEventSources.SqsEventSource(hostedGenesisQueue, { batchSize: 1 }));
 		provisionWorkerFn.addEventSource(new lambdaEventSources.SqsEventSource(provisionQueue, { batchSize: 1 }));
 		commWorkerFn.addEventSource(new lambdaEventSources.SqsEventSource(commQueue, { batchSize: 1 }));
 
@@ -1685,6 +1714,7 @@ export class LesserHostStack extends cdk.Stack {
 			new cdk.CfnOutput(this, 'AttestationSigningKeyId', { value: attestationSigningKey.keyId });
 			new cdk.CfnOutput(this, 'PreviewQueueUrl', { value: previewQueue.queueUrl });
 			new cdk.CfnOutput(this, 'SafetyQueueUrl', { value: safetyQueue.queueUrl });
+			new cdk.CfnOutput(this, 'HostedGenesisQueueUrl', { value: hostedGenesisQueue.queueUrl });
 			new cdk.CfnOutput(this, 'ProvisionQueueUrl', { value: provisionQueue.queueUrl });
 			new cdk.CfnOutput(this, 'RenderWorkerFunctionName', { value: renderWorkerFn.functionName });
 			new cdk.CfnOutput(this, 'AiWorkerFunctionName', { value: aiWorkerFn.functionName });

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -469,6 +469,41 @@ test('provision worker receives deploy runner role arn for tenant trust repair',
 	);
 });
 
+test('hosted genesis durable async queue is wired to control plane and ai worker', () => {
+	const template = synthTemplate();
+	const queues = findResourceEntries(template, 'AWS::SQS::Queue');
+	const queue = queues.find(([, resource]) =>
+		resource.Properties?.QueueName === 'lesser-host-lab-hosted-genesis-queue'
+	);
+	const dlq = queues.find(([, resource]) =>
+		resource.Properties?.QueueName === 'lesser-host-lab-hosted-genesis-dlq'
+	);
+	assert.ok(queue, 'expected hosted genesis worker queue');
+	assert.ok(dlq, 'expected hosted genesis DLQ');
+	assert.equal(queue[1].Properties?.VisibilityTimeout, 180, 'hosted genesis queue must cover ai-worker timeout');
+	assert.deepEqual(
+		queue[1].Properties?.RedrivePolicy,
+		{
+			deadLetterTargetArn: { 'Fn::GetAtt': [dlq[0], 'Arn'] },
+			maxReceiveCount: 3,
+		},
+		'hosted genesis queue must fail closed to its DLQ after bounded retries',
+	);
+
+	const controlPlane = findLambdaByFunctionName(template, 'control-plane-api');
+	const aiWorker = findLambdaByFunctionName(template, 'ai-worker');
+	const controlPlaneEnv = lambdaEnvironment(controlPlane);
+	const aiWorkerEnv = lambdaEnvironment(aiWorker);
+	assert.ok('HOSTED_GENESIS_QUEUE_URL' in controlPlaneEnv, 'control plane must receive hosted genesis queue url');
+	assert.ok('HOSTED_GENESIS_QUEUE_URL' in aiWorkerEnv, 'ai worker must receive hosted genesis queue url');
+	assert.equal(aiWorker?.Timeout, 120, 'ai worker needs durable async LLM work timeout headroom');
+
+	const mappings = findResources(template, 'AWS::Lambda::EventSourceMapping');
+	const mapping = mappings.find((entry) => JSON.stringify(entry).includes(queue[0]) && JSON.stringify(entry).includes('AiWorker'));
+	assert.ok(mapping, 'expected hosted genesis queue event source on ai-worker');
+	assert.equal(mapping.BatchSize, 1, 'hosted genesis jobs must process one conversation turn at a time');
+});
+
 test('web asset bundling does not execute npm locally in CI', () => {
 	assert.equal(shouldUseLocalWebBundling({ CI: 'true' }), false);
 	assert.equal(shouldUseLocalWebBundling({ GITHUB_ACTIONS: 'true' }), false);
@@ -704,7 +739,7 @@ test('M0.13 distribution: bearer-auth API/trust origins are NOT OAC-protected', 
 	}
 });
 
-test('M8.1 distribution: Lesser instance mint-conversation route uses SSE origin', () => {
+test('P49 M2 distribution: Lesser instance mint-conversation route uses mint-conversation REST origin', () => {
 	const config = distributionConfig(synthTemplate());
 	const exactLesserPattern = 'api/v1/soul/instance/agents/register/*/mint-conversation*';
 	const behavior = (config.CacheBehaviors ?? []).find((b) => b.PathPattern === exactLesserPattern);
@@ -716,7 +751,7 @@ test('M8.1 distribution: Lesser instance mint-conversation route uses SSE origin
 	const domainSourceId = originDomainSourceLogicalId(origin);
 	assert.ok(
 		domainSourceId.startsWith('ControlPlaneSseRestApi'),
-		`exact Lesser-used instance mint-conversation route must use the SSE-capable REST API origin; got ${domainSourceId}`,
+		`exact Lesser-used instance mint-conversation route must use the mint-conversation REST origin while returning durable JSON; got ${domainSourceId}`,
 	);
 });
 

--- a/docs/contracts/hosted-genesis-conversation.md
+++ b/docs/contracts/hosted-genesis-conversation.md
@@ -5,7 +5,8 @@ failure this contract fixes was a transport-success response (`HTTP 200` plus a 
 conversation as `in_progress` with no declarations and Lesser could not persist a `host_conversation_id`.
 
 This document is a contract artifact for Host, Lesser, Greater, and Sim. M1.1 only locks names and examples; it does
-not implement the M2 async worker/queue.
+not implement the M2 async worker/queue. M2 implements the Lesser instance-key JSON projection, hosted-genesis worker
+queue, idempotent retry semantics, and fail-closed finalize behavior described here.
 
 ## Authoritative Lesser route family
 
@@ -21,6 +22,12 @@ control-plane session tokens.
 - `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
   - Durable status read.
   - Source of truth for polling, resume, declaration readiness, and typed failure recovery.
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete`
+  - Progress-safe completion/extraction handoff for Lesser.
+  - `HTTP 202` returns the compact HostConversation progress envelope while assistant or declaration extraction work is
+    still running.
+  - `HTTP 200` returns the same compact HostConversation envelope with `status=declaration_ready` only when valid
+    produced declarations exist; it never returns raw transcript fields.
 
 SSE may remain available for portal/native Host UI routes, but SSE is not the authoritative completion mechanism for
 the Lesser instance-key path.
@@ -64,6 +71,16 @@ Locked status enum:
 The current implementation's legacy `completed` state maps to the locked `declaration_ready` contract status when and
 only when valid `produced_declarations` are present. Downstream M1.2/M1.3 consumers should project
 `declaration_ready`, not infer terminal success from transport status or from the legacy word `completed`.
+
+### `created` projection decision for Lesser
+
+Host keeps `created` in the locked enum for durable records that exist before the first accepted user turn (for example,
+future pre-created/reserved conversations). On the Lesser instance-key route family, Host collapses `created` snapshots
+to `in_progress`. The POST path persists a conversation id and accepted user turn before returning to Lesser, so the
+first successful Lesser-visible status is `in_progress`, not `created`.
+
+Lesser M3 should therefore project Host `created` as its local `in_progress` row if a status read ever observes it, and
+should not wait for an explicit local `created` projection before persisting `host_conversation_id`.
 
 ## Invariants
 

--- a/docs/contracts/openapi.yaml
+++ b/docs/contracts/openapi.yaml
@@ -114,7 +114,7 @@ components:
                   maxLength: 128
                 conversation_status:
                   type: string
-                  enum: [unknown, pending, in_progress, completed, failed]
+                  enum: [unknown, pending, created, in_progress, assistant_turn_ready, declaration_extraction_pending, declaration_ready, completed, failed]
                 expected_status:
                   type: string
                   minLength: 1
@@ -717,7 +717,7 @@ components:
           type: string
         latest_conversation_status:
           type: string
-          enum: [in_progress, completed, failed]
+          enum: [created, in_progress, assistant_turn_ready, declaration_extraction_pending, declaration_ready, completed, failed]
         latest_review_sha256:
           type: string
           pattern: "^[0-9a-f]{64}$"
@@ -1061,6 +1061,10 @@ components:
           type: string
           minLength: 1
           maxLength: 128
+        lesser_request_id:
+          type: string
+          minLength: 1
+          maxLength: 128
 
     SoulHostedGenesisConversationResponse:
       $ref: "../spec/v3/schemas/hosted-genesis.conversation.response.schema.json"
@@ -1088,7 +1092,10 @@ components:
           type: string
         status:
           type: string
-          enum: [in_progress, completed, failed]
+          description: >
+            Legacy raw Host record status. `completed` is retained for backward compatibility and maps to the
+            durable hosted-genesis contract status `declaration_ready` only when valid produced declarations exist.
+          enum: [created, in_progress, assistant_turn_ready, declaration_extraction_pending, declaration_ready, completed, failed]
         usage:
           $ref: "#/components/schemas/AIUsage"
         charged_credits:
@@ -1146,7 +1153,7 @@ components:
           type: string
         status:
           type: string
-          enum: [in_progress, completed, failed]
+          enum: [created, in_progress, assistant_turn_ready, declaration_extraction_pending, declaration_ready, completed, failed]
         usage:
           $ref: "#/components/schemas/AIUsage"
         charged_credits:
@@ -2963,10 +2970,12 @@ paths:
       summary: Complete or replay an instance-key registration mint conversation
       description: |
         Server-to-server route for managed Lesser instances. Completes a conversation inside the authenticated instance
-        boundary and persists the produced declarations for finalize preflight/finalize. If the stored conversation is
-        already `completed` and has valid produced declarations, the route is idempotent and returns the completed
-        conversation without re-extracting or rewriting declarations. Failed conversations and completed conversations
-        without valid produced declarations fail closed with structured state details.
+        boundary and persists the produced declarations for finalize preflight/finalize. If Host has accepted the turn
+        but the assistant turn or declaration extraction is not ready yet, this route returns `202` plus the durable
+        HostConversation progress envelope; HTTP success is not terminal. If the stored conversation is already
+        `completed`/`declaration_ready` and has valid produced declarations, the route is idempotent and returns the
+        compact HostConversation declaration-ready envelope without re-extracting or rewriting declarations. Failed conversations and completed
+        conversations without valid produced declarations fail closed with structured state details.
       security:
         - instanceKeyAuth: []
       parameters:
@@ -2992,11 +3001,17 @@ paths:
               $ref: "#/components/schemas/SoulMintConversationCompleteRequest"
       responses:
         "200":
-          description: OK
+          description: Terminal replay or synchronous completion with valid produced declarations; returns the compact HostConversation envelope and never raw transcript fields.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/SoulMintConversation"
+                $ref: "#/components/schemas/SoulHostedGenesisConversationResponse"
+        "202":
+          description: Assistant turn or declaration extraction is still in progress; inspect `conversation.status`.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SoulHostedGenesisConversationResponse"
         "400":
           description: Invalid request
           content:

--- a/docs/project-49-durable-hosted-genesis.md
+++ b/docs/project-49-durable-hosted-genesis.md
@@ -1,0 +1,53 @@
+# Project 49 — Durable async hosted soul genesis
+
+## M2 host implementation
+
+M2 moves the Lesser instance-key hosted-genesis mint conversation path from transport-coupled SSE completion to a
+durable JSON status contract owned by Host.
+
+### Lesser instance-key path
+
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation`
+  - Accepts a user turn, persists the Host `conversation_id` before returning, debits exactly once for a matching
+    `idempotency_key`, and returns `202` JSON with `conversation.status=in_progress`.
+  - Echoes client-safe `idempotency_key`, `correlation_id`, and `lesser_request_id` values through `trace_ids` when
+    present.
+  - Does not return raw Host browser tokens, raw Instance API keys, or raw LLM transcripts.
+- `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
+  - Returns the compact durable HostConversation projection for polling/resume.
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete`
+  - Returns `202` progress while the assistant turn or declaration extraction is still running.
+  - Returns terminal `200` success as the compact HostConversation `declaration_ready` envelope only when valid produced
+    declarations exist; it does not expose raw transcripts.
+- Finalize/preflight/begin/finalize fail closed unless the active conversation has valid produced declarations.
+
+SSE can remain for non-instance Host UI routes, but it is no longer the authoritative Lesser completion mechanism.
+CloudFront may still route the mint-conversation subtree through Host's REST control-plane mint-conversation origin for
+transport compatibility; the Lesser instance-key contract is JSON state, not SSE state.
+
+### Worker and retry model
+
+The control plane enqueues hosted-genesis work on `HOSTED_GENESIS_QUEUE_URL`. The AI worker consumes one hosted-genesis
+job at a time and re-loads all durable state before writing:
+
+1. registration id and agent id
+2. registration domain
+3. managed instance ownership/boundary
+4. conversation id/status/latest turn
+5. idempotency row when present
+
+The queue has an SQS-managed encrypted DLQ, three receive attempts, and a one-message batch size. Worker failures update
+the conversation to `failed` with a bounded recovery action; DLQ visibility is alarmed. Retry with the same
+`idempotency_key` and request hash replays the existing conversation/turn and does not append another user message or
+debit credits again.
+
+### `created` status decision
+
+Host keeps `created` in the locked enum for internal/future pre-created durable records. For the Lesser instance-key
+projection, Host collapses `created` to `in_progress`. Lesser M3 should therefore project any observed `created`
+snapshot as `in_progress` and persist `host_conversation_id` immediately.
+
+### Boundaries
+
+M2 is local code, contract, and synthesis work only. Lab canary deploy, live deploy, and any cloud mutation are
+operator/steward follow-ups after review and merge.

--- a/docs/spec/v3/README.md
+++ b/docs/spec/v3/README.md
@@ -12,6 +12,11 @@ soul creation. They describe server-held instance-key calls only; they do not es
 path. The hosted-genesis examples lock `in_progress`, terminal `declaration_ready` with produced declarations, and
 `failed` with typed bounded recovery.
 
+The hosted-genesis status enum includes `created` for Host durable records that may be reserved before the first
+accepted user turn. Host collapses `created` to `in_progress` on the Lesser instance-key projection because Lesser's
+first accepted POST response already has a persisted `conversation_id` and user turn. Lesser consumers should persist
+`host_conversation_id` immediately and may project any observed `created` snapshot as `in_progress`.
+
 Managed `@lessersoul.ai` email examples use the Project 37 current-channel form
 `<agent-local-id>.<instance-slug>@lessersoul.ai`. Bare `<agent-local-id>@lessersoul.ai`
 addresses are legacy inbound aliases only after migration and should not appear as

--- a/internal/aiworker/hosted_genesis.go
+++ b/internal/aiworker/hosted_genesis.go
@@ -1,0 +1,463 @@
+package aiworker
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/secrets"
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const hostedGenesisRunTimeout = 2 * time.Minute
+
+const (
+	hostedGenesisFailureLLMUnavailable              = "llm_unavailable"
+	hostedGenesisFailureAssistantTurnFailed         = "assistant_turn_failed"
+	hostedGenesisFailureDeclarationExtractionFailed = "declaration_extraction_failed"
+	hostedGenesisFailureInvalidCompletionState      = "invalid_completion_state"
+	hostedGenesisFailureTenantBoundaryViolation     = "tenant_boundary_violation"
+)
+
+type hostedGenesisStore interface {
+	GetSoulAgentRegistration(ctx context.Context, id string) (*models.SoulAgentRegistration, error)
+	GetDomain(ctx context.Context, domain string) (*models.Domain, error)
+	GetInstance(ctx context.Context, slug string) (*models.Instance, error)
+	GetSoulAgentMintConversation(ctx context.Context, agentID string, conversationID string) (*models.SoulAgentMintConversation, error)
+	PutSoulAgentMintConversation(ctx context.Context, item *models.SoulAgentMintConversation) error
+	GetSoulMintConversationIdempotency(ctx context.Context, instanceSlug string, registrationID string, idempotencyKey string) (*models.SoulMintConversationIdempotency, error)
+}
+
+type hostedGenesisMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type hostedGenesisProducedDeclarations struct {
+	SelfDescription soul.SelfDescriptionV2 `json:"selfDescription"`
+	Capabilities    []soul.CapabilityV2    `json:"capabilities"`
+	Boundaries      []soul.BoundaryV2      `json:"boundaries"`
+	Transparency    map[string]any         `json:"transparency"`
+}
+
+func (s *Server) handleHostedGenesisQueueMessage(ctx *apptheory.EventContext, msg events.SQSMessage) error {
+	if s == nil || s.store == nil {
+		return fmt.Errorf("store not initialized")
+	}
+	if ctx == nil {
+		return fmt.Errorf("event context is nil")
+	}
+	var qm hostedgenesis.QueueMessage
+	if err := json.Unmarshal([]byte(msg.Body), &qm); err != nil {
+		return nil
+	}
+	if strings.TrimSpace(qm.Kind) != hostedgenesis.QueueMessageKind {
+		return nil
+	}
+	switch strings.TrimSpace(qm.Step) {
+	case hostedgenesis.StepAssistantTurn:
+		return s.processHostedGenesisAssistantTurn(ctx.Context(), ctx.RequestID, qm)
+	case hostedgenesis.StepDeclarationExtraction:
+		return s.processHostedGenesisDeclarationExtraction(ctx.Context(), ctx.RequestID, qm)
+	default:
+		return nil
+	}
+}
+
+func (s *Server) hostedGenesisStore() (hostedGenesisStore, bool) {
+	if s == nil || s.store == nil {
+		return nil, false
+	}
+	st, ok := s.store.(hostedGenesisStore)
+	return st, ok
+}
+
+func (s *Server) processHostedGenesisAssistantTurn(ctx context.Context, workerRequestID string, msg hostedgenesis.QueueMessage) error {
+	st, ok := s.hostedGenesisStore()
+	if !ok {
+		return fmt.Errorf("hosted genesis store not initialized")
+	}
+	reg, conv, err := s.loadAndValidateHostedGenesisJob(ctx, st, msg)
+	if err != nil {
+		return err
+	}
+	if conv == nil || reg == nil {
+		return nil
+	}
+	if strings.TrimSpace(conv.LatestTurnID) != strings.TrimSpace(msg.TurnID) || strings.TrimSpace(conv.Status) != models.SoulMintConversationStatusInProgress {
+		return nil
+	}
+
+	messages, err := decodeHostedGenesisMessages(conv.Messages)
+	if err != nil || len(messages) == 0 {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureInvalidCompletionState, workerRequestID)
+		return nil
+	}
+	modelSet := strings.TrimSpace(conv.Model)
+	apiKey, appErr := hostedGenesisAPIKey(ctx, modelSet)
+	if appErr != nil {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureLLMUnavailable, workerRequestID)
+		return nil
+	}
+
+	llmMessages := make([]llm.MintConversationMessage, 0, len(messages))
+	for _, m := range messages {
+		llmMessages = append(llmMessages, llm.MintConversationMessage{Role: strings.ToLower(strings.TrimSpace(m.Role)), Content: strings.TrimSpace(m.Content)})
+	}
+	runCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), hostedGenesisRunTimeout)
+	defer cancel()
+	fullResponse, usage, err := runHostedGenesisAssistantModel(runCtx, apiKey, modelSet, hostedGenesisSystemPrompt(reg), llmMessages)
+	if err != nil || strings.TrimSpace(fullResponse) == "" {
+		log.Printf("aiworker: hosted genesis assistant turn failed agent_hash=%s conversation_hash=%s provider=%s err=%v", hostedGenesisAuditHash(conv.AgentID), hostedGenesisAuditHash(conv.ConversationID), hostedGenesisProvider(modelSet), err)
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureAssistantTurnFailed, workerRequestID)
+		return err
+	}
+
+	messages = append(messages, hostedGenesisMessage{Role: "assistant", Content: fullResponse})
+	messagesJSON, err := json.Marshal(messages)
+	if err != nil {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureAssistantTurnFailed, workerRequestID)
+		return nil
+	}
+	now := time.Now().UTC()
+	conv.Messages = models.EncodeSoulMintConversationBlob(string(messagesJSON))
+	conv.Usage = addAIUsageWorker(conv.Usage, usage)
+	conv.Status = models.SoulMintConversationStatusAssistantTurnReady
+	conv.StatusReason = ""
+	conv.RequestID = firstNonEmptyWorker(msg.RequestID, workerRequestID, conv.RequestID)
+	conv.UpdatedAt = now
+	encodeHostedGenesisPrivateFields(conv)
+	_ = conv.UpdateKeys()
+	return st.PutSoulAgentMintConversation(ctx, conv)
+}
+
+func (s *Server) processHostedGenesisDeclarationExtraction(ctx context.Context, workerRequestID string, msg hostedgenesis.QueueMessage) error {
+	st, ok := s.hostedGenesisStore()
+	if !ok {
+		return fmt.Errorf("hosted genesis store not initialized")
+	}
+	reg, conv, err := s.loadAndValidateHostedGenesisJob(ctx, st, msg)
+	if err != nil || reg == nil || conv == nil {
+		return err
+	}
+	if strings.TrimSpace(conv.Status) != models.SoulMintConversationStatusDeclarationExtractionPending {
+		return nil
+	}
+	messages, err := decodeHostedGenesisMessages(conv.Messages)
+	if err != nil || len(messages) == 0 || !hostedGenesisHasAssistant(messages) {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureInvalidCompletionState, workerRequestID)
+		return nil
+	}
+	modelSet := strings.TrimSpace(conv.Model)
+	apiKey, appErr := hostedGenesisAPIKey(ctx, modelSet)
+	if appErr != nil {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureLLMUnavailable, workerRequestID)
+		return nil
+	}
+	in := llm.MintConversationDeclarationsInput{
+		Registration: llm.MintConversationRegistrationContext{
+			Domain:               strings.TrimSpace(reg.DomainNormalized),
+			LocalID:              strings.TrimSpace(reg.LocalID),
+			AgentID:              strings.TrimSpace(reg.AgentID),
+			DeclaredCapabilities: append([]string(nil), reg.Capabilities...),
+		},
+		Messages: make([]llm.MintConversationMessage, 0, len(messages)),
+	}
+	for _, m := range messages {
+		in.Messages = append(in.Messages, llm.MintConversationMessage{Role: strings.ToLower(strings.TrimSpace(m.Role)), Content: strings.TrimSpace(m.Content)})
+	}
+	draft, usage, err := runHostedGenesisDeclarationModel(ctx, apiKey, modelSet, in)
+	if err != nil {
+		log.Printf("aiworker: hosted genesis declaration extraction failed agent_hash=%s conversation_hash=%s provider=%s err=%v", hostedGenesisAuditHash(conv.AgentID), hostedGenesisAuditHash(conv.ConversationID), hostedGenesisProvider(modelSet), err)
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureDeclarationExtractionFailed, workerRequestID)
+		return err
+	}
+	decl, err := buildHostedGenesisDeclarationsDraft(draft, time.Now().UTC(), modelSet)
+	if err != nil {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureDeclarationExtractionFailed, workerRequestID)
+		return nil
+	}
+	b, err := json.Marshal(decl)
+	if err != nil {
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureDeclarationExtractionFailed, workerRequestID)
+		return nil
+	}
+	now := time.Now().UTC()
+	conv.ProducedDeclarations = models.EncodeSoulMintConversationBlob(string(b))
+	conv.Usage = addAIUsageWorker(conv.Usage, usage)
+	conv.Status = models.SoulMintConversationStatusDeclarationReady
+	conv.StatusReason = ""
+	conv.RequestID = firstNonEmptyWorker(msg.RequestID, workerRequestID, conv.RequestID)
+	conv.CompletedAt = now
+	conv.UpdatedAt = now
+	encodeHostedGenesisPrivateFields(conv)
+	_ = conv.UpdateKeys()
+	return st.PutSoulAgentMintConversation(ctx, conv)
+}
+
+func (s *Server) loadAndValidateHostedGenesisJob(ctx context.Context, st hostedGenesisStore, msg hostedgenesis.QueueMessage) (*models.SoulAgentRegistration, *models.SoulAgentMintConversation, error) {
+	reg, err := st.GetSoulAgentRegistration(ctx, msg.RegistrationID)
+	if err != nil || reg == nil {
+		return nil, nil, nil
+	}
+	if !hostedGenesisRegistrationMatchesJob(reg, msg) {
+		return nil, nil, nil
+	}
+	if !hostedGenesisJobBoundaryValid(ctx, st, reg, msg) {
+		conv, _ := st.GetSoulAgentMintConversation(ctx, msg.AgentID, msg.ConversationID)
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureTenantBoundaryViolation, msg.RequestID)
+		return nil, nil, nil
+	}
+	if !hostedGenesisJobIdempotencyValid(ctx, st, msg) {
+		conv, _ := st.GetSoulAgentMintConversation(ctx, msg.AgentID, msg.ConversationID)
+		s.markHostedGenesisConversationFailed(ctx, st, conv, hostedGenesisFailureInvalidCompletionState, msg.RequestID)
+		return nil, nil, nil
+	}
+	conv, err := st.GetSoulAgentMintConversation(ctx, msg.AgentID, msg.ConversationID)
+	if err != nil || conv == nil {
+		return reg, nil, nil
+	}
+	conv.Messages = models.DecodeSoulMintConversationBlob(conv.Messages)
+	conv.ProducedDeclarations = models.DecodeSoulMintConversationBlob(conv.ProducedDeclarations)
+	return reg, conv, nil
+}
+
+var runHostedGenesisAssistantModel = defaultRunHostedGenesisAssistantModel
+
+func defaultRunHostedGenesisAssistantModel(ctx context.Context, apiKey string, modelSet string, systemPrompt string, messages []llm.MintConversationMessage) (string, models.AIUsage, error) {
+	switch {
+	case strings.HasPrefix(strings.ToLower(modelSet), "openai:"):
+		return llm.StreamMintConversationOpenAI(ctx, apiKey, modelSet, systemPrompt, messages, func(string) {})
+	case strings.HasPrefix(strings.ToLower(modelSet), "anthropic:"):
+		return llm.StreamMintConversationAnthropic(ctx, apiKey, modelSet, systemPrompt, messages, func(string) {})
+	default:
+		return "", models.AIUsage{}, fmt.Errorf("unsupported model set")
+	}
+}
+
+var runHostedGenesisDeclarationModel = defaultRunHostedGenesisDeclarationModel
+
+func defaultRunHostedGenesisDeclarationModel(ctx context.Context, apiKey string, modelSet string, in llm.MintConversationDeclarationsInput) (llm.MintConversationDeclarationsDraft, models.AIUsage, error) {
+	switch {
+	case strings.HasPrefix(strings.ToLower(modelSet), "openai:"):
+		return llm.MintConversationDeclarationsOpenAI(ctx, apiKey, modelSet, in)
+	case strings.HasPrefix(strings.ToLower(modelSet), "anthropic:"):
+		return llm.MintConversationDeclarationsAnthropic(ctx, apiKey, modelSet, in)
+	default:
+		return llm.MintConversationDeclarationsDraft{}, models.AIUsage{}, fmt.Errorf("unsupported model set")
+	}
+}
+
+func hostedGenesisRegistrationMatchesJob(reg *models.SoulAgentRegistration, msg hostedgenesis.QueueMessage) bool {
+	return reg != nil && strings.EqualFold(strings.TrimSpace(reg.AgentID), strings.TrimSpace(msg.AgentID))
+}
+
+func hostedGenesisJobBoundaryValid(ctx context.Context, st hostedGenesisStore, reg *models.SoulAgentRegistration, msg hostedgenesis.QueueMessage) bool {
+	domain, domainErr := st.GetDomain(ctx, reg.DomainNormalized)
+	if domainErr != nil || domain == nil || !hostedGenesisDomainActive(domain) || !strings.EqualFold(strings.TrimSpace(domain.InstanceSlug), strings.TrimSpace(msg.InstanceSlug)) {
+		return false
+	}
+	inst, instErr := st.GetInstance(ctx, msg.InstanceSlug)
+	return instErr == nil && inst != nil && strings.EqualFold(strings.TrimSpace(inst.Slug), strings.TrimSpace(msg.InstanceSlug))
+}
+
+func hostedGenesisJobIdempotencyValid(ctx context.Context, st hostedGenesisStore, msg hostedgenesis.QueueMessage) bool {
+	if strings.TrimSpace(msg.IdempotencyKey) == "" {
+		return true
+	}
+	idem, idemErr := st.GetSoulMintConversationIdempotency(ctx, msg.InstanceSlug, msg.RegistrationID, msg.IdempotencyKey)
+	return idemErr == nil && idem != nil &&
+		strings.EqualFold(strings.TrimSpace(idem.ConversationID), strings.TrimSpace(msg.ConversationID)) &&
+		strings.EqualFold(strings.TrimSpace(idem.TurnID), strings.TrimSpace(msg.TurnID))
+}
+
+func (s *Server) markHostedGenesisConversationFailed(ctx context.Context, st hostedGenesisStore, conv *models.SoulAgentMintConversation, reason string, requestID string) {
+	if st == nil || conv == nil {
+		return
+	}
+	now := time.Now().UTC()
+	conv.Status = models.SoulMintConversationStatusFailed
+	conv.StatusReason = strings.TrimSpace(reason)
+	conv.RequestID = firstNonEmptyWorker(requestID, conv.RequestID)
+	conv.UpdatedAt = now
+	conv.CompletedAt = now
+	encodeHostedGenesisPrivateFields(conv)
+	_ = conv.UpdateKeys()
+	_ = st.PutSoulAgentMintConversation(ctx, conv)
+}
+
+func encodeHostedGenesisPrivateFields(conv *models.SoulAgentMintConversation) {
+	if conv == nil {
+		return
+	}
+	conv.Messages = models.EncodeSoulMintConversationBlob(models.DecodeSoulMintConversationBlob(conv.Messages))
+	conv.ProducedDeclarations = models.EncodeSoulMintConversationBlob(models.DecodeSoulMintConversationBlob(conv.ProducedDeclarations))
+}
+
+func decodeHostedGenesisMessages(raw string) ([]hostedGenesisMessage, error) {
+	raw = models.DecodeSoulMintConversationBlob(raw)
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	var messages []hostedGenesisMessage
+	if err := json.Unmarshal([]byte(raw), &messages); err != nil {
+		return nil, err
+	}
+	return messages, nil
+}
+
+func hostedGenesisHasAssistant(messages []hostedGenesisMessage) bool {
+	for _, msg := range messages {
+		if strings.EqualFold(strings.TrimSpace(msg.Role), "assistant") && strings.TrimSpace(msg.Content) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func hostedGenesisDomainActive(domain *models.Domain) bool {
+	if domain == nil {
+		return false
+	}
+	status := strings.ToLower(strings.TrimSpace(domain.Status))
+	return status == models.DomainStatusVerified || status == models.DomainStatusActive
+}
+
+func hostedGenesisAPIKey(ctx context.Context, modelSet string) (string, error) {
+	modelSetNorm := strings.ToLower(strings.TrimSpace(modelSet))
+	switch {
+	case strings.HasPrefix(modelSetNorm, "openai:"):
+		if k := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); k != "" {
+			return k, nil
+		}
+		return secrets.OpenAIServiceKey(ctx, nil)
+	case strings.HasPrefix(modelSetNorm, "anthropic:"):
+		if k := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); k != "" {
+			return k, nil
+		}
+		if k := strings.TrimSpace(os.Getenv("CLAUDE_API_KEY")); k != "" {
+			return k, nil
+		}
+		return secrets.ClaudeAPIKey(ctx, nil)
+	default:
+		return "", fmt.Errorf("unsupported model set")
+	}
+}
+
+func hostedGenesisSystemPrompt(reg *models.SoulAgentRegistration) string {
+	var sb strings.Builder
+	sb.WriteString("You are a Soul Registry minting assistant helping an AI agent define self-description, capabilities, boundaries, and transparency. Keep responses concise and safe; never ask for or reveal credentials.\n\n")
+	if reg != nil {
+		if strings.TrimSpace(reg.DomainNormalized) != "" {
+			sb.WriteString("Domain: " + strings.TrimSpace(reg.DomainNormalized) + "\n")
+		}
+		if strings.TrimSpace(reg.LocalID) != "" {
+			sb.WriteString("Local ID: " + strings.TrimSpace(reg.LocalID) + "\n")
+		}
+		if len(reg.Capabilities) > 0 {
+			b, _ := json.Marshal(reg.Capabilities)
+			sb.WriteString("Declared capabilities: " + string(b) + "\n")
+		}
+	}
+	return sb.String()
+}
+
+func buildHostedGenesisDeclarationsDraft(draft llm.MintConversationDeclarationsDraft, now time.Time, modelSet string) (hostedGenesisProducedDeclarations, error) {
+	decl := hostedGenesisProducedDeclarations{
+		SelfDescription: draft.SelfDescription,
+		Capabilities:    []soul.CapabilityV2{},
+		Boundaries:      []soul.BoundaryV2{},
+		Transparency:    draft.Transparency,
+	}
+	decl.SelfDescription.AuthoredBy = "agent"
+	decl.SelfDescription.MintingModel = strings.TrimSpace(modelSet)
+	if err := decl.SelfDescription.Validate(); err != nil {
+		return hostedGenesisProducedDeclarations{}, err
+	}
+	for _, c := range draft.Capabilities {
+		c.ClaimLevel = "self-declared"
+		if strings.TrimSpace(c.Capability) == "" || strings.TrimSpace(c.Scope) == "" {
+			continue
+		}
+		if err := c.Validate(); err != nil {
+			continue
+		}
+		decl.Capabilities = append(decl.Capabilities, c)
+	}
+	for i, b := range draft.Boundaries {
+		entry := soul.BoundaryV2{
+			ID:             fmt.Sprintf("mint-%d-%02d", now.Unix(), i+1),
+			Category:       strings.ToLower(strings.TrimSpace(b.Category)),
+			Statement:      strings.TrimSpace(b.Statement),
+			Rationale:      strings.TrimSpace(b.Rationale),
+			AddedAt:        now.UTC().Format(time.RFC3339),
+			AddedInVersion: "1",
+			Signature:      "0x00",
+		}
+		if err := entry.Validate(); err != nil {
+			continue
+		}
+		decl.Boundaries = append(decl.Boundaries, entry)
+	}
+	if decl.Transparency == nil {
+		decl.Transparency = map[string]any{}
+	}
+	return decl, nil
+}
+
+func addAIUsageWorker(existing models.AIUsage, delta models.AIUsage) models.AIUsage {
+	out := existing
+	if strings.TrimSpace(out.Provider) == "" {
+		out.Provider = strings.TrimSpace(delta.Provider)
+	}
+	if strings.TrimSpace(out.Model) == "" {
+		out.Model = strings.TrimSpace(delta.Model)
+	}
+	out.InputTokens += delta.InputTokens
+	out.OutputTokens += delta.OutputTokens
+	total := delta.TotalTokens
+	if total == 0 && (delta.InputTokens != 0 || delta.OutputTokens != 0) {
+		total = delta.InputTokens + delta.OutputTokens
+	}
+	out.TotalTokens += total
+	out.DurationMs += delta.DurationMs
+	out.ToolCalls += delta.ToolCalls
+	return out
+}
+
+func firstNonEmptyWorker(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func hostedGenesisProvider(modelSet string) string {
+	if i := strings.Index(strings.TrimSpace(modelSet), ":"); i > 0 {
+		return strings.ToLower(strings.TrimSpace(modelSet[:i]))
+	}
+	return "unknown"
+}
+
+func hostedGenesisAuditHash(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(raw))
+	return "sha256:" + hex.EncodeToString(sum[:])[:16]
+}

--- a/internal/aiworker/hosted_genesis_internal_test.go
+++ b/internal/aiworker/hosted_genesis_internal_test.go
@@ -1,0 +1,655 @@
+package aiworker
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-lambda-go/events"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/artifacts"
+	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/soul"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type fakeHostedGenesisStore struct {
+	fakeAIStore
+
+	mu       sync.Mutex
+	reg      *models.SoulAgentRegistration
+	domain   *models.Domain
+	instance *models.Instance
+	conv     *models.SoulAgentMintConversation
+	idem     *models.SoulMintConversationIdempotency
+	putCount int
+}
+
+const (
+	hostedGenesisWorkerOpenAIKey   = "openai-test-key"
+	hostedGenesisWorkerOpenAIModel = "openai:gpt-test"
+)
+
+func (f *fakeHostedGenesisStore) GetSoulAgentRegistration(_ context.Context, id string) (*models.SoulAgentRegistration, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.reg == nil || strings.TrimSpace(f.reg.ID) != strings.TrimSpace(id) {
+		return nil, errNotFound
+	}
+	cp := *f.reg
+	return &cp, nil
+}
+
+func (f *fakeHostedGenesisStore) GetDomain(_ context.Context, domain string) (*models.Domain, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.domain == nil || !strings.EqualFold(strings.TrimSpace(f.domain.Domain), strings.TrimSpace(domain)) {
+		return nil, errNotFound
+	}
+	cp := *f.domain
+	return &cp, nil
+}
+
+func (f *fakeHostedGenesisStore) GetInstance(_ context.Context, slug string) (*models.Instance, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.instance == nil || !strings.EqualFold(strings.TrimSpace(f.instance.Slug), strings.TrimSpace(slug)) {
+		return nil, errNotFound
+	}
+	cp := *f.instance
+	return &cp, nil
+}
+
+func (f *fakeHostedGenesisStore) GetSoulAgentMintConversation(_ context.Context, agentID string, conversationID string) (*models.SoulAgentMintConversation, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.conv == nil ||
+		!strings.EqualFold(strings.TrimSpace(f.conv.AgentID), strings.TrimSpace(agentID)) ||
+		strings.TrimSpace(f.conv.ConversationID) != strings.TrimSpace(conversationID) {
+		return nil, errNotFound
+	}
+	cp := *f.conv
+	return &cp, nil
+}
+
+func (f *fakeHostedGenesisStore) PutSoulAgentMintConversation(_ context.Context, item *models.SoulAgentMintConversation) error {
+	if item == nil {
+		return nil
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	cp := *item
+	f.conv = &cp
+	f.putCount++
+	return nil
+}
+
+func (f *fakeHostedGenesisStore) GetSoulMintConversationIdempotency(_ context.Context, instanceSlug string, registrationID string, idempotencyKey string) (*models.SoulMintConversationIdempotency, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.idem == nil ||
+		!strings.EqualFold(strings.TrimSpace(f.idem.InstanceSlug), strings.TrimSpace(instanceSlug)) ||
+		strings.TrimSpace(f.idem.RegistrationID) != strings.TrimSpace(registrationID) ||
+		strings.TrimSpace(f.idem.IdempotencyKey) != strings.TrimSpace(idempotencyKey) {
+		return nil, errNotFound
+	}
+	cp := *f.idem
+	return &cp, nil
+}
+
+func newHostedGenesisWorkerStore(turnID string) *fakeHostedGenesisStore {
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	return &fakeHostedGenesisStore{
+		fakeAIStore: fakeAIStore{jobs: map[string]*models.AIJob{}, results: map[string]*models.AIResult{}},
+		reg: &models.SoulAgentRegistration{
+			ID:               "reg-worker",
+			DomainNormalized: "agent.example",
+			LocalID:          "agent",
+			AgentID:          "0x" + strings.Repeat("44", 32),
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		},
+		domain: &models.Domain{
+			Domain:       "agent.example",
+			InstanceSlug: "inst-worker",
+			Status:       models.DomainStatusVerified,
+			CreatedAt:    now,
+			UpdatedAt:    now,
+		},
+		instance: &models.Instance{
+			Slug:      "inst-worker",
+			Status:    models.InstanceStatusActive,
+			CreatedAt: now,
+			UpdatedAt: now,
+		},
+		conv: &models.SoulAgentMintConversation{
+			AgentID:        "0x" + strings.Repeat("44", 32),
+			ConversationID: "conv-worker",
+			Model:          "deterministic",
+			Messages:       models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"reload-safe-user-turn"}]`),
+			Status:         models.SoulMintConversationStatusInProgress,
+			LatestTurnID:   turnID,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		idem: &models.SoulMintConversationIdempotency{
+			InstanceSlug:   "inst-worker",
+			RegistrationID: "reg-worker",
+			AgentID:        "0x" + strings.Repeat("44", 32),
+			ConversationID: "conv-worker",
+			TurnID:         turnID,
+			IdempotencyKey: "idem-worker",
+			RequestHash:    strings.Repeat("a", 64),
+			Status:         models.SoulMintConversationIdempotencyStatusProcessing,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	}
+}
+
+func hostedGenesisWorkerQueueMessage(step string, turnID string) hostedgenesis.QueueMessage {
+	return hostedgenesis.QueueMessage{
+		Kind:           hostedgenesis.QueueMessageKind,
+		Step:           step,
+		RegistrationID: "reg-worker",
+		InstanceSlug:   "inst-worker",
+		AgentID:        "0x" + strings.Repeat("44", 32),
+		ConversationID: "conv-worker",
+		TurnID:         turnID,
+		RequestID:      "req-host",
+		IdempotencyKey: "idem-worker",
+	}
+}
+
+func hostedGenesisWorkerSQSMessage(t *testing.T, msg hostedgenesis.QueueMessage) events.SQSMessage {
+	t.Helper()
+	body, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal queue message: %v", err)
+	}
+	return events.SQSMessage{Body: string(body)}
+}
+
+func TestHostedGenesisQueueMessageDispatchesDurableKinds(t *testing.T) {
+	t.Parallel()
+
+	srv := NewServer(config.Config{}, newHostedGenesisWorkerStore("turn-worker"), artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	ctx := &apptheory.EventContext{RequestID: "worker-req"}
+	for _, body := range []string{
+		`{bad json`,
+		`{"kind":"other","step":"assistant_turn"}`,
+		`{"kind":"hosted_genesis_conversation","step":"unknown"}`,
+	} {
+		if err := srv.handleHostedGenesisQueueMessage(ctx, events.SQSMessage{Body: body}); err != nil {
+			t.Fatalf("expected non-durable queue body to drop, got %v", err)
+		}
+	}
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	srv = NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err := srv.handleHostedGenesisQueueMessage(ctx, hostedGenesisWorkerSQSMessage(t, hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker")))
+	if err != nil {
+		t.Fatalf("unexpected assistant queue error: %v", err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureLLMUnavailable)
+}
+
+func TestHostedGenesisWorkerReloadsDurableTurnBeforeFailureWrite(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected worker error: %v", err)
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.putCount != 1 || st.conv == nil {
+		t.Fatalf("expected one fail-closed conversation write, putCount=%d conv=%#v", st.putCount, st.conv)
+	}
+	if st.conv.Status != models.SoulMintConversationStatusFailed || st.conv.StatusReason != hostedGenesisFailureLLMUnavailable {
+		t.Fatalf("expected llm_unavailable failure after reload, got %#v", st.conv)
+	}
+	if decoded := models.DecodeSoulMintConversationBlob(st.conv.Messages); !strings.Contains(decoded, "reload-safe-user-turn") {
+		t.Fatalf("worker lost persisted user turn on failure write: %q", decoded)
+	}
+	if strings.Contains(st.conv.Messages, "reload-safe-user-turn") {
+		t.Fatalf("worker stored raw transcript instead of encoded private field: %q", st.conv.Messages)
+	}
+}
+
+func TestHostedGenesisWorkerRejectsMismatchedIdempotencyTurn(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-original")
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-replayed-wrong"))
+	if err != nil {
+		t.Fatalf("unexpected worker error: %v", err)
+	}
+
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureInvalidCompletionState)
+}
+
+func TestHostedGenesisAssistantTurnDropsStaleConversation(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Status = models.SoulMintConversationStatusAssistantTurnReady
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil || st.putCount != 0 {
+		t.Fatalf("expected stale assistant turn to drop without write, put=%d err=%v", st.putCount, err)
+	}
+}
+
+func TestHostedGenesisAssistantTurnRejectsInvalidTranscript(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Messages = models.EncodeSoulMintConversationBlob(`not-json`)
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected invalid transcript error: %v", err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureInvalidCompletionState)
+}
+
+func TestHostedGenesisJobValidationRejectsTenantBoundaryMismatch(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.domain.InstanceSlug = "other-instance"
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	reg, conv, err := srv.loadAndValidateHostedGenesisJob(context.Background(), st, hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil || reg != nil || conv != nil {
+		t.Fatalf("expected boundary mismatch to drop job, reg=%#v conv=%#v err=%v", reg, conv, err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureTenantBoundaryViolation)
+}
+
+func TestHostedGenesisJobValidationAllowsMissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	msg := hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker")
+	msg.IdempotencyKey = ""
+
+	reg, conv, err := srv.loadAndValidateHostedGenesisJob(context.Background(), st, msg)
+	if err != nil || reg == nil || conv == nil {
+		t.Fatalf("expected valid job without idempotency key, reg=%#v conv=%#v err=%v", reg, conv, err)
+	}
+	if decoded := models.DecodeSoulMintConversationBlob(conv.Messages); !strings.Contains(decoded, "reload-safe-user-turn") {
+		t.Fatalf("expected decoded durable transcript, got %q", decoded)
+	}
+}
+
+func TestHostedGenesisJobValidationDropsRegistrationMismatch(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	msg := hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker")
+	msg.AgentID = "0x" + strings.Repeat("55", 32)
+
+	reg, conv, err := srv.loadAndValidateHostedGenesisJob(context.Background(), st, msg)
+	if err != nil || reg != nil || conv != nil || st.putCount != 0 {
+		t.Fatalf("expected registration mismatch to drop without write, reg=%#v conv=%#v put=%d err=%v", reg, conv, st.putCount, err)
+	}
+}
+
+func TestHostedGenesisDeclarationExtractionProgressSafeFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("user only conversation remains progress safe", func(t *testing.T) {
+		t.Parallel()
+
+		st := newHostedGenesisWorkerStore("turn-worker")
+		st.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+		srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+		err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+		if err != nil {
+			t.Fatalf("unexpected declaration extraction error: %v", err)
+		}
+		assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureInvalidCompletionState)
+	})
+
+	t.Run("assistant transcript without provider key fails closed", func(t *testing.T) {
+		t.Parallel()
+
+		st := newHostedGenesisWorkerStore("turn-worker")
+		st.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+		st.conv.Messages = models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"describe"},{"role":"assistant","content":"draft"}]`)
+		srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+		ctx := &apptheory.EventContext{RequestID: "worker-req"}
+
+		err := srv.handleHostedGenesisQueueMessage(ctx, hostedGenesisWorkerSQSMessage(t, hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker")))
+		if err != nil {
+			t.Fatalf("unexpected declaration queue error: %v", err)
+		}
+		assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureLLMUnavailable)
+	})
+}
+
+func TestHostedGenesisDeclarationExtractionDropsNonPendingStatus(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Status = models.SoulMintConversationStatusAssistantTurnReady
+	st.conv.Messages = models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"describe"},{"role":"assistant","content":"draft"}]`)
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+	if err != nil || st.putCount != 0 {
+		t.Fatalf("expected non-pending extraction to drop without write, put=%d err=%v", st.putCount, err)
+	}
+}
+
+func TestHostedGenesisDeclarationExtractionRejectsInvalidTranscript(t *testing.T) {
+	t.Parallel()
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+	st.conv.Messages = models.EncodeSoulMintConversationBlob(`not-json`)
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+
+	err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected invalid extraction transcript error: %v", err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureInvalidCompletionState)
+}
+
+func TestHostedGenesisWorkerCompletesAssistantAndDeclarationTurns(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", hostedGenesisWorkerOpenAIKey)
+	oldAssistant := runHostedGenesisAssistantModel
+	oldDeclaration := runHostedGenesisDeclarationModel
+	t.Cleanup(func() {
+		runHostedGenesisAssistantModel = oldAssistant
+		runHostedGenesisDeclarationModel = oldDeclaration
+	})
+	runHostedGenesisAssistantModel = func(_ context.Context, apiKey string, modelSet string, systemPrompt string, messages []llm.MintConversationMessage) (string, models.AIUsage, error) {
+		if apiKey != hostedGenesisWorkerOpenAIKey || modelSet != hostedGenesisWorkerOpenAIModel || !strings.Contains(systemPrompt, "agent.example") || len(messages) != 1 {
+			t.Fatalf("unexpected assistant model input: key=%q model=%q prompt=%q messages=%#v", apiKey, modelSet, systemPrompt, messages)
+		}
+		return "assistant ready", models.AIUsage{Provider: testProviderOpenAI, Model: "gpt-test", InputTokens: 2, OutputTokens: 3}, nil
+	}
+	runHostedGenesisDeclarationModel = func(_ context.Context, apiKey string, modelSet string, in llm.MintConversationDeclarationsInput) (llm.MintConversationDeclarationsDraft, models.AIUsage, error) {
+		if apiKey != hostedGenesisWorkerOpenAIKey || modelSet != hostedGenesisWorkerOpenAIModel || in.Registration.Domain != "agent.example" || len(in.Messages) != 2 {
+			t.Fatalf("unexpected declaration model input: key=%q model=%q in=%#v", apiKey, modelSet, in)
+		}
+		return validHostedGenesisDraft(), models.AIUsage{Provider: testProviderOpenAI, Model: "gpt-test", TotalTokens: 11}, nil
+	}
+
+	assistantStore := newHostedGenesisWorkerStore("turn-worker")
+	assistantStore.conv.Model = hostedGenesisWorkerOpenAIModel
+	srv := NewServer(config.Config{}, assistantStore, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected assistant success error: %v", err)
+	}
+	assertHostedGenesisAssistantReady(t, assistantStore)
+
+	declarationStore := newHostedGenesisWorkerStore("turn-worker")
+	declarationStore.conv.Model = hostedGenesisWorkerOpenAIModel
+	declarationStore.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+	declarationStore.conv.Messages = models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"describe"},{"role":"assistant","content":"assistant ready"}]`)
+	srv = NewServer(config.Config{}, declarationStore, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err = srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected declaration success error: %v", err)
+	}
+	assertHostedGenesisDeclarationReady(t, declarationStore)
+}
+
+func TestHostedGenesisWorkerFailsClosedOnEmptyAssistantResponse(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", hostedGenesisWorkerOpenAIKey)
+	oldAssistant := runHostedGenesisAssistantModel
+	t.Cleanup(func() { runHostedGenesisAssistantModel = oldAssistant })
+	runHostedGenesisAssistantModel = func(context.Context, string, string, string, []llm.MintConversationMessage) (string, models.AIUsage, error) {
+		return "", models.AIUsage{}, nil
+	}
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Model = hostedGenesisWorkerOpenAIModel
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected empty assistant response error: %v", err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureAssistantTurnFailed)
+}
+
+func TestHostedGenesisWorkerFailsClosedOnInvalidDeclarationDraft(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", hostedGenesisWorkerOpenAIKey)
+	oldDeclaration := runHostedGenesisDeclarationModel
+	t.Cleanup(func() { runHostedGenesisDeclarationModel = oldDeclaration })
+	runHostedGenesisDeclarationModel = func(context.Context, string, string, llm.MintConversationDeclarationsInput) (llm.MintConversationDeclarationsDraft, models.AIUsage, error) {
+		draft := validHostedGenesisDraft()
+		draft.SelfDescription.Purpose = "short"
+		return draft, models.AIUsage{}, nil
+	}
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Model = hostedGenesisWorkerOpenAIModel
+	st.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+	st.conv.Messages = models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"describe"},{"role":"assistant","content":"assistant ready"}]`)
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+	if err != nil {
+		t.Fatalf("unexpected invalid declaration draft error: %v", err)
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureDeclarationExtractionFailed)
+}
+
+func TestHostedGenesisWorkerReturnsDeclarationModelError(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", hostedGenesisWorkerOpenAIKey)
+	oldDeclaration := runHostedGenesisDeclarationModel
+	t.Cleanup(func() { runHostedGenesisDeclarationModel = oldDeclaration })
+	runHostedGenesisDeclarationModel = func(context.Context, string, string, llm.MintConversationDeclarationsInput) (llm.MintConversationDeclarationsDraft, models.AIUsage, error) {
+		return llm.MintConversationDeclarationsDraft{}, models.AIUsage{}, context.Canceled
+	}
+
+	st := newHostedGenesisWorkerStore("turn-worker")
+	st.conv.Model = hostedGenesisWorkerOpenAIModel
+	st.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+	st.conv.Messages = models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"describe"},{"role":"assistant","content":"assistant ready"}]`)
+	srv := NewServer(config.Config{}, st, artifacts.New(""), fakeComprehend{}, fakeRekognition{})
+	err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker"))
+	if err == nil {
+		t.Fatalf("expected declaration model error")
+	}
+	assertHostedGenesisWorkerFailure(t, st, hostedGenesisFailureDeclarationExtractionFailed)
+}
+
+func TestHostedGenesisWorkerRequiresStoreAndContext(t *testing.T) {
+	t.Parallel()
+
+	srv := &Server{}
+	if err := srv.processHostedGenesisAssistantTurn(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepAssistantTurn, "turn-worker")); err == nil {
+		t.Fatalf("expected assistant turn store initialization error")
+	}
+	if err := srv.processHostedGenesisDeclarationExtraction(context.Background(), "worker-req", hostedGenesisWorkerQueueMessage(hostedgenesis.StepDeclarationExtraction, "turn-worker")); err == nil {
+		t.Fatalf("expected declaration extraction store initialization error")
+	}
+	if err := srv.handleHostedGenesisQueueMessage(nil, events.SQSMessage{}); err == nil {
+		t.Fatalf("expected nil event context error")
+	}
+}
+
+func TestHostedGenesisAPIKeyUsesProviderEnvironment(t *testing.T) {
+	t.Setenv("OPENAI_API_KEY", " openai-env ")
+	openAIKey, err := hostedGenesisAPIKey(context.Background(), "openai:gpt-5")
+	if err != nil || openAIKey != "openai-env" {
+		t.Fatalf("expected openai env key, key=%q err=%v", openAIKey, err)
+	}
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("CLAUDE_API_KEY", " claude-env ")
+	claudeKey, err := hostedGenesisAPIKey(context.Background(), "anthropic:claude-sonnet-4-6")
+	if err != nil || claudeKey != "claude-env" {
+		t.Fatalf("expected claude env key, key=%q err=%v", claudeKey, err)
+	}
+	if _, err := hostedGenesisAPIKey(context.Background(), "deterministic"); err == nil {
+		t.Fatalf("expected unsupported model error")
+	}
+}
+
+func TestHostedGenesisModelRunnersRejectUnsupportedModel(t *testing.T) {
+	t.Parallel()
+
+	if _, _, err := runHostedGenesisAssistantModel(context.Background(), "key", "deterministic", "system", nil); err == nil {
+		t.Fatalf("expected unsupported assistant model error")
+	}
+	if _, _, err := runHostedGenesisDeclarationModel(context.Background(), "key", "deterministic", llm.MintConversationDeclarationsInput{}); err == nil {
+		t.Fatalf("expected unsupported declaration model error")
+	}
+}
+
+func TestHostedGenesisTranscriptAndStatusHelpers(t *testing.T) {
+	t.Parallel()
+
+	messages, err := decodeHostedGenesisMessages(models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"hello"},{"role":"assistant","content":"ready"}]`))
+	if err != nil || !hostedGenesisHasAssistant(messages) {
+		t.Fatalf("expected decoded assistant transcript, messages=%#v err=%v", messages, err)
+	}
+	if _, err := decodeHostedGenesisMessages(`not-json`); err == nil {
+		t.Fatalf("expected invalid transcript json error")
+	}
+
+	if !hostedGenesisDomainActive(&models.Domain{Status: models.DomainStatusVerified}) ||
+		!hostedGenesisDomainActive(&models.Domain{Status: models.DomainStatusActive}) ||
+		hostedGenesisDomainActive(&models.Domain{Status: models.DomainStatusPending}) {
+		t.Fatalf("domain active helper mismatch")
+	}
+	if hostedGenesisProvider("anthropic:claude") != "anthropic" || hostedGenesisProvider("deterministic") != "unknown" {
+		t.Fatalf("provider helper mismatch")
+	}
+	if got := hostedGenesisAuditHash(" agent-1 "); !strings.HasPrefix(got, "sha256:") || len(got) != len("sha256:")+16 {
+		t.Fatalf("unexpected audit hash: %q", got)
+	}
+	if hostedGenesisAuditHash("") != "" || firstNonEmptyWorker(" ", "\n") != "" {
+		t.Fatalf("empty helper inputs should stay empty")
+	}
+	var srv *Server
+	if st, ok := srv.hostedGenesisStore(); ok || st != nil {
+		t.Fatalf("nil server should not expose hosted genesis store")
+	}
+}
+
+func TestHostedGenesisPromptAndUsageHelpers(t *testing.T) {
+	t.Parallel()
+
+	reg := newHostedGenesisWorkerStore("turn-worker").reg
+	reg.Capabilities = []string{"planning"}
+	if prompt := hostedGenesisSystemPrompt(reg); !strings.Contains(prompt, "agent.example") || !strings.Contains(prompt, "planning") {
+		t.Fatalf("system prompt omitted registration context: %q", prompt)
+	}
+
+	usage := addAIUsageWorker(models.AIUsage{Provider: testProviderOpenAI, InputTokens: 1}, models.AIUsage{Model: "gpt", InputTokens: 2, OutputTokens: 3, DurationMs: 4, ToolCalls: 1})
+	if usage.Provider != testProviderOpenAI || usage.Model != "gpt" || usage.InputTokens != 3 || usage.OutputTokens != 3 || usage.TotalTokens != 5 || usage.DurationMs != 4 || usage.ToolCalls != 1 {
+		t.Fatalf("usage merge mismatch: %#v", usage)
+	}
+}
+
+func TestHostedGenesisDeclarationsDraftBuilder(t *testing.T) {
+	t.Parallel()
+
+	decl, err := buildHostedGenesisDeclarationsDraft(validHostedGenesisDraft(), time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC), "anthropic:claude-sonnet-4-6")
+	if err != nil {
+		t.Fatalf("unexpected declarations draft error: %v", err)
+	}
+	if decl.SelfDescription.AuthoredBy != "agent" ||
+		decl.SelfDescription.MintingModel != "anthropic:claude-sonnet-4-6" ||
+		len(decl.Capabilities) != 1 ||
+		len(decl.Boundaries) != 1 ||
+		decl.Transparency == nil {
+		t.Fatalf("unexpected produced declarations: %#v", decl)
+	}
+	badDraft := validHostedGenesisDraft()
+	badDraft.SelfDescription.Purpose = "short"
+	if _, err := buildHostedGenesisDeclarationsDraft(badDraft, time.Now(), "openai:gpt-5"); err == nil {
+		t.Fatalf("expected invalid self-description error")
+	}
+}
+
+func validHostedGenesisDraft() llm.MintConversationDeclarationsDraft {
+	return llm.MintConversationDeclarationsDraft{
+		SelfDescription: soul.SelfDescriptionV2{
+			Purpose: "Help users plan hosted soul genesis with explicit safety limits.",
+		},
+		Capabilities: []soul.CapabilityV2{
+			{Capability: "hosted_genesis_planning", Scope: "Draft safe registration declarations."},
+			{Capability: "", Scope: "ignored"},
+		},
+		Boundaries: []llm.MintConversationBoundaryDraft{
+			{Category: "refusal", Statement: "I will not reveal credentials.", Rationale: "protects operators"},
+			{Category: "", Statement: ""},
+		},
+	}
+}
+
+func assertHostedGenesisWorkerFailure(t *testing.T, st *fakeHostedGenesisStore, reason string) {
+	t.Helper()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.putCount != 1 || st.conv == nil {
+		t.Fatalf("expected one fail-closed conversation write, putCount=%d conv=%#v", st.putCount, st.conv)
+	}
+	if st.conv.Status != models.SoulMintConversationStatusFailed || st.conv.StatusReason != reason {
+		t.Fatalf("expected %s failure, got %#v", reason, st.conv)
+	}
+}
+
+func assertHostedGenesisAssistantReady(t *testing.T, st *fakeHostedGenesisStore) {
+	t.Helper()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.putCount != 1 || st.conv == nil {
+		t.Fatalf("expected one assistant write, putCount=%d conv=%#v", st.putCount, st.conv)
+	}
+	if st.conv.Status != models.SoulMintConversationStatusAssistantTurnReady || st.conv.StatusReason != "" {
+		t.Fatalf("expected assistant-ready status, got %#v", st.conv)
+	}
+	decoded := models.DecodeSoulMintConversationBlob(st.conv.Messages)
+	if !strings.Contains(decoded, "assistant ready") || strings.Contains(st.conv.Messages, "assistant ready") {
+		t.Fatalf("assistant transcript encoding mismatch raw=%q decoded=%q", st.conv.Messages, decoded)
+	}
+	if st.conv.Usage.TotalTokens != 5 || st.conv.RequestID != "req-host" {
+		t.Fatalf("assistant metadata mismatch: %#v", st.conv)
+	}
+}
+
+func assertHostedGenesisDeclarationReady(t *testing.T, st *fakeHostedGenesisStore) {
+	t.Helper()
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.putCount != 1 || st.conv == nil {
+		t.Fatalf("expected one declaration write, putCount=%d conv=%#v", st.putCount, st.conv)
+	}
+	if st.conv.Status != models.SoulMintConversationStatusDeclarationReady || st.conv.CompletedAt.IsZero() {
+		t.Fatalf("expected declaration-ready status, got %#v", st.conv)
+	}
+	decoded := models.DecodeSoulMintConversationBlob(st.conv.ProducedDeclarations)
+	if !strings.Contains(decoded, "hosted_genesis_planning") || strings.Contains(st.conv.ProducedDeclarations, "hosted_genesis_planning") {
+		t.Fatalf("declaration encoding mismatch raw=%q decoded=%q", st.conv.ProducedDeclarations, decoded)
+	}
+	if st.conv.Usage.TotalTokens != 11 || st.conv.RequestID != "req-host" {
+		t.Fatalf("declaration metadata mismatch: %#v", st.conv)
+	}
+}

--- a/internal/aiworker/server.go
+++ b/internal/aiworker/server.go
@@ -104,6 +104,10 @@ func (s *Server) Register(app *apptheory.App) {
 	if queueName != "" {
 		app.SQS(queueName, s.handleSafetyQueueMessage)
 	}
+	hostedGenesisQueueName := sqsQueueNameFromURL(s.cfg.HostedGenesisQueueURL)
+	if hostedGenesisQueueName != "" {
+		app.SQS(hostedGenesisQueueName, s.handleHostedGenesisQueueMessage)
+	}
 }
 
 func (s *Server) handleSafetyQueueMessage(ctx *apptheory.EventContext, msg events.SQSMessage) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -53,11 +53,12 @@ type Config struct {
 	ENSGatewaySigningPrivateKey   string
 	ENSGatewaySignatureTTLSeconds int64
 
-	ArtifactBucketName string
-	PreviewQueueURL    string
-	SafetyQueueURL     string
-	ProvisionQueueURL  string
-	CommQueueURL       string
+	ArtifactBucketName    string
+	PreviewQueueURL       string
+	SafetyQueueURL        string
+	HostedGenesisQueueURL string
+	ProvisionQueueURL     string
+	CommQueueURL          string
 
 	BootstrapWalletAddress string
 
@@ -245,11 +246,12 @@ func Load() Config {
 		ENSGatewaySigningPrivateKey:   envString("ENS_GATEWAY_SIGNING_PRIVATE_KEY"),
 		ENSGatewaySignatureTTLSeconds: ensGatewayTTL,
 
-		ArtifactBucketName: envString("ARTIFACT_BUCKET_NAME"),
-		PreviewQueueURL:    envString("PREVIEW_QUEUE_URL"),
-		SafetyQueueURL:     envString("SAFETY_QUEUE_URL"),
-		ProvisionQueueURL:  envString("PROVISION_QUEUE_URL"),
-		CommQueueURL:       envString("COMM_QUEUE_URL"),
+		ArtifactBucketName:    envString("ARTIFACT_BUCKET_NAME"),
+		PreviewQueueURL:       envString("PREVIEW_QUEUE_URL"),
+		SafetyQueueURL:        envString("SAFETY_QUEUE_URL"),
+		HostedGenesisQueueURL: envString("HOSTED_GENESIS_QUEUE_URL"),
+		ProvisionQueueURL:     envString("PROVISION_QUEUE_URL"),
+		CommQueueURL:          envString("COMM_QUEUE_URL"),
 
 		BootstrapWalletAddress: envString("BOOTSTRAP_WALLET_ADDRESS"),
 

--- a/internal/controlplane/handlers_soul_instance_bootstrap.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap.go
@@ -146,11 +146,11 @@ func (s *Server) handleSoulInstanceMintConversation(ctx *apptheory.Context) (*ap
 	if appErr != nil {
 		return nil, appErr
 	}
-	resp, err := s.handleSoulMintConversationForRegistration(ctx, mintConversationRegistrationContext{
+	resp, err := s.handleSoulMintConversationForRegistrationAsync(ctx, mintConversationRegistrationContext{
 		reg:        regCtx.reg,
 		inst:       regCtx.inst,
 		agentIDHex: regCtx.agentIDHex,
-	})
+	}, regCtx.instanceSlug)
 	if err != nil {
 		return nil, soulInstanceBootstrapConversationErrorFromError(err)
 	}
@@ -166,14 +166,11 @@ func (s *Server) handleSoulInstanceGetRegistrationMintConversation(ctx *apptheor
 	if appErr := rejectOversizeSoulMintInstanceConversation(convCtx.conv); appErr != nil {
 		return nil, appErr
 	}
-	resp, err := soulMintInstanceReadJSON(http.StatusOK, soulInstanceMintConversationResponse{
-		Version:      "1",
-		Conversation: convCtx.conv,
-	}, soulMintInstanceReadSingleMaxBytes)
-	if err != nil {
-		return nil, soulMintInstanceReadResponseError(err)
-	}
-	return resp, nil
+	return hostedGenesisConversationJSON(http.StatusOK, convCtx.conv, hostedGenesisProjectionOptions{
+		RegistrationID:  convCtx.reg.ID,
+		RequestID:       strings.TrimSpace(ctx.RequestID),
+		CollapseCreated: true,
+	})
 }
 
 func (s *Server) handleSoulInstanceCompleteMintConversation(ctx *apptheory.Context) (*apptheory.Response, error) {
@@ -183,18 +180,27 @@ func (s *Server) handleSoulInstanceCompleteMintConversation(ctx *apptheory.Conte
 	}
 	publishGuardErr := s.ensureMintConversationAgentNotPublished(ctx.Context(), convCtx.agentIDHex)
 	if replayReady, reason := mintConversationCompletionReplayReady(convCtx.conv); replayReady {
-		return apptheory.JSON(http.StatusOK, convCtx.conv)
+		return hostedGenesisConversationJSON(http.StatusOK, convCtx.conv, hostedGenesisProjectionOptions{RegistrationID: convCtx.reg.ID, RequestID: strings.TrimSpace(ctx.RequestID), CollapseCreated: true})
 	} else if reason != "" {
 		return nil, soulInstanceMintConversationCompletionConflict(convCtx.conv, reason)
 	}
 	if publishGuardErr != nil {
 		return nil, soulInstanceBootstrapConversationErrorFromAppError(publishGuardErr)
 	}
-	resp, err := s.completeSoulMintConversationForRegistration(ctx, mintConversationRegistrationContext{
+	if ok, _ := mintConversationHasDurableAssistantTurn(convCtx.conv); !ok {
+		return hostedGenesisConversationJSON(http.StatusAccepted, convCtx.conv, hostedGenesisProjectionOptions{RegistrationID: convCtx.reg.ID, RequestID: strings.TrimSpace(ctx.RequestID), CollapseCreated: true})
+	}
+	if strings.TrimSpace(convCtx.conv.Status) == models.SoulMintConversationStatusDeclarationExtractionPending || parseMintConversationCompleteDeclarations(ctx) == "" {
+		if err := s.startHostedGenesisDeclarationExtraction(ctx, convCtx); err != nil {
+			return nil, soulInstanceBootstrapConversationErrorFromError(err)
+		}
+		return hostedGenesisConversationJSON(http.StatusAccepted, convCtx.conv, hostedGenesisProjectionOptions{RegistrationID: convCtx.reg.ID, RequestID: strings.TrimSpace(ctx.RequestID), CollapseCreated: true})
+	}
+	resp, err := s.completeSoulMintConversationForRegistrationWithProjection(ctx, mintConversationRegistrationContext{
 		reg:        convCtx.reg,
 		inst:       convCtx.inst,
 		agentIDHex: convCtx.agentIDHex,
-	}, convCtx.conv, convCtx.conversationID)
+	}, convCtx.conv, convCtx.conversationID, &hostedGenesisProjectionOptions{RegistrationID: convCtx.reg.ID, RequestID: strings.TrimSpace(ctx.RequestID), CollapseCreated: true})
 	if err != nil {
 		return nil, soulInstanceBootstrapConversationErrorFromError(err)
 	}
@@ -307,7 +313,7 @@ func (s *Server) loadSoulInstanceMintConversationFinalizeContext(ctx *apptheory.
 	if s == nil || s.soulPacks == nil || strings.TrimSpace(s.cfg.SoulPackBucketName) == "" {
 		return mintConversationFinalizeContext{}, soulInstanceBootstrapConversationErrorFromAppError(&apptheory.AppError{Code: "app.conflict", Message: "soul registry bucket is not configured"})
 	}
-	if appErr := requireMintConversationStatus(convCtx.conv, models.SoulMintConversationStatusCompleted, "conversation is not completed", "conversation has no produced declarations"); appErr != nil {
+	if appErr := requireMintConversationReadyForFinalize(convCtx.conv, "conversation is not completed", "conversation has no produced declarations"); appErr != nil {
 		return mintConversationFinalizeContext{}, soulInstanceBootstrapConversationErrorFromAppError(appErr)
 	}
 	identity, err := s.getSoulAgentIdentity(ctx.Context(), convCtx.agentIDHex)

--- a/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -19,6 +18,7 @@ import (
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
 
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
@@ -31,6 +31,7 @@ const (
 	soulInstanceBootstrapTestPrincipalDeclaration = "I declare authority over this Lesser-hosted soul."
 	soulInstanceBootstrapTestSigningMethodEIP191  = "eip191_personal_sign"
 	soulInstanceBootstrapTestInvalidRegSig        = "invalid registration signature"
+	soulInstanceBootstrapTestIdempotencyKey       = "idem-1"
 )
 
 func TestSoulInstanceBootstrapScaffold_RequiresStrictInstanceKey(t *testing.T) {
@@ -687,56 +688,110 @@ func TestSoulInstanceFinalizeMintConversation_ConversationIdsCannotCrossRegistra
 	}
 }
 
-func TestSoulInstanceMintConversation_StartStreamsAndPersistsDurableState(t *testing.T) {
+func TestSoulInstanceMintConversation_StartReturnsJSONAndEnqueuesDurableState(t *testing.T) {
 	tdb := newMintConversationTestDB()
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	streamParams := make(chan streamMintConversationParams, 1)
-	s.mintConversationStreamer = func(_ctx context.Context, eventCh chan<- apptheory.SSEEvent, p streamMintConversationParams) {
-		defer close(eventCh)
-		streamParams <- p
-		eventCh <- apptheory.SSEEvent{Event: "conversation_start", Data: soulMintConversationStartEvent{ConversationID: p.conversationID, Model: p.modelSet}}
-		eventCh <- apptheory.SSEEvent{Event: "delta", Data: soulMintConversationDeltaEvent{Text: soulInstanceBootstrapTestConversationMessage}}
-		eventCh <- apptheory.SSEEvent{Event: "conversation_done", Data: soulMintConversationDoneEvent{ConversationID: p.conversationID, FullResponse: soulInstanceBootstrapTestConversationMessage}}
+	enqueued := make(chan hostedgenesis.QueueMessage, 1)
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		enqueued <- msg
+		return nil
 	}
 
 	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
 	stubMintConversationRegistration(t, tdb, reg)
 	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
 	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
-		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage}),
+		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: soulInstanceBootstrapTestIdempotencyKey, CorrelationID: "corr-1"}),
 		map[string]string{"id": reg.ID},
 	))
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if resp.Status != http.StatusOK || resp.Headers["content-type"][0] != "text/event-stream" {
-		t.Fatalf("expected SSE 200 response, got %#v", resp)
-	}
-	body, readErr := io.ReadAll(resp.BodyReader)
-	if readErr != nil {
-		t.Fatalf("read SSE: %v", readErr)
-	}
-	bodyText := string(body)
-	if !strings.Contains(bodyText, "event: conversation_start") || !strings.Contains(bodyText, "event: conversation_done") {
-		t.Fatalf("expected start/done SSE events, got %q", bodyText)
-	}
-
-	var p streamMintConversationParams
-	select {
-	case p = <-streamParams:
-	case <-time.After(time.Second):
-		t.Fatalf("streamer was not invoked")
-	}
-	if p.agentIDHex != reg.AgentID || p.modelSet != "anthropic:claude-sonnet-4-6" || len(p.existingMessages) != 1 || p.existingMessages[0].Content != soulInstanceBootstrapTestConversationMessage {
-		t.Fatalf("unexpected stream params: %#v", p)
-	}
+	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	assertSoulInstanceMintConversationQueued(t, enqueued, reg.ID, out.Conversation.ConversationID)
 	tdb.qLifecycle.AssertCalled(t, "Create")
+}
+
+func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	enqueued := make(chan hostedgenesis.QueueMessage, 1)
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		enqueued <- msg
+		return nil
+	}
+	idemKey := "idem-retry-1"
+	reqHash := hostedGenesisRequestHash(reg.ID, "", "anthropic:claude-sonnet-4-6", soulInstanceBootstrapTestConversationMessage)
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulMintConversationIdempotency](t, args, 0)
+		*dest = models.SoulMintConversationIdempotency{
+			InstanceSlug:   soulInstanceBootstrapTestInstanceSlug,
+			RegistrationID: reg.ID,
+			AgentID:        reg.AgentID,
+			ConversationID: mintConversationTestConversationID,
+			TurnID:         "turn-existing",
+			IdempotencyKey: idemKey,
+			RequestHash:    reqHash,
+			RequestID:      "req-original",
+			CorrelationID:  "corr-original",
+			Status:         models.SoulMintConversationIdempotencyStatusProcessing,
+		}
+	}).Once()
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"hello"}]`),
+		Status:         models.SoulMintConversationStatusInProgress,
+		LatestTurnID:   "turn-existing",
+		RequestID:      "req-original",
+		CorrelationID:  "corr-original",
+		IdempotencyKey: idemKey,
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+
+	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: idemKey, CorrelationID: "corr-retry"}),
+		map[string]string{"id": reg.ID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 replay, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.MessageCount != 1 || out.Conversation.TraceIDs.IdempotencyKey != idemKey {
+		t.Fatalf("expected idempotent status replay without duplicate user message, got %#v", out)
+	}
+	select {
+	case msg := <-enqueued:
+		if msg.TurnID != "turn-existing" || msg.ConversationID != mintConversationTestConversationID {
+			t.Fatalf("unexpected replay queue message: %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected replay to re-enqueue existing turn")
+	}
+	tdb.db.AssertNumberOfCalls(t, "TransactWrite", 0)
+	tdb.qBudget.AssertNumberOfCalls(t, "First", 0)
 }
 
 func TestSoulInstanceMintConversation_ContinueRejectsModelChange(t *testing.T) {
@@ -773,12 +828,10 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	streamParams := make(chan streamMintConversationParams, 1)
-	s.mintConversationStreamer = func(_ctx context.Context, eventCh chan<- apptheory.SSEEvent, p streamMintConversationParams) {
-		defer close(eventCh)
-		streamParams <- p
-		eventCh <- apptheory.SSEEvent{Event: "conversation_start", Data: soulMintConversationStartEvent{ConversationID: p.conversationID, Model: p.modelSet}}
-		eventCh <- apptheory.SSEEvent{Event: "conversation_done", Data: soulMintConversationDoneEvent{ConversationID: p.conversationID, FullResponse: "continued"}}
+	enqueued := make(chan hostedgenesis.QueueMessage, 1)
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		enqueued <- msg
+		return nil
 	}
 
 	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
@@ -790,7 +843,7 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 		ConversationID: mintConversationTestConversationID,
 		Model:          "anthropic:claude-sonnet-4-6",
 		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"first"},{"role":"assistant","content":"reply"}]`),
-		Status:         models.SoulMintConversationStatusInProgress,
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
 		Usage:          models.AIUsage{TotalTokens: 9},
 		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
@@ -804,23 +857,27 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	_, _ = io.ReadAll(resp.BodyReader)
-
-	var p streamMintConversationParams
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusInProgress || out.Conversation.MessageCount != 3 {
+		t.Fatalf("expected stored conversation status with appended user turn, got %#v", out)
+	}
 	select {
-	case p = <-streamParams:
+	case msg := <-enqueued:
+		if msg.ConversationID != mintConversationTestConversationID || msg.Step != hostedgenesis.StepAssistantTurn {
+			t.Fatalf("unexpected queued message: %#v", msg)
+		}
 	case <-time.After(time.Second):
-		t.Fatalf("streamer was not invoked")
-	}
-	if p.conversationID != mintConversationTestConversationID || p.modelSet != "anthropic:claude-sonnet-4-6" || p.existingUsage.TotalTokens != 9 {
-		t.Fatalf("expected stored conversation context, got %#v", p)
-	}
-	if len(p.existingMessages) != 3 || p.existingMessages[0].Content != "first" || p.existingMessages[1].Content != "reply" || p.existingMessages[2].Content != "second" {
-		t.Fatalf("expected stored transcript plus new user message, got %#v", p.existingMessages)
+		t.Fatalf("hosted genesis turn was not enqueued")
 	}
 }
 
-func TestSoulInstanceGetRegistrationMintConversation_ReturnsDecodedEnvelope(t *testing.T) {
+func TestSoulInstanceGetRegistrationMintConversation_ReturnsStatusEnvelopeWithoutRawTranscript(t *testing.T) {
 	t.Parallel()
 
 	tdb := newMintConversationTestDB()
@@ -833,7 +890,7 @@ func TestSoulInstanceGetRegistrationMintConversation_ReturnsDecodedEnvelope(t *t
 		AgentID:              reg.AgentID,
 		ConversationID:       mintConversationTestConversationID,
 		Model:                "anthropic:claude-sonnet-4-6",
-		Messages:             encodeMintConversationBlob(`[{"role":"user","content":"private"}]`),
+		Messages:             encodeMintConversationBlob(`[{"role":"user","content":"private transcript"}]`),
 		ProducedDeclarations: encodeMintConversationBlob(`{"private":true}`),
 		Status:               models.SoulMintConversationStatusCompleted,
 		CreatedAt:            time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
@@ -850,12 +907,16 @@ func TestSoulInstanceGetRegistrationMintConversation_ReturnsDecodedEnvelope(t *t
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%q", resp.Status, string(resp.Body))
 	}
-	var out soulInstanceMintConversationResponse
+	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Version != "1" || out.Conversation == nil || !strings.Contains(out.Conversation.Messages, `"private"`) || !strings.Contains(out.Conversation.ProducedDeclarations, `"private":true`) {
-		t.Fatalf("expected decoded conversation envelope, got %#v", out)
+	if out.Version != "1" || out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil || out.Conversation.Failure.Code != hostedGenesisFailureInvalidProducedDeclarations {
+		t.Fatalf("expected compact failed status for invalid legacy declarations, got %#v", out)
+	}
+	body := string(resp.Body)
+	if strings.Contains(body, "private transcript") || strings.Contains(body, `"private":true`) || strings.Contains(body, mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("status envelope leaked private transcript/declarations/credential: %s", body)
 	}
 }
 
@@ -914,14 +975,70 @@ func TestSoulInstanceCompleteMintConversation_PersistsDeclarationsAndFinalizeRea
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%q", resp.Status, string(resp.Body))
 	}
-	var out models.SoulAgentMintConversation
+	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Status != models.SoulMintConversationStatusCompleted || !strings.Contains(out.ProducedDeclarations, `"selfDescription"`) {
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationReady || out.Conversation.ProducedDeclarations == nil {
 		t.Fatalf("expected completed conversation with declarations, got %#v", out)
 	}
+	body := string(resp.Body)
+	if strings.Contains(body, "describe yourself") || strings.Contains(body, "done") || strings.Contains(body, mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("instance completion leaked transcript or credential material: %s", body)
+	}
 	tdb.qLifecycle.AssertCalled(t, "Create")
+}
+
+func TestSoulInstanceCompleteMintConversation_AssistantReadyWithoutDeclarationsQueuesExtraction(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	enqueued := make(chan hostedgenesis.QueueMessage, 1)
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		enqueued <- msg
+		return nil
+	}
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"describe yourself"},{"role":"assistant","content":"ready"}]`),
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
+		LatestTurnID:   "turn-ready",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	expectSoulInstanceMintConversationExtractionDebit(t, tdb)
+
+	resp, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationExtractionPending || out.Conversation.ProducedDeclarations != nil {
+		t.Fatalf("expected declaration extraction progress without terminal declarations, got %#v", out)
+	}
+	select {
+	case msg := <-enqueued:
+		if msg.Step != hostedgenesis.StepDeclarationExtraction || msg.ConversationID != mintConversationTestConversationID {
+			t.Fatalf("unexpected extraction queue message: %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("expected declaration extraction to be enqueued")
+	}
 }
 
 func TestSoulInstanceCompleteMintConversation_ReturnsCompletedConversationReplay(t *testing.T) {
@@ -959,12 +1076,15 @@ func TestSoulInstanceCompleteMintConversation_ReturnsCompletedConversationReplay
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%q", resp.Status, string(resp.Body))
 	}
-	var out models.SoulAgentMintConversation
+	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Status != models.SoulMintConversationStatusCompleted || out.ProducedDeclarations != string(declBytes) {
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationReady || out.Conversation.ProducedDeclarations == nil || out.Conversation.ProducedDeclarations.DeclarationHash == "" {
 		t.Fatalf("expected stored completed declarations, got %#v", out)
+	}
+	if strings.Contains(string(resp.Body), `"messages"`) || strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("instance completion replay leaked private fields: %s", string(resp.Body))
 	}
 	tdb.qConv.AssertNumberOfCalls(t, "Update", 0)
 	tdb.qLifecycle.AssertNumberOfCalls(t, "Create", 0)
@@ -1009,18 +1129,18 @@ func TestSoulInstanceCompleteMintConversation_ReplaysHostedContractEmptyDeclarat
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%q", resp.Status, string(resp.Body))
 	}
-	var out models.SoulAgentMintConversation
+	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Status != models.SoulMintConversationStatusCompleted || out.ProducedDeclarations != string(declBytes) {
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationReady || out.Conversation.ProducedDeclarations == nil || len(out.Conversation.ProducedDeclarations.Declarations.Capabilities) != 0 || len(out.Conversation.ProducedDeclarations.Declarations.Boundaries) != 0 {
 		t.Fatalf("expected stored hosted declarations with empty arrays, got %#v", out)
 	}
 	tdb.qConv.AssertNumberOfCalls(t, "Update", 0)
 	tdb.qLifecycle.AssertNumberOfCalls(t, "Create", 0)
 }
 
-func TestSoulInstanceCompleteMintConversation_RejectsInvalidStates(t *testing.T) {
+func TestSoulInstanceCompleteMintConversation_RejectsTerminalInvalidStates(t *testing.T) {
 	t.Parallel()
 
 	for _, tc := range []struct {
@@ -1043,108 +1163,60 @@ func TestSoulInstanceCompleteMintConversation_RejectsInvalidStates(t *testing.T)
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			tdb := newMintConversationTestDB()
-			s := newMintConversationServer(tdb)
-			reg := mintConversationHandleReg()
-			expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
-			stubMintConversationRegistration(t, tdb, reg)
-			stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
-			stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
-				AgentID:        reg.AgentID,
-				ConversationID: mintConversationTestConversationID,
-				Status:         tc.status,
-				CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
-			})
-			stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
-
-			_, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
-				map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
-				mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
-				map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
-			))
-			appErr := requireAppTheoryError(t, err)
-			assertMintConversationCompletionConflictDetails(t, appErr, soulInstanceBootstrapCodeConflict, http.StatusConflict, tc.status, false, false, tc.reason)
+			assertSoulInstanceCompleteTerminalConflict(t, tc.status, tc.reason)
 		})
 	}
+}
 
-	t.Run("empty conversation has no durable assistant turn", func(t *testing.T) {
-		t.Parallel()
+func TestSoulInstanceCompleteMintConversation_ReturnsProgressWithoutAssistantTurn(t *testing.T) {
+	t.Parallel()
 
-		for _, tc := range []struct {
-			name     string
-			messages string
-			wantMsg  string
-		}{
-			{name: "no messages", messages: "", wantMsg: "conversation has no durable messages"},
-			{name: "user only", messages: `[{"role":"user","content":"describe yourself"}]`, wantMsg: "conversation has no completed assistant turn"},
-		} {
-			tc := tc
-			t.Run(tc.name, func(t *testing.T) {
-				t.Parallel()
+	for _, tc := range []struct {
+		name     string
+		messages string
+	}{
+		{name: "no messages", messages: ""},
+		{name: "user only", messages: `[{"role":"user","content":"describe yourself"}]`},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-				reg, identity, _ := soulInstanceHostedInstanceTrustFixture(t)
-				tdb := newMintConversationTestDB()
-				s := newMintConversationServer(tdb)
-				expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
-				stubMintConversationRegistration(t, tdb, reg)
-				stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
-				conv := models.SoulAgentMintConversation{
-					AgentID:        reg.AgentID,
-					ConversationID: mintConversationTestConversationID,
-					Status:         models.SoulMintConversationStatusInProgress,
-					CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
-				}
-				if strings.TrimSpace(tc.messages) != "" {
-					conv.Messages = encodeMintConversationBlob(tc.messages)
-				}
-				stubMintConversationConversation(t, tdb, conv)
-				stubMintConversationIdentity(t, tdb, identity, nil)
-
-				_, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
-					map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
-					mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
-					map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
-				))
-				appErr := requireAppTheoryError(t, err)
-				if appErr.Code != soulInstanceBootstrapCodeConflict || appErr.StatusCode != http.StatusConflict || appErr.Message != tc.wantMsg {
-					t.Fatalf("expected durable assistant-turn conflict %q, got %#v", tc.wantMsg, appErr)
-				}
-				tdb.qConv.AssertNumberOfCalls(t, "Update", 0)
-			})
-		}
-	})
-
-	t.Run("already published agent", func(t *testing.T) {
-		t.Parallel()
-
-		tdb := newMintConversationTestDB()
-		s := newMintConversationServer(tdb)
-		reg := mintConversationHandleReg()
-		identity := testMintConversationIdentity()
-		identity.AgentID = reg.AgentID
-		identity.SelfDescriptionVersion = 1
-
-		expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
-		stubMintConversationRegistration(t, tdb, reg)
-		stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
-		stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
-			AgentID:        reg.AgentID,
-			ConversationID: mintConversationTestConversationID,
-			Status:         models.SoulMintConversationStatusInProgress,
-			CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+			assertSoulInstanceCompleteProgressWithoutAssistant(t, tc.messages)
 		})
-		stubMintConversationIdentity(t, tdb, identity, nil)
+	}
+}
 
-		_, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
-			map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
-			mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
-			map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
-		))
-		appErr := requireAppTheoryError(t, err)
-		if appErr.Code != soulInstanceBootstrapCodeConflict || appErr.StatusCode != http.StatusConflict || appErr.Message != soulMintConversationAlreadyPublishedMessage {
-			t.Fatalf("expected already-published conflict, got %#v", appErr)
-		}
+func TestSoulInstanceCompleteMintConversation_RejectsAlreadyPublishedAgent(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	identity := testMintConversationIdentity()
+	identity.AgentID = reg.AgentID
+	identity.SelfDescriptionVersion = 1
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Status:         models.SoulMintConversationStatusInProgress,
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
+	stubMintConversationIdentity(t, tdb, identity, nil)
+
+	_, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulInstanceBootstrapCodeConflict || appErr.StatusCode != http.StatusConflict || appErr.Message != soulMintConversationAlreadyPublishedMessage {
+		t.Fatalf("expected already-published conflict, got %#v", appErr)
+	}
 }
 
 func TestSoulInstanceFinalizeMintConversation_BeginAndPreflightReturnCanonicalSigningMaterial(t *testing.T) {
@@ -1228,12 +1300,15 @@ func TestSoulInstanceHostedInstanceTrustCompleteAcceptsDeclarations(t *testing.T
 	if resp.Status != http.StatusOK {
 		t.Fatalf("expected 200, got %d body=%q", resp.Status, string(resp.Body))
 	}
-	var out models.SoulAgentMintConversation
+	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Status != models.SoulMintConversationStatusCompleted || !strings.Contains(out.ProducedDeclarations, `"selfDescription"`) {
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationReady || out.Conversation.ProducedDeclarations == nil {
 		t.Fatalf("expected completed hosted conversation, got %#v", out)
+	}
+	if strings.Contains(string(resp.Body), `"messages"`) || strings.Contains(string(resp.Body), "describe yourself") || strings.Contains(string(resp.Body), "done") || strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("hosted instance-trust complete leaked private fields: %s", string(resp.Body))
 	}
 }
 
@@ -1820,6 +1895,7 @@ func expectSoulInstanceMintConversationDebit(t *testing.T, tdb *mintConversation
 			t.Fatalf("unexpected mint conversation ledger entry: %#v", entry)
 		}
 	})
+	tb.On("Create", mock.AnythingOfType("*models.SoulMintConversationIdempotency"), mock.Anything).Return(tb).Maybe()
 	if expectCreate {
 		tb.On("Create", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
 			conv := testutil.RequireMockArg[*models.SoulAgentMintConversation](t, args, 0)
@@ -1830,6 +1906,26 @@ func expectSoulInstanceMintConversationDebit(t *testing.T, tdb *mintConversation
 	} else {
 		tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
 	}
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.InstanceBudgetMonth"), mock.Anything, mock.Anything).Return(tb).Once()
+	tb.On("Execute").Return(nil).Once()
+}
+
+func expectSoulInstanceMintConversationExtractionDebit(t *testing.T, tdb *mintConversationTestDB) {
+	t.Helper()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tdb.db.TransactWriteBuilder = tb
+	tdb.qBudget.On("First", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.InstanceBudgetMonth](t, args, 0)
+		*dest = models.InstanceBudgetMonth{InstanceSlug: soulInstanceBootstrapTestInstanceSlug, Month: time.Now().UTC().Format("2006-01"), IncludedCredits: 100, UsedCredits: 0}
+	}).Once()
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("Put", mock.AnythingOfType("*models.UsageLedgerEntry"), mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		entry := testutil.RequireMockArg[*models.UsageLedgerEntry](t, args, 0)
+		if entry.Module != soulMintConversationExtractModule || entry.RequestedCredits != soulMintConversationExtractBaseCredits {
+			t.Fatalf("unexpected extraction ledger entry: %#v", entry)
+		}
+	})
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
 	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.InstanceBudgetMonth"), mock.Anything, mock.Anything).Return(tb).Once()
 	tb.On("Execute").Return(nil).Once()
 }
@@ -2012,6 +2108,117 @@ func assertSoulInstanceFinalizeBoundaryRequirements(t *testing.T, out soulMintCo
 		out.BoundaryRequirements[0].SignatureHex == "" {
 		t.Fatalf("unexpected boundary requirements: %#v", out.BoundaryRequirements)
 	}
+}
+
+func assertSoulInstanceMintConversationAcceptedResponse(t *testing.T, resp *apptheory.Response) hostedGenesisConversationResponse {
+	t.Helper()
+	if resp.Status != http.StatusAccepted || !strings.Contains(resp.Headers["content-type"][0], "application/json") {
+		t.Fatalf("expected JSON 202 response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.ConversationID == "" ||
+		out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
+		out.Conversation.RequestID != "req-instance-bootstrap" ||
+		out.Conversation.MessageCount != 1 {
+		t.Fatalf("expected in-progress durable status, got %#v", out)
+	}
+	if out.Conversation.TraceIDs == nil ||
+		out.Conversation.TraceIDs.IdempotencyKey != soulInstanceBootstrapTestIdempotencyKey ||
+		out.Conversation.TraceIDs.CorrelationID != "corr-1" {
+		t.Fatalf("expected trace ids, got %#v", out.Conversation.TraceIDs)
+	}
+	if strings.Contains(string(resp.Body), soulInstanceBootstrapTestConversationMessage) ||
+		strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("response leaked transcript or credential material: %s", string(resp.Body))
+	}
+	return out
+}
+
+func assertSoulInstanceMintConversationQueued(t *testing.T, enqueued <-chan hostedgenesis.QueueMessage, registrationID string, conversationID string) {
+	t.Helper()
+	select {
+	case msg := <-enqueued:
+		if msg.Kind != hostedgenesis.QueueMessageKind ||
+			msg.Step != hostedgenesis.StepAssistantTurn ||
+			msg.ConversationID != conversationID ||
+			msg.RegistrationID != registrationID ||
+			msg.IdempotencyKey != soulInstanceBootstrapTestIdempotencyKey {
+			t.Fatalf("unexpected queued message: %#v", msg)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("hosted genesis turn was not enqueued")
+	}
+}
+
+func assertSoulInstanceCompleteTerminalConflict(t *testing.T, status string, reason string) {
+	t.Helper()
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Status:         status,
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+
+	_, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	appErr := requireAppTheoryError(t, err)
+	assertMintConversationCompletionConflictDetails(t, appErr, soulInstanceBootstrapCodeConflict, http.StatusConflict, status, false, false, reason)
+}
+
+func assertSoulInstanceCompleteProgressWithoutAssistant(t *testing.T, messages string) {
+	t.Helper()
+	reg, identity, _ := soulInstanceHostedInstanceTrustFixture(t)
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	conv := models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Status:         models.SoulMintConversationStatusInProgress,
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	}
+	if strings.TrimSpace(messages) != "" {
+		conv.Messages = encodeMintConversationBlob(messages)
+	}
+	stubMintConversationConversation(t, tdb, conv)
+	stubMintConversationIdentity(t, tdb, identity, nil)
+
+	resp, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, map[string]any{"declarations": testMintConversationDecl()}),
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected progress response error: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 progress response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
+		out.Conversation.ConversationID != mintConversationTestConversationID ||
+		out.Conversation.PollAfterSeconds == 0 {
+		t.Fatalf("expected in-progress completion response, got %#v", out)
+	}
+	tdb.qConv.AssertNumberOfCalls(t, "Update", 0)
 }
 
 func assertSoulInstanceHostedInstanceTrustFinalizePreflight(t *testing.T, out soulMintConversationFinalizeBeginResponse) {

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
-	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -37,7 +36,6 @@ const (
 	soulMintConversationStreamModule  = "soul.mint_conversation.stream"
 	soulMintConversationExtractModule = "soul.mint_conversation.extract"
 	defaultSoulMintConversationModel  = "anthropic:claude-sonnet-4-6"
-	mintConversationBlobPrefix        = "b64:"
 
 	soulMintConversationAlreadyPublishedMessage = "registration is already published"
 
@@ -55,9 +53,12 @@ const (
 // --- Request / Response types ---
 
 type soulMintConversationRequest struct {
-	ConversationID string `json:"conversation_id,omitempty"` // Empty = start new conversation.
-	Model          string `json:"model,omitempty"`           // e.g. "anthropic:claude-sonnet-4-6"
-	Message        string `json:"message"`                   // User's message for this turn.
+	ConversationID  string `json:"conversation_id,omitempty"` // Empty = start new conversation.
+	Model           string `json:"model,omitempty"`           // e.g. "anthropic:claude-sonnet-4-6"
+	Message         string `json:"message"`                   // User's message for this turn.
+	IdempotencyKey  string `json:"idempotency_key,omitempty"`
+	CorrelationID   string `json:"correlation_id,omitempty"`
+	LesserRequestID string `json:"lesser_request_id,omitempty"`
 }
 
 type soulMintConversationMessage struct {
@@ -408,17 +409,6 @@ func (s *Server) listSoulAgentMintConversations(ctx context.Context, agentIDHex 
 	return items, nil
 }
 
-func (s *Server) loadMintConversationByStatus(ctx context.Context, agentIDHex string, conversationID string, expectedStatus string, statusMessage string, emptyDeclMessage string) (*models.SoulAgentMintConversation, *apptheory.AppError) {
-	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx, agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", conversationID))
-	if err != nil {
-		return nil, &apptheory.AppError{Code: "app.not_found", Message: "conversation not found"}
-	}
-	if appErr := requireMintConversationStatus(conv, expectedStatus, statusMessage, emptyDeclMessage); appErr != nil {
-		return nil, appErr
-	}
-	return conv, nil
-}
-
 func (s *Server) loadMintConversationForCompletion(ctx context.Context, agentIDHex string, conversationID string) (*models.SoulAgentMintConversation, *apptheory.AppError) {
 	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx, agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", conversationID))
 	if err != nil {
@@ -434,7 +424,7 @@ func mintConversationCompletionReplayReady(conv *models.SoulAgentMintConversatio
 	}
 	decodeMintConversationFields(conv)
 	switch strings.TrimSpace(conv.Status) {
-	case models.SoulMintConversationStatusCompleted:
+	case models.SoulMintConversationStatusCompleted, models.SoulMintConversationStatusDeclarationReady:
 		present, valid := mintConversationProducedDeclarationsState(conv)
 		if valid {
 			return true, ""
@@ -443,7 +433,7 @@ func mintConversationCompletionReplayReady(conv *models.SoulAgentMintConversatio
 			return false, soulMintConversationCompleteReasonMissingDeclarations
 		}
 		return false, soulMintConversationCompleteReasonInvalidDeclarations
-	case models.SoulMintConversationStatusInProgress:
+	case models.SoulMintConversationStatusInProgress, models.SoulMintConversationStatusAssistantTurnReady, models.SoulMintConversationStatusDeclarationExtractionPending:
 		return false, ""
 	default:
 		return false, soulMintConversationCompleteReasonInvalidState
@@ -487,16 +477,21 @@ func mintConversationCompletionStateConflict(conv *models.SoulAgentMintConversat
 		WithDetails(mintConversationCompletionConflictDetails(conv, reason))
 }
 
-func requireMintConversationStatus(conv *models.SoulAgentMintConversation, expectedStatus string, statusMessage string, emptyDeclMessage string) *apptheory.AppError {
+func requireMintConversationReadyForFinalize(conv *models.SoulAgentMintConversation, statusMessage string, emptyDeclMessage string) *apptheory.AppError {
 	if conv == nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	decodeMintConversationFields(conv)
-	if conv.Status != expectedStatus {
+	status := strings.TrimSpace(conv.Status)
+	if status != models.SoulMintConversationStatusCompleted && status != models.SoulMintConversationStatusDeclarationReady {
 		return &apptheory.AppError{Code: "app.conflict", Message: statusMessage}
 	}
-	if emptyDeclMessage != "" && strings.TrimSpace(conv.ProducedDeclarations) == "" {
+	present, valid := mintConversationProducedDeclarationsState(conv)
+	if !present {
 		return &apptheory.AppError{Code: "app.conflict", Message: emptyDeclMessage}
+	}
+	if !valid {
+		return &apptheory.AppError{Code: "app.conflict", Message: "conversation has invalid produced declarations"}
 	}
 	return nil
 }
@@ -505,22 +500,33 @@ func requireMintConversationDurableAssistantTurn(conv *models.SoulAgentMintConve
 	if conv == nil {
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	ok, reason := mintConversationHasDurableAssistantTurn(conv)
+	if ok {
+		return nil
+	}
+	return &apptheory.AppError{Code: appErrCodeConflict, Message: reason}
+}
+
+func mintConversationHasDurableAssistantTurn(conv *models.SoulAgentMintConversation) (bool, string) {
+	if conv == nil {
+		return false, "conversation has no durable messages"
+	}
 	decodeMintConversationFields(conv)
 	rawMessages := strings.TrimSpace(conv.Messages)
 	if rawMessages == "" {
-		return &apptheory.AppError{Code: appErrCodeConflict, Message: "conversation has no durable messages"}
+		return false, "conversation has no durable messages"
 	}
 
 	var messages []soulMintConversationMessage
 	if err := json.Unmarshal([]byte(rawMessages), &messages); err != nil {
-		return &apptheory.AppError{Code: appErrCodeConflict, Message: "conversation messages are invalid"}
+		return false, "conversation messages are invalid"
 	}
 	for _, msg := range messages {
 		if strings.EqualFold(strings.TrimSpace(msg.Role), "assistant") && strings.TrimSpace(msg.Content) != "" {
-			return nil
+			return true, ""
 		}
 	}
-	return &apptheory.AppError{Code: appErrCodeConflict, Message: "conversation has no completed assistant turn"}
+	return false, "conversation has no completed assistant turn"
 }
 
 func (s *Server) loadMintConversationFinalizeContext(ctx *apptheory.Context) (mintConversationFinalizeContext, *apptheory.AppError) {
@@ -532,8 +538,11 @@ func (s *Server) loadMintConversationFinalizeContext(ctx *apptheory.Context) (mi
 	if appErr != nil {
 		return mintConversationFinalizeContext{}, appErr
 	}
-	conv, appErr := s.loadMintConversationByStatus(ctx.Context(), regCtx.agentIDHex, conversationID, models.SoulMintConversationStatusCompleted, "conversation is not completed", "conversation has no produced declarations")
-	if appErr != nil {
+	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx.Context(), regCtx.agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", conversationID))
+	if err != nil {
+		return mintConversationFinalizeContext{}, &apptheory.AppError{Code: "app.not_found", Message: "conversation not found"}
+	}
+	if appErr := requireMintConversationReadyForFinalize(conv, "conversation is not completed", "conversation has no produced declarations"); appErr != nil {
 		return mintConversationFinalizeContext{}, appErr
 	}
 	identity, err := s.getSoulAgentIdentity(ctx.Context(), regCtx.agentIDHex)
@@ -1245,36 +1254,6 @@ func (s *Server) handleSoulAgentCompleteMintConversation(ctx *apptheory.Context)
 	}, conv, conversationID)
 }
 
-func (s *Server) completeSoulMintConversationForRegistration(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, conv *models.SoulAgentMintConversation, conversationID string) (*apptheory.Response, error) {
-	now := time.Now().UTC()
-	if appErr := requireMintConversationDurableAssistantTurn(conv); appErr != nil {
-		return nil, appErr
-	}
-	declarationsJSON, extractUsage, appErr := s.resolveMintConversationCompletion(ctx, regCtx, conv, conversationID, now)
-	if appErr != nil {
-		return nil, appErr
-	}
-	if appErr := s.persistCompletedMintConversation(ctx.Context(), conv, declarationsJSON, extractUsage, now); appErr != nil {
-		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to complete conversation"}
-	}
-	promotion := s.loadOrFallbackSoulAgentPromotion(ctx.Context(), regCtx.agentIDHex, buildSoulAgentPromotionFromRegistration(regCtx.reg, now))
-	promotion = updateSoulAgentPromotionForConversation(promotion, conversationID, models.SoulMintConversationStatusCompleted, now)
-	promotion = updateSoulAgentPromotionReviewDigest(promotion, declarationsJSON)
-	if appErr := s.saveSoulAgentPromotion(ctx.Context(), promotion); appErr != nil {
-		return nil, appErr
-	}
-	if appErr := s.saveSoulAgentPromotionLifecycleEvent(ctx.Context(), buildSoulAgentPromotionLifecycleEvent(promotion, soulAgentPromotionLifecycleEventInput{
-		EventType:      models.SoulAgentPromotionEventTypeFinalizeReady,
-		RequestID:      strings.TrimSpace(ctx.RequestID),
-		ConversationID: conversationID,
-		OccurredAt:     now,
-	})); appErr != nil {
-		return nil, appErr
-	}
-
-	return apptheory.JSON(http.StatusOK, conv)
-}
-
 // handleSoulGetMintConversation retrieves a mint conversation record.
 func (s *Server) handleSoulGetMintConversation(ctx *apptheory.Context) (*apptheory.Response, error) {
 	regCtx, appErr := s.requireMintConversationRegistrationContext(ctx, false)
@@ -1334,8 +1313,11 @@ func (s *Server) handleSoulAgentBeginFinalizeMintConversation(ctx *apptheory.Con
 	if appErr != nil {
 		return nil, appErr
 	}
-	conv, appErr := s.loadMintConversationByStatus(ctx.Context(), agentCtx.agentIDHex, conversationID, models.SoulMintConversationStatusCompleted, "conversation is not completed", "conversation has no produced declarations")
-	if appErr != nil {
+	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx.Context(), agentCtx.agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", conversationID))
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "conversation not found"}
+	}
+	if appErr := requireMintConversationReadyForFinalize(conv, "conversation is not completed", "conversation has no produced declarations"); appErr != nil {
 		return nil, appErr
 	}
 	return s.beginFinalizeMintConversation(ctx, mintConversationFinalizeContext{
@@ -1375,8 +1357,11 @@ func (s *Server) handleSoulAgentFinalizeMintConversation(ctx *apptheory.Context)
 	if appErr != nil {
 		return nil, appErr
 	}
-	conv, appErr := s.loadMintConversationByStatus(ctx.Context(), agentCtx.agentIDHex, conversationID, models.SoulMintConversationStatusCompleted, "conversation is not completed", "conversation has no produced declarations")
-	if appErr != nil {
+	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx.Context(), agentCtx.agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", conversationID))
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.not_found", Message: "conversation not found"}
+	}
+	if appErr := requireMintConversationReadyForFinalize(conv, "conversation is not completed", "conversation has no produced declarations"); appErr != nil {
 		return nil, appErr
 	}
 
@@ -1816,23 +1801,11 @@ func (s *Server) persistCompletedMintConversation(ctx context.Context, conv *mod
 }
 
 func encodeMintConversationBlob(raw string) string {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" {
-		return ""
-	}
-	return mintConversationBlobPrefix + base64.StdEncoding.EncodeToString([]byte(trimmed))
+	return models.EncodeSoulMintConversationBlob(raw)
 }
 
 func decodeMintConversationBlob(raw string) string {
-	trimmed := strings.TrimSpace(raw)
-	if trimmed == "" || !strings.HasPrefix(trimmed, mintConversationBlobPrefix) {
-		return trimmed
-	}
-	decoded, err := base64.StdEncoding.DecodeString(strings.TrimPrefix(trimmed, mintConversationBlobPrefix))
-	if err != nil {
-		return trimmed
-	}
-	return strings.TrimSpace(string(decoded))
+	return models.DecodeSoulMintConversationBlob(raw)
 }
 
 func decodeMintConversationFields(conv *models.SoulAgentMintConversation) {

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -1,0 +1,436 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+type hostedGenesisTurnSession struct {
+	conversationID   string
+	turnID           string
+	modelSet         string
+	existingMessages []soulMintConversationMessage
+	existingUsage    models.AIUsage
+	isNew            bool
+	conv             *models.SoulAgentMintConversation
+}
+
+func (s *Server) handleSoulMintConversationForRegistrationAsync(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, instanceSlug string) (*apptheory.Response, error) {
+	if publishGuardErr := s.ensureMintConversationAgentNotPublished(ctx.Context(), regCtx.agentIDHex); publishGuardErr != nil {
+		return nil, publishGuardErr
+	}
+	req, message, err := requireMintConversationMessage(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if validationErr := validateHostedGenesisRequestIDs(&req); validationErr != nil {
+		return nil, validationErr
+	}
+
+	now := time.Now().UTC()
+	instanceSlug = firstNonEmpty(instanceSlug, regCtx.inst.Slug)
+	reqHash := hostedGenesisRequestHash(regCtx.reg.ID, req.ConversationID, req.Model, message)
+	if replayResp, replayed, replayErr := s.replayHostedGenesisIdempotencyResponse(ctx, regCtx, instanceSlug, req, reqHash); replayErr != nil || replayed {
+		return replayResp, replayErr
+	}
+
+	session, appErr := s.loadHostedGenesisTurnSession(ctx.Context(), regCtx.agentIDHex, req.ConversationID, req.Model)
+	if appErr != nil {
+		return nil, appErr
+	}
+	if session.modelSet == "" {
+		return nil, &apptheory.AppError{Code: "app.bad_request", Message: "model is required"}
+	}
+	if _, appErr := s.apiKeyForMintConversationModel(ctx.Context(), session.modelSet); appErr != nil {
+		// Validate provider configuration before debiting or enqueueing. The worker
+		// reloads the key for the actual LLM call.
+		return nil, appErr
+	}
+
+	updatedMessages, messagesJSON, err := serializeHostedGenesisAcceptedTurn(session, message)
+	if err != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to serialize conversation"}
+	}
+	idem := buildHostedGenesisIdempotency(instanceSlug, regCtx, session, req, reqHash, now, strings.TrimSpace(ctx.RequestID))
+	if appErr := s.persistHostedGenesisAcceptedTurn(ctx.Context(), regCtx, session, updatedMessages, messagesJSON, idem, firstNonEmpty(req.IdempotencyKey, ctx.RequestID), strings.TrimSpace(ctx.RequestID), now); appErr != nil {
+		return nil, appErr
+	}
+
+	conv := buildHostedGenesisAcceptedConversation(regCtx, session, req, messagesJSON, strings.TrimSpace(ctx.RequestID), now)
+	if enqueueErr := s.enqueueHostedGenesisTurn(ctx.Context(), buildHostedGenesisAssistantQueueMessage(regCtx, instanceSlug, session, req, strings.TrimSpace(ctx.RequestID))); enqueueErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue hosted genesis turn"}
+	}
+
+	if appErr := s.saveHostedGenesisAcceptedPromotion(ctx.Context(), regCtx, session, strings.TrimSpace(ctx.RequestID), now); appErr != nil {
+		return nil, appErr
+	}
+
+	return hostedGenesisConversationJSON(http.StatusAccepted, conv, hostedGenesisProjectionOptions{
+		RegistrationID:  regCtx.reg.ID,
+		RequestID:       strings.TrimSpace(ctx.RequestID),
+		CollapseCreated: true,
+		CorrelationID:   req.CorrelationID,
+		IdempotencyKey:  req.IdempotencyKey,
+		LesserRequestID: req.LesserRequestID,
+	})
+}
+
+func serializeHostedGenesisAcceptedTurn(session hostedGenesisTurnSession, message string) ([]soulMintConversationMessage, string, error) {
+	updatedMessages := append(append([]soulMintConversationMessage(nil), session.existingMessages...), soulMintConversationMessage{Role: "user", Content: message})
+	messagesJSON, err := json.Marshal(updatedMessages)
+	return updatedMessages, string(messagesJSON), err
+}
+
+func buildHostedGenesisAcceptedConversation(regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, req soulMintConversationRequest, messagesJSON string, requestID string, now time.Time) *models.SoulAgentMintConversation {
+	conv := session.conv
+	if conv == nil {
+		conv = &models.SoulAgentMintConversation{AgentID: regCtx.agentIDHex, ConversationID: session.conversationID, Model: session.modelSet, CreatedAt: now}
+	}
+	conv.Messages = messagesJSON
+	conv.Status = models.SoulMintConversationStatusInProgress
+	conv.LatestTurnID = session.turnID
+	conv.RequestID = strings.TrimSpace(requestID)
+	conv.CorrelationID = strings.TrimSpace(req.CorrelationID)
+	conv.IdempotencyKey = strings.TrimSpace(req.IdempotencyKey)
+	conv.UpdatedAt = now
+	if conv.CreatedAt.IsZero() {
+		conv.CreatedAt = now
+	}
+	return conv
+}
+
+func buildHostedGenesisAssistantQueueMessage(regCtx mintConversationRegistrationContext, instanceSlug string, session hostedGenesisTurnSession, req soulMintConversationRequest, requestID string) hostedgenesis.QueueMessage {
+	return hostedgenesis.QueueMessage{
+		Kind:           hostedgenesis.QueueMessageKind,
+		Step:           hostedgenesis.StepAssistantTurn,
+		RegistrationID: strings.TrimSpace(regCtx.reg.ID),
+		InstanceSlug:   strings.TrimSpace(instanceSlug),
+		AgentID:        strings.TrimSpace(regCtx.agentIDHex),
+		ConversationID: strings.TrimSpace(session.conversationID),
+		TurnID:         strings.TrimSpace(session.turnID),
+		RequestID:      strings.TrimSpace(requestID),
+		CorrelationID:  strings.TrimSpace(req.CorrelationID),
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+	}
+}
+
+func (s *Server) saveHostedGenesisAcceptedPromotion(ctx context.Context, regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, requestID string, now time.Time) *apptheory.AppError {
+	promotion := s.loadOrFallbackSoulAgentPromotion(ctx, regCtx.agentIDHex, buildSoulAgentPromotionFromRegistration(regCtx.reg, now))
+	previousPromotion := cloneSoulAgentPromotion(promotion)
+	promotion = updateSoulAgentPromotionForConversation(promotion, session.conversationID, models.SoulMintConversationStatusInProgress, now)
+	if appErr := s.saveSoulAgentPromotion(ctx, promotion); appErr != nil {
+		return appErr
+	}
+	if shouldEmitSoulPromotionReviewStartedEvent(previousPromotion, promotion, session.conversationID) {
+		if appErr := s.saveSoulAgentPromotionLifecycleEvent(ctx, buildSoulAgentPromotionLifecycleEvent(promotion, soulAgentPromotionLifecycleEventInput{
+			EventType:      models.SoulAgentPromotionEventTypeReviewStarted,
+			RequestID:      strings.TrimSpace(requestID),
+			ConversationID: session.conversationID,
+			OccurredAt:     now,
+		})); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+func (s *Server) replayHostedGenesisIdempotencyResponse(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, instanceSlug string, req soulMintConversationRequest, reqHash string) (*apptheory.Response, bool, error) {
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		return nil, false, nil
+	}
+	replay, replayMsg, replayErr := s.replayHostedGenesisIdempotency(ctx, regCtx, instanceSlug, req, reqHash)
+	if replayErr != nil || replay == nil {
+		return nil, replay != nil, replayErr
+	}
+	if enqueueErr := s.enqueueHostedGenesisTurn(ctx.Context(), replayMsg); enqueueErr != nil {
+		return nil, true, &apptheory.AppError{Code: "app.internal", Message: "failed to enqueue hosted genesis turn"}
+	}
+	resp, err := hostedGenesisConversationJSON(http.StatusAccepted, replay, hostedGenesisProjectionOptions{
+		RegistrationID:  regCtx.reg.ID,
+		RequestID:       strings.TrimSpace(ctx.RequestID),
+		CollapseCreated: true,
+		CorrelationID:   req.CorrelationID,
+		IdempotencyKey:  req.IdempotencyKey,
+		LesserRequestID: req.LesserRequestID,
+	})
+	return resp, true, err
+}
+
+func validateHostedGenesisRequestIDs(req *soulMintConversationRequest) error {
+	if req == nil {
+		return nil
+	}
+	if strings.TrimSpace(req.ConversationID) != "" && !soulMintInstanceReadConversationIDSafe(req.ConversationID) {
+		return hostedGenesisBadRequest("conversation_id")
+	}
+	var ok bool
+	if req.IdempotencyKey, ok = hostedGenesisSafeToken(req.IdempotencyKey, 128); !ok {
+		return hostedGenesisBadRequest("idempotency_key")
+	}
+	if req.CorrelationID, ok = hostedGenesisSafeToken(req.CorrelationID, 128); !ok {
+		return hostedGenesisBadRequest("correlation_id")
+	}
+	if req.LesserRequestID, ok = hostedGenesisSafeToken(req.LesserRequestID, 128); !ok {
+		return hostedGenesisBadRequest("lesser_request_id")
+	}
+	return nil
+}
+
+func (s *Server) loadHostedGenesisTurnSession(ctx context.Context, agentIDHex string, requestedConversationID string, requestedModel string) (hostedGenesisTurnSession, *apptheory.AppError) {
+	session := hostedGenesisTurnSession{
+		conversationID: strings.TrimSpace(requestedConversationID),
+		modelSet:       strings.TrimSpace(requestedModel),
+	}
+	turn, err := newToken(16)
+	if err != nil {
+		return hostedGenesisTurnSession{}, &apptheory.AppError{Code: "app.internal", Message: "failed to create turn id"}
+	}
+	session.turnID = "turn_" + turn
+	if session.conversationID == "" {
+		if session.modelSet == "" {
+			session.modelSet = defaultSoulMintConversationModel
+		}
+		token, tokenErr := newToken(16)
+		if tokenErr != nil {
+			return hostedGenesisTurnSession{}, &apptheory.AppError{Code: "app.internal", Message: "failed to create conversation id"}
+		}
+		session.conversationID = token
+		session.isNew = true
+		return session, nil
+	}
+
+	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx, agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", session.conversationID))
+	if err != nil {
+		return hostedGenesisTurnSession{}, &apptheory.AppError{Code: "app.not_found", Message: "conversation not found"}
+	}
+	decodeMintConversationFields(conv)
+	status := strings.TrimSpace(conv.Status)
+	if status != models.SoulMintConversationStatusInProgress && status != models.SoulMintConversationStatusAssistantTurnReady && status != models.SoulMintConversationStatusCreated {
+		return hostedGenesisTurnSession{}, &apptheory.AppError{Code: "app.conflict", Message: "conversation cannot accept a new turn"}
+	}
+
+	storedModel := strings.TrimSpace(conv.Model)
+	if storedModel != "" {
+		if session.modelSet != "" && !strings.EqualFold(storedModel, session.modelSet) {
+			return hostedGenesisTurnSession{}, &apptheory.AppError{Code: "app.conflict", Message: "cannot change model for an existing conversation"}
+		}
+		session.modelSet = storedModel
+	}
+	if strings.TrimSpace(conv.Messages) != "" {
+		_ = json.Unmarshal([]byte(conv.Messages), &session.existingMessages)
+	}
+	session.existingUsage = conv.Usage
+	session.conv = conv
+	return session, nil
+}
+
+func buildHostedGenesisIdempotency(instanceSlug string, regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, req soulMintConversationRequest, reqHash string, now time.Time, requestID string) *models.SoulMintConversationIdempotency {
+	if strings.TrimSpace(req.IdempotencyKey) == "" {
+		return nil
+	}
+	item := &models.SoulMintConversationIdempotency{
+		InstanceSlug:   strings.TrimSpace(instanceSlug),
+		RegistrationID: strings.TrimSpace(regCtx.reg.ID),
+		AgentID:        strings.TrimSpace(regCtx.agentIDHex),
+		ConversationID: strings.TrimSpace(session.conversationID),
+		TurnID:         strings.TrimSpace(session.turnID),
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+		RequestHash:    strings.TrimSpace(reqHash),
+		RequestID:      strings.TrimSpace(requestID),
+		CorrelationID:  strings.TrimSpace(req.CorrelationID),
+		Status:         models.SoulMintConversationIdempotencyStatusProcessing,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	_ = item.UpdateKeys()
+	return item
+}
+
+func (s *Server) replayHostedGenesisIdempotency(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, instanceSlug string, req soulMintConversationRequest, reqHash string) (*models.SoulAgentMintConversation, hostedgenesis.QueueMessage, error) {
+	if s == nil || s.store == nil || s.store.DB == nil || ctx == nil || strings.TrimSpace(req.IdempotencyKey) == "" {
+		return nil, hostedgenesis.QueueMessage{}, nil
+	}
+	item, err := s.getHostedGenesisIdempotency(ctx.Context(), instanceSlug, regCtx.reg.ID, req.IdempotencyKey)
+	if theoryErrors.IsNotFound(err) {
+		return nil, hostedgenesis.QueueMessage{}, nil
+	}
+	if err != nil {
+		return nil, hostedgenesis.QueueMessage{}, &apptheory.AppError{Code: "app.internal", Message: "failed to load idempotency key"}
+	}
+	if strings.TrimSpace(item.RequestHash) != strings.TrimSpace(reqHash) {
+		return nil, hostedgenesis.QueueMessage{}, &apptheory.AppError{Code: "app.conflict", Message: "idempotency key already used for a different request"}
+	}
+	conv, err := getSoulAgentItemBySK[models.SoulAgentMintConversation](s, ctx.Context(), regCtx.agentIDHex, fmt.Sprintf("MINT_CONVERSATION#%s", item.ConversationID))
+	if err != nil {
+		return nil, hostedgenesis.QueueMessage{}, &apptheory.AppError{Code: "app.internal", Message: "idempotent conversation is unavailable"}
+	}
+	decodeMintConversationFields(conv)
+	msg := hostedgenesis.QueueMessage{
+		Kind:           hostedgenesis.QueueMessageKind,
+		Step:           hostedgenesis.StepAssistantTurn,
+		RegistrationID: strings.TrimSpace(regCtx.reg.ID),
+		InstanceSlug:   strings.TrimSpace(instanceSlug),
+		AgentID:        strings.TrimSpace(regCtx.agentIDHex),
+		ConversationID: strings.TrimSpace(item.ConversationID),
+		TurnID:         strings.TrimSpace(item.TurnID),
+		RequestID:      strings.TrimSpace(ctx.RequestID),
+		CorrelationID:  firstNonEmpty(req.CorrelationID, item.CorrelationID),
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+	}
+	return conv, msg, nil
+}
+
+func (s *Server) getHostedGenesisIdempotency(ctx context.Context, instanceSlug string, registrationID string, idempotencyKey string) (*models.SoulMintConversationIdempotency, error) {
+	var item models.SoulMintConversationIdempotency
+	if err := s.store.DB.WithContext(ctx).
+		Model(&models.SoulMintConversationIdempotency{}).
+		Where("PK", "=", models.SoulMintConversationIdempotencyPK(instanceSlug, registrationID, idempotencyKey)).
+		Where("SK", "=", "STATE").
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+func (s *Server) persistHostedGenesisAcceptedTurn(ctx context.Context, regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, updatedMessages []soulMintConversationMessage, messagesJSON string, idem *models.SoulMintConversationIdempotency, ledgerRequestID string, hostRequestID string, now time.Time) *apptheory.AppError {
+	extraWrites := func(tx core.TransactionBuilder, creditsRequested int64) error {
+		if idem != nil {
+			tx.Create(idem)
+		}
+		if session.isNew {
+			conv := &models.SoulAgentMintConversation{
+				AgentID:        regCtx.agentIDHex,
+				ConversationID: session.conversationID,
+				Model:          session.modelSet,
+				Messages:       encodeMintConversationBlob(messagesJSON),
+				Status:         models.SoulMintConversationStatusInProgress,
+				LatestTurnID:   session.turnID,
+				RequestID:      strings.TrimSpace(hostRequestID),
+				ChargedCredits: creditsRequested,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}
+			if idem != nil {
+				conv.CorrelationID = idem.CorrelationID
+				conv.IdempotencyKey = idem.IdempotencyKey
+			}
+			_ = conv.UpdateKeys()
+			tx.Create(conv)
+			return nil
+		}
+
+		update := &models.SoulAgentMintConversation{
+			AgentID:        regCtx.agentIDHex,
+			ConversationID: session.conversationID,
+		}
+		_ = update.UpdateKeys()
+		tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
+			ub.Add("ChargedCredits", creditsRequested)
+			ub.Set("Messages", encodeMintConversationBlob(messagesJSON))
+			ub.Set("Status", models.SoulMintConversationStatusInProgress)
+			ub.Set("StatusReason", "")
+			ub.Set("LatestTurnID", session.turnID)
+			ub.Set("RequestID", strings.TrimSpace(hostRequestID))
+			ub.Set("UpdatedAt", now)
+			if idem != nil {
+				ub.Set("CorrelationID", strings.TrimSpace(idem.CorrelationID))
+				ub.Set("IdempotencyKey", strings.TrimSpace(idem.IdempotencyKey))
+			}
+			return nil
+		}, tabletheory.IfExists())
+		return nil
+	}
+
+	if _, appErr := s.debitSoulMintConversationCredits(
+		ctx,
+		regCtx.inst,
+		soulMintConversationStreamModule,
+		session.conversationID,
+		strings.TrimSpace(ledgerRequestID),
+		soulMintConversationStreamBaseCredits,
+		now,
+		extraWrites,
+	); appErr != nil {
+		return appErr
+	}
+	_ = updatedMessages
+	return nil
+}
+
+func (s *Server) enqueueHostedGenesisTurn(ctx context.Context, msg hostedgenesis.QueueMessage) error {
+	if s == nil || s.enqueueHostedGenesisMessage == nil {
+		return fmt.Errorf("hosted genesis queue is not configured")
+	}
+	if strings.TrimSpace(msg.Kind) == "" {
+		msg.Kind = hostedgenesis.QueueMessageKind
+	}
+	if err := s.enqueueHostedGenesisMessage(ctx, msg); err != nil {
+		log.Printf("controlplane: enqueue hosted genesis turn failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(msg.AgentID), soulMintInstanceReadAuditHash(msg.ConversationID), err)
+		return err
+	}
+	return nil
+}
+
+func (s *Server) startHostedGenesisDeclarationExtraction(ctx *apptheory.Context, convCtx soulInstanceBootstrapConversationContext) error {
+	if convCtx.conv == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	now := time.Now().UTC()
+	if strings.TrimSpace(convCtx.conv.Status) != models.SoulMintConversationStatusDeclarationExtractionPending {
+		creditsDebited, appErr := s.debitSoulMintConversationCredits(
+			ctx.Context(),
+			convCtx.inst,
+			soulMintConversationExtractModule,
+			convCtx.conversationID,
+			firstNonEmpty(convCtx.conv.IdempotencyKey, ctx.RequestID),
+			soulMintConversationExtractBaseCredits,
+			now,
+			func(tx core.TransactionBuilder, creditsRequested int64) error {
+				update := &models.SoulAgentMintConversation{AgentID: convCtx.agentIDHex, ConversationID: convCtx.conversationID}
+				_ = update.UpdateKeys()
+				tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
+					ub.Add("ChargedCredits", creditsRequested)
+					ub.Set("Status", models.SoulMintConversationStatusDeclarationExtractionPending)
+					ub.Set("StatusReason", "")
+					ub.Set("RequestID", strings.TrimSpace(ctx.RequestID))
+					ub.Set("UpdatedAt", now)
+					return nil
+				}, tabletheory.IfExists())
+				return nil
+			},
+		)
+		if appErr != nil {
+			return appErr
+		}
+		convCtx.conv.ChargedCredits += creditsDebited
+		convCtx.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+		convCtx.conv.StatusReason = ""
+		convCtx.conv.RequestID = strings.TrimSpace(ctx.RequestID)
+		convCtx.conv.UpdatedAt = now
+	}
+	return s.enqueueHostedGenesisTurn(ctx.Context(), hostedgenesis.QueueMessage{
+		Kind:           hostedgenesis.QueueMessageKind,
+		Step:           hostedgenesis.StepDeclarationExtraction,
+		RegistrationID: strings.TrimSpace(convCtx.reg.ID),
+		InstanceSlug:   strings.TrimSpace(convCtx.instanceSlug),
+		AgentID:        strings.TrimSpace(convCtx.agentIDHex),
+		ConversationID: strings.TrimSpace(convCtx.conversationID),
+		TurnID:         strings.TrimSpace(convCtx.conv.LatestTurnID),
+		RequestID:      strings.TrimSpace(ctx.RequestID),
+		CorrelationID:  strings.TrimSpace(convCtx.conv.CorrelationID),
+		IdempotencyKey: strings.TrimSpace(convCtx.conv.IdempotencyKey),
+	})
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_complete.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_complete.go
@@ -1,0 +1,55 @@
+package controlplane
+
+import (
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func (s *Server) completeSoulMintConversationForRegistration(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, conv *models.SoulAgentMintConversation, conversationID string) (*apptheory.Response, error) {
+	return s.completeSoulMintConversationForRegistrationWithProjection(ctx, regCtx, conv, conversationID, nil)
+}
+
+func (s *Server) completeSoulMintConversationForRegistrationWithProjection(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, conv *models.SoulAgentMintConversation, conversationID string, projectionOpts *hostedGenesisProjectionOptions) (*apptheory.Response, error) {
+	now := time.Now().UTC()
+	if appErr := requireMintConversationDurableAssistantTurn(conv); appErr != nil {
+		return nil, appErr
+	}
+	declarationsJSON, extractUsage, appErr := s.resolveMintConversationCompletion(ctx, regCtx, conv, conversationID, now)
+	if appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.persistCompletedMintConversation(ctx.Context(), conv, declarationsJSON, extractUsage, now); appErr != nil {
+		return nil, &apptheory.AppError{Code: "app.internal", Message: "failed to complete conversation"}
+	}
+	promotion := s.loadOrFallbackSoulAgentPromotion(ctx.Context(), regCtx.agentIDHex, buildSoulAgentPromotionFromRegistration(regCtx.reg, now))
+	promotion = updateSoulAgentPromotionForConversation(promotion, conversationID, models.SoulMintConversationStatusCompleted, now)
+	promotion = updateSoulAgentPromotionReviewDigest(promotion, declarationsJSON)
+	if appErr := s.saveSoulAgentPromotion(ctx.Context(), promotion); appErr != nil {
+		return nil, appErr
+	}
+	if appErr := s.saveSoulAgentPromotionLifecycleEvent(ctx.Context(), buildSoulAgentPromotionLifecycleEvent(promotion, soulAgentPromotionLifecycleEventInput{
+		EventType:      models.SoulAgentPromotionEventTypeFinalizeReady,
+		RequestID:      strings.TrimSpace(ctx.RequestID),
+		ConversationID: conversationID,
+		OccurredAt:     now,
+	})); appErr != nil {
+		return nil, appErr
+	}
+
+	if projectionOpts != nil {
+		opts := *projectionOpts
+		if strings.TrimSpace(opts.RegistrationID) == "" && regCtx.reg != nil {
+			opts.RegistrationID = regCtx.reg.ID
+		}
+		if strings.TrimSpace(opts.RequestID) == "" {
+			opts.RequestID = strings.TrimSpace(ctx.RequestID)
+		}
+		return hostedGenesisConversationJSON(http.StatusOK, conv, opts)
+	}
+	return apptheory.JSON(http.StatusOK, conv)
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -39,6 +39,7 @@ type mintConversationTestDB struct {
 	qInstance    *ttmocks.MockQuery
 	qKey         *ttmocks.MockQuery
 	qConv        *ttmocks.MockQuery
+	qMintIdem    *ttmocks.MockQuery
 	qBudget      *ttmocks.MockQuery
 	qIdentity    *ttmocks.MockQuery
 	qAudit       *ttmocks.MockQuery
@@ -69,6 +70,7 @@ func newMintConversationTestDB() *mintConversationTestDB {
 		qInstance:    new(ttmocks.MockQuery),
 		qKey:         new(ttmocks.MockQuery),
 		qConv:        new(ttmocks.MockQuery),
+		qMintIdem:    new(ttmocks.MockQuery),
 		qBudget:      new(ttmocks.MockQuery),
 		qIdentity:    new(ttmocks.MockQuery),
 		qAudit:       new(ttmocks.MockQuery),
@@ -95,6 +97,7 @@ func newMintConversationTestDB() *mintConversationTestDB {
 			tdb.convModels = append(tdb.convModels, &copy)
 		}
 	})
+	db.On("Model", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(tdb.qMintIdem).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.InstanceBudgetMonth")).Return(tdb.qBudget).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.SoulAgentIdentity")).Return(tdb.qIdentity).Maybe()
 	db.On("Model", mock.AnythingOfType("*models.AuditLogEntry")).Return(tdb.qAudit).Maybe().Run(captureMintConversationAuditModel(tdb))
@@ -118,7 +121,7 @@ func newMintConversationTestDB() *mintConversationTestDB {
 		}
 	})
 
-	for _, q := range []*ttmocks.MockQuery{tdb.qReg, tdb.qOp, tdb.qDomain, tdb.qInstance, tdb.qKey, tdb.qConv, tdb.qBudget, tdb.qIdentity, tdb.qAudit, tdb.qWalletIdx, tdb.qPromotion, tdb.qLifecycle, tdb.qWalletAgent, tdb.qDomainAgent, tdb.qCapAgent, tdb.qUser, tdb.qChannel, tdb.qENS} {
+	for _, q := range []*ttmocks.MockQuery{tdb.qReg, tdb.qOp, tdb.qDomain, tdb.qInstance, tdb.qKey, tdb.qConv, tdb.qMintIdem, tdb.qBudget, tdb.qIdentity, tdb.qAudit, tdb.qWalletIdx, tdb.qPromotion, tdb.qLifecycle, tdb.qWalletAgent, tdb.qDomainAgent, tdb.qCapAgent, tdb.qUser, tdb.qChannel, tdb.qENS} {
 		q.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(q).Maybe()
 		q.On("Index", mock.Anything).Return(q).Maybe()
 		q.On("Limit", mock.Anything).Return(q).Maybe()

--- a/internal/controlplane/handlers_soul_mint_conversation_status.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_status.go
@@ -1,0 +1,406 @@
+package controlplane
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+const hostedGenesisConversationVersion = "1"
+
+const (
+	hostedGenesisFailureLLMUnavailable              = "llm_unavailable"
+	hostedGenesisFailureAssistantTurnFailed         = "assistant_turn_failed"
+	hostedGenesisFailureDeclarationExtractionFailed = "declaration_extraction_failed"
+	hostedGenesisFailureInvalidCompletionState      = "invalid_completion_state"
+	hostedGenesisFailureMissingProducedDeclarations = "missing_produced_declarations"
+	hostedGenesisFailureInvalidProducedDeclarations = "invalid_produced_declarations"
+	hostedGenesisFailureTenantBoundaryViolation     = "tenant_boundary_violation"
+	hostedGenesisFailureOperatorActionRequired      = "operator_action_required"
+	hostedGenesisRecoveryRefreshState               = "refresh_state"
+	hostedGenesisRecoveryRetrySameStep              = "retry_same_step"
+	hostedGenesisRecoveryRestartSoulBootstrap       = "restart_soul_bootstrap"
+	hostedGenesisRecoveryOperatorAction             = "operator_action"
+	hostedGenesisDefaultPollAfterSeconds            = 2
+)
+
+type hostedGenesisConversationResponse struct {
+	Version      string                              `json:"version"`
+	RequestID    string                              `json:"request_id"`
+	Conversation hostedGenesisConversationProjection `json:"conversation"`
+}
+
+type hostedGenesisConversationProjection struct {
+	RegistrationID       string                             `json:"registration_id"`
+	ConversationID       string                             `json:"conversation_id"`
+	AgentID              string                             `json:"agent_id"`
+	Status               string                             `json:"status"`
+	LatestTurnID         string                             `json:"latest_turn_id,omitempty"`
+	MessageCount         int                                `json:"message_count"`
+	ProducedDeclarations *hostedGenesisProducedDeclarations `json:"produced_declarations,omitempty"`
+	Failure              *hostedGenesisFailure              `json:"failure,omitempty"`
+	RequestID            string                             `json:"request_id"`
+	TraceIDs             *hostedGenesisTraceIDs             `json:"trace_ids,omitempty"`
+	PollAfterSeconds     int                                `json:"poll_after_seconds,omitempty"`
+	CreatedAt            *time.Time                         `json:"created_at,omitempty"`
+	UpdatedAt            *time.Time                         `json:"updated_at,omitempty"`
+	CompletedAt          *time.Time                         `json:"completed_at,omitempty"`
+}
+
+type hostedGenesisProducedDeclarations struct {
+	DeclarationID   string                                   `json:"declaration_id"`
+	DeclarationHash string                                   `json:"declaration_hash"`
+	ProducedAt      string                                   `json:"produced_at"`
+	Declarations    soulMintConversationProducedDeclarations `json:"declarations"`
+	Evidence        hostedGenesisDeclarationEvidence         `json:"evidence"`
+}
+
+type hostedGenesisDeclarationEvidence struct {
+	Source         string `json:"source"`
+	RegistrationID string `json:"registration_id"`
+	ConversationID string `json:"conversation_id"`
+	AgentID        string `json:"agent_id"`
+	MessageCount   int    `json:"message_count"`
+	Model          string `json:"model,omitempty"`
+	RequestID      string `json:"request_id"`
+}
+
+type hostedGenesisFailure struct {
+	Code      string                       `json:"code"`
+	Message   string                       `json:"message"`
+	Retryable bool                         `json:"retryable"`
+	Recovery  hostedGenesisFailureRecovery `json:"recovery"`
+}
+
+type hostedGenesisFailureRecovery struct {
+	Action            string `json:"action"`
+	MaxAttempts       int    `json:"max_attempts,omitempty"`
+	RetryAfterSeconds int    `json:"retry_after_seconds,omitempty"`
+	Reason            string `json:"reason,omitempty"`
+}
+
+type hostedGenesisTraceIDs struct {
+	HostRequestID   string `json:"host_request_id,omitempty"`
+	CorrelationID   string `json:"correlation_id,omitempty"`
+	IdempotencyKey  string `json:"idempotency_key,omitempty"`
+	LesserRequestID string `json:"lesser_request_id,omitempty"`
+}
+
+type mintConversationStatusProjection struct {
+	ConversationID              string
+	Status                      string
+	Reason                      string
+	ProducedDeclarationsPresent bool
+	ProducedDeclarationsValid   bool
+	RequestID                   string
+	MessageCount                int
+}
+
+type hostedGenesisProjectionOptions struct {
+	RegistrationID  string
+	RequestID       string
+	CollapseCreated bool
+	CorrelationID   string
+	IdempotencyKey  string
+	LesserRequestID string
+}
+
+func mintConversationStatusProjectionFromModel(conv *models.SoulAgentMintConversation, collapseCreated bool) mintConversationStatusProjection {
+	if conv == nil {
+		return mintConversationStatusProjection{Status: models.SoulMintConversationStatusFailed, Reason: hostedGenesisFailureInvalidCompletionState}
+	}
+	decodeMintConversationFields(conv)
+	present, valid := mintConversationProducedDeclarationsState(conv)
+	status := strings.ToLower(strings.TrimSpace(conv.Status))
+	reason := strings.TrimSpace(conv.StatusReason)
+	if reason == "" {
+		switch status {
+		case models.SoulMintConversationStatusCompleted, models.SoulMintConversationStatusDeclarationReady:
+			if !present {
+				reason = hostedGenesisFailureMissingProducedDeclarations
+			} else if !valid {
+				reason = hostedGenesisFailureInvalidProducedDeclarations
+			}
+		}
+	}
+
+	switch status {
+	case models.SoulMintConversationStatusCompleted, models.SoulMintConversationStatusDeclarationReady:
+		if valid {
+			status = models.SoulMintConversationStatusDeclarationReady
+		} else {
+			status = models.SoulMintConversationStatusFailed
+			if reason == "" {
+				reason = hostedGenesisFailureInvalidProducedDeclarations
+			}
+		}
+	case models.SoulMintConversationStatusCreated:
+		if collapseCreated {
+			status = models.SoulMintConversationStatusInProgress
+		}
+	case models.SoulMintConversationStatusInProgress,
+		models.SoulMintConversationStatusAssistantTurnReady,
+		models.SoulMintConversationStatusDeclarationExtractionPending,
+		models.SoulMintConversationStatusFailed:
+		// locked status; no rewrite.
+	default:
+		status = models.SoulMintConversationStatusFailed
+		if reason == "" {
+			reason = hostedGenesisFailureInvalidCompletionState
+		}
+	}
+	if status == models.SoulMintConversationStatusFailed && reason == "" {
+		reason = hostedGenesisFailureAssistantTurnFailed
+	}
+
+	return mintConversationStatusProjection{
+		ConversationID:              strings.TrimSpace(conv.ConversationID),
+		Status:                      status,
+		Reason:                      reason,
+		ProducedDeclarationsPresent: present,
+		ProducedDeclarationsValid:   valid,
+		RequestID:                   strings.TrimSpace(conv.RequestID),
+		MessageCount:                mintConversationMessageCount(conv),
+	}
+}
+
+func buildHostedGenesisConversationResponse(conv *models.SoulAgentMintConversation, opts hostedGenesisProjectionOptions) hostedGenesisConversationResponse {
+	if conv == nil {
+		return hostedGenesisConversationResponse{Version: hostedGenesisConversationVersion, RequestID: strings.TrimSpace(opts.RequestID)}
+	}
+	decodeMintConversationFields(conv)
+	status := mintConversationStatusProjectionFromModel(conv, opts.CollapseCreated)
+	requestID := firstNonEmpty(opts.RequestID, status.RequestID, conv.RequestID)
+	trace := hostedGenesisTraceIDs{
+		HostRequestID:   requestID,
+		CorrelationID:   firstNonEmpty(opts.CorrelationID, conv.CorrelationID),
+		IdempotencyKey:  firstNonEmpty(opts.IdempotencyKey, conv.IdempotencyKey),
+		LesserRequestID: strings.TrimSpace(opts.LesserRequestID),
+	}
+	projection := hostedGenesisConversationProjection{
+		RegistrationID: strings.TrimSpace(opts.RegistrationID),
+		ConversationID: strings.TrimSpace(conv.ConversationID),
+		AgentID:        strings.ToLower(strings.TrimSpace(conv.AgentID)),
+		Status:         status.Status,
+		LatestTurnID:   strings.TrimSpace(conv.LatestTurnID),
+		MessageCount:   status.MessageCount,
+		RequestID:      requestID,
+		TraceIDs:       nilIfEmptyTrace(trace),
+		CreatedAt:      timePtrIfSet(conv.CreatedAt),
+		UpdatedAt:      timePtrIfSet(firstTime(conv.UpdatedAt, conv.CompletedAt, conv.CreatedAt)),
+		CompletedAt:    timePtrIfSet(conv.CompletedAt),
+	}
+	if isHostedGenesisProgressStatus(status.Status) {
+		projection.PollAfterSeconds = hostedGenesisDefaultPollAfterSeconds
+	}
+	if status.Status == models.SoulMintConversationStatusDeclarationReady && status.ProducedDeclarationsValid {
+		if produced := buildHostedGenesisProducedDeclarations(conv, strings.TrimSpace(opts.RegistrationID), requestID, status.MessageCount); produced != nil {
+			projection.ProducedDeclarations = produced
+		}
+	}
+	if status.Status == models.SoulMintConversationStatusFailed {
+		projection.Failure = hostedGenesisFailureFromReason(status.Reason)
+	}
+	return hostedGenesisConversationResponse{
+		Version:      hostedGenesisConversationVersion,
+		RequestID:    requestID,
+		Conversation: projection,
+	}
+}
+
+func hostedGenesisConversationJSON(status int, conv *models.SoulAgentMintConversation, opts hostedGenesisProjectionOptions) (*apptheory.Response, error) {
+	return apptheory.JSON(status, buildHostedGenesisConversationResponse(conv, opts))
+}
+
+func isHostedGenesisProgressStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case models.SoulMintConversationStatusCreated,
+		models.SoulMintConversationStatusInProgress,
+		models.SoulMintConversationStatusAssistantTurnReady,
+		models.SoulMintConversationStatusDeclarationExtractionPending:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildHostedGenesisProducedDeclarations(conv *models.SoulAgentMintConversation, registrationID string, requestID string, messageCount int) *hostedGenesisProducedDeclarations {
+	if conv == nil {
+		return nil
+	}
+	raw := strings.TrimSpace(conv.ProducedDeclarations)
+	if raw == "" {
+		return nil
+	}
+	decl, appErr := parseAndValidateMintConversationDeclarations(raw)
+	if appErr != nil {
+		return nil
+	}
+	sum := sha256.Sum256([]byte(raw))
+	declHash := hex.EncodeToString(sum[:])
+	producedAt := conv.CompletedAt
+	if producedAt.IsZero() {
+		producedAt = firstTime(conv.UpdatedAt, conv.CreatedAt)
+	}
+	return &hostedGenesisProducedDeclarations{
+		DeclarationID:   "decl_" + declHash[:16],
+		DeclarationHash: "sha256:" + declHash,
+		ProducedAt:      producedAt.UTC().Format(time.RFC3339Nano),
+		Declarations:    decl,
+		Evidence: hostedGenesisDeclarationEvidence{
+			Source:         "host_conversation",
+			RegistrationID: strings.TrimSpace(registrationID),
+			ConversationID: strings.TrimSpace(conv.ConversationID),
+			AgentID:        strings.ToLower(strings.TrimSpace(conv.AgentID)),
+			MessageCount:   messageCount,
+			Model:          strings.TrimSpace(conv.Model),
+			RequestID:      strings.TrimSpace(requestID),
+		},
+	}
+}
+
+func hostedGenesisFailureFromReason(reason string) *hostedGenesisFailure {
+	code := normalizeHostedGenesisFailureCode(reason)
+	retryable := code == hostedGenesisFailureLLMUnavailable || code == hostedGenesisFailureAssistantTurnFailed || code == hostedGenesisFailureDeclarationExtractionFailed
+	recovery := hostedGenesisFailureRecovery{Action: hostedGenesisRecoveryRefreshState, Reason: code}
+	if retryable {
+		recovery.Action = hostedGenesisRecoveryRetrySameStep
+		recovery.MaxAttempts = 3
+		recovery.RetryAfterSeconds = 30
+	}
+	if code == hostedGenesisFailureTenantBoundaryViolation || code == hostedGenesisFailureOperatorActionRequired {
+		recovery.Action = hostedGenesisRecoveryOperatorAction
+	}
+	if code == hostedGenesisFailureMissingProducedDeclarations || code == hostedGenesisFailureInvalidProducedDeclarations {
+		recovery.Action = hostedGenesisRecoveryRestartSoulBootstrap
+	}
+	return &hostedGenesisFailure{
+		Code:      code,
+		Message:   hostedGenesisFailureMessage(code),
+		Retryable: retryable,
+		Recovery:  recovery,
+	}
+}
+
+func normalizeHostedGenesisFailureCode(reason string) string {
+	switch strings.TrimSpace(reason) {
+	case hostedGenesisFailureLLMUnavailable,
+		hostedGenesisFailureAssistantTurnFailed,
+		hostedGenesisFailureDeclarationExtractionFailed,
+		hostedGenesisFailureInvalidCompletionState,
+		hostedGenesisFailureMissingProducedDeclarations,
+		hostedGenesisFailureInvalidProducedDeclarations,
+		hostedGenesisFailureTenantBoundaryViolation,
+		hostedGenesisFailureOperatorActionRequired:
+		return strings.TrimSpace(reason)
+	default:
+		return hostedGenesisFailureAssistantTurnFailed
+	}
+}
+
+func hostedGenesisFailureMessage(code string) string {
+	switch code {
+	case hostedGenesisFailureLLMUnavailable:
+		return "Assistant turn failed before declaration extraction."
+	case hostedGenesisFailureDeclarationExtractionFailed:
+		return "Declaration extraction failed."
+	case hostedGenesisFailureInvalidCompletionState:
+		return "Conversation cannot be completed from the current state."
+	case hostedGenesisFailureMissingProducedDeclarations:
+		return "Produced declarations are missing."
+	case hostedGenesisFailureInvalidProducedDeclarations:
+		return "Produced declarations are invalid."
+	case hostedGenesisFailureTenantBoundaryViolation:
+		return "Conversation failed instance boundary validation."
+	case hostedGenesisFailureOperatorActionRequired:
+		return "Operator action is required."
+	default:
+		return "Assistant turn failed before declaration extraction."
+	}
+}
+
+func mintConversationMessageCount(conv *models.SoulAgentMintConversation) int {
+	if conv == nil {
+		return 0
+	}
+	decodeMintConversationFields(conv)
+	if strings.TrimSpace(conv.Messages) == "" {
+		return 0
+	}
+	var messages []soulMintConversationMessage
+	if err := json.Unmarshal([]byte(conv.Messages), &messages); err != nil {
+		return 0
+	}
+	return len(messages)
+}
+
+func firstTime(values ...time.Time) time.Time {
+	for _, value := range values {
+		if !value.IsZero() {
+			return value.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func timePtrIfSet(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	v := value.UTC()
+	return &v
+}
+
+func nilIfEmptyTrace(trace hostedGenesisTraceIDs) *hostedGenesisTraceIDs {
+	if strings.TrimSpace(trace.HostRequestID) == "" && strings.TrimSpace(trace.CorrelationID) == "" && strings.TrimSpace(trace.IdempotencyKey) == "" && strings.TrimSpace(trace.LesserRequestID) == "" {
+		return nil
+	}
+	return &trace
+}
+
+func hostedGenesisRequestHash(registrationID string, conversationID string, model string, message string) string {
+	payload := map[string]string{
+		"registration_id": strings.TrimSpace(registrationID),
+		"conversation_id": strings.TrimSpace(conversationID),
+		"model":           strings.TrimSpace(model),
+		"message_hash":    sha256HexTrimmed(message),
+	}
+	b, _ := json.Marshal(payload)
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func hostedGenesisSafeToken(value string, maxLen int) (string, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", true
+	}
+	if maxLen <= 0 {
+		maxLen = 128
+	}
+	if len(value) > maxLen {
+		return "", false
+	}
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z':
+		case r >= 'A' && r <= 'Z':
+		case r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.' || r == ':':
+		default:
+			return "", false
+		}
+	}
+	return value, true
+}
+
+func hostedGenesisBadRequest(field string) *apptheory.AppError {
+	return &apptheory.AppError{Code: "app.bad_request", Message: fmt.Sprintf("%s is invalid", field)}
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_status_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_status_internal_test.go
@@ -1,0 +1,172 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestMintConversationStatusProjection_LegacyCompletedMapsOnlyWithValidDeclarations(t *testing.T) {
+	valid := string(mustMarshalJSON(t, testMintConversationDecl()))
+	conv := &models.SoulAgentMintConversation{
+		AgentID:              "0x" + strings.Repeat("22", 32),
+		ConversationID:       "conv-legacy",
+		Messages:             encodeMintConversationBlob(`[{"role":"user","content":"secret prompt"},{"role":"assistant","content":"secret reply"}]`),
+		ProducedDeclarations: encodeMintConversationBlob(valid),
+		Status:               models.SoulMintConversationStatusCompleted,
+		RequestID:            "req-legacy",
+		CreatedAt:            time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+		CompletedAt:          time.Date(2026, 3, 7, 12, 5, 0, 0, time.UTC),
+	}
+	proj := mintConversationStatusProjectionFromModel(conv, true)
+	if proj.ConversationID != "conv-legacy" || proj.Status != models.SoulMintConversationStatusDeclarationReady || proj.Reason != "" || !proj.ProducedDeclarationsPresent || !proj.ProducedDeclarationsValid || proj.RequestID != "req-legacy" || proj.MessageCount != 2 {
+		t.Fatalf("unexpected valid legacy projection: %#v", proj)
+	}
+	resp := buildHostedGenesisConversationResponse(conv, hostedGenesisProjectionOptions{RegistrationID: "reg-1", RequestID: "req-legacy", CollapseCreated: true})
+	body, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(body), "secret prompt") || strings.Contains(string(body), "secret reply") {
+		t.Fatalf("status response leaked raw transcript: %s", string(body))
+	}
+
+	conv.ProducedDeclarations = encodeMintConversationBlob(`{"private":true}`)
+	proj = mintConversationStatusProjectionFromModel(conv, true)
+	if proj.Status != models.SoulMintConversationStatusFailed || proj.Reason != hostedGenesisFailureInvalidProducedDeclarations || !proj.ProducedDeclarationsPresent || proj.ProducedDeclarationsValid {
+		t.Fatalf("unexpected invalid legacy projection: %#v", proj)
+	}
+}
+
+func TestMintConversationStatusProjection_CollapsesCreatedForLesserPath(t *testing.T) {
+	conv := &models.SoulAgentMintConversation{ConversationID: "conv-created", Status: models.SoulMintConversationStatusCreated, RequestID: "req-created"}
+	if got := mintConversationStatusProjectionFromModel(conv, true); got.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected created to collapse to in_progress for Lesser projection, got %#v", got)
+	}
+	if got := mintConversationStatusProjectionFromModel(conv, false); got.Status != models.SoulMintConversationStatusCreated {
+		t.Fatalf("expected created to remain available without collapse, got %#v", got)
+	}
+}
+
+func TestHostedGenesisRequestHashIncludesConversationID(t *testing.T) {
+	withoutConversation := hostedGenesisRequestHash("reg-1", "", "anthropic:claude-sonnet-4-6", "same turn")
+	withConversation := hostedGenesisRequestHash("reg-1", "conv-2", "anthropic:claude-sonnet-4-6", "same turn")
+	if withoutConversation == withConversation {
+		t.Fatalf("idempotency request hash must distinguish existing conversation turns")
+	}
+}
+
+func TestHostedGenesisFailureProjectionHelpers(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		reason   string
+		action   string
+		retry    bool
+		message  string
+		maxTries int
+	}{
+		{reason: hostedGenesisFailureLLMUnavailable, action: hostedGenesisRecoveryRetrySameStep, retry: true, message: "Assistant turn failed before declaration extraction.", maxTries: 3},
+		{reason: hostedGenesisFailureDeclarationExtractionFailed, action: hostedGenesisRecoveryRetrySameStep, retry: true, message: "Declaration extraction failed.", maxTries: 3},
+		{reason: hostedGenesisFailureInvalidCompletionState, action: hostedGenesisRecoveryRefreshState, message: "Conversation cannot be completed from the current state."},
+		{reason: hostedGenesisFailureMissingProducedDeclarations, action: hostedGenesisRecoveryRestartSoulBootstrap, message: "Produced declarations are missing."},
+		{reason: hostedGenesisFailureInvalidProducedDeclarations, action: hostedGenesisRecoveryRestartSoulBootstrap, message: "Produced declarations are invalid."},
+		{reason: hostedGenesisFailureTenantBoundaryViolation, action: hostedGenesisRecoveryOperatorAction, message: "Conversation failed instance boundary validation."},
+		{reason: hostedGenesisFailureOperatorActionRequired, action: hostedGenesisRecoveryOperatorAction, message: "Operator action is required."},
+		{reason: "unknown", action: hostedGenesisRecoveryRetrySameStep, retry: true, message: "Assistant turn failed before declaration extraction.", maxTries: 3},
+	} {
+		tc := tc
+		t.Run(tc.reason, func(t *testing.T) {
+			t.Parallel()
+
+			failure := hostedGenesisFailureFromReason(tc.reason)
+			if failure.Message != tc.message ||
+				failure.Retryable != tc.retry ||
+				failure.Recovery.Action != tc.action ||
+				failure.Recovery.MaxAttempts != tc.maxTries {
+				t.Fatalf("unexpected failure projection: %#v", failure)
+			}
+		})
+	}
+}
+
+func TestHostedGenesisSafeTokenHelper(t *testing.T) {
+	t.Parallel()
+
+	if got, ok := hostedGenesisSafeToken(" token-1:ok ", 16); !ok || got != "token-1:ok" {
+		t.Fatalf("expected safe token, got %q ok=%v", got, ok)
+	}
+	if got, ok := hostedGenesisSafeToken(strings.Repeat("x", 17), 16); ok || got != "" {
+		t.Fatalf("expected oversize token rejection, got %q ok=%v", got, ok)
+	}
+	if got, ok := hostedGenesisSafeToken("bad/token", 16); ok || got != "" {
+		t.Fatalf("expected invalid token rejection, got %q ok=%v", got, ok)
+	}
+	if appErr := hostedGenesisBadRequest("trace_id"); appErr.Code != appErrCodeBadRequest || !strings.Contains(appErr.Message, "trace_id") {
+		t.Fatalf("unexpected bad request error: %#v", appErr)
+	}
+}
+
+func TestHostedGenesisTimeAndTraceHelpers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	if firstTime(time.Time{}, now) != now || !firstTime(time.Time{}).IsZero() {
+		t.Fatalf("firstTime mismatch")
+	}
+	if timePtrIfSet(time.Time{}) != nil || !timePtrIfSet(now).Equal(now) {
+		t.Fatalf("time pointer helper mismatch")
+	}
+	if nilIfEmptyTrace(hostedGenesisTraceIDs{}) != nil ||
+		nilIfEmptyTrace(hostedGenesisTraceIDs{HostRequestID: "req-1"}) == nil {
+		t.Fatalf("trace nil helper mismatch")
+	}
+}
+
+func TestHostedGenesisMessageCountHelper(t *testing.T) {
+	t.Parallel()
+
+	conv := &models.SoulAgentMintConversation{Messages: encodeMintConversationBlob(`[{"role":"user","content":"one"},{"role":"assistant","content":"two"}]`)}
+	if mintConversationMessageCount(conv) != 2 ||
+		mintConversationMessageCount(&models.SoulAgentMintConversation{Messages: encodeMintConversationBlob(`not-json`)}) != 0 ||
+		mintConversationMessageCount(nil) != 0 {
+		t.Fatalf("message count helper mismatch")
+	}
+}
+
+func TestMintConversationStatusProjection_ProgressAndFailedStates(t *testing.T) {
+	t.Parallel()
+
+	for _, status := range []string{
+		models.SoulMintConversationStatusInProgress,
+		models.SoulMintConversationStatusAssistantTurnReady,
+		models.SoulMintConversationStatusDeclarationExtractionPending,
+	} {
+		status := status
+		t.Run(status, func(t *testing.T) {
+			t.Parallel()
+
+			conv := &models.SoulAgentMintConversation{ConversationID: "conv-" + status, Status: status, RequestID: "req-progress"}
+			resp := buildHostedGenesisConversationResponse(conv, hostedGenesisProjectionOptions{RegistrationID: "reg-1", RequestID: "req-progress", CollapseCreated: true})
+			if resp.Conversation.Status != status || resp.Conversation.PollAfterSeconds == 0 || resp.Conversation.Failure != nil {
+				t.Fatalf("unexpected progress projection: %#v", resp)
+			}
+		})
+	}
+
+	failed := &models.SoulAgentMintConversation{
+		ConversationID: "conv-failed",
+		Status:         models.SoulMintConversationStatusFailed,
+		StatusReason:   hostedGenesisFailureTenantBoundaryViolation,
+		RequestID:      "req-failed",
+	}
+	resp := buildHostedGenesisConversationResponse(failed, hostedGenesisProjectionOptions{RegistrationID: "reg-1", RequestID: "req-failed"})
+	if resp.Conversation.Status != models.SoulMintConversationStatusFailed ||
+		resp.Conversation.Failure == nil ||
+		resp.Conversation.Failure.Recovery.Action != hostedGenesisRecoveryOperatorAction {
+		t.Fatalf("unexpected failed projection: %#v", resp)
+	}
+}

--- a/internal/controlplane/queues_sqs.go
+++ b/internal/controlplane/queues_sqs.go
@@ -12,22 +12,29 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 
 	"github.com/equaltoai/lesser-host/internal/commworker"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/provisioning"
 )
 
 type queueClient struct {
-	provisionQueueURL string
-	commQueueURL      string
+	provisionQueueURL     string
+	commQueueURL          string
+	hostedGenesisQueueURL string
 
 	once   sync.Once
 	client *sqs.Client
 	err    error
 }
 
-func newQueueClient(provisionQueueURL string, commQueueURL string) *queueClient {
+func newQueueClient(provisionQueueURL string, commQueueURL string, hostedGenesisQueueURL ...string) *queueClient {
+	hostedURL := ""
+	if len(hostedGenesisQueueURL) > 0 {
+		hostedURL = hostedGenesisQueueURL[0]
+	}
 	return &queueClient{
-		provisionQueueURL: strings.TrimSpace(provisionQueueURL),
-		commQueueURL:      strings.TrimSpace(commQueueURL),
+		provisionQueueURL:     strings.TrimSpace(provisionQueueURL),
+		commQueueURL:          strings.TrimSpace(commQueueURL),
+		hostedGenesisQueueURL: strings.TrimSpace(hostedURL),
 	}
 }
 
@@ -85,6 +92,32 @@ func (q *queueClient) enqueueCommMessage(ctx context.Context, msg commworker.Que
 	url := strings.TrimSpace(q.commQueueURL)
 	if url == "" {
 		return fmt.Errorf("comm queue url is not configured")
+	}
+
+	body, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+
+	client, err := q.sqsClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	_, err = client.SendMessage(ctx, &sqs.SendMessageInput{
+		QueueUrl:    aws.String(url),
+		MessageBody: aws.String(string(body)),
+	})
+	return err
+}
+
+func (q *queueClient) enqueueHostedGenesisMessage(ctx context.Context, msg hostedgenesis.QueueMessage) error {
+	if q == nil {
+		return fmt.Errorf("queue client is nil")
+	}
+	url := strings.TrimSpace(q.hostedGenesisQueueURL)
+	if url == "" {
+		return fmt.Errorf("hosted genesis queue url is not configured")
 	}
 
 	body, err := json.Marshal(msg)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/equaltoai/lesser-host/internal/commmailbox"
 	"github.com/equaltoai/lesser-host/internal/commworker"
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/outboundhttp"
 	"github.com/equaltoai/lesser-host/internal/payments"
 	"github.com/equaltoai/lesser-host/internal/store"
@@ -56,7 +57,8 @@ type Server struct {
 	telnyxSendSMS       func(ctx context.Context, from string, to string, text string) (string, error)
 	telnyxCallVoice     func(ctx context.Context, from string, to string, texmlURL string, statusCallbackURL string) (string, error)
 
-	enqueueCommMessage func(ctx context.Context, msg commworker.QueueMessage) error
+	enqueueCommMessage          func(ctx context.Context, msg commworker.QueueMessage) error
+	enqueueHostedGenesisMessage func(ctx context.Context, msg hostedgenesis.QueueMessage) error
 
 	// paymentsProviderFactory is a test-injection hook. When non-nil, handlers
 	// use it instead of payments.NewProvider.
@@ -73,7 +75,7 @@ func NewServer(cfg config.Config, st *store.Store) *Server {
 		cfg:                  cfg,
 		store:                st,
 		webAuthn:             webAuthn,
-		queues:               newQueueClient(cfg.ProvisionQueueURL, cfg.CommQueueURL),
+		queues:               newQueueClient(cfg.ProvisionQueueURL, cfg.CommQueueURL, cfg.HostedGenesisQueueURL),
 		r53:                  newRoute53Client(),
 		soulPacks:            artifacts.New(cfg.SoulPackBucketName),
 		soulAvatarCache:      &soulPublicAvatarCache{},
@@ -98,6 +100,7 @@ func NewServer(cfg config.Config, st *store.Store) *Server {
 		srv.mailboxContentStore = commmailbox.NewS3Store(cfg.SoulCommMailboxBucketName)
 	}
 	srv.enqueueCommMessage = srv.queues.enqueueCommMessage
+	srv.enqueueHostedGenesisMessage = srv.queues.enqueueHostedGenesisMessage
 	return srv
 }
 

--- a/internal/hostedgenesis/queue.go
+++ b/internal/hostedgenesis/queue.go
@@ -1,0 +1,23 @@
+package hostedgenesis
+
+// QueueMessage is the durable async worker command for hosted/off-chain soul
+// genesis. It carries only ids, hashes, and bounded client-safe correlation
+// values; raw credentials and raw transcript text stay in Host's store.
+type QueueMessage struct {
+	Kind           string `json:"kind"`
+	Step           string `json:"step"`
+	RegistrationID string `json:"registration_id"`
+	InstanceSlug   string `json:"instance_slug"`
+	AgentID        string `json:"agent_id"`
+	ConversationID string `json:"conversation_id"`
+	TurnID         string `json:"turn_id,omitempty"`
+	RequestID      string `json:"request_id,omitempty"`
+	CorrelationID  string `json:"correlation_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+}
+
+const (
+	QueueMessageKind          = "hosted_genesis_conversation"
+	StepAssistantTurn         = "assistant_turn"
+	StepDeclarationExtraction = "declaration_extraction"
+)

--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -77,6 +77,7 @@ func LambdaInit() (DB, error) {
 		&models.SoulAgentContinuity{},
 		&models.SoulLifecycleChallenge{},
 		&models.SoulAgentMintConversation{},
+		&models.SoulMintConversationIdempotency{},
 		&models.SoulAgentValidationRecord{},
 		&models.SoulCommMessageStatus{},
 		&models.SoulCommMailboxMessage{},

--- a/internal/store/models/soul_agent_mint_conversation.go
+++ b/internal/store/models/soul_agent_mint_conversation.go
@@ -1,6 +1,9 @@
 package models
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -8,9 +11,17 @@ import (
 
 // SoulMintConversationStatus* constants define minting conversation states.
 const (
-	SoulMintConversationStatusInProgress = "in_progress"
-	SoulMintConversationStatusCompleted  = "completed"
-	SoulMintConversationStatusFailed     = "failed"
+	SoulMintConversationStatusCreated                      = "created"
+	SoulMintConversationStatusInProgress                   = "in_progress"
+	SoulMintConversationStatusAssistantTurnReady           = "assistant_turn_ready"
+	SoulMintConversationStatusDeclarationExtractionPending = "declaration_extraction_pending"
+	SoulMintConversationStatusDeclarationReady             = "declaration_ready"
+	SoulMintConversationStatusFailed                       = "failed"
+
+	// SoulMintConversationStatusCompleted is the legacy terminal status stored by
+	// pre-Project-49 records. New durable hosted-genesis responses project it as
+	// declaration_ready only when valid produced declarations are present.
+	SoulMintConversationStatusCompleted = "completed"
 )
 
 // SoulAgentMintConversation stores a minting conversation record for a soul agent.
@@ -32,11 +43,17 @@ type SoulAgentMintConversation struct {
 	Messages             string `theorydb:"attr:messages" json:"messages,omitempty"`                          // JSON array of conversation messages
 	ProducedDeclarations string `theorydb:"attr:producedDeclarations" json:"produced_declarations,omitempty"` // JSON object of structured output
 	Status               string `theorydb:"attr:status" json:"status"`
+	StatusReason         string `theorydb:"attr:statusReason" json:"status_reason,omitempty"`
+	LatestTurnID         string `theorydb:"attr:latestTurnId" json:"latest_turn_id,omitempty"`
+	RequestID            string `theorydb:"attr:requestId" json:"request_id,omitempty"`
+	CorrelationID        string `theorydb:"attr:correlationId" json:"correlation_id,omitempty"`
+	IdempotencyKey       string `theorydb:"attr:idempotencyKey" json:"idempotency_key,omitempty"`
 
 	Usage          AIUsage `theorydb:"attr:usage" json:"usage,omitempty"`
 	ChargedCredits int64   `theorydb:"attr:chargedCredits" json:"charged_credits,omitempty"`
 
 	CreatedAt   time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt   time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
 	CompletedAt time.Time `theorydb:"attr:completedAt" json:"completed_at,omitempty"`
 }
 
@@ -51,6 +68,9 @@ func (m *SoulAgentMintConversation) BeforeCreate() error {
 	if strings.TrimSpace(m.Status) == "" {
 		m.Status = SoulMintConversationStatusInProgress
 	}
+	if m.UpdatedAt.IsZero() {
+		m.UpdatedAt = m.CreatedAt
+	}
 	if err := m.UpdateKeys(); err != nil {
 		return err
 	}
@@ -60,7 +80,7 @@ func (m *SoulAgentMintConversation) BeforeCreate() error {
 	if err := requireNonEmpty("conversationId", m.ConversationID); err != nil {
 		return err
 	}
-	if err := requireOneOf("status", m.Status, SoulMintConversationStatusInProgress, SoulMintConversationStatusCompleted, SoulMintConversationStatusFailed); err != nil {
+	if err := requireOneOf("status", m.Status, SoulMintConversationAllowedStatuses()...); err != nil {
 		return err
 	}
 	return nil
@@ -77,7 +97,7 @@ func (m *SoulAgentMintConversation) BeforeUpdate() error {
 	if err := requireNonEmpty("conversationId", m.ConversationID); err != nil {
 		return err
 	}
-	if err := requireOneOf("status", m.Status, SoulMintConversationStatusInProgress, SoulMintConversationStatusCompleted, SoulMintConversationStatusFailed); err != nil {
+	if err := requireOneOf("status", m.Status, SoulMintConversationAllowedStatuses()...); err != nil {
 		return err
 	}
 	return nil
@@ -91,6 +111,11 @@ func (m *SoulAgentMintConversation) UpdateKeys() error {
 	m.Messages = strings.TrimSpace(m.Messages)
 	m.ProducedDeclarations = strings.TrimSpace(m.ProducedDeclarations)
 	m.Status = strings.ToLower(strings.TrimSpace(m.Status))
+	m.StatusReason = strings.TrimSpace(m.StatusReason)
+	m.LatestTurnID = strings.TrimSpace(m.LatestTurnID)
+	m.RequestID = strings.TrimSpace(m.RequestID)
+	m.CorrelationID = strings.TrimSpace(m.CorrelationID)
+	m.IdempotencyKey = strings.TrimSpace(m.IdempotencyKey)
 
 	m.PK = fmt.Sprintf("SOUL#AGENT#%s", m.AgentID)
 	m.SK = fmt.Sprintf("MINT_CONVERSATION#%s", m.ConversationID)
@@ -102,3 +127,183 @@ func (m *SoulAgentMintConversation) GetPK() string { return m.PK }
 
 // GetSK returns the sort key for SoulAgentMintConversation.
 func (m *SoulAgentMintConversation) GetSK() string { return m.SK }
+
+// SoulMintConversationAllowedStatuses returns statuses accepted by the store
+// model. It intentionally includes legacy "completed" for old records.
+func SoulMintConversationAllowedStatuses() []string {
+	return []string{
+		SoulMintConversationStatusCreated,
+		SoulMintConversationStatusInProgress,
+		SoulMintConversationStatusAssistantTurnReady,
+		SoulMintConversationStatusDeclarationExtractionPending,
+		SoulMintConversationStatusDeclarationReady,
+		SoulMintConversationStatusFailed,
+		SoulMintConversationStatusCompleted,
+	}
+}
+
+const soulMintConversationBlobPrefix = "b64:"
+
+// EncodeSoulMintConversationBlob stores bounded private transcript/declaration
+// payloads as opaque base64 strings so raw JSON is not accidentally projected.
+func EncodeSoulMintConversationBlob(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+	return soulMintConversationBlobPrefix + base64.StdEncoding.EncodeToString([]byte(trimmed))
+}
+
+// DecodeSoulMintConversationBlob decodes transcript/declaration payloads. It
+// retains compatibility with the pre-M2 base64 prefix format.
+func DecodeSoulMintConversationBlob(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" || !strings.HasPrefix(trimmed, soulMintConversationBlobPrefix) {
+		return trimmed
+	}
+	encoded := strings.TrimPrefix(trimmed, soulMintConversationBlobPrefix)
+	if decoded, err := base64.StdEncoding.DecodeString(encoded); err == nil {
+		return strings.TrimSpace(string(decoded))
+	}
+	return trimmed
+}
+
+const (
+	SoulMintConversationIdempotencyStatusProcessing = "processing"
+	SoulMintConversationIdempotencyStatusSucceeded  = "succeeded"
+	SoulMintConversationIdempotencyStatusFailed     = "failed"
+)
+
+// SoulMintConversationIdempotency reserves a caller-provided hosted-genesis
+// idempotency key without storing raw browser tokens, raw Instance API keys, or
+// raw transcript text.
+type SoulMintConversationIdempotency struct {
+	_ struct{} `theorydb:"naming:camelCase"`
+
+	PK  string `theorydb:"pk,attr:PK" json:"-"`
+	SK  string `theorydb:"sk,attr:SK" json:"-"`
+	TTL int64  `theorydb:"ttl,attr:ttl" json:"-"`
+
+	InstanceSlug   string `theorydb:"attr:instanceSlug" json:"instance_slug"`
+	RegistrationID string `theorydb:"attr:registrationId" json:"registration_id"`
+	AgentID        string `theorydb:"attr:agentId" json:"agent_id"`
+	ConversationID string `theorydb:"attr:conversationId" json:"conversation_id"`
+	TurnID         string `theorydb:"attr:turnId" json:"turn_id"`
+	IdempotencyKey string `theorydb:"attr:idempotencyKey" json:"idempotency_key"`
+	RequestHash    string `theorydb:"attr:requestHash" json:"request_hash"`
+	RequestID      string `theorydb:"attr:requestId" json:"request_id,omitempty"`
+	CorrelationID  string `theorydb:"attr:correlationId" json:"correlation_id,omitempty"`
+	Status         string `theorydb:"attr:status" json:"status"`
+
+	CreatedAt time.Time `theorydb:"attr:createdAt" json:"created_at"`
+	UpdatedAt time.Time `theorydb:"attr:updatedAt" json:"updated_at,omitempty"`
+}
+
+// TableName returns the database table name for SoulMintConversationIdempotency.
+func (SoulMintConversationIdempotency) TableName() string { return MainTableName() }
+
+// BeforeCreate sets defaults and keys before creating SoulMintConversationIdempotency.
+func (m *SoulMintConversationIdempotency) BeforeCreate() error {
+	now := time.Now().UTC()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = now
+	}
+	if m.UpdatedAt.IsZero() {
+		m.UpdatedAt = m.CreatedAt
+	}
+	if strings.TrimSpace(m.Status) == "" {
+		m.Status = SoulMintConversationIdempotencyStatusProcessing
+	}
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("registrationId", m.RegistrationID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("conversationId", m.ConversationID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("turnId", m.TurnID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("idempotencyKey", m.IdempotencyKey); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("requestHash", m.RequestHash); err != nil {
+		return err
+	}
+	return requireOneOf("status", m.Status, SoulMintConversationIdempotencyStatusProcessing, SoulMintConversationIdempotencyStatusSucceeded, SoulMintConversationIdempotencyStatusFailed)
+}
+
+// BeforeUpdate updates timestamps and keys before updating SoulMintConversationIdempotency.
+func (m *SoulMintConversationIdempotency) BeforeUpdate() error {
+	m.UpdatedAt = time.Now().UTC()
+	if err := m.UpdateKeys(); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("instanceSlug", m.InstanceSlug); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("registrationId", m.RegistrationID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("agentId", m.AgentID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("conversationId", m.ConversationID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("turnId", m.TurnID); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("idempotencyKey", m.IdempotencyKey); err != nil {
+		return err
+	}
+	if err := requireNonEmpty("requestHash", m.RequestHash); err != nil {
+		return err
+	}
+	return requireOneOf("status", m.Status, SoulMintConversationIdempotencyStatusProcessing, SoulMintConversationIdempotencyStatusSucceeded, SoulMintConversationIdempotencyStatusFailed)
+}
+
+// UpdateKeys updates the database keys for SoulMintConversationIdempotency.
+func (m *SoulMintConversationIdempotency) UpdateKeys() error {
+	m.InstanceSlug = strings.ToLower(strings.TrimSpace(m.InstanceSlug))
+	m.RegistrationID = strings.TrimSpace(m.RegistrationID)
+	m.AgentID = strings.ToLower(strings.TrimSpace(m.AgentID))
+	m.ConversationID = strings.TrimSpace(m.ConversationID)
+	m.TurnID = strings.TrimSpace(m.TurnID)
+	m.IdempotencyKey = strings.TrimSpace(m.IdempotencyKey)
+	m.RequestHash = strings.ToLower(strings.TrimSpace(m.RequestHash))
+	m.RequestID = strings.TrimSpace(m.RequestID)
+	m.CorrelationID = strings.TrimSpace(m.CorrelationID)
+	m.Status = strings.ToLower(strings.TrimSpace(m.Status))
+
+	m.PK = SoulMintConversationIdempotencyPK(m.InstanceSlug, m.RegistrationID, m.IdempotencyKey)
+	m.SK = stateSortKey
+	m.TTL = m.CreatedAt.UTC().Add(7 * 24 * time.Hour).Unix()
+	return nil
+}
+
+// GetPK returns the partition key for SoulMintConversationIdempotency.
+func (m *SoulMintConversationIdempotency) GetPK() string { return m.PK }
+
+// GetSK returns the sort key for SoulMintConversationIdempotency.
+func (m *SoulMintConversationIdempotency) GetSK() string { return m.SK }
+
+// SoulMintConversationIdempotencyPK returns the primary key used to reserve a
+// hosted-genesis idempotency key.
+func SoulMintConversationIdempotencyPK(instanceSlug string, registrationID string, idempotencyKey string) string {
+	scope := strings.Join([]string{
+		strings.ToLower(strings.TrimSpace(instanceSlug)),
+		strings.TrimSpace(registrationID),
+		strings.TrimSpace(idempotencyKey),
+	}, "#")
+	sum := sha256.Sum256([]byte(scope))
+	return "SOUL#MINT_CONVERSATION#IDEMPOTENCY#" + hex.EncodeToString(sum[:])
+}

--- a/internal/store/soul_mint_conversation.go
+++ b/internal/store/soul_mint_conversation.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// GetSoulAgentRegistration loads a soul agent registration by id.
+func (s *Store) GetSoulAgentRegistration(ctx context.Context, id string) (*models.SoulAgentRegistration, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	probe := &models.SoulAgentRegistration{ID: strings.TrimSpace(id)}
+	_ = probe.UpdateKeys()
+	var item models.SoulAgentRegistration
+	if err := s.DB.WithContext(ctx).
+		Model(&models.SoulAgentRegistration{}).
+		Where("PK", "=", probe.PK).
+		Where("SK", "=", probe.SK).
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// GetDomain loads a managed domain by normalized domain name.
+func (s *Store) GetDomain(ctx context.Context, domain string) (*models.Domain, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	var item models.Domain
+	if err := s.DB.WithContext(ctx).
+		Model(&models.Domain{}).
+		Where("PK", "=", fmt.Sprintf("DOMAIN#%s", strings.ToLower(strings.TrimSpace(domain)))).
+		Where("SK", "=", models.SKMetadata).
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// GetInstance loads instance metadata by slug.
+func (s *Store) GetInstance(ctx context.Context, slug string) (*models.Instance, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	var item models.Instance
+	if err := s.DB.WithContext(ctx).
+		Model(&models.Instance{}).
+		Where("PK", "=", fmt.Sprintf("INSTANCE#%s", strings.ToLower(strings.TrimSpace(slug)))).
+		Where("SK", "=", models.SKMetadata).
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// GetSoulAgentMintConversation loads a soul mint conversation by agent and conversation id.
+func (s *Store) GetSoulAgentMintConversation(ctx context.Context, agentID string, conversationID string) (*models.SoulAgentMintConversation, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	var item models.SoulAgentMintConversation
+	if err := s.DB.WithContext(ctx).
+		Model(&models.SoulAgentMintConversation{}).
+		Where("PK", "=", fmt.Sprintf("SOUL#AGENT#%s", strings.ToLower(strings.TrimSpace(agentID)))).
+		Where("SK", "=", fmt.Sprintf("MINT_CONVERSATION#%s", strings.TrimSpace(conversationID))).
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}
+
+// PutSoulAgentMintConversation stores a soul mint conversation record.
+func (s *Store) PutSoulAgentMintConversation(ctx context.Context, item *models.SoulAgentMintConversation) error {
+	if s == nil || s.DB == nil || item == nil {
+		return theoryErrors.ErrItemNotFound
+	}
+	return s.DB.WithContext(ctx).Model(item).CreateOrUpdate()
+}
+
+// GetSoulMintConversationIdempotency loads a hosted-genesis idempotency reservation.
+func (s *Store) GetSoulMintConversationIdempotency(ctx context.Context, instanceSlug string, registrationID string, idempotencyKey string) (*models.SoulMintConversationIdempotency, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	var item models.SoulMintConversationIdempotency
+	if err := s.DB.WithContext(ctx).
+		Model(&models.SoulMintConversationIdempotency{}).
+		Where("PK", "=", models.SoulMintConversationIdempotencyPK(instanceSlug, registrationID, idempotencyKey)).
+		Where("SK", "=", "STATE").
+		First(&item); err != nil {
+		return nil, err
+	}
+	return &item, nil
+}

--- a/web/scripts/verify-lesser-host-contracts.mjs
+++ b/web/scripts/verify-lesser-host-contracts.mjs
@@ -15,6 +15,7 @@ const openapiPath = path.join(repoRoot, 'docs', 'contracts', 'openapi.yaml');
 const sseContractPath = path.join(repoRoot, 'docs', 'contracts', 'soul-mint-conversation-sse.json');
 const specV3SchemasDir = path.join(repoRoot, 'docs', 'spec', 'v3', 'schemas');
 const specV3FixturesDir = path.join(repoRoot, 'docs', 'spec', 'v3', 'fixtures');
+const hostedGenesisContractPath = path.join(repoRoot, 'docs', 'contracts', 'hosted-genesis-conversation.md');
 const generatedAdapterPath = path.join(webDir, 'src', 'lib', 'greater', 'adapters', 'rest', 'generated', 'lesser-host-api.ts');
 const openapiTypescriptBin = path.join(webDir, 'node_modules', '.bin', 'openapi-typescript');
 
@@ -157,8 +158,11 @@ function verifyOpenApiSurface() {
     openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation']?.post;
   const instanceGet =
     openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}']?.get;
+  const instanceComplete =
+    openapi.paths['/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete']?.post;
   assert(instancePost, 'missing instance-key registration mint-conversation POST operation');
   assert(instanceGet, 'missing instance-key registration mint-conversation GET operation');
+  assert(instanceComplete, 'missing instance-key registration mint-conversation complete operation');
   assert(
     instancePost.operationId === 'soulInstanceStartRegistrationMintConversation',
     'instance-key registration mint-conversation POST must not be locked to an SSE operation id'
@@ -187,6 +191,18 @@ function verifyOpenApiSurface() {
     instancePost?.requestBody?.content?.['application/json']?.schema?.$ref ===
       '#/components/schemas/SoulHostedGenesisMintConversationRequest',
     'instance-key registration mint-conversation POST must use the hosted-genesis JSON request schema'
+  );
+  assert(
+    openapi.components?.schemas?.SoulHostedGenesisMintConversationRequest?.properties?.lesser_request_id,
+    'hosted-genesis POST request schema must include optional lesser_request_id for trace echoing'
+  );
+  assert(
+    jsonSchemaRef(instanceComplete, '202', 'application/json') === '#/components/schemas/SoulHostedGenesisConversationResponse',
+    'instance-key registration mint-conversation complete 202 must return progress-safe HostConversation JSON'
+  );
+  assert(
+    jsonSchemaRef(instanceComplete, '200', 'application/json') === '#/components/schemas/SoulHostedGenesisConversationResponse',
+    'instance-key registration mint-conversation complete 200 must return compact HostConversation JSON without raw transcript fields'
   );
 
   for (const route of requiredInstanceBootstrapPaths) {
@@ -297,6 +313,13 @@ function assertHostedGenesisConversationExample(file, expectedStatus) {
 }
 
 function verifyHostedGenesisConversationSurface() {
+  const contractDoc = readFileSync(hostedGenesisContractPath, 'utf8');
+  assert(
+    contractDoc.includes('collapses `created` to `in_progress`') ||
+      contractDoc.includes('collapses `created` snapshots'),
+    'hosted-genesis contract must document the Lesser projection decision for created status'
+  );
+
   const schema = JSON.parse(readFileSync(path.join(specV3SchemasDir, 'hosted-genesis.conversation.response.schema.json'), 'utf8'));
   const statusEnum = schema?.$defs?.status?.enum ?? [];
   for (const status of [

--- a/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
+++ b/web/src/lib/greater/adapters/rest/generated/lesser-host-api.ts
@@ -512,10 +512,12 @@ export interface paths {
         /**
          * Complete or replay an instance-key registration mint conversation
          * @description Server-to-server route for managed Lesser instances. Completes a conversation inside the authenticated instance
-         *     boundary and persists the produced declarations for finalize preflight/finalize. If the stored conversation is
-         *     already `completed` and has valid produced declarations, the route is idempotent and returns the completed
-         *     conversation without re-extracting or rewriting declarations. Failed conversations and completed conversations
-         *     without valid produced declarations fail closed with structured state details.
+         *     boundary and persists the produced declarations for finalize preflight/finalize. If Host has accepted the turn
+         *     but the assistant turn or declaration extraction is not ready yet, this route returns `202` plus the durable
+         *     HostConversation progress envelope; HTTP success is not terminal. If the stored conversation is already
+         *     `completed`/`declaration_ready` and has valid produced declarations, the route is idempotent and returns the
+         *     compact HostConversation declaration-ready envelope without re-extracting or rewriting declarations. Failed conversations and completed
+         *     conversations without valid produced declarations fail closed with structured state details.
          */
         post: operations["soulInstanceCompleteRegistrationMintConversation"];
         delete?: never;
@@ -1108,7 +1110,7 @@ export interface components {
                 details?: {
                     reason?: string;
                     /** @enum {string} */
-                    conversation_status?: "unknown" | "pending" | "in_progress" | "completed" | "failed";
+                    conversation_status?: "unknown" | "pending" | "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "completed" | "failed";
                     expected_status?: string;
                     produced_declarations_present?: boolean;
                     produced_declarations_valid?: boolean;
@@ -1368,7 +1370,7 @@ export interface components {
             principal_address?: string;
             latest_conversation_id?: string;
             /** @enum {string} */
-            latest_conversation_status?: "in_progress" | "completed" | "failed";
+            latest_conversation_status?: "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "completed" | "failed";
             latest_review_sha256?: string;
             latest_boundary_count?: number;
             latest_capability_count?: number;
@@ -1512,6 +1514,7 @@ export interface components {
             message: string;
             idempotency_key?: string;
             correlation_id?: string;
+            lesser_request_id?: string;
         };
         SoulHostedGenesisConversationResponse: components["schemas"]["hosted-genesis.conversation.response.schema"];
         SoulMintConversation: {
@@ -1520,8 +1523,11 @@ export interface components {
             model: string;
             messages?: string;
             produced_declarations?: string;
-            /** @enum {string} */
-            status: "in_progress" | "completed" | "failed";
+            /**
+             * @description Legacy raw Host record status. `completed` is retained for backward compatibility and maps to the durable hosted-genesis contract status `declaration_ready` only when valid produced declarations exist.
+             * @enum {string}
+             */
+            status: "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "completed" | "failed";
             usage?: components["schemas"]["AIUsage"];
             charged_credits?: number;
             /** Format: date-time */
@@ -1543,7 +1549,7 @@ export interface components {
             conversation_id: string;
             model?: string;
             /** @enum {string} */
-            status: "in_progress" | "completed" | "failed";
+            status: "created" | "in_progress" | "assistant_turn_ready" | "declaration_extraction_pending" | "declaration_ready" | "completed" | "failed";
             usage?: components["schemas"]["AIUsage"];
             charged_credits?: number;
             /** Format: date-time */
@@ -4494,13 +4500,22 @@ export interface operations {
             };
         };
         responses: {
-            /** @description OK */
+            /** @description Terminal replay or synchronous completion with valid produced declarations; returns the compact HostConversation envelope and never raw transcript fields. */
             200: {
                 headers: {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SoulMintConversation"];
+                    "application/json": components["schemas"]["hosted-genesis.conversation.response.schema"];
+                };
+            };
+            /** @description Assistant turn or declaration extraction is still in progress; inspect `conversation.status`. */
+            202: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["hosted-genesis.conversation.response.schema"];
                 };
             };
             /** @description Invalid request */


### PR DESCRIPTION
Staging→main promotion (operator-merged).

Promotes lesser-host **staging** (`4d5018d`) to **main**. Content: P49 **M2** — durable async hosted-genesis conversation API (#747, closes #731-#735): durable status model/projection, JSON in_progress progress response (SSE no longer authoritative for the Lesser path), async worker/queue + idempotency, progress-safe complete + fail-closed finalize, CDK/routes/contracts/docs. CI green (go-test, golangci-lint, cdk-synth, contracts-compile, contract-verify, web-build, gov-rubric 40/0/0).

`created` decision: Host keeps `created` in the enum (internal/future); Lesser instance-key projection collapses it to `in_progress`.

M1.1 (#745) already promoted via #746. **Deploy/lab-canary is a separate operator step after merge** (M6). Prepared by factory; merge to main is operator-owned.