### PR TITLE
P51 genesis v2: populate transcript for all statuses and add stuck-turn recovery

### DIFF
--- a/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,116 @@ import (
 	"github.com/equaltoai/lesser-host/internal/store/models"
 	"github.com/equaltoai/lesser-host/internal/testutil"
 )
+
+func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	runnerCalled := false
+	s.hostedGenesisAssistantRunner = func(_ context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		runnerCalled = true
+		if len(in.messages) != 1 || in.messages[0].Role != hostedGenesisTranscriptRoleUser || in.messages[0].Content != "stuck user turn" {
+			t.Fatalf("recovery must replay existing accepted messages without appending a duplicate turn: %#v", in.messages)
+		}
+		if strings.Contains(in.systemPrompt, mintConversationInstanceReadTestRawKey) {
+			t.Fatalf("recovery prompt leaked instance key")
+		}
+		return hostedGenesisAssistantRunResult{
+			fullResponse: "recovered assistant turn",
+			usage:        models.AIUsage{Provider: "test", Model: in.modelSet, InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
+		}, nil
+	}
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubSoulInstanceRecoveryConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"stuck user turn"}]`),
+		Status:         models.SoulMintConversationStatusInProgress,
+		LatestTurnID:   "turn-stuck",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubSoulInstanceRecoverySession(t, tdb, hostedGenesisRecoverySessionFixture(t, reg, hostedgenesis.StatusInProgress, ""))
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	if !runnerCalled {
+		t.Fatalf("expected recovery to rerun the assistant turn")
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 recovery response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
+		out.Conversation.MessageCount != 2 ||
+		len(out.Conversation.Messages) != 2 ||
+		out.Conversation.Messages[1].Content != "recovered assistant turn" {
+		t.Fatalf("expected recovered assistant-ready response with transcript, got %#v", out.Conversation)
+	}
+	if strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("recovery response leaked credential material: %s", string(resp.Body))
+	}
+}
+
+func TestSoulInstanceRecoverMintConversation_NonStuckIsNoop(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	s.hostedGenesisAssistantRunner = func(_ context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		t.Fatalf("non-stuck recovery must not rerun assistant turn: %#v", in)
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubSoulInstanceRecoveryConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"already done"},{"role":"assistant","content":"ready"}]`),
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
+		LatestTurnID:   "turn-ready",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubSoulInstanceRecoverySession(t, tdb, hostedGenesisRecoverySessionFixture(t, reg, hostedgenesis.StatusAssistantTurnReady, "checkpoint://hosted-genesis/conv-1/assistant/turn-ready"))
+
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 noop response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
+		len(out.Conversation.Messages) != 2 ||
+		out.Conversation.Messages[1].Content != "ready" {
+		t.Fatalf("expected current assistant-ready state without recovery mutation, got %#v", out.Conversation)
+	}
+	tdb.db.AssertNotCalled(t, "TransactWrite", mock.Anything, mock.Anything)
+}
 
 func TestSoulInstanceGetRegistrationMintConversation_ReturnsRecoveryWithoutQueueOrLeaks(t *testing.T) {
 	tdb := newMintConversationTestDB()
@@ -44,6 +155,57 @@ func TestSoulInstanceGetRegistrationMintConversation_ReturnsRecoveryWithoutQueue
 	assertHostedGenesisFailedRecoveryProjection(t, out.Conversation)
 	assertHostedGenesisResponseNoForbiddenValues(t, resp.Body, hostedGenesisStatusForbiddenValues())
 	assertHostedGenesisStatusAuditNoLeaks(t, tdb, append(hostedGenesisStatusForbiddenValues(), soulInstanceBootstrapTestInstanceSlug, reg.AgentID, mintConversationTestConversationID))
+}
+
+func stubSoulInstanceRecoveryConversation(t *testing.T, tdb *mintConversationTestDB, conv models.SoulAgentMintConversation) {
+	t.Helper()
+	tdb.qConv.On("First", mock.AnythingOfType("*models.SoulAgentMintConversation")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.SoulAgentMintConversation](t, args, 0)
+		*dest = conv
+	}).Once()
+}
+
+func stubSoulInstanceRecoverySession(t *testing.T, tdb *mintConversationTestDB, session models.HostedGenesisSession) {
+	t.Helper()
+	tdb.qHosted.On("First", mock.AnythingOfType("*models.HostedGenesisSession")).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		*dest = session
+	}).Once()
+}
+
+func hostedGenesisRecoverySessionFixture(t *testing.T, reg models.SoulAgentRegistration, status hostedgenesis.Status, assistantCheckpointRef string) models.HostedGenesisSession {
+	t.Helper()
+	now := time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC)
+	session := models.HostedGenesisSession{
+		Version:                3,
+		InstanceSlug:           soulInstanceBootstrapTestInstanceSlug,
+		RegistrationID:         reg.ID,
+		AgentID:                reg.AgentID,
+		ConversationID:         mintConversationTestConversationID,
+		Status:                 string(status),
+		Model:                  "anthropic:claude-sonnet-4-6",
+		LatestTurnID:           "turn-stuck",
+		MessageCount:           1,
+		AssistantCheckpointRef: strings.TrimSpace(assistantCheckpointRef),
+		TurnLedger: []hostedgenesis.TurnLedgerEntry{{
+			TurnID:         "turn-stuck",
+			ChargedCredits: soulMintConversationStreamBaseCredits,
+			MessageCount:   1,
+			AcceptedAt:     now,
+		}},
+		RequestID: "req-original",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if status == hostedgenesis.StatusAssistantTurnReady {
+		session.LatestTurnID = "turn-ready"
+		session.MessageCount = 2
+		session.TurnLedger[0].TurnID = "turn-ready"
+	}
+	if err := session.BeforeCreate(); err != nil {
+		t.Fatalf("session fixture: %v", err)
+	}
+	return session
 }
 
 func stubFailedRecoveryLegacyMintConversation(t *testing.T, tdb *mintConversationTestDB, reg models.SoulAgentRegistration, now time.Time) {

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -26,19 +26,21 @@ const (
 )
 
 type hostedGenesisTurnSession struct {
-	conversationID   string
-	turnID           string
-	modelSet         string
-	existingMessages []soulMintConversationMessage
-	existingUsage    models.AIUsage
-	sessionIsNew     bool
-	expectedStatus   hostedgenesis.Status
-	expectedVersion  int64
-	replayed         bool
-	requestHash      string
-	idempotency      *models.SoulMintConversationIdempotency
-	conv             *models.SoulAgentMintConversation
-	session          *models.HostedGenesisSession
+	conversationID     string
+	turnID             string
+	modelSet           string
+	existingMessages   []soulMintConversationMessage
+	existingUsage      models.AIUsage
+	sessionIsNew       bool
+	expectedStatus     hostedgenesis.Status
+	expectedVersion    int64
+	progressVersion    int64
+	hasProgressVersion bool
+	replayed           bool
+	requestHash        string
+	idempotency        *models.SoulMintConversationIdempotency
+	conv               *models.SoulAgentMintConversation
+	session            *models.HostedGenesisSession
 }
 
 func (s *Server) handleSoulMintConversationForRegistrationAsync(ctx *apptheory.Context, regCtx mintConversationRegistrationContext, instanceSlug string) (*apptheory.Response, error) {
@@ -297,6 +299,9 @@ func (s *Server) persistHostedGenesisProgression(ctx context.Context, accepted h
 }
 
 func hostedGenesisAcceptedTurnPostPersistVersion(session hostedGenesisTurnSession) int64 {
+	if session.hasProgressVersion {
+		return session.progressVersion
+	}
 	if session.sessionIsNew {
 		if session.session != nil {
 			return session.session.Version

--- a/internal/controlplane/handlers_soul_mint_conversation_instance_read.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_instance_read.go
@@ -28,8 +28,9 @@ const (
 	soulMintInstanceReadListMaxBytes            = 1024 * 1024
 	soulMintInstanceReadSingleMaxBytes          = 2 * 1024 * 1024
 
-	soulMintInstanceReadRouteList   = "mint_conversation_list"
-	soulMintInstanceReadRouteSingle = "mint_conversation_single"
+	soulMintInstanceReadRouteList    = "mint_conversation_list"
+	soulMintInstanceReadRouteSingle  = "mint_conversation_single"
+	soulMintInstanceReadRouteRecover = "mint_conversation_recover"
 
 	soulMintInstanceReadCodeInvalidRequest    = "soul_mint.invalid_request"
 	soulMintInstanceReadCodeUnauthorized      = "soul_mint.unauthorized"

--- a/internal/controlplane/handlers_soul_mint_conversation_recover.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_recover.go
@@ -1,0 +1,133 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func (s *Server) handleSoulInstanceRecoverMintConversation(ctx *apptheory.Context) (*apptheory.Response, error) {
+	started := time.Now().UTC()
+	convCtx, appErr := s.requireSoulInstanceBootstrapConversationContext(ctx)
+	if appErr != nil {
+		return nil, appErr
+	}
+	decodeMintConversationFields(convCtx.conv)
+	if appErr := rejectOversizeSoulMintInstanceConversation(convCtx.conv); appErr != nil {
+		return nil, appErr
+	}
+
+	if !hostedGenesisSessionNeedsAssistantRecovery(convCtx.session) {
+		resp, err := hostedGenesisConversationJSONFromSession(http.StatusOK, convCtx.session, convCtx.conv, hostedGenesisProjectionOptions{
+			RegistrationID:  convCtx.reg.ID,
+			RequestID:       strings.TrimSpace(ctx.RequestID),
+			CollapseCreated: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		s.recordSoulMintInstanceReadAudit(ctx, convCtx.key, convCtx.agentIDHex, convCtx.conversationID, soulMintInstanceReadRouteRecover, "noop", resp.Status, len(resp.Body), started)
+		return resp, nil
+	}
+
+	turnSession, acceptedMessages, buildErr := hostedGenesisRecoveryTurnSession(convCtx)
+	if buildErr != nil {
+		return nil, soulInstanceBootstrapConversationErrorFromAppError(buildErr)
+	}
+	apiKey, apiKeyErr := s.apiKeyForMintConversationModel(ctx.Context(), turnSession.modelSet)
+	if apiKeyErr != nil {
+		return nil, soulInstanceBootstrapConversationErrorFromAppError(apiKeyErr)
+	}
+
+	progressedSession, progressedConv, status, progressErr := s.progressHostedGenesisAcceptedTurn(
+		ctx.Context(),
+		mintConversationRegistrationContext{reg: convCtx.reg, inst: convCtx.inst, agentIDHex: convCtx.agentIDHex},
+		turnSession,
+		convCtx.conv,
+		acceptedMessages,
+		apiKey,
+		strings.TrimSpace(ctx.RequestID),
+	)
+	if progressErr != nil {
+		return nil, soulInstanceBootstrapConversationErrorFromAppError(progressErr)
+	}
+	resp, err := hostedGenesisConversationJSONFromSession(status, progressedSession, progressedConv, hostedGenesisProjectionOptions{
+		RegistrationID:  convCtx.reg.ID,
+		RequestID:       strings.TrimSpace(ctx.RequestID),
+		CollapseCreated: true,
+	})
+	if err != nil {
+		return nil, err
+	}
+	s.recordSoulMintInstanceReadAudit(ctx, convCtx.key, convCtx.agentIDHex, convCtx.conversationID, soulMintInstanceReadRouteRecover, "success", resp.Status, len(resp.Body), started)
+	return resp, nil
+}
+
+func hostedGenesisSessionNeedsAssistantRecovery(session *models.HostedGenesisSession) bool {
+	if session == nil {
+		return false
+	}
+	return hostedgenesis.NormalizeStatus(session.Status) == hostedgenesis.StatusInProgress &&
+		strings.TrimSpace(session.AssistantCheckpointRef) == ""
+}
+
+func hostedGenesisRecoveryTurnSession(convCtx soulInstanceBootstrapConversationContext) (hostedGenesisTurnSession, []soulMintConversationMessage, *apptheory.AppError) {
+	if convCtx.session == nil || convCtx.conv == nil {
+		return hostedGenesisTurnSession{}, nil, &apptheory.AppError{Code: soulMintAppErrCodeNotFound, Message: "conversation not found"}
+	}
+	if !hostedGenesisConversationMatchesSession(convCtx.session, convCtx.conv) ||
+		!strings.EqualFold(strings.TrimSpace(convCtx.session.RegistrationID), strings.TrimSpace(convCtx.reg.ID)) {
+		return hostedGenesisTurnSession{}, nil, &apptheory.AppError{Code: appErrCodeForbidden, Message: "conversation is outside the registration boundary"}
+	}
+	messages, appErr := hostedGenesisRecoveryMessages(convCtx.conv)
+	if appErr != nil {
+		return hostedGenesisTurnSession{}, nil, appErr
+	}
+	turnID := firstNonEmpty(convCtx.session.LatestTurnID, convCtx.conv.LatestTurnID)
+	if turnID == "" && len(convCtx.session.TurnLedger) > 0 {
+		turnID = convCtx.session.TurnLedger[len(convCtx.session.TurnLedger)-1].Normalize().TurnID
+	}
+	if turnID == "" {
+		return hostedGenesisTurnSession{}, nil, &apptheory.AppError{Code: soulMintAppErrCodeConflict, Message: "conversation cannot recover without an accepted turn"}
+	}
+	modelSet := firstNonEmpty(convCtx.session.Model, convCtx.conv.Model, defaultSoulMintConversationModel)
+	session := hostedGenesisTurnSession{
+		conversationID:     strings.TrimSpace(convCtx.session.ConversationID),
+		turnID:             strings.TrimSpace(turnID),
+		modelSet:           strings.TrimSpace(modelSet),
+		existingMessages:   append([]soulMintConversationMessage(nil), messages...),
+		existingUsage:      convCtx.conv.Usage,
+		expectedStatus:     hostedgenesis.StatusInProgress,
+		expectedVersion:    convCtx.session.Version,
+		progressVersion:    convCtx.session.Version,
+		hasProgressVersion: true,
+		conv:               convCtx.conv,
+		session:            convCtx.session,
+	}
+	return session, messages, nil
+}
+
+func hostedGenesisRecoveryMessages(conv *models.SoulAgentMintConversation) ([]soulMintConversationMessage, *apptheory.AppError) {
+	if conv == nil {
+		return nil, &apptheory.AppError{Code: soulMintAppErrCodeNotFound, Message: "conversation not found"}
+	}
+	raw := strings.TrimSpace(models.DecodeSoulMintConversationBlob(conv.Messages))
+	if raw == "" {
+		return nil, &apptheory.AppError{Code: soulMintAppErrCodeConflict, Message: "conversation cannot recover without stored messages"}
+	}
+	var messages []soulMintConversationMessage
+	if err := json.Unmarshal([]byte(raw), &messages); err != nil || len(messages) == 0 {
+		return nil, &apptheory.AppError{Code: soulMintAppErrCodeConflict, Message: "conversation cannot recover without stored messages"}
+	}
+	for i := range messages {
+		messages[i].Role = strings.ToLower(strings.TrimSpace(messages[i].Role))
+		messages[i].Content = strings.TrimSpace(messages[i].Content)
+	}
+	return messages, nil
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_session.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_session.go
@@ -61,7 +61,7 @@ func buildHostedGenesisConversationResponseFromSession(session *models.HostedGen
 		UpdatedAt:        timePtrIfSet(projection.UpdatedAt),
 		CompletedAt:      timePtrIfSet(projection.CompletedAt),
 	}
-	if projection.Status == hostedgenesis.StatusAssistantTurnReady {
+	if hostedGenesisStatusIncludesMessages(string(projection.Status)) {
 		if messages, bounded := buildHostedGenesisConversationMessages(session, conv); len(messages) > 0 {
 			responseProjection.Messages = messages
 			responseProjection.MessagesTruncated = bounded

--- a/internal/controlplane/handlers_soul_mint_conversation_session_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_session_internal_test.go
@@ -73,7 +73,35 @@ func TestHostedGenesisProducedDeclarationsFromSessionTrustsCheckpointHash(t *tes
 	}
 }
 
-func TestHostedGenesisSessionProjectionIncludesBoundedMessages(t *testing.T) {
+func TestHostedGenesisSessionProjectionIncludesInProgressMessages(t *testing.T) {
+	t.Parallel()
+
+	acceptedAt := time.Date(2026, 3, 7, 12, 1, 0, 0, time.UTC)
+	session := testHostedGenesisSessionProjectionBase()
+	session.Status = string(hostedgenesis.StatusInProgress)
+	session.MessageCount = 1
+	session.TurnLedger = []hostedgenesis.TurnLedgerEntry{{
+		TurnID:         "turn-session",
+		MessageCount:   1,
+		ChargedCredits: soulMintConversationStreamBaseCredits,
+		AcceptedAt:     acceptedAt,
+	}}
+	conv := &models.SoulAgentMintConversation{
+		AgentID:        session.AgentID,
+		ConversationID: session.ConversationID,
+		Messages:       models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"hello while waiting"}]`),
+	}
+
+	resp := buildHostedGenesisConversationResponseFromSession(session, conv, hostedGenesisProjectionOptions{RequestID: "req-visible"})
+	if len(resp.Conversation.Messages) != 1 || resp.Conversation.MessagesTruncated {
+		t.Fatalf("expected one untruncated in-progress transcript message, got %#v", resp.Conversation)
+	}
+	if got := resp.Conversation.Messages[0]; got.ID != "msg_000001" || got.Order != 1 || got.Role != hostedGenesisTranscriptRoleUser || got.Content != "hello while waiting" || got.CreatedAt == nil || !got.CreatedAt.Equal(acceptedAt) {
+		t.Fatalf("unexpected in-progress message projection: %#v", got)
+	}
+}
+
+func TestHostedGenesisSessionProjectionIncludesAssistantReadyMessages(t *testing.T) {
 	t.Parallel()
 
 	acceptedAt := time.Date(2026, 3, 7, 12, 1, 0, 0, time.UTC)
@@ -140,6 +168,24 @@ func TestHostedGenesisSessionProjectionBoundsAndOmitsUnsafeMessages(t *testing.T
 	mismatched.AgentID = "0x" + strings.Repeat("99", 32)
 	if projected, _ := buildHostedGenesisConversationMessages(session, &mismatched); len(projected) != 0 {
 		t.Fatalf("mismatched compatibility row must not project transcript, got %#v", projected)
+	}
+}
+
+func TestHostedGenesisSessionProjectionOmitsTerminalMessages(t *testing.T) {
+	t.Parallel()
+
+	session := testHostedGenesisSessionProjectionBase()
+	session.Status = string(hostedgenesis.StatusFailed)
+	session.Failure = testHostedGenesisFailure(hostedgenesis.FailureCodeAssistantTurnFailed)
+	conv := &models.SoulAgentMintConversation{
+		AgentID:        session.AgentID,
+		ConversationID: session.ConversationID,
+		Messages:       models.EncodeSoulMintConversationBlob(`[{"role":"user","content":"do not include terminal transcript"}]`),
+	}
+
+	resp := buildHostedGenesisConversationResponseFromSession(session, conv, hostedGenesisProjectionOptions{RequestID: "req-terminal"})
+	if len(resp.Conversation.Messages) != 0 || strings.Contains(string(mustMarshalJSON(t, resp)), "do not include terminal transcript") {
+		t.Fatalf("terminal status should omit transcript messages, got %#v", resp.Conversation)
 	}
 }
 

--- a/internal/controlplane/handlers_soul_mint_conversation_status.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_status.go
@@ -360,6 +360,18 @@ func hostedGenesisTranscriptContentUnsafe(content string) bool {
 	return false
 }
 
+func hostedGenesisStatusIncludesMessages(status string) bool {
+	switch strings.TrimSpace(status) {
+	case models.SoulMintConversationStatusCreated,
+		models.SoulMintConversationStatusInProgress,
+		models.SoulMintConversationStatusAssistantTurnReady,
+		models.SoulMintConversationStatusDeclarationExtractionPending:
+		return true
+	default:
+		return false
+	}
+}
+
 func isHostedGenesisProgressStatus(status string) bool {
 	switch strings.TrimSpace(status) {
 	case models.SoulMintConversationStatusCreated,

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -288,6 +288,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Post("/api/v1/soul/instance/agents/register/{id}/verify", s.handleSoulInstanceAgentRegistrationVerify)
 	app.Post("/api/v1/soul/instance/agents/register/{id}/mint-conversation", s.handleSoulInstanceMintConversation)
 	app.Get("/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}", s.handleSoulInstanceGetRegistrationMintConversation)
+	app.Post("/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/recover", s.handleSoulInstanceRecoverMintConversation)
 	app.Post("/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/complete", s.handleSoulInstanceCompleteMintConversation)
 	app.Post("/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/finalize/preflight", s.handleSoulInstanceFinalizeMintConversationPreflight)
 	app.Post("/api/v1/soul/instance/agents/register/{id}/mint-conversation/{conversationId}/finalize/begin", s.handleSoulInstanceBeginFinalizeMintConversation)


### PR DESCRIPTION
Closes #859. Populates Messages in conversation response for all non-terminal statuses. Adds POST /mint-conversation/{conversationId}/recover endpoint for stuck in_progress sessions.