### PR TITLE
chore: explore AppTheory MicroVMs for hosted genesis

### DIFF
--- a/cdk/lib/hosted-genesis-microvm-exploration.ts
+++ b/cdk/lib/hosted-genesis-microvm-exploration.ts
@@ -1,0 +1,46 @@
+import type {
+  AppTheoryMicrovmControllerProps,
+  AppTheoryMicrovmImageProps,
+  AppTheoryMicrovmNetworkConnectorProps,
+} from "@theory-cloud/apptheory-cdk";
+
+export const HOSTED_GENESIS_MICROVM_NAMESPACE = "hosted-genesis" as const;
+export const HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH = "host-dynamodb-hosted-genesis-session" as const;
+
+export interface HostedGenesisMicrovmCdkMapping {
+  readonly networkConnector: Array<keyof AppTheoryMicrovmNetworkConnectorProps>;
+  readonly image: Array<keyof AppTheoryMicrovmImageProps>;
+  readonly controller: Array<keyof AppTheoryMicrovmControllerProps>;
+  readonly nonAuthoritativeState: typeof HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH;
+}
+
+// Compile-only AppTheory v1.14 MicroVM CDK API mapping for Project 49. This
+// file intentionally creates no constructs and is not imported by the stack, so
+// `cdk synth` remains a non-deploying dependency/API proof for the exploration.
+export const hostedGenesisMicrovmCdkMapping: HostedGenesisMicrovmCdkMapping = {
+  networkConnector: ["vpc", "subnets", "securityGroups", "connectorName", "networkProtocol", "operatorRole"],
+  image: [
+    "name",
+    "description",
+    "baseImageArn",
+    "baseImageVersion",
+    "buildRoleArn",
+    "codeArtifact",
+    "egressNetworkConnectors",
+    "hooks",
+    "logging",
+    "resources",
+    "environmentVariables",
+  ],
+  controller: [
+    "controller",
+    "authorizer",
+    "microvmImage",
+    "egressNetworkConnectors",
+    "executionRole",
+    "sessionTableName",
+    "sessionTableRemovalPolicy",
+    "enableSessionTablePointInTimeRecovery",
+  ],
+  nonAuthoritativeState: HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH,
+};

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.12.1/theory-cloud-apptheory-cdk-1.12.1.tgz",
+        "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.14.0/theory-cloud-apptheory-cdk-1.14.0.tgz",
         "aws-cdk-lib": "2.257.0",
         "constructs": "10.6.0"
       },
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@theory-cloud/apptheory-cdk": {
-      "version": "1.12.1",
-      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.12.1/theory-cloud-apptheory-cdk-1.12.1.tgz",
-      "integrity": "sha512-zAUUEOViQyICTsGcSfDXjEhcEbb3FmFOMdEyFK7CA1fcHrboHsr49ZfUJX5SmWQ1Mq0AicPtAPHuc+8mGiguiA==",
+      "version": "1.14.0",
+      "resolved": "https://github.com/theory-cloud/AppTheory/releases/download/v1.14.0/theory-cloud-apptheory-cdk-1.14.0.tgz",
+      "integrity": "sha512-hRYlLID9uPrcAO8LFzX1DoC+xgrKF9sHA5LqBezPCKwDUAJ9Leg9VhrYFtRTPnXPHhilGLhekUFD99hFozBhTA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -14,7 +14,7 @@
     "destroy": "npm run build && cdk destroy --all"
   },
   "dependencies": {
-    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.12.1/theory-cloud-apptheory-cdk-1.12.1.tgz",
+    "@theory-cloud/apptheory-cdk": "https://github.com/theory-cloud/AppTheory/releases/download/v1.14.0/theory-cloud-apptheory-cdk-1.14.0.tgz",
     "aws-cdk-lib": "2.257.0",
     "constructs": "10.6.0"
   },

--- a/docs/adr/0008-app-theory-microvm-hosted-genesis-exploration.md
+++ b/docs/adr/0008-app-theory-microvm-hosted-genesis-exploration.md
@@ -1,0 +1,203 @@
+# ADR 0008: AppTheory MicroVM hosted-genesis exploration
+
+- Status: Proposed exploration
+- Date: 2026-06-24
+- Related issues: #766, #767
+
+## Context
+
+Project 49 made Lesser's hosted-genesis path JSON-authoritative, but the current implementation still places SQS and an
+AI-worker turn processor on the user-visible critical path. Issue #766 scopes the replacement direction: Host owns a
+DynamoDB-backed `HostedGenesisSession`, DynamoDB remains the recovery source of truth, and Lambda MicroVMs provide only
+the stateful per-session execution context. SQS may survive as telemetry, janitor, or background work, but not as the
+source of truth for resume/recovery.
+
+AppTheory v1.14.0 introduces Lambda MicroVM CDK and runtime APIs. This ADR records how Host should map those APIs before
+any deploying implementation is attempted. This PR is non-deploying: it updates dependency pins, compiles a bounded API
+mapping, and documents the design. It does not create MicroVMs, mutate AWS, touch SSM/Secrets Manager, rotate keys, or
+edit sibling repos.
+
+## AppTheory v1.14.0 APIs discovered
+
+### CDK deployment surfaces
+
+Host can consume these TypeScript constructs from `@theory-cloud/apptheory-cdk` v1.14.0:
+
+- `AppTheoryMicrovmNetworkConnector`
+  - CloudFormation surface for `AWS::Lambda::NetworkConnector`.
+  - Requires caller-provided VPC, subnets, and security groups; AppTheory does not choose a default VPC boundary.
+  - Exposes `networkConnectorArn` for image/controller wiring.
+- `AppTheoryMicrovmImage`
+  - CloudFormation surface for `AWS::Lambda::MicrovmImage`.
+  - Requires `baseImageArn`, `baseImageVersion`, `buildRoleArn`, `codeArtifact`, egress connectors, hook config,
+    logging config, and one resource requirement.
+  - Models image hooks (`ready`, `validate`) and runtime hooks (`run`, `suspend`, `resume`, `terminate`).
+- `AppTheoryMicrovmController`
+  - Creates a protected HTTP API with routes:
+    - `POST /microvms`
+    - `POST /microvms/{session_id}/start`
+    - `POST /microvms/{session_id}/stop`
+    - `GET /microvms/{session_id}/status`
+    - `GET /microvms/{session_id}`
+  - Creates a controller Lambda and a TableTheory-shaped session registry table with `pk`, `sk`, and `ttl`.
+  - Fails closed without a Lambda request authorizer.
+  - Wires reserved environment variables including `APPTHEORY_MICROVM_CONTRACT_NAME`,
+    `APPTHEORY_MICROVM_CONTRACT_VERSION`, `APPTHEORY_MICROVM_SESSION_REGISTRY_TABLE`,
+    `APPTHEORY_MICROVM_IMAGE_REF`, and `APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS`.
+  - Grants MicroVM control-plane actions scoped to the configured image plus network-connector pass-through.
+
+The compile-only mapping in `cdk/lib/hosted-genesis-microvm-exploration.ts` imports these v1.14.0 prop types and records
+which properties Host expects to use. It intentionally creates no constructs and is not imported by the live stack.
+
+### Go runtime surfaces
+
+Host can consume these Go APIs from `github.com/theory-cloud/apptheory/runtime/microvm` v1.14.0:
+
+- `ControllerRequest` / `ControllerResponse` with commands `create`, `start`, `stop`, `status`, and `session`.
+- `AuthContext` and `SessionSpec` for sanitized, tenant-bound controller envelopes.
+- `DefaultControllerContract`, `DefaultSessionRegistryContract`, and `ValidateEscapeHatches` for contract checks.
+- `SessionRecord`, `SessionStatus`, `SessionRegistryRecord`, and `TableTheorySessionRegistry` for AppTheory's
+  MicroVM execution registry shape.
+- `RegistryClient` and `Client` for a constrained controller client abstraction.
+- `LifecycleAdapter` with hooks `prepare_image`, `start`, `readiness`, `stop`, `teardown`, and `failure`, and states
+  from `requested` through `ready`, `terminated`, or `failed`.
+- `testkit/microvm.FakeClient` for deterministic non-AWS controller tests.
+
+The compile-safe scaffold in `internal/hostedgenesis/microvm_exploration.go` builds sanitized AppTheory controller
+requests from Host ids only. It proves the mapping against the AppTheory controller/testkit without AWS calls.
+
+## Host mapping decision
+
+### Source-of-truth model
+
+Host must add a first-class `HostedGenesisSession` model in its own DynamoDB state before any real MicroVM-backed
+implementation. That model is authoritative for:
+
+- `instance_slug`, `registration_id`, `agent_id`, `conversation_id`, active turn id, and owner boundary;
+- expected-version transitions and idempotency request hashes;
+- command ledger and current server-authored next action;
+- compact transcript/checkpoint references and declaration checkpoints;
+- MicroVM execution reference (`microvm_session_id`, endpoint token reference, lifecycle state, image version);
+- typed failure category and recovery action; and
+- terminal publish/finalize eligibility.
+
+AppTheory's MicroVM session registry is useful controller state and execution cache, but it is not Host's recovery
+source of truth. Host reconciles from `HostedGenesisSession` first, then issues or skips MicroVM commands.
+
+### Tenant and auth mapping
+
+- AppTheory `tenant_id`: `slug:<instance_slug>`.
+- AppTheory `namespace`: `hosted-genesis`.
+- AppTheory `session_id`: Host `conversation_id` unless a later migration requires a separate opaque execution id.
+- AppTheory `auth_context.subject`: sanitized service subject (`lesser-host:hosted-genesis`), not a bearer token.
+- AppTheory `session_spec.metadata`: safe ids only (`source_of_truth`, `registration_id`, `agent_id`,
+  `conversation_id`, optional `turn_id`). No raw transcript, prompt, Instance API key, wallet signature, AWS credential,
+  provider key, SSM value, or raw lifecycle payload crosses this boundary.
+
+### Host API surface for the real implementation
+
+The existing Lesser-facing hosted-genesis routes should remain the public compatibility surface, but their internals
+should call a `HostedGenesisSession` orchestrator rather than enqueueing critical SQS work:
+
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation`
+  - Commit or load `HostedGenesisSession` with expected-version/idempotency semantics.
+  - Create/start/resume the MicroVM execution context only after the DynamoDB session checkpoint exists.
+  - Return the compact HostConversation envelope from DynamoDB.
+- `GET /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}`
+  - Read `HostedGenesisSession` and return the server-authored status/next action.
+- `POST /api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete`
+  - Advance declaration extraction or return terminal declaration readiness from DynamoDB.
+- Recovery/admin/internal follow-ups:
+  - `resume/recover`: server-authored action from `HostedGenesisSession` chooses resume existing MicroVM, replay an
+    idempotent command, restart from a checkpoint, or terminal operator action.
+  - `terminate`: stop/terminate MicroVM execution while keeping terminal Host evidence.
+  - `publish/finalize`: still fails closed unless DynamoDB has a valid terminal declaration checkpoint.
+
+### Failure and recovery matrix
+
+| Failure | Authoritative state | Recovery action |
+| --- | --- | --- |
+| Host process crash | `HostedGenesisSession` expected version + command ledger | Reload session, inspect last committed command, resume/replay idempotently. |
+| MicroVM suspended mid-turn | `HostedGenesisSession` nonterminal action + MicroVM lifecycle ref | Resume MicroVM if within TTL; otherwise restart from the last Host checkpoint. |
+| MicroVM terminated/expired | Host checkpoint/declaration state | Start a new MicroVM execution session from checkpoint or mark `operator_action` if checkpoint is insufficient. |
+| Duplicate Lesser retry | Idempotency row + request hash | Return existing conversation/status without another debit or duplicate user turn. |
+| Stale Lesser/Sim state | Host status read | Caller must accept server-authored next action; local UI state is not recovery authority. |
+| Deploy during active session | Host session image/version fields | Continue old image when safe, or suspend/restart from checkpoint with explicit version transition. |
+| LLM/provider failure | Host typed failure category | `retry_same_step` when safe; otherwise `operator_action` or bounded restart. |
+| Publish without declaration checkpoint | Host terminal declaration fields | Fail closed; publish/finalize remains forbidden. |
+
+## Consumer release verification and provisioning impact
+
+This exploration does not modify managed-instance provisioning, managed-update, or consumer release verification.
+Future MicroVM deployment work must preserve per-slug AWS account isolation and checksum-based release verification. If
+MicroVM images become managed release assets, they must enter the `managed-release-certification` / `managed-release-readiness`
+path before provisioning or managed update consumes them.
+
+## Framework-feedback signal
+
+### Target framework
+
+AppTheory CDK and AppTheory Go runtime, v1.14.0.
+
+### Concern under Host constraints
+
+Host needs a MicroVM controller for a governance-sensitive, multi-tenant hosted-genesis workflow where Host's own
+DynamoDB model is authoritative and MicroVM state is execution/cache only.
+
+### Idiomatic shape Host wants
+
+```go
+session := loadHostedGenesisSessionFromHostDynamoDB(...)
+request := microvm.ControllerRequest{ /* tenant-bound ids only */ }
+response, err := controller.Handle(ctx, request) // backed by an AppTheory AWS MicroVM client adapter
+recordMicroVMExecutionRef(session, response)
+```
+
+```ts
+new AppTheoryMicrovmController(this, "HostedGenesisMicrovmController", {
+  controller,
+  authorizer,
+  microvmImage,
+  egressNetworkConnectors,
+  sessionRegistry: importedOrExistingHostScopedRegistry,
+});
+```
+
+### Current gap / risk
+
+- The CDK controller construct creates its own MicroVM session registry table. Host can treat that as controller cache,
+  but a future implementation needs an explicit pattern for importing or delegating registry state without confusing it
+  with Host's authoritative `HostedGenesisSession` table.
+- The Go runtime exposes a constrained `Client` interface and a registry-backed test/client path, but this exploration did
+  not find a concrete AWS Lambda MicroVM client adapter for `RunMicrovm`, `ResumeMicrovm`, auth-token creation, suspend,
+  and terminate. If Host implements that adapter directly, it must avoid turning raw AWS SDK access into an escape hatch.
+- The runtime controller vocabulary has `create/start/stop/status/session`; Host's user-facing recovery model also needs
+  `resume/recover`, `publish/finalize`, and checkpoint replay. Those should stay Host-owned, but the boundary should be
+  documented upstream so consumers do not overload MicroVM controller state as workflow state.
+
+### Proposed next step
+
+Ask the AppTheory steward to scope: imported/external session-registry support or a documented controller-cache pattern;
+a concrete constrained AWS MicroVM client adapter; and guidance for workflow-owned recovery models layered over MicroVM
+execution sessions. Host should not patch or vendor AppTheory locally.
+
+## Risks and blockers before implementation
+
+- AWS Lambda MicroVM APIs are new and may not be available in every deploy region/account context Host uses.
+- Host needs a lab-only canary plan that proves suspend/resume and duplicate retry before any live rollout.
+- MicroVM image build inputs (`baseImageArn`, build role, code artifact, lifecycle hooks) require an operator-owned
+  deployment design; this PR intentionally does not create them.
+- The authorizer for `AppTheoryMicrovmController` must fail closed and must not accept raw Instance API keys or Host
+  control-plane sessions directly from Lesser/Sim.
+- MicroVM endpoints and auth tokens must never be returned to browsers or sibling repos; Host proxies/mediates through
+  server-authored actions.
+- Existing `SOUL_REG` / `MINT_CONVERSATION` rows need a migration plan that preserves early `conversation_id`
+  persistence and maps pre-queue `in_progress` rows to a deterministic recovery action.
+
+## Validation plan for this exploration
+
+- Dependency pin proof: Go `github.com/theory-cloud/apptheory` and CDK `@theory-cloud/apptheory-cdk` move to v1.14.0.
+- Compile proof: Go tests validate AppTheory MicroVM contracts and the sanitized controller envelope.
+- CDK proof: TypeScript build imports v1.14.0 MicroVM prop types without adding stack resources; synth remains
+  non-deploying.
+- Guard proof: Existing hosted-genesis/template/custom-domain guards still pass against synthesized templates.

--- a/go.mod
+++ b/go.mod
@@ -34,8 +34,8 @@ require (
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v79 v79.12.0
-	github.com/theory-cloud/apptheory v1.12.1
-	github.com/theory-cloud/tabletheory v1.9.1
+	github.com/theory-cloud/apptheory v1.14.0
+	github.com/theory-cloud/tabletheory v1.10.1
 	golang.org/x/net v0.55.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -277,10 +277,10 @@ github.com/supranational/blst v0.3.16 h1:bTDadT+3fK497EvLdWRQEjiGnUtzJ7jjIUMF0jq
 github.com/supranational/blst v0.3.16/go.mod h1:jZJtfjgudtNl4en1tzwPIV3KjUnQUvG3/j+w+fVonLw=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7 h1:epCh84lMvA70Z7CTTCmYQn2CKbY8j86K7/FAIr141uY=
 github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7/go.mod h1:q4W45IWZaF22tdD+VEXcAWRA037jwmWEB5VWYORlTpc=
-github.com/theory-cloud/apptheory v1.12.1 h1:j7Ym+4B2+BARmrhVSIWFvCrKf96vi1TXDwRqTviHLJs=
-github.com/theory-cloud/apptheory v1.12.1/go.mod h1:9BjPQVSVLfSdnuK0jy8OD4aQunpPeqY/90Zrp4kvb9o=
-github.com/theory-cloud/tabletheory v1.9.1 h1:J7MSMDbekdOkh8RV8xKEwhAxfEZtlallfiJ1lbsKlj4=
-github.com/theory-cloud/tabletheory v1.9.1/go.mod h1:lZm1UPyuoVBC7F3C8o8RPu4u0yzR1tAVLo5huwGz7VQ=
+github.com/theory-cloud/apptheory v1.14.0 h1:OV/bzggj0/zA/tmcPhWg9Atmk3nwgktaG2OvXP7X1Fw=
+github.com/theory-cloud/apptheory v1.14.0/go.mod h1:qNM++Ve7hGvPqqPZQ9oEzcoiQNfKREQoff9R7EZHS18=
+github.com/theory-cloud/tabletheory v1.10.1 h1:kO1qgxCl6TyOE464PJQUVYBISwikheuQa+D1iKXIMo0=
+github.com/theory-cloud/tabletheory v1.10.1/go.mod h1:lmDjZzL7vQjo14XC8NfWro02hLl3YFaU3l4LYWyCS+0=
 github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/gjson v1.18.0 h1:FIDeeyB800efLX89e5a8Y0BNH+LOngJyGrIWxG2FKQY=
 github.com/tidwall/gjson v1.18.0/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=

--- a/internal/hostedgenesis/microvm_exploration.go
+++ b/internal/hostedgenesis/microvm_exploration.go
@@ -1,0 +1,177 @@
+package hostedgenesis
+
+import (
+	"errors"
+	"strings"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+)
+
+const (
+	// MicroVMNamespace is the AppTheory MicroVM namespace Host will use for
+	// hosted-genesis execution sessions. The durable Host HostedGenesisSession
+	// record remains the source of truth; this namespace scopes execution/cache
+	// records only.
+	MicroVMNamespace = "hosted-genesis"
+
+	// MicroVMSourceOfTruth records the recovery invariant in MicroVM session
+	// metadata without giving the MicroVM authoritative state ownership.
+	MicroVMSourceOfTruth = "host-dynamodb-hosted-genesis-session"
+
+	// MicroVMControllerID is the stable Host controller id used in AppTheory
+	// session records for non-deploying contract tests and future controller code.
+	MicroVMControllerID = "lesser-host-hosted-genesis"
+
+	// MicroVMAuthSubject is a sanitized service subject. It is not a bearer token,
+	// Instance API key, wallet signature, or cloud credential.
+	MicroVMAuthSubject = "lesser-host:hosted-genesis"
+)
+
+var errInvalidMicroVMBinding = errors.New("hosted genesis microvm binding is incomplete")
+
+// MicroVMSessionBinding is the safe identifier envelope Host may pass to an
+// AppTheory MicroVM controller. It intentionally carries only durable Host ids
+// and tenant-bound routing ids; raw transcripts, prompts, bearer tokens,
+// Instance API keys, AWS credentials, and provider secrets stay out of the
+// MicroVM controller envelope.
+type MicroVMSessionBinding struct {
+	InstanceSlug   string
+	RegistrationID string
+	AgentID        string
+	ConversationID string
+	TurnID         string
+}
+
+// Validate fails closed if the binding cannot be tied back to one hosted
+// genesis conversation in Host's DynamoDB state.
+func (b MicroVMSessionBinding) Validate() error {
+	if strings.TrimSpace(b.InstanceSlug) == "" ||
+		strings.TrimSpace(b.RegistrationID) == "" ||
+		strings.TrimSpace(b.AgentID) == "" ||
+		strings.TrimSpace(b.ConversationID) == "" {
+		return errInvalidMicroVMBinding
+	}
+	return nil
+}
+
+// TenantID returns the tenant boundary Host should use for the AppTheory
+// controller. The slug is the managed-instance boundary; AppTheory also binds
+// the namespace in its registry keys.
+func (b MicroVMSessionBinding) TenantID() string {
+	slug := strings.TrimSpace(b.InstanceSlug)
+	if slug == "" {
+		return ""
+	}
+	return "slug:" + slug
+}
+
+// Metadata returns the only HostedGenesisSession references that may cross into
+// the AppTheory MicroVM session spec. These ids let Host reconcile execution
+// state back to DynamoDB without making MicroVM memory/disk authoritative.
+func (b MicroVMSessionBinding) Metadata() map[string]string {
+	metadata := map[string]string{
+		"source_of_truth": MicroVMSourceOfTruth,
+		"registration_id": strings.TrimSpace(b.RegistrationID),
+		"agent_id":        strings.TrimSpace(b.AgentID),
+		"conversation_id": strings.TrimSpace(b.ConversationID),
+	}
+	if turnID := strings.TrimSpace(b.TurnID); turnID != "" {
+		metadata["turn_id"] = turnID
+	}
+	return metadata
+}
+
+// NewMicroVMCreateRequest builds the AppTheory v1.14 MicroVM create envelope
+// Host would use after a HostedGenesisSession row has been committed in
+// DynamoDB. The function is a compile-safe exploration scaffold: it does not
+// call AWS, create a MicroVM, enqueue SQS, or mutate Host state.
+func NewMicroVMCreateRequest(
+	requestID string,
+	binding MicroVMSessionBinding,
+	imageRef string,
+	networkConnectorRef string,
+) (runtimemicrovm.ControllerRequest, error) {
+	requestID = strings.TrimSpace(requestID)
+	imageRef = strings.TrimSpace(imageRef)
+	networkConnectorRef = strings.TrimSpace(networkConnectorRef)
+	if requestID == "" || imageRef == "" || networkConnectorRef == "" {
+		return runtimemicrovm.ControllerRequest{}, errInvalidMicroVMBinding
+	}
+	if err := binding.Validate(); err != nil {
+		return runtimemicrovm.ControllerRequest{}, err
+	}
+	return runtimemicrovm.ControllerRequest{
+		Command:             runtimemicrovm.CommandCreate,
+		RequestID:           requestID,
+		TenantID:            binding.TenantID(),
+		Namespace:           MicroVMNamespace,
+		AuthContext:         authContext(binding),
+		SessionID:           strings.TrimSpace(binding.ConversationID),
+		ImageRef:            imageRef,
+		NetworkConnectorRef: networkConnectorRef,
+		SessionSpec: runtimemicrovm.SessionSpec{
+			Metadata: binding.Metadata(),
+		},
+	}, nil
+}
+
+// NewMicroVMCommandRequest builds a start/stop/status/session controller
+// envelope for an existing hosted-genesis MicroVM execution session. Host state
+// must decide whether this command is allowed before calling the controller.
+func NewMicroVMCommandRequest(
+	command runtimemicrovm.Command,
+	requestID string,
+	binding MicroVMSessionBinding,
+) (runtimemicrovm.ControllerRequest, error) {
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return runtimemicrovm.ControllerRequest{}, errInvalidMicroVMBinding
+	}
+	if err := binding.Validate(); err != nil {
+		return runtimemicrovm.ControllerRequest{}, err
+	}
+	switch command {
+	case runtimemicrovm.CommandStart,
+		runtimemicrovm.CommandStop,
+		runtimemicrovm.CommandStatus,
+		runtimemicrovm.CommandSession:
+		return runtimemicrovm.ControllerRequest{
+			Command:     command,
+			RequestID:   requestID,
+			TenantID:    binding.TenantID(),
+			Namespace:   MicroVMNamespace,
+			AuthContext: authContext(binding),
+			SessionID:   strings.TrimSpace(binding.ConversationID),
+		}, nil
+	default:
+		return runtimemicrovm.ControllerRequest{}, errInvalidMicroVMBinding
+	}
+}
+
+// ValidateAppTheoryMicroVMContracts validates the AppTheory v1.14 controller,
+// registry, and escape-hatch contracts Host depends on for the next
+// implementation milestone.
+func ValidateAppTheoryMicroVMContracts() error {
+	if err := runtimemicrovm.ValidateControllerContract(runtimemicrovm.DefaultControllerContract()); err != nil {
+		return err
+	}
+	if err := runtimemicrovm.ValidateSessionRegistryContract(runtimemicrovm.DefaultSessionRegistryContract()); err != nil {
+		return err
+	}
+	return runtimemicrovm.ValidateEscapeHatches(runtimemicrovm.EscapeHatches{})
+}
+
+func authContext(binding MicroVMSessionBinding) runtimemicrovm.AuthContext {
+	return runtimemicrovm.AuthContext{
+		Subject:   MicroVMAuthSubject,
+		TenantID:  binding.TenantID(),
+		Namespace: MicroVMNamespace,
+		Entitlements: []string{
+			"hosted_genesis:execute",
+			"hosted_genesis:read_session",
+		},
+		Metadata: map[string]string{
+			"instance_slug": strings.TrimSpace(binding.InstanceSlug),
+		},
+	}
+}

--- a/internal/hostedgenesis/microvm_exploration_test.go
+++ b/internal/hostedgenesis/microvm_exploration_test.go
@@ -1,0 +1,89 @@
+package hostedgenesis
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+	microvmtestkit "github.com/theory-cloud/apptheory/testkit/microvm"
+)
+
+func TestMicroVMCreateRequestUsesAppTheoryContract(t *testing.T) {
+	require.NoError(t, ValidateAppTheoryMicroVMContracts())
+
+	binding := MicroVMSessionBinding{
+		InstanceSlug:   "demo",
+		RegistrationID: "reg_123",
+		AgentID:        "agent_123",
+		ConversationID: "conv_123",
+		TurnID:         "turn_123",
+	}
+	req, err := NewMicroVMCreateRequest("req_123", binding, "image-arn", "connector-arn")
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.CommandCreate, req.Command)
+	require.Equal(t, "slug:demo", req.TenantID)
+	require.Equal(t, MicroVMNamespace, req.Namespace)
+	require.Equal(t, "conv_123", req.SessionID)
+	require.Equal(t, MicroVMSourceOfTruth, req.SessionSpec.Metadata["source_of_truth"])
+	require.NotContains(t, req.SessionSpec.Metadata, "bearer_token")
+	require.NotContains(t, req.SessionSpec.Metadata, "raw_aws_credentials")
+
+	controller, err := runtimemicrovm.NewController(
+		microvmtestkit.NewFakeClient(),
+		runtimemicrovm.WithControllerID(MicroVMControllerID),
+	)
+	require.NoError(t, err)
+	resp, err := controller.Handle(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, runtimemicrovm.CommandCreate, resp.Command)
+	require.Equal(t, runtimemicrovm.StateRequested, resp.State)
+	require.Equal(t, "conv_123", resp.SessionID)
+	require.Equal(t, int64(1), resp.RegistryVersion)
+}
+
+func TestMicroVMCommandRequestMapsExistingSession(t *testing.T) {
+	binding := MicroVMSessionBinding{
+		InstanceSlug:   "demo",
+		RegistrationID: "reg_123",
+		AgentID:        "agent_123",
+		ConversationID: "conv_123",
+	}
+	for _, command := range []runtimemicrovm.Command{
+		runtimemicrovm.CommandStart,
+		runtimemicrovm.CommandStop,
+		runtimemicrovm.CommandStatus,
+		runtimemicrovm.CommandSession,
+	} {
+		t.Run(string(command), func(t *testing.T) {
+			req, err := NewMicroVMCommandRequest(command, "req_123", binding)
+			require.NoError(t, err)
+			require.Equal(t, command, req.Command)
+			require.Equal(t, "slug:demo", req.TenantID)
+			require.Equal(t, MicroVMNamespace, req.Namespace)
+			require.Equal(t, "conv_123", req.SessionID)
+			require.Empty(t, req.SessionSpec.Metadata)
+		})
+	}
+
+	_, err := NewMicroVMCommandRequest(runtimemicrovm.CommandCreate, "req_123", binding)
+	require.Error(t, err)
+}
+
+func TestMicroVMBindingFailsClosedWhenUnbound(t *testing.T) {
+	_, err := NewMicroVMCreateRequest("req_123", MicroVMSessionBinding{
+		InstanceSlug:   "demo",
+		RegistrationID: "reg_123",
+		AgentID:        "agent_123",
+		// Missing conversation id would break DynamoDB HostedGenesisSession recovery.
+	}, "image-arn", "connector-arn")
+	require.Error(t, err)
+
+	_, err = NewMicroVMCreateRequest("req_123", MicroVMSessionBinding{
+		InstanceSlug:   "demo",
+		RegistrationID: "reg_123",
+		AgentID:        "agent_123",
+		ConversationID: "conv_123",
+	}, "", "connector-arn")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Milestone
Project 49 — Host AppTheory v1.14.0 MicroVM exploration

Closes #767

## Classification
dependency-maintenance / framework-feedback / operational-reliability / provisioning-adjacent exploration

## Surfaces affected
- Go module pins (`go.mod`, `go.sum`)
- CDK package pin/lockfile (`cdk/package.json`, `cdk/package-lock.json`)
- Compile-only CDK MicroVM API mapping (`cdk/lib/hosted-genesis-microvm-exploration.ts`)
- Compile-only hosted-genesis runtime scaffold/tests (`internal/hostedgenesis/*microvm*`)
- ADR for #766/#767 MicroVM hosted-genesis mapping (`docs/adr/0008-app-theory-microvm-hosted-genesis-exploration.md`)

## Specialist walks referenced
- Provisioning / managed-update / release verification: no provisioning/release-verification behavior changed; future MicroVM images must enter managed-release certification/readiness before consumption.
- Framework: AppTheory v1.14.0 MicroVM APIs inspected; framework-feedback signal recorded in ADR for imported/external registry guidance and constrained AWS MicroVM client adapter needs.
- Governance rubric: local verifier passed.
- Soul registry / Trust API / CSP: no contract, on-chain, instance-auth, attestation, CSP, or web pin behavior changed.

## Multi-tenant isolation impact
No weakening. The scaffold binds AppTheory `tenant_id` to `slug:<instance_slug>` and namespace `hosted-genesis`, and passes only safe Host ids into MicroVM session metadata.

## On-chain impact
None. No Sepolia/mainnet deploys, contract changes, Safe payloads, key rotations, or on-chain calls.

## Consumer impact
No live runtime behavior is enabled. This is a bounded non-deploying exploration for replacing the hosted-genesis SQS critical path with Host DynamoDB `HostedGenesisSession` authority plus MicroVM execution/cache context.

## Exact AppTheory pin diff
- `go.mod`: `github.com/theory-cloud/apptheory v1.12.1` -> `v1.14.0`
- `go.sum`: AppTheory sums moved from `v1.12.1` to `v1.14.0`
- `cdk/package.json`: `@theory-cloud/apptheory-cdk` tarball `v1.12.1/theory-cloud-apptheory-cdk-1.12.1.tgz` -> `v1.14.0/theory-cloud-apptheory-cdk-1.14.0.tgz`
- `cdk/package-lock.json`: root dependency + resolved package version/url/integrity moved to `1.14.0` (`sha512-hRYlLID9uPrcAO8LFzX1DoC+xgrKF9sHA5LqBezPCKwDUAJ9Leg9VhrYFtRTPnXPHhilGLhekUFD99hFozBhTA==`)
- Go MVS selected `github.com/theory-cloud/tabletheory v1.10.1` because AppTheory v1.14.0 requires it. FaceTheory pins were not changed.

## MicroVM API mapping / proof
- CDK v1.14.0 exports `AppTheoryMicrovmNetworkConnector`, `AppTheoryMicrovmImage`, and `AppTheoryMicrovmController`.
- Runtime v1.14.0 exports `runtime/microvm` controller envelopes, commands (`create/start/stop/status/session`), `AuthContext`, `SessionSpec`, lifecycle contract/state helpers, TableTheory-shaped registry helpers, and `testkit/microvm.FakeClient`.
- `internal/hostedgenesis/microvm_exploration.go` compiles a Host mapping that creates sanitized AppTheory controller requests only after Host has a DynamoDB-backed session id; MicroVM metadata carries safe ids only and records `host-dynamodb-hosted-genesis-session` as the source of truth.
- `cdk/lib/hosted-genesis-microvm-exploration.ts` type-checks the AppTheory CDK prop names Host would need without adding/importing stack resources.

## Validation
- `go test ./...` — PASS
- `go vet ./...` — PASS
- `gofmt -l $(git ls-files '*.go' ; find internal/hostedgenesis -name '*.go' -print) | sort -u` — PASS (empty)
- `git diff --check` — PASS
- `cd cdk && npm ci` — PASS (npm reported existing audit findings)
- `cd cdk && npm run build` — PASS
- `cd cdk && npm test` — PASS (49/49 Node tests)
- `cd cdk && npx cdk synth --all -c stage=lab` — completed; CDK CLI reported `--all` ignored, so exact non-deploy equivalent was rerun
- `cd cdk && npx cdk synth -c stage=lab` — PASS
- `node ../scripts/validate-hosted-genesis-template.mjs cdk.out/lesser-host-lab.template.json` — PASS
- `node ../scripts/validate-deploy-template-placeholders.mjs cdk.out/lesser-host-lab.template.json` — PASS
- `node ../scripts/validate-live-domain-template.mjs lab cdk.out/lesser-host-lab.template.json` — PASS (intentional lab skip); live accept/reject coverage also passed in `npm test`
- `node ../scripts/validate-cfn-dependency-cycles.mjs cdk.out/lesser-host-lab.template.json` — PASS
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (40 pass / 0 fail / 0 blocked)

## Risks / blockers before real MicroVM implementation
- AWS Lambda MicroVM region/account availability and image build inputs need a lab canary design.
- Host still needs an authoritative `HostedGenesisSession` DynamoDB model/state machine before any MicroVM execution becomes runtime behavior.
- AppTheory controller registry must remain execution/cache only; Host should ask AppTheory for imported/external registry guidance and a constrained AWS MicroVM client adapter.
- MicroVM endpoints/auth tokens must remain Host-mediated and must not be returned to Lesser/Sim/browser clients.
- Migration from existing `SOUL_REG` / `MINT_CONVERSATION` rows must provide deterministic recovery for pre-queue `in_progress` conversations.

## Stage rollout plan (handoff after merge)
- [ ] Merged to staging after review and CI
- [ ] Promoted from staging to main by operator
- [ ] No deploy is required for this non-deploying exploration
- [ ] Future implementation PR must start with lab-only canary/suspend-resume proof before live consideration

## Cross-repo coordination
None in this PR. AppTheory framework feedback is documented for the principal/framework steward; no AppTheory, Lesser, Sim, or FaceTheory code was edited.
