### PR TITLE
fix(provision): wait for update instance role readiness (#838)

### DIFF
--- a/internal/provisionworker/update_jobs.go
+++ b/internal/provisionworker/update_jobs.go
@@ -66,6 +66,13 @@ const (
 	updatePhaseStatusSkipped   = "skipped"
 )
 
+const (
+	updateInstanceRoleReadinessNote = "waiting for instance role readiness before ensuring instance key secret"
+	updateInstanceRoleReadinessCode = "instance_role_not_ready"
+	updateInstanceRoleReadinessMsg  = "timed out waiting for instance role readiness before ensuring instance key secret"
+	updateInstanceRoleReadinessAge  = provisionMaxAssumeRoleAge
+)
+
 type deployRunnerInfo struct {
 	Status        string
 	DeepLink      string
@@ -766,6 +773,38 @@ func (s *Server) retryUpdateJobOrFail(
 	return jitteredBackoff(job.Attempts, baseDelay, maxDelay), false, nil
 }
 
+func updateInstanceRoleReadinessStartedAt(job *models.UpdateJob) time.Time {
+	if job == nil {
+		return time.Time{}
+	}
+	if !job.CreatedAt.IsZero() {
+		return job.CreatedAt
+	}
+	return job.UpdatedAt
+}
+
+func updateInstanceRoleReadinessDeadlineExceeded(job *models.UpdateJob, now time.Time) bool {
+	startedAt := updateInstanceRoleReadinessStartedAt(job)
+	if startedAt.IsZero() {
+		return true
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	return now.Sub(startedAt) > updateInstanceRoleReadinessAge
+}
+
+func (s *Server) waitForUpdateInstanceRoleReadiness(ctx context.Context, job *models.UpdateJob, requestID string, now time.Time) (time.Duration, bool, error) {
+	if updateInstanceRoleReadinessDeadlineExceeded(job, now) {
+		return 0, false, s.failUpdateJob(ctx, job, requestID, now, updateInstanceRoleReadinessCode, updateInstanceRoleReadinessMsg)
+	}
+	job.Note = updateInstanceRoleReadinessNote
+	if err := s.persistUpdateJobAndInstance(ctx, job, requestID, now, nil); err != nil {
+		return 0, false, err
+	}
+	return provisionDefaultPollDelay, false, nil
+}
+
 type managedUpdateMetadata struct {
 	accountID  string
 	roleName   string
@@ -911,6 +950,9 @@ func (s *Server) advanceUpdateInstanceConfig(ctx context.Context, job *models.Up
 	}
 	secretArn, err := s.ensureManagedInstanceKeySecret(ctx, pseudo, inst)
 	if err != nil {
+		if errors.Is(err, errAssumeRoleNotReady) {
+			return s.waitForUpdateInstanceRoleReadiness(ctx, job, requestID, now)
+		}
 		return s.retryUpdateJobOrFail(ctx, job, requestID, now, "instance_key_secret_failed", "failed to ensure instance key secret: "+err.Error(), provisionDefaultShortRetryDelay, 5*time.Minute)
 	}
 

--- a/internal/provisionworker/update_jobs_more_internal_test.go
+++ b/internal/provisionworker/update_jobs_more_internal_test.go
@@ -1030,6 +1030,102 @@ func TestAdvanceUpdateInstanceConfig_FailsWhenInstanceMetadataMissing(t *testing
 	require.Equal(t, "missing_instance_metadata", job.ErrorCode)
 }
 
+func TestAdvanceUpdateInstanceConfig_WaitsForAssumeRoleReadiness(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             "slug",
+			Owner:            "wallet-deadbeef",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "example.com",
+		}
+	}).Once()
+
+	now := time.Unix(1000, 0).UTC()
+	srv := &Server{
+		cfg:   config.Config{ManagedInstanceRoleName: "role", Stage: "lab"},
+		store: store.New(db),
+		sts:   &fakeSTS{err: errors.New("AccessDenied: role is still propagating")},
+	}
+	job := &models.UpdateJob{
+		ID:           "j1",
+		InstanceSlug: "slug",
+		Status:       models.UpdateJobStatusRunning,
+		Step:         updateStepInstanceConfig,
+		MaxAttempts:  1,
+		CreatedAt:    now.Add(-time.Minute),
+	}
+
+	delay, done, err := srv.advanceUpdateInstanceConfig(context.Background(), job, "req", now)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, provisionDefaultPollDelay, delay)
+	require.Equal(t, models.UpdateJobStatusRunning, job.Status)
+	require.Equal(t, updateStepInstanceConfig, job.Step)
+	require.Equal(t, updateInstanceRoleReadinessNote, job.Note)
+	require.Empty(t, job.ErrorCode)
+	require.Empty(t, job.ErrorMessage)
+	require.Equal(t, int64(0), job.Attempts)
+}
+
+func TestAdvanceUpdateInstanceConfig_FailsWhenAssumeRoleReadinessDeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	db := ttmocks.NewMockExtendedDB()
+	qInst := new(ttmocks.MockQuery)
+
+	db.On("WithContext", mock.Anything).Return(db).Maybe()
+	db.On("Model", mock.AnythingOfType("*models.Instance")).Return(qInst).Maybe()
+	qInst.On("Where", mock.Anything, mock.Anything, mock.Anything).Return(qInst).Maybe()
+	qInst.On("ConsistentRead").Return(qInst).Maybe()
+	qInst.On("First", mock.AnythingOfType("*models.Instance")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.Instance](t, args, 0)
+		*dest = models.Instance{
+			Slug:             "slug",
+			Owner:            "wallet-deadbeef",
+			HostedAccountID:  "123",
+			HostedRegion:     "us-east-1",
+			HostedBaseDomain: "example.com",
+		}
+	}).Once()
+
+	now := time.Unix(1000, 0).UTC()
+	srv := &Server{
+		cfg:   config.Config{ManagedInstanceRoleName: "role", Stage: "lab"},
+		store: store.New(db),
+		sts:   &fakeSTS{err: errors.New("NoSuchEntity: role has not propagated")},
+	}
+	job := &models.UpdateJob{
+		ID:           "j1",
+		InstanceSlug: "slug",
+		Status:       models.UpdateJobStatusRunning,
+		Step:         updateStepInstanceConfig,
+		MaxAttempts:  10,
+		CreatedAt:    now.Add(-(updateInstanceRoleReadinessAge + time.Second)),
+	}
+
+	delay, done, err := srv.advanceUpdateInstanceConfig(context.Background(), job, "req", now)
+	require.NoError(t, err)
+	require.False(t, done)
+	require.Equal(t, time.Duration(0), delay)
+	require.Equal(t, models.UpdateJobStatusError, job.Status)
+	require.Equal(t, updateStepFailed, job.Step)
+	require.Equal(t, updateInstanceRoleReadinessCode, job.ErrorCode)
+	require.Equal(t, updateInstanceRoleReadinessMsg, job.ErrorMessage)
+	require.Equal(t, updateInstanceRoleReadinessMsg, job.Note)
+	require.Equal(t, int64(0), job.Attempts)
+}
+
 func TestAdvanceUpdateInstanceConfig_RetriesWhenSecretsManagerClientCannotBeAssumed(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Treat wrapped errAssumeRoleNotReady during managed update instance configuration as bounded readiness, not as a generic instance-key secret failure. The job remains running with an operator-visible readiness note and polls on the standard provisioner poll delay until the existing assume-role readiness age is exceeded, then fails with the distinct instance_role_not_ready code.\n\nPreserves generic instance_key_secret_failed handling for real secret/tag/cross-stage failures.\n\nCloses #837