### PR TITLE
fix: guard live deploys against missing lesser.host domain

### DIFF
--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -560,6 +560,10 @@ function deployTemplatePlaceholderGuardPath(): string {
 	return join(process.cwd(), '..', 'scripts', 'validate-deploy-template-placeholders.mjs');
 }
 
+function liveDomainTemplateGuardPath(): string {
+	return join(process.cwd(), '..', 'scripts', 'validate-live-domain-template.mjs');
+}
+
 function writeTemplateGuardFixture(template: SynthesizedTemplate): { path: string; cleanup: () => void } {
 	const outdir = mkdtempSync(join(tmpdir(), 'lesser-host-template-guard-'));
 	const templatePath = join(outdir, 'template.json');
@@ -582,6 +586,16 @@ function runHostedGenesisTemplateGuard(templatePath: string): { status: number |
 
 function runDeployTemplatePlaceholderGuard(templatePath: string): { status: number | null; stderr: string } {
 	const result = spawnSync(process.execPath, [deployTemplatePlaceholderGuardPath(), templatePath], {
+		encoding: 'utf8',
+	});
+	return {
+		status: result.status,
+		stderr: result.stderr,
+	};
+}
+
+function runLiveDomainTemplateGuard(stage: string, templatePath: string): { status: number | null; stderr: string } {
+	const result = spawnSync(process.execPath, [liveDomainTemplateGuardPath(), stage, templatePath], {
 		encoding: 'utf8',
 	});
 	return {
@@ -703,6 +717,50 @@ test('deploy template placeholder guard rejects placeholder org vending env wiri
 		const result = runDeployTemplatePlaceholderGuard(fixture.path);
 		assert.notEqual(result.status, 0, 'expected placeholder env wiring to fail deploy template guard');
 		assert.match(result.stderr, /MANAGED_ORG_VENDING_ROLE_ARN/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('live custom-domain deploy guard rejects synthesized live templates without domain context', () => {
+	const fixture = writeTemplateGuardFixture(synthTemplateForStage('live'));
+	try {
+		const result = runLiveDomainTemplateGuard('live', fixture.path);
+		assert.notEqual(result.status, 0, 'expected no-domain live template to fail live custom-domain guard');
+		assert.match(result.stderr, /cdk\/cdk\.context\.local\.json/);
+		assert.match(result.stderr, /webHostedZoneId/);
+		assert.match(result.stderr, /missing Aliases entry lesser\.host/);
+		assert.match(result.stderr, /missing Route53 apex A record/);
+		assert.match(result.stderr, /PUBLIC_BASE_URL/);
+		assert.match(result.stderr, /WebUrl output/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('live custom-domain deploy guard accepts domain-backed synthesized live templates', () => {
+	const fixture = writeTemplateGuardFixture(synthTemplateForStage('live', {
+		webHostedZoneId: 'ZEXAMPLELESSERHOST',
+		webHostedZoneName: 'lesser.host',
+	}));
+	try {
+		const result = runLiveDomainTemplateGuard('live', fixture.path);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stderr, /preserves lesser\.host CloudFront alias/);
+		assert.match(result.stderr, /ACM viewer certificate/);
+		assert.match(result.stderr, /Route53 A\/AAAA records/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('live custom-domain deploy guard skips lab templates intentionally', () => {
+	const fixture = writeTemplateGuardFixture(synthTemplate());
+	try {
+		const result = runLiveDomainTemplateGuard('lab', fixture.path);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stderr, /skipped stage lab/);
+		assert.match(result.stderr, /only live is required to preserve lesser\.host/);
 	} finally {
 		fixture.cleanup();
 	}

--- a/docs/runbook-live-custom-domain-deploy-guard.md
+++ b/docs/runbook-live-custom-domain-deploy-guard.md
@@ -1,0 +1,84 @@
+# Live custom-domain deploy guard runbook
+
+## Purpose
+
+The live `lesser.host` stack must always preserve the canonical first-party Host domain. A live deploy is unsafe if the
+synthesized CloudFormation artifact would remove the `lesser.host` CloudFront alias, ACM viewer certificate, Route53 A /
+AAAA records, or runtime URLs.
+
+## Required operator-local context
+
+Live deploys require operator-local CDK context in `cdk/cdk.context.local.json`. Do not commit that file. At minimum, the
+file must provide a real `webHostedZoneId` for the `lesser.host` hosted zone, with `webHostedZoneName` left as or set to
+`lesser.host`.
+
+Safe shape:
+
+```json
+{
+  "context": {
+    "webHostedZoneId": "<operator-local-lesser-host-zone-id>",
+    "webHostedZoneName": "lesser.host"
+  }
+}
+```
+
+The repository intentionally keeps `webHostedZoneId` empty in `cdk/cdk.json` and
+`cdk/cdk.context.local.json.example` so private Route53 values do not enter git.
+
+## What the guard checks
+
+`scripts/app-theory-cdk.sh up live` synthesizes a fresh Cloud Assembly and then runs
+`scripts/validate-live-domain-template.mjs live <template>` before `cdk deploy`. The validator inspects the synthesized
+template artifact and fails before CloudFormation mutation unless all of the following are true:
+
+- the CloudFront distribution has alias `lesser.host`;
+- the viewer certificate is ACM-backed, not the CloudFront default certificate;
+- Route53 apex A and AAAA records for `lesser.host` are present;
+- every live Lambda `PUBLIC_BASE_URL` value in the template is `https://lesser.host`;
+- the `WebUrl` output is `https://lesser.host`.
+
+Lab/open-source behavior remains intentional: the validator skips non-live stages, so a lab template without
+operator-local hosted-zone context can continue to use a CloudFront distribution URL.
+
+## Non-mutating proof commands
+
+These commands synthesize and validate artifacts only. They do not deploy.
+
+```bash
+cd cdk
+npm run build
+npx cdk synth -c stage=live --output .build/live-nodomain
+node ../scripts/validate-live-domain-template.mjs live .build/live-nodomain/lesser-host-live.template.json
+```
+
+Expected result: failure. The error names `cdk/cdk.context.local.json` and `webHostedZoneId`.
+
+```bash
+cd cdk
+npm run build
+npx cdk synth \
+  -c stage=live \
+  -c webHostedZoneId=ZEXAMPLELESSERHOST \
+  -c webHostedZoneName=lesser.host \
+  --output .build/live-domain
+node ../scripts/validate-live-domain-template.mjs live .build/live-domain/lesser-host-live.template.json
+```
+
+Expected result: success. `ZEXAMPLELESSERHOST` is a fake test value for local proof only; do not put operational values in
+git.
+
+For the AppTheory wrapper preflight without CloudFormation mutation:
+
+```bash
+LESSER_HOST_CDK_DRY_RUN=1 AWS_PROFILE=<operator-profile> theory app up --stage live --execute
+```
+
+Actual live deploys remain operator-authorized only. Never set a timeout on a CDK deploy.
+
+## Incident encoded by this guard
+
+On 2026-06-23, a live deploy was run after the gitignored operator-local context was missing. Because `webHostedZoneId`
+was absent, the live template omitted the custom-domain resources and CloudFormation deleted `WebAliasA`,
+`WebAliasAAAA`, and `WebCertificate`. Route53 apex had only NS/SOA records, CloudFront had `Aliases.Quantity = 0` with
+`CloudFrontDefaultCertificate = true`, and Sim SSR failed DNS lookup for `lesser.host`.

--- a/scripts/app-theory-cdk.sh
+++ b/scripts/app-theory-cdk.sh
@@ -87,6 +87,7 @@ case "$action" in
     fi
     "$repo_root/scripts/validate-hosted-genesis-template.mjs" "$template_path"
     "$repo_root/scripts/validate-deploy-template-placeholders.mjs" "$template_path"
+    "$repo_root/scripts/validate-live-domain-template.mjs" "$stage" "$template_path"
     "$repo_root/scripts/validate-cfn-dependency-cycles.mjs" "$template_path"
 
     if [ "${LESSER_HOST_CDK_DRY_RUN:-}" = "1" ]; then

--- a/scripts/validate-live-domain-template.mjs
+++ b/scripts/validate-live-domain-template.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+import { readFileSync } from 'node:fs';
+
+const canonicalDomain = 'lesser.host';
+const canonicalUrl = `https://${canonicalDomain}`;
+
+function usage() {
+	console.error('usage: validate-live-domain-template.mjs <stage> <cloudformation-template.json>');
+}
+
+function fail(details) {
+	const detailText = details.length > 0 ? details.join('; ') : 'unknown validation failure';
+	console.error(
+		`live custom-domain guard: synthesized live template would omit or remove the canonical first-party Host domain ${canonicalDomain}; refusing before cdk deploy. Ensure cdk/cdk.context.local.json contains a valid webHostedZoneId for ${canonicalDomain}. Details: ${detailText}`,
+	);
+	process.exit(1);
+}
+
+function asRecord(value) {
+	return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function valueSummary(value) {
+	if (typeof value === 'string') return value;
+	if (value === undefined) return '<missing>';
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function normalizedDnsName(value) {
+	return typeof value === 'string' ? value.trim().replace(/\.$/, '').toLowerCase() : '';
+}
+
+function arrayIncludesString(value, expected) {
+	return Array.isArray(value) && value.some((entry) => typeof entry === 'string' && entry === expected);
+}
+
+const stage = process.argv[2]?.trim().toLowerCase();
+const templatePath = process.argv[3];
+if (!stage || !templatePath || process.argv.length !== 4) {
+	usage();
+	process.exit(2);
+}
+
+if (stage !== 'live') {
+	console.error(
+		`live custom-domain guard: skipped stage ${stage}; only live is required to preserve ${canonicalDomain}`,
+	);
+	process.exit(0);
+}
+
+let template;
+try {
+	template = JSON.parse(readFileSync(templatePath, 'utf8'));
+} catch (err) {
+	fail([`failed to read template ${templatePath}: ${err instanceof Error ? err.message : String(err)}`]);
+}
+
+const resources = asRecord(template.Resources);
+const outputs = asRecord(template.Outputs);
+const resourceEntries = Object.entries(resources).map(([logicalId, resource]) => [logicalId, asRecord(resource)]);
+const problems = [];
+
+const distributions = resourceEntries.filter(([, resource]) => resource.Type === 'AWS::CloudFront::Distribution');
+if (distributions.length !== 1) {
+	problems.push(`expected exactly one CloudFront distribution, found ${distributions.length}`);
+} else {
+	const distributionConfig = asRecord(asRecord(distributions[0][1].Properties).DistributionConfig);
+	if (!arrayIncludesString(distributionConfig.Aliases, canonicalDomain)) {
+		problems.push(
+			`CloudFront distribution is missing Aliases entry ${canonicalDomain} (got ${valueSummary(distributionConfig.Aliases)})`,
+		);
+	}
+
+	const viewerCertificate = asRecord(distributionConfig.ViewerCertificate);
+	if (viewerCertificate.CloudFrontDefaultCertificate === true) {
+		problems.push('CloudFront distribution uses CloudFrontDefaultCertificate=true');
+	}
+	if (!Object.prototype.hasOwnProperty.call(viewerCertificate, 'AcmCertificateArn')) {
+		problems.push(
+			`CloudFront distribution viewer certificate is not ACM-backed (ViewerCertificate ${valueSummary(distributionConfig.ViewerCertificate)})`,
+		);
+	}
+}
+
+const recordSets = resourceEntries.filter(([, resource]) => resource.Type === 'AWS::Route53::RecordSet');
+const hasApexRecord = (type) =>
+	recordSets.some(([, resource]) => {
+		const properties = asRecord(resource.Properties);
+		return properties.Type === type && normalizedDnsName(properties.Name) === canonicalDomain;
+	});
+if (!hasApexRecord('A')) {
+	problems.push(`missing Route53 apex A record for ${canonicalDomain}`);
+}
+if (!hasApexRecord('AAAA')) {
+	problems.push(`missing Route53 apex AAAA record for ${canonicalDomain}`);
+}
+
+const lambdaPublicBaseUrls = resourceEntries
+	.filter(([, resource]) => resource.Type === 'AWS::Lambda::Function')
+	.map(([logicalId, resource]) => {
+		const variables = asRecord(asRecord(asRecord(resource.Properties).Environment).Variables);
+		return [logicalId, variables.PUBLIC_BASE_URL];
+	})
+	.filter(([, value]) => value !== undefined);
+if (lambdaPublicBaseUrls.length === 0) {
+	problems.push('no Lambda PUBLIC_BASE_URL runtime environment values found');
+}
+for (const [logicalId, value] of lambdaPublicBaseUrls) {
+	if (value !== canonicalUrl) {
+		problems.push(`Lambda ${logicalId} PUBLIC_BASE_URL is ${valueSummary(value)}, expected ${canonicalUrl}`);
+	}
+}
+
+const webUrlOutput = asRecord(outputs.WebUrl).Value;
+if (webUrlOutput !== canonicalUrl) {
+	problems.push(`WebUrl output is ${valueSummary(webUrlOutput)}, expected ${canonicalUrl}`);
+}
+
+if (problems.length > 0) {
+	fail(problems);
+}
+
+console.error(
+	`live custom-domain guard: OK synthesized live template preserves ${canonicalDomain} CloudFront alias, ACM viewer certificate, Route53 A/AAAA records, PUBLIC_BASE_URL, and WebUrl`,
+);


### PR DESCRIPTION
## Milestone
Project 49 live custom-domain deploy guard — make missing live `webHostedZoneId` fail before CloudFormation mutation.

## Classification
Operational reliability / deploy safety / security invariant.

## Surfaces affected
- `scripts/app-theory-cdk.sh`
- `scripts/validate-live-domain-template.mjs`
- `cdk/test/lesser-host-stack.test.ts`
- `docs/runbook-live-custom-domain-deploy-guard.md`

## Specialist walks referenced
- Governance rubric: no verifier/pack change.
- Provisioning / managed-update / release verification: not touched.
- Soul registry: none.
- Trust API / CSP / instance-auth: none.
- Framework: no local framework patch.

## Multi-tenant isolation impact
None. This only validates host live deploy artifacts before deploy.

## On-chain impact
None.

## Consumer impact
Protects `lesser.host` live first-party domain availability for Host/Sim/Lesser integration after Project 49.

## Tasks
- [x] Add artifact-inspecting live custom-domain template guard.
- [x] Wire guard into the AppTheory CDK wrapper before `cdk deploy`.
- [x] Add deterministic CDK tests for no-domain rejection, domain-backed pass, and lab skip behavior.
- [x] Document the live operator-local domain context runbook.

## Validation
- `node scripts/validate-live-domain-template.mjs live cdk/.build/inspect-live-nodomain/lesser-host-live.template.json` exits 1 and names `cdk/cdk.context.local.json` + `webHostedZoneId`; rejects missing CloudFront alias, ACM viewer certificate, Route53 A/AAAA, runtime `PUBLIC_BASE_URL`, and `WebUrl`.
- `node scripts/validate-live-domain-template.mjs live cdk/.build/inspect-live-domain/lesser-host-live.template.json` exits 0 with fake `ZEXAMPLELESSERHOST` domain context.
- `node --test --test-name-pattern 'live custom-domain deploy guard' dist/test/lesser-host-stack.test.js` — PASS 3/3.
- `cd cdk && npm test` — PASS 46/46.
- `LESSER_HOST_CDK_DRY_RUN=1 AWS_PROFILE=Lesser scripts/app-theory-cdk.sh up live` exits 1 before deploy on missing local domain context; no cloud mutation/deploy.
- `git diff --check` — PASS.
- `git ls-files '*.go' | xargs -r gofmt -l` — empty.

## Stage rollout plan (handoff after merge)
- [ ] Merged to staging after review + CI.
- [ ] Promoted from staging to main by operator.
- [ ] Operator verifies `cdk/cdk.context.local.json` contains live `webHostedZoneId`.
- [ ] Lab deploy/soak if required by operator.
- [ ] Live deploy only with explicit operator authorization; no CDK timeout.

## Cross-repo coordination
No sibling repo edits. This guards Host deploy safety for Sim/Lesser/Host integration.

## Notes
No DNS recovery, CloudFormation, ACM, Route53, CloudFront, SQS, or deploy mutation performed. No private operational values committed.

Closes #757