### PR TITLE
P51 genesis v2: add GET mint-conversations list endpoint (#865)

### DIFF
--- a/internal/controlplane/handlers_soul_mint_conversation_list.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_list.go
@@ -1,0 +1,99 @@
+package controlplane
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+)
+
+// soulInstanceMintConversationListSummary is the compact conversation summary
+// projected for the instance-key list endpoint. It excludes messages,
+// produced declarations, and all private/internal fields.
+type soulInstanceMintConversationListSummary struct {
+	ConversationID string    `json:"conversation_id"`
+	RegistrationID string    `json:"registration_id"`
+	Status         string    `json:"status"`
+	MessageCount   int       `json:"message_count"`
+	LatestTurnID   string    `json:"latest_turn_id,omitempty"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at,omitempty"`
+}
+
+type soulInstanceMintConversationListResponse struct {
+	Conversations []soulInstanceMintConversationListSummary `json:"conversations"`
+}
+
+// handleSoulInstanceListMintConversationSummaries returns a bounded list of
+// conversation summaries for an agent within the authenticated instance
+// boundary. It queries HostedGenesisSession (the durable source of truth) via
+// the agent-scoped GSI2 index, projects metadata-only summaries, sorts by
+// updated_at descending, and bounds to max 50 results.
+//
+// This handler is instance-key authenticated and reuses the same auth context
+// as the single-conversation read handler. No messages, produced declarations,
+// or other private transcript material are included in the response.
+func (s *Server) handleSoulInstanceListMintConversationSummaries(ctx *apptheory.Context) (*apptheory.Response, error) {
+	start := time.Now()
+	reqCtx, appErr := s.requireMintConversationInstanceReadContext(ctx)
+	if appErr != nil {
+		s.logSoulMintInstanceReadAccess(ctx, nil, ctxParam(ctx, "agentId"), "", soulMintInstanceReadRouteList, "error", appErr.StatusCode, 0, start)
+		return nil, appErr
+	}
+
+	limit, appErr := parseSoulMintInstanceReadLimit(ctx)
+	if appErr != nil {
+		s.logSoulMintInstanceReadAccess(ctx, reqCtx.key, reqCtx.agentIDHex, "", soulMintInstanceReadRouteList, "error", appErr.StatusCode, 0, start)
+		return nil, appErr
+	}
+
+	sessions, err := s.store.ListHostedGenesisSessionsByAgent(ctx.Context(), reqCtx.key.InstanceSlug, reqCtx.agentIDHex)
+	if err != nil {
+		appErr := soulMintInstanceReadError(soulMintInstanceReadCodeInternal, "failed to list mint conversations", http.StatusInternalServerError, nil)
+		s.logSoulMintInstanceReadAccess(ctx, reqCtx.key, reqCtx.agentIDHex, "", soulMintInstanceReadRouteList, "error", appErr.StatusCode, 0, start)
+		return nil, appErr
+	}
+
+	summaries := make([]soulInstanceMintConversationListSummary, 0, len(sessions))
+	for _, session := range sessions {
+		if session == nil {
+			continue
+		}
+		summaries = append(summaries, soulInstanceMintConversationListSummary{
+			ConversationID: strings.TrimSpace(session.ConversationID),
+			RegistrationID: strings.TrimSpace(session.RegistrationID),
+			Status:         strings.TrimSpace(session.Status),
+			MessageCount:   session.MessageCount,
+			LatestTurnID:   strings.TrimSpace(session.LatestTurnID),
+			CreatedAt:      session.CreatedAt.UTC(),
+			UpdatedAt:      session.UpdatedAt.UTC(),
+		})
+	}
+
+	// GSI2 sorts by createdAt; sort by updated_at descending in-memory as
+	// required by the list contract. Tie-break by conversation_id for stability.
+	sort.SliceStable(summaries, func(i, j int) bool {
+		if summaries[i].UpdatedAt.Equal(summaries[j].UpdatedAt) {
+			return summaries[i].ConversationID > summaries[j].ConversationID
+		}
+		return summaries[i].UpdatedAt.After(summaries[j].UpdatedAt)
+	})
+
+	// Bound to the requested limit (max 50, enforced by parseSoulMintInstanceReadLimit).
+	if limit > 0 && len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+
+	resp, jsonErr := soulMintInstanceReadJSON(http.StatusOK, soulInstanceMintConversationListResponse{
+		Conversations: summaries,
+	}, soulMintInstanceReadListMaxBytes)
+	if jsonErr != nil {
+		appErr := soulMintInstanceReadResponseError(jsonErr)
+		s.logSoulMintInstanceReadAccess(ctx, reqCtx.key, reqCtx.agentIDHex, "", soulMintInstanceReadRouteList, "error", appErr.StatusCode, 0, start)
+		return nil, appErr
+	}
+	s.recordSoulMintInstanceReadAudit(ctx, reqCtx.key, reqCtx.agentIDHex, "", soulMintInstanceReadRouteList, "success", resp.Status, len(resp.Body), start)
+	return resp, nil
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_list_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_list_internal_test.go
@@ -1,0 +1,454 @@
+package controlplane
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// constTestListRegPrefix avoids goconst collisions with "reg-1" used in other
+// test files in this package.
+const constTestListRegPrefix = "list-reg"
+
+// mockMethodAll is the testify mock method name for DynamoDB All(). Centralized
+// to avoid goconst duplicate-string findings across the filter helpers below.
+const mockMethodAll = "All"
+
+func filterMockAllCalls(q *ttmocks.MockQuery) {
+	var filtered []*mock.Call
+	for _, call := range q.ExpectedCalls {
+		if call.Method != mockMethodAll {
+			filtered = append(filtered, call)
+		}
+	}
+	q.ExpectedCalls = filtered
+}
+
+func TestSoulInstanceListMintConversationSummaries_ReturnsConversationsForAgent(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	baseTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	stubHostedGenesisSessionList(t, tdb, []models.HostedGenesisSession{
+		{
+			InstanceSlug:   "inst1",
+			RegistrationID: constTestListRegPrefix + "-a",
+			AgentID:        identity.AgentID,
+			ConversationID: "conv-a",
+			Status:         string(hostedgenesis.StatusInProgress),
+			LatestTurnID:   "turn-1",
+			MessageCount:   3,
+			CreatedAt:      baseTime,
+			UpdatedAt:      baseTime.Add(time.Hour),
+		},
+		{
+			InstanceSlug:   "inst1",
+			RegistrationID: constTestListRegPrefix + "-b",
+			AgentID:        identity.AgentID,
+			ConversationID: "conv-b",
+			Status:         string(hostedgenesis.StatusDeclarationReady),
+			LatestTurnID:   "turn-2",
+			MessageCount:   5,
+			CreatedAt:      baseTime.Add(2 * time.Hour),
+			UpdatedAt:      baseTime.Add(3 * time.Hour),
+		},
+	})
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", map[string][]string{"limit": {"50"}})
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.Status)
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	if len(out.Conversations) != 2 {
+		t.Fatalf("expected 2 conversations, got %d", len(out.Conversations))
+	}
+	assertListSummaryValid(t, out.Conversations[0], "conv-b", constTestListRegPrefix+"-b", "turn-2", 5)
+	assertListSummaryValid(t, out.Conversations[1], "conv-a", constTestListRegPrefix+"-a", "turn-1", 3)
+}
+
+func assertListSummaryValid(t *testing.T, c soulInstanceMintConversationListSummary, wantConv, wantReg, wantTurn string, wantMsgCount int) {
+	t.Helper()
+	if c.ConversationID != wantConv {
+		t.Fatalf("expected conversation_id %q, got %q", wantConv, c.ConversationID)
+	}
+	if c.RegistrationID != wantReg {
+		t.Fatalf("expected registration_id %q, got %q", wantReg, c.RegistrationID)
+	}
+	if c.Status == "" {
+		t.Fatalf("status must not be empty: %#v", c)
+	}
+	if c.MessageCount != wantMsgCount {
+		t.Fatalf("expected message_count %d, got %d", wantMsgCount, c.MessageCount)
+	}
+	if c.LatestTurnID != wantTurn {
+		t.Fatalf("expected latest_turn_id %q, got %q", wantTurn, c.LatestTurnID)
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_BoundedToFifty(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	baseTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	sessions := make([]models.HostedGenesisSession, 55)
+	for i := range sessions {
+		sessions[i] = models.HostedGenesisSession{
+			InstanceSlug:   "inst1",
+			RegistrationID: fmt.Sprintf("%s-%03d", constTestListRegPrefix, i),
+			AgentID:        identity.AgentID,
+			ConversationID: fmt.Sprintf("conv-%03d", i),
+			Status:         string(hostedgenesis.StatusInProgress),
+			LatestTurnID:   fmt.Sprintf("turn-%03d", i),
+			MessageCount:   i + 1,
+			CreatedAt:      baseTime.Add(time.Duration(i) * time.Minute),
+			UpdatedAt:      baseTime.Add(time.Duration(i) * time.Minute),
+		}
+	}
+	stubHostedGenesisSessionList(t, tdb, sessions)
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", map[string][]string{"limit": {"50"}})
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Conversations) != 50 {
+		t.Fatalf("expected exactly 50 conversations (bounded), got %d", len(out.Conversations))
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_SortedByUpdatedAtDescending(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	// Sessions intentionally not in updated_at order to verify sort.
+	baseTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	stubHostedGenesisSessionList(t, tdb, []models.HostedGenesisSession{
+		{
+			InstanceSlug:   "inst1",
+			RegistrationID: constTestListRegPrefix + "-old",
+			AgentID:        identity.AgentID,
+			ConversationID: "conv-old",
+			Status:         string(hostedgenesis.StatusInProgress),
+			MessageCount:   1,
+			CreatedAt:      baseTime,
+			UpdatedAt:      baseTime, // oldest updated_at
+		},
+		{
+			InstanceSlug:   "inst1",
+			RegistrationID: constTestListRegPrefix + "-newest",
+			AgentID:        identity.AgentID,
+			ConversationID: "conv-newest",
+			Status:         string(hostedgenesis.StatusDeclarationReady),
+			MessageCount:   2,
+			CreatedAt:      baseTime.Add(2 * time.Hour),
+			UpdatedAt:      baseTime.Add(5 * time.Hour), // newest updated_at
+		},
+		{
+			InstanceSlug:   "inst1",
+			RegistrationID: constTestListRegPrefix + "-mid",
+			AgentID:        identity.AgentID,
+			ConversationID: "conv-mid",
+			Status:         string(hostedgenesis.StatusFailed),
+			MessageCount:   3,
+			CreatedAt:      baseTime.Add(time.Hour),
+			UpdatedAt:      baseTime.Add(3 * time.Hour), // middle updated_at
+		},
+	})
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", map[string][]string{"limit": {"50"}})
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Conversations) != 3 {
+		t.Fatalf("expected 3 conversations, got %d", len(out.Conversations))
+	}
+	expected := []string{"conv-newest", "conv-mid", "conv-old"}
+	for i, want := range expected {
+		if out.Conversations[i].ConversationID != want {
+			t.Fatalf("position %d: expected %q, got %q — full order: %#v", i, want, out.Conversations[i].ConversationID, out.Conversations)
+		}
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_NoMessagesOrDeclarationsInSummary(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	baseTime := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	stubHostedGenesisSessionList(t, tdb, []models.HostedGenesisSession{
+		{
+			InstanceSlug:           "inst1",
+			RegistrationID:         constTestListRegPrefix + "-secret",
+			AgentID:                identity.AgentID,
+			ConversationID:         "conv-a",
+			Status:                 string(hostedgenesis.StatusInProgress),
+			MessageCount:           2,
+			LatestTurnID:           "turn-1",
+			InputCheckpointRef:     "checkpoint://secret/input",
+			AssistantCheckpointRef: "checkpoint://secret/assistant",
+			TurnLedger: []hostedgenesis.TurnLedgerEntry{{
+				TurnID:         "turn-1",
+				ChargedCredits: 5,
+				MessageCount:   2,
+			}},
+			CreatedAt: baseTime,
+			UpdatedAt: baseTime.Add(time.Hour),
+		},
+	})
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", nil)
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	body := string(resp.Body)
+	for _, forbidden := range []string{
+		"messages",
+		"produced_declarations",
+		"input_checkpoint_ref",
+		"assistant_checkpoint_ref",
+		"turn_ledger",
+		"checkpoint://secret",
+		"charged_credits",
+		mintConversationInstanceReadTestRawKey,
+	} {
+		if strings.Contains(body, forbidden) {
+			t.Fatalf("summary response leaked forbidden field %q: %s", forbidden, body)
+		}
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Conversations) != 1 {
+		t.Fatalf("expected 1 conversation, got %d", len(out.Conversations))
+	}
+	c := out.Conversations[0]
+	if c.ConversationID != "conv-a" || c.RegistrationID != constTestListRegPrefix+"-secret" {
+		t.Fatalf("unexpected summary: %#v", c)
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_UnauthenticatedRejected(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+
+	ctx := &apptheory.Context{
+		RequestID: "req-no-auth",
+		Params:    map[string]string{"agentId": "0xabc"},
+		Request: apptheory.Request{
+			Headers: map[string][]string{},
+		},
+	}
+
+	_, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulMintInstanceReadCodeUnauthorized || appErr.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected unauthorized 401, got %#v", appErr)
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_EmptyAgentReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", nil)
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error for empty agent: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 for empty agent, got %d", resp.Status)
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversations == nil {
+		t.Fatalf("conversations must be an empty array, not nil")
+	}
+	if len(out.Conversations) != 0 {
+		t.Fatalf("expected 0 conversations for empty agent, got %d", len(out.Conversations))
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_StoreErrorReturns500(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	// Remove default Maybe All mock and replace with error return.
+	filterMockAllCalls(tdb.qHosted)
+	tdb.qHosted.On(mockMethodAll, mock.Anything).Return(fmt.Errorf("dynamodb unavailable")).Once()
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", nil)
+
+	_, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulMintInstanceReadCodeInternal || appErr.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected internal error 500, got %#v", appErr)
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_NotFoundReturnsEmptyList(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	// NotFound from DynamoDB should be treated as empty list, not error.
+	filterMockAllCalls(tdb.qHosted)
+	tdb.qHosted.On(mockMethodAll, mock.Anything).Return(theoryErrors.ErrItemNotFound).Once()
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", nil)
+
+	resp, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	if err != nil {
+		t.Fatalf("unexpected error for not-found: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 for not-found, got %d", resp.Status)
+	}
+
+	var out soulInstanceMintConversationListResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(out.Conversations) != 0 {
+		t.Fatalf("expected 0 conversations for not-found, got %d", len(out.Conversations))
+	}
+}
+
+func TestSoulInstanceListMintConversationSummaries_InvalidLimitRejected(t *testing.T) {
+	t.Parallel()
+
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	identity := testMintConversationIdentity()
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, "inst1")
+	stubMintConversationIdentity(t, tdb, identity, nil)
+	stubMintConversationInstanceDomain(t, tdb, identity.Domain, "inst1")
+
+	ctx := newMintConversationInstanceReadContext(identity.AgentID, "", map[string][]string{"limit": {"999"}})
+
+	_, err := s.handleSoulInstanceListMintConversationSummaries(ctx)
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulMintInstanceReadCodeInvalidRequest || appErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected invalid request 400, got %#v", appErr)
+	}
+}
+
+// stubHostedGenesisSessionList mocks the GSI2 query result for
+// ListHostedGenesisSessionsByAgent, populating the destination slice with
+// the provided sessions. Sessions are used as-is without BeforeCreate —
+// the handler only reads domain fields, not computed PK/SK keys.
+func stubHostedGenesisSessionList(t *testing.T, tdb *mintConversationTestDB, sessions []models.HostedGenesisSession) {
+	t.Helper()
+
+	items := make([]*models.HostedGenesisSession, len(sessions))
+	for i := range sessions {
+		cp := sessions[i]
+		items[i] = &cp
+	}
+	// Append a nil entry to verify the handler skips nil sessions safely.
+	items = append(items, nil)
+
+	// Remove the default Maybe All mock from qHosted so the specific
+	// Once mock below is the one testify matches.
+	filterMockAllCalls(tdb.qHosted)
+
+	tdb.qHosted.On(mockMethodAll, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		dest := testutil.RequireMockArg[*[]*models.HostedGenesisSession](t, args, 0)
+		*dest = items
+	}).Once()
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -281,7 +281,7 @@ func (s *Server) RegisterRoutes(app *apptheory.App) {
 	app.Post("/api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/archive", s.handleSoulCommMailboxArchive)
 	app.Post("/api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/unarchive", s.handleSoulCommMailboxUnarchive)
 	app.Post("/api/v1/soul/comm/mailbox/{agentId}/messages/{messageRef}/delete", s.handleSoulCommMailboxDelete)
-	app.Get("/api/v1/soul/instance/agents/{agentId}/mint-conversations", s.handleSoulInstanceListMintConversations)
+	app.Get("/api/v1/soul/instance/agents/{agentId}/mint-conversations", s.handleSoulInstanceListMintConversationSummaries)
 	app.Get("/api/v1/soul/instance/agents/{agentId}/mint-conversations/{conversationId}", s.handleSoulInstanceGetMintConversation)
 	app.Post("/api/v1/soul/instance/agents/register/begin", s.handleSoulInstanceAgentRegistrationBegin)
 	app.Post("/api/v1/soul/instance/agents/register/{id}/principal-declaration/preflight", s.handleSoulInstanceAgentRegistrationPrincipalDeclarationPreflight)

--- a/internal/store/soul_mint_conversation.go
+++ b/internal/store/soul_mint_conversation.go
@@ -84,6 +84,25 @@ func (s *Store) PutSoulAgentMintConversation(ctx context.Context, item *models.S
 	return s.DB.WithContext(ctx).Model(item).CreateOrUpdate()
 }
 
+// ListHostedGenesisSessionsByAgent queries all hosted-genesis sessions for an agent
+// within a managed instance using the agent-scoped GSI2 index. Results are ordered
+// by GSI2SK (createdAt) natively; callers sort by updatedAt in-memory if needed.
+func (s *Store) ListHostedGenesisSessionsByAgent(ctx context.Context, instanceSlug string, agentID string) ([]*models.HostedGenesisSession, error) {
+	if s == nil || s.DB == nil {
+		return nil, theoryErrors.ErrItemNotFound
+	}
+	var items []*models.HostedGenesisSession
+	err := s.DB.WithContext(ctx).
+		Model(&models.HostedGenesisSession{}).
+		Index("gsi2").
+		Where("gsi2PK", "=", models.HostedGenesisSessionAgentGSI2PK(instanceSlug, agentID)).
+		All(&items)
+	if err != nil && !theoryErrors.IsNotFound(err) {
+		return nil, err
+	}
+	return items, nil
+}
+
 // GetSoulMintConversationIdempotency loads a hosted-genesis idempotency reservation.
 func (s *Store) GetSoulMintConversationIdempotency(ctx context.Context, instanceSlug string, registrationID string, idempotencyKey string) (*models.SoulMintConversationIdempotency, error) {
 	if s == nil || s.DB == nil {


### PR DESCRIPTION
* Staging (#861)

* P51 M6.12: project hosted genesis transcript (#857)

Expose a bounded private conversation.messages projection at assistant_turn_ready so Lesser can relay the hosted genesis transcript same-origin without receiving Host credentials. HostedGenesisSession remains authoritative for ids/status/retry/billing/declaration readiness; SoulAgentMintConversation.Messages is only compatibility transcript input after conversation and agent ids match.\n\nTranscript entries are capped to 64 messages and 8192 characters, use ordinal client-safe ids, include user turn timestamps only from the turn ledger, and omit the projection when stored compatibility content is malformed, mismatched, or credential/infrastructure-shaped.\n\nNo AppTheory/TableTheory changes, target-account/IAM changes, cloud mutation, on-chain mutation, or Host credential exposure.



* chore: untrack agent materials, gitignore opencode.json, track cdk.context.json (#858)

Migrate agent identity content (.agents/, .codex/, opencode.json) from git-tracked to untracked per TheoryMCP migration. Add opencode.json, .agents/, .codex/, .claude/ to .gitignore. Track cdk/cdk.context.json for deterministic CDK synth.

* feat: populate transcript for all statuses and add stuck-turn recovery (#860)

Closes #859

- Populate Messages in conversation response for all non-terminal statuses using hostedGenesisStatusIncludesMessages, not just assistant_turn_ready
- Add POST /mint-conversation/{conversationId}/recover endpoint
- Recovery handler checks for stuck in_progress with no assistant checkpoint, re-runs the assistant turn, idempotent for non-stuck sessions
- Add tests for transcript projection and recovery flow

---------



* feat: add GET mint-conversations list endpoint for instance-key agents

Add GET /api/v1/soul/instance/agents/{agentId}/mint-conversations that returns a bounded list (max 50) of conversation summaries for an agent within the authenticated instance boundary.

The handler queries HostedGenesisSession (the durable source of truth) via the agent-scoped GSI2 index, projects metadata-only summaries (conversation_id, registration_id, status, message_count, latest_turn_id, created_at, updated_at), sorts by updated_at descending, and bounds to the requested limit. No messages, produced declarations, or private transcript material are included in the summary response.

The route previously pointed to handleSoulInstanceListMintConversations which queried the legacy SoulAgentMintConversation model lacking registration_id and message_count fields. The new handler queries HostedGenesisSession which has all required summary fields and a purpose-built GSI2 agent index.

Closes #864

---------