### PR TITLE
fix: default live lesser.host domain resolution

### DIFF
--- a/cdk/lib/lesser-host-stack.ts
+++ b/cdk/lib/lesser-host-stack.ts
@@ -1208,8 +1208,7 @@ export class LesserHostStack extends cdk.Stack {
 
 		const webRootDomain = (this.node.tryGetContext('webRootDomain') as string | undefined) ?? 'lesser.host';
 		const webHostedZoneId = sanitizedOptionalContextString(this.node.tryGetContext('webHostedZoneId'));
-		const webHostedZoneName =
-			(this.node.tryGetContext('webHostedZoneName') as string | undefined) ?? webRootDomain;
+		const webHostedZoneName = (this.node.tryGetContext('webHostedZoneName') as string | undefined) ?? webRootDomain;
 		const webDomainName = stage === 'live' ? webRootDomain : `${stage}.${webRootDomain}`;
 
 		const webBucket = new s3.Bucket(this, 'WebBucket', {
@@ -1397,14 +1396,17 @@ export class LesserHostStack extends cdk.Stack {
 }`),
 		});
 
-		let webZone: route53.IHostedZone | undefined;
-		let webCert: acm.ICertificate | undefined;
+		let webZone: route53.IHostedZone | undefined; let webCert: acm.ICertificate | undefined;
 		if (webHostedZoneId.trim()) {
 			webZone = route53.HostedZone.fromHostedZoneAttributes(this, 'WebHostedZone', {
 				hostedZoneId: webHostedZoneId.trim(),
 				zoneName: webHostedZoneName.trim() || webRootDomain,
 			});
+		} else if (stage === 'live') {
+			webZone = route53.HostedZone.fromLookup(this, 'WebHostedZone', { domainName: webHostedZoneName.trim() || webRootDomain, privateZone: false });
+		}
 
+		if (webZone) {
 			webCert = new acm.DnsValidatedCertificate(this, 'WebCertificate', {
 				domainName: webDomainName,
 				hostedZone: webZone,

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -27,6 +27,15 @@ import {
 
 process.env.GOTOOLCHAIN = process.env.GOTOOLCHAIN || 'auto';
 
+const liveLookupAccount = '123456789012';
+const liveLookupRegion = 'us-east-1';
+const liveLookupHostedZoneId = 'ZEXAMPLELESSERHOST';
+const liveLookupContextKey = `hosted-zone:account=${liveLookupAccount}:domainName=lesser.host:privateZone=false:region=${liveLookupRegion}`;
+const liveLookupContext = {
+	[liveLookupContextKey]: { Id: `/hostedzone/${liveLookupHostedZoneId}`, Name: 'lesser.host.' },
+};
+const liveStackEnv = { account: liveLookupAccount, region: liveLookupRegion };
+
 type SynthesizedTemplate = {
 	Resources?: Record<string, { Type?: string; Properties?: Record<string, unknown> }>;
 	Outputs?: Record<string, unknown>;
@@ -34,14 +43,14 @@ type SynthesizedTemplate = {
 
 let synthesizedTemplate: SynthesizedTemplate | undefined;
 
-function synthesizeTemplate(stage: string, context: Record<string, unknown>, stackId: string): SynthesizedTemplate {
+function synthesizeTemplate(stage: string, context: Record<string, unknown>, stackId: string, props: cdk.StackProps = {}): SynthesizedTemplate {
 	// Full LesserHostStack synthesis stages web assets. Keep each test synth in
 	// its own short-lived outdir so repeated assertions cannot accumulate
 	// copied web/CDK asset directories and exhaust hosted runner disk.
 	const outdir = mkdtempSync(join(tmpdir(), 'lesser-host-cdk-test-'));
 	try {
 		const app = new cdk.App({ context, outdir });
-		const stack = new LesserHostStack(app, stackId, { stage });
+		const stack = new LesserHostStack(app, stackId, { stage, ...props });
 		const assembly = app.synth();
 		const artifact = assembly.getStackArtifact(stack.artifactId);
 		return JSON.parse(readFileSync(artifact.templateFullPath, 'utf8')) as SynthesizedTemplate;
@@ -62,10 +71,11 @@ function synthTemplateWithContext(context: Record<string, unknown>): Synthesized
 }
 
 function synthTemplateForStage(stage: string, context: Record<string, unknown> = {}): SynthesizedTemplate {
-	if (Object.keys(context).length === 0 && stage.trim() !== 'live') {
+	const isLive = stage.trim() === 'live';
+	if (Object.keys(context).length === 0 && !isLive) {
 		return synthTemplate();
 	}
-	return synthesizeTemplate(stage, context, `TestLesserHostStack-${stage}`);
+	return synthesizeTemplate(stage, isLive ? { ...liveLookupContext, ...context } : context, `TestLesserHostStack-${stage}`, isLive ? { env: liveStackEnv } : {});
 }
 
 function runDependencyCycleValidator(template: Record<string, unknown>) {
@@ -660,6 +670,30 @@ function withPlaceholderManagedOrgVendingEnv(template: SynthesizedTemplate): Syn
 	return copy;
 }
 
+function normalizedDnsName(value: unknown): string {
+	return typeof value === 'string' ? value.trim().replace(/\.$/, '').toLowerCase() : '';
+}
+
+function withoutLiveDomainBindings(template: SynthesizedTemplate): SynthesizedTemplate {
+	const copy = JSON.parse(JSON.stringify(template)) as SynthesizedTemplate;
+	for (const [, resource] of findResourceEntries(copy, 'AWS::CloudFront::Distribution')) {
+		const config = (resource.Properties?.DistributionConfig ?? {}) as Record<string, unknown>;
+		delete config.Aliases;
+		config.ViewerCertificate = { CloudFrontDefaultCertificate: true };
+	}
+	for (const [logicalId, resource] of findResourceEntries(copy, 'AWS::Route53::RecordSet')) {
+		if (logicalId.startsWith('WebAlias') || normalizedDnsName(resource.Properties?.Name) === 'lesser.host') {
+			delete copy.Resources?.[logicalId];
+		}
+	}
+	for (const [, resource] of findResourceEntries(copy, 'AWS::Lambda::Function')) {
+		const variables = ((resource.Properties?.Environment as { Variables?: Record<string, unknown> } | undefined)?.Variables) ?? {};
+		if (variables.PUBLIC_BASE_URL !== undefined) variables.PUBLIC_BASE_URL = 'https://d111111abcdef8.cloudfront.net';
+	}
+	(copy.Outputs!.WebUrl as { Value?: unknown }).Value = 'https://d111111abcdef8.cloudfront.net';
+	return copy;
+}
+
 test('hosted genesis deploy preflight validator accepts the synthesized M2 template', () => {
 	const fixture = writeTemplateGuardFixture(synthTemplate());
 	try {
@@ -722,13 +756,40 @@ test('deploy template placeholder guard rejects placeholder org vending env wiri
 	}
 });
 
-test('live custom-domain deploy guard rejects synthesized live templates without domain context', () => {
-	const fixture = writeTemplateGuardFixture(synthTemplateForStage('live'));
+test('live synthesizes lesser.host by default without local webHostedZoneId context', () => {
+	const template = synthTemplateForStage('live');
+	const config = distributionConfig(template) as DistributionConfig & { Aliases?: unknown; ViewerCertificate?: Record<string, unknown> };
+	assert.deepEqual(config.Aliases, ['lesser.host']);
+	assert.ok(config.ViewerCertificate && 'AcmCertificateArn' in config.ViewerCertificate);
+
+	const apexRecords = findResources(template, 'AWS::Route53::RecordSet').filter((record) =>
+		normalizedDnsName(record.Name) === 'lesser.host'
+	);
+	assert.deepEqual(new Set(apexRecords.map((record) => record.Type)), new Set(['A', 'AAAA']));
+	const publicBaseUrls = findResources(template, 'AWS::Lambda::Function')
+		.map((fn) => lambdaEnvironment(fn).PUBLIC_BASE_URL)
+		.filter((value) => value !== undefined);
+	assert.ok(publicBaseUrls.length > 0, 'expected live lambdas to receive PUBLIC_BASE_URL');
+	assert.ok(publicBaseUrls.every((value) => value === 'https://lesser.host'));
+	assert.equal((template.Outputs?.WebUrl as { Value?: unknown } | undefined)?.Value, 'https://lesser.host');
+
+	const fixture = writeTemplateGuardFixture(template);
 	try {
 		const result = runLiveDomainTemplateGuard('live', fixture.path);
-		assert.notEqual(result.status, 0, 'expected no-domain live template to fail live custom-domain guard');
-		assert.match(result.stderr, /cdk\/cdk\.context\.local\.json/);
-		assert.match(result.stderr, /webHostedZoneId/);
+		assert.equal(result.status, 0, result.stderr);
+		assert.match(result.stderr, /preserves lesser\.host CloudFront alias/);
+	} finally {
+		fixture.cleanup();
+	}
+});
+
+test('live custom-domain deploy guard remains a backstop for broken domain resolution', () => {
+	const fixture = writeTemplateGuardFixture(withoutLiveDomainBindings(synthTemplateForStage('live')));
+	try {
+		const result = runLiveDomainTemplateGuard('live', fixture.path);
+		assert.notEqual(result.status, 0, 'expected broken live template to fail live custom-domain guard');
+		assert.doesNotMatch(result.stderr, /cdk\/cdk\.context\.local\.json/);
+		assert.match(result.stderr, /domain resolution is broken or AWS hosted-zone lookup\/profile access is unavailable/);
 		assert.match(result.stderr, /missing Aliases entry lesser\.host/);
 		assert.match(result.stderr, /missing Route53 apex A record/);
 		assert.match(result.stderr, /PUBLIC_BASE_URL/);
@@ -738,11 +799,13 @@ test('live custom-domain deploy guard rejects synthesized live templates without
 	}
 });
 
-test('live custom-domain deploy guard accepts domain-backed synthesized live templates', () => {
-	const fixture = writeTemplateGuardFixture(synthTemplateForStage('live', {
-		webHostedZoneId: 'ZEXAMPLELESSERHOST',
+test('live custom-domain deploy guard accepts explicit diagnostic hosted-zone context', () => {
+	const template = synthTemplateForStage('live', {
+		webHostedZoneId: 'ZEXPLICITLESSERHOST',
 		webHostedZoneName: 'lesser.host',
-	}));
+	});
+	assert.ok(findResources(template, 'AWS::Route53::RecordSet').some((record) => record.HostedZoneId === 'ZEXPLICITLESSERHOST'));
+	const fixture = writeTemplateGuardFixture(template);
 	try {
 		const result = runLiveDomainTemplateGuard('live', fixture.path);
 		assert.equal(result.status, 0, result.stderr);

--- a/docs/runbook-live-custom-domain-deploy-guard.md
+++ b/docs/runbook-live-custom-domain-deploy-guard.md
@@ -6,25 +6,19 @@ The live `lesser.host` stack must always preserve the canonical first-party Host
 synthesized CloudFormation artifact would remove the `lesser.host` CloudFront alias, ACM viewer certificate, Route53 A /
 AAAA records, or runtime URLs.
 
-## Required operator-local context
+## Default live domain resolution
 
-Live deploys require operator-local CDK context in `cdk/cdk.context.local.json`. Do not commit that file. At minimum, the
-file must provide a real `webHostedZoneId` for the `lesser.host` hosted zone, with `webHostedZoneName` left as or set to
-`lesser.host`.
+Normal live synth/deploy must resolve the canonical hosted zone by domain and synthesize `lesser.host` by construction.
+Operators should not need `cdk/cdk.context.local.json` or an explicit `-c webHostedZoneId=...` override for the standard
+live path. With the real deploy AWS profile available, `scripts/app-theory-cdk.sh up live` performs a non-mutating
+Route53 hosted-zone lookup for `lesser.host` during synth and then validates the resulting template before deploy.
 
-Safe shape:
+Explicit `webHostedZoneId` / `webHostedZoneName` context remains available only for diagnostics and deterministic tests.
+Do not commit operational Route53 values. A hosted-zone id is not a secret, but the preferred live behavior is domain
+lookup under the deploy profile rather than hidden operator-local context.
 
-```json
-{
-  "context": {
-    "webHostedZoneId": "<operator-local-lesser-host-zone-id>",
-    "webHostedZoneName": "lesser.host"
-  }
-}
-```
-
-The repository intentionally keeps `webHostedZoneId` empty in `cdk/cdk.json` and
-`cdk/cdk.context.local.json.example` so private Route53 values do not enter git.
+Lab/open-source behavior remains intentional: non-live stages do not default to the live apex domain, and the validator
+skips non-live stages so a lab template without hosted-zone context can continue to use a CloudFront distribution URL.
 
 ## What the guard checks
 
@@ -38,21 +32,30 @@ template artifact and fails before CloudFormation mutation unless all of the fol
 - every live Lambda `PUBLIC_BASE_URL` value in the template is `https://lesser.host`;
 - the `WebUrl` output is `https://lesser.host`.
 
-Lab/open-source behavior remains intentional: the validator skips non-live stages, so a lab template without
-operator-local hosted-zone context can continue to use a CloudFront distribution URL.
+If the guard fails, do not work around it by creating hidden local context. Treat the failure as evidence that CDK domain
+resolution is broken or the AWS profile/lookup path is unavailable, then fix the resolution path before any live deploy.
 
 ## Non-mutating proof commands
 
 These commands synthesize and validate artifacts only. They do not deploy.
 
 ```bash
-cd cdk
-npm run build
-npx cdk synth -c stage=live --output .build/live-nodomain
-node ../scripts/validate-live-domain-template.mjs live .build/live-nodomain/lesser-host-live.template.json
+# Preferred live proof under the real deploy profile; do not set a CDK timeout.
+LESSER_HOST_CDK_DRY_RUN=1 AWS_PROFILE=Lesser scripts/app-theory-cdk.sh up live
 ```
 
-Expected result: failure. The error names `cdk/cdk.context.local.json` and `webHostedZoneId`.
+Expected result: success. The wrapper runs the hosted genesis guard, deploy-template placeholder guard, live custom-domain
+guard, and CloudFormation dependency-cycle guard, then stops before `cdk deploy`.
+
+For deterministic local proof without AWS lookup, run the CDK tests. They inject a mocked CDK hosted-zone lookup result
+for `lesser.host` and then validate the synthesized template artifact with the same guard:
+
+```bash
+cd cdk
+npm test
+```
+
+For one-off diagnostics only, an explicit context override can still be used with a fake test hosted-zone id:
 
 ```bash
 cd cdk
@@ -68,12 +71,6 @@ node ../scripts/validate-live-domain-template.mjs live .build/live-domain/lesser
 Expected result: success. `ZEXAMPLELESSERHOST` is a fake test value for local proof only; do not put operational values in
 git.
 
-For the AppTheory wrapper preflight without CloudFormation mutation:
-
-```bash
-LESSER_HOST_CDK_DRY_RUN=1 AWS_PROFILE=<operator-profile> theory app up --stage live --execute
-```
-
 Actual live deploys remain operator-authorized only. Never set a timeout on a CDK deploy.
 
 ## Incident encoded by this guard
@@ -81,4 +78,5 @@ Actual live deploys remain operator-authorized only. Never set a timeout on a CD
 On 2026-06-23, a live deploy was run after the gitignored operator-local context was missing. Because `webHostedZoneId`
 was absent, the live template omitted the custom-domain resources and CloudFormation deleted `WebAliasA`,
 `WebAliasAAAA`, and `WebCertificate`. Route53 apex had only NS/SOA records, CloudFront had `Aliases.Quantity = 0` with
-`CloudFrontDefaultCertificate = true`, and Sim SSR failed DNS lookup for `lesser.host`.
+`CloudFrontDefaultCertificate = true`, and Sim SSR failed DNS lookup for `lesser.host`. The corrected requirement is that
+normal live synth resolves and uses `lesser.host` without hidden local context, with this guard retained as a backstop.

--- a/scripts/validate-live-domain-template.mjs
+++ b/scripts/validate-live-domain-template.mjs
@@ -11,7 +11,7 @@ function usage() {
 function fail(details) {
 	const detailText = details.length > 0 ? details.join('; ') : 'unknown validation failure';
 	console.error(
-		`live custom-domain guard: synthesized live template would omit or remove the canonical first-party Host domain ${canonicalDomain}; refusing before cdk deploy. Ensure cdk/cdk.context.local.json contains a valid webHostedZoneId for ${canonicalDomain}. Details: ${detailText}`,
+		`live custom-domain guard: synthesized live template would omit or remove the canonical first-party Host domain ${canonicalDomain}; refusing before cdk deploy. Live CDK domain resolution must synthesize ${canonicalDomain} by default; this failure means CDK domain resolution is broken or AWS hosted-zone lookup/profile access is unavailable. Details: ${detailText}`,
 	);
 	process.exit(1);
 }


### PR DESCRIPTION
## Milestone
Project 49 live domain default correction after PR #758 — live Host synth/deploy must use `lesser.host` by construction without hidden local context.

## Classification
Operational reliability / deploy safety / security invariant.

## Surfaces affected
- `cdk/lib/lesser-host-stack.ts` live web hosted-zone resolution
- `scripts/validate-live-domain-template.mjs` failure messaging
- `cdk/test/lesser-host-stack.test.ts` deterministic live default + guard tests
- `docs/runbook-live-custom-domain-deploy-guard.md`

## Specialist walks referenced
- Governance rubric: no verifier/pack change; full Gov-infra rubric run locally.
- Provisioning / managed-update / release verification: not touched.
- Soul registry: none.
- Trust API / CSP / instance-auth: none.
- Framework: no local framework patch.

## Multi-tenant isolation impact
None. This only changes Host live deploy synthesis/validation and does not read or write tenant data.

## On-chain impact
None.

## Consumer impact
Protects the canonical `lesser.host` first-party domain and public runtime URLs for Host/Sim/Lesser integration.

## Tasks
- [x] Resolve the live public hosted zone by canonical domain when `webHostedZoneId` is not explicitly supplied.
- [x] Preserve explicit hosted-zone id context for diagnostics/tests and preserve non-live behavior.
- [x] Update guard failure messaging/runbook away from hidden `cdk.context.local.json` as the normal path.
- [x] Add deterministic no-local-context live template/guard coverage.

## Validation
- `cd cdk && npm test` — PASS (47/47)
- `git diff --check` — PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (40 pass / 0 fail / 0 blocked)
- `LESSER_HOST_CDK_DRY_RUN=1 AWS_PROFILE=Lesser scripts/app-theory-cdk.sh up live` — PASS with no `cdk/cdk.context.local.json`; hosted genesis guard, placeholder guard, live custom-domain guard, and dependency-cycle guard all passed; stopped before deploy.

## Stage rollout plan (handoff after merge)
- [ ] Merge to `staging` after review + CI.
- [ ] Operator promotion from `staging` to `main`.
- [ ] Operator-authorized lab verification/soak as needed.
- [ ] Operator-authorized live deploy only; no CDK timeout.

## Cross-repo coordination
None. No sibling repo edits.

## Notes
No CloudFormation, Route53, ACM, CloudFront, SQS, AWS runtime, on-chain, or sibling-repo mutation was performed. The live dry-run used only non-mutating synth/lookup/preflight validation and then exited before deploy.

Closes #760