### PR TITLE
fix(provision): wait for update instance role readiness

### DIFF
--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -66,6 +66,13 @@ const (
 	updatePhaseStatusSkipped   = "skipped"
 )
 
+const (
+	updateInstanceRoleReadinessNote = "waiting for instance role readiness before ensuring instance key secret"
+	updateInstanceRoleReadinessCode = "instance_role_not_ready"
+	updateInstanceRoleReadinessMsg  = "timed out waiting for instance role readiness before ensuring instance key secret"
+	updateInstanceRoleReadinessAge  = provisionMaxAssumeRoleAge
+)
+
 type deployRunnerInfo struct {
 	Status        string
 	DeepLink      string
@@ -766,6 +773,38 @@ func (s *Server) retryUpdateJobOrFail(
 	return jitteredBackoff(job.Attempts, baseDelay, maxDelay), false, nil
 }
 
+func updateInstanceRoleReadinessStartedAt(job *models.UpdateJob) time.Time {
+	if job == nil {
+		return time.Time{}
+	}
+	if !job.CreatedAt.IsZero() {
+		return job.CreatedAt
+	}
+	return job.UpdatedAt
+}
+
+func updateInstanceRoleReadinessDeadlineExceeded(job *models.UpdateJob, now time.Time) bool {
+	startedAt := updateInstanceRoleReadinessStartedAt(job)
+	if startedAt.IsZero() {
+		return true
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.Sub(startedAt) > updateInstanceRoleReadinessAge
+}
+
+func (s *Server) waitForUpdateInstanceRoleReadiness(ctx context.Context, job *models.UpdateJob, requestID string, now time.Time) (time.Duration, bool, error) {
+	if updateInstanceRoleReadinessDeadlineExceeded(job, now) {
+		return 0, false, s.failUpdateJob(ctx, job, requestID, now, updateInstanceRoleReadinessCode, updateInstanceRoleReadinessMsg)
+	}
+	job.Note = updateInstanceRoleReadinessNote
+	if err := s.persistUpdateJobAndInstance(ctx, job, requestID, now, nil); err != nil {
+		return 0, false, err
+	}
+	return provisionDefaultPollDelay, false, nil
+}
+
 type managedUpdateMetadata struct {
 	accountID  string
 	roleName   string
@@ -911,6 +950,9 @@ func (s *Server) advanceUpdateInstanceConfig(ctx context.Context, job *models.Up
 	}
 	secretArn, err := s.ensureManagedInstanceKeySecret(ctx, pseudo, inst)
 	if err != nil {
+		if errors.Is(err, errAssumeRoleNotReady) {
+			return s.waitForUpdateInstanceRoleReadiness(ctx, job, requestID, now)
+		}
 		return s.retryUpdateJobOrFail(ctx, job, requestID, now, "instance_key_secret_failed", "failed to ensure instance key secret: "+err.Error(), provisionDefaultShortRetryDelay, 5*time.Minute)
 	}
 

--- a/internal/provisionworker/update_jobs_more_internal_test.go
+++ b/internal/provisionworker/update_jobs_more_internal_test.go
@@ -1030,6 +1030,102 @@ func TestAdvanceUpdateInstanceConfig_FailsWhenInstanceMetadataMissing(t *testing
 	require.Equal(t, "missing_instance_metadata", job.ErrorCode)
 }
 
+func TestAdvanceUpdateInstanceConfig_WaitsForAssumeRoleReadiness(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             "slug",
+			Owner:            "wallet-deadbeef",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "example.com",
+		}
+	}).Once()
+
+	now := time.Unix(1000, 0).UTC()
+	srv := &Server{
+		cfg:   config.Config{ManagedInstanceRoleName: "role", Stage: "lab"},
+		store: store.New(db),
+		sts:   &fakeSTS{err: errors.New("AccessDenied: role is still propagating")},
+	}
+	job := &models.UpdateJob{
+		ID:           "j1",
+		InstanceSlug: "slug",
+		Status:       models.UpdateJobStatusRunning,
+		Step:         updateStepInstanceConfig,
+		MaxAttempts:  1,
+		CreatedAt:    now.Add(-time.Minute),
+	}
+
+	delay, done, err := srv.advanceUpdateInstanceConfig(context.Background(), job, "req", now)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, provisionDefaultPollDelay, delay)
+	require.Equal(t, models.UpdateJobStatusRunning, job.Status)
+	require.Equal(t, updateStepInstanceConfig, job.Step)
+	require.Equal(t, updateInstanceRoleReadinessNote, job.Note)
+	require.Empty(t, job.ErrorCode)
+	require.Empty(t, job.ErrorMessage)
+	require.Equal(t, int64(0), job.Attempts)
+}
+
+func TestAdvanceUpdateInstanceConfig_FailsWhenAssumeRoleReadinessDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             "slug",
+			Owner:            "wallet-deadbeef",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "example.com",
+		}
+	}).Once()
+
+	now := time.Unix(1000, 0).UTC()
+	srv := &Server{
+		cfg:   config.Config{ManagedInstanceRoleName: "role", Stage: "lab"},
+		store: store.New(db),
+		sts:   &fakeSTS{err: errors.New("NoSuchEntity: role has not propagated")},
+	}
+	job := &models.UpdateJob{
+		ID:           "j1",
+		InstanceSlug: "slug",
+		Status:       models.UpdateJobStatusRunning,
+		Step:         updateStepInstanceConfig,
+		MaxAttempts:  10,
+		CreatedAt:    now.Add(-(updateInstanceRoleReadinessAge + time.Second)),
+	}
+
+	delay, done, err := srv.advanceUpdateInstanceConfig(context.Background(), job, "req", now)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, time.Duration(0), delay)
+	require.Equal(t, models.UpdateJobStatusError, job.Status)
+	require.Equal(t, updateStepFailed, job.Step)
+	require.Equal(t, updateInstanceRoleReadinessCode, job.ErrorCode)
+	require.Equal(t, updateInstanceRoleReadinessMsg, job.ErrorMessage)
+	require.Equal(t, updateInstanceRoleReadinessMsg, job.Note)
+	require.Equal(t, int64(0), job.Attempts)
+}
+
 func TestAdvanceUpdateInstanceConfig_RetriesWhenSecretsManagerClientCannotBeAssumed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Milestone
Project 51 blocker fix — Host managed Lesser update must tolerate instance-role readiness

## Classification
managed-update / provisioning / operational-reliability / bug-fix

## Surfaces affected
- `internal/provisionworker/update_jobs.go`
- `internal/provisionworker/update_jobs_more_internal_test.go`

## Specialist walks referenced
- Investigation: issue #837 reproduced in source as managed update instance config treating wrapped `errAssumeRoleNotReady` as generic `instance_key_secret_failed`.
- Provisioning / managed-update audit: managed-update instance configuration only; no Consumer release verification, CodeBuild runner, DNS, trust API, on-chain, web/CSP, or framework source changes.

## Multi-tenant isolation impact
Preserved. No cross-tenant reads/writes, shared credentials, IAM trust weakening, raw InstanceKey logging, or secret ownership changes.

## On-chain impact
None.

## Consumer impact
Managed Lesser updates now stay active while the instance role is still propagating. The update records an operator-visible readiness note and requeues on the standard provisioning poll delay. If the bounded readiness deadline is exceeded, it fails deterministically with `instance_role_not_ready` instead of generic `instance_key_secret_failed`.

## Tasks
- [x] Detect wrapped `errAssumeRoleNotReady` from `ensureManagedInstanceKeySecret` during update instance config.
- [x] Poll/requeue with note `waiting for instance role readiness before ensuring instance key secret` without burning generic failure attempts.
- [x] Fail deterministically with `instance_role_not_ready` after the bounded readiness age.
- [x] Preserve generic `instance_key_secret_failed` behavior for real secret/tag/cross-stage errors.
- [x] Add regression coverage for readiness wait and timeout paths.

## Validation
- `go test ./internal/provisionworker/...` — PASS
- `gofmt -l internal/provisionworker/update_jobs.go internal/provisionworker/update_jobs_more_internal_test.go` — PASS (empty)
- `go test ./...` — PASS
- `go vet ./...` — PASS
- `git diff --check` — PASS

## Stage rollout plan (operator-owned after merge)
- [ ] Merged to staging after review and CI, including Gov-infra rubric gate
- [ ] Promoted from staging to main by operator
- [ ] Deployed to lab by operator
- [ ] Lab soak verifies managed Lesser update waits through IAM readiness
- [ ] Deployed to live by operator authorization

## Cross-repo coordination
None. Host-owned managed-update reliability fix only.

Closes #837