### PR TITLE
feat: P52 H1.1 in-VM MicroVM genesis workload + explicit LLM timeout (kills G4/G8)

### DIFF
--- a/cdk/lib/hosted-genesis-microvm.ts
+++ b/cdk/lib/hosted-genesis-microvm.ts
@@ -13,6 +13,7 @@ import * as cdk from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as ec2 from "aws-cdk-lib/aws-ec2";
 import * as lambda from "aws-cdk-lib/aws-lambda";
+import * as s3assets from "aws-cdk-lib/aws-s3-assets";
 import type { Construct } from "constructs";
 
 export const HOSTED_GENESIS_MICROVM_NAMESPACE = "hosted-genesis" as const;
@@ -29,7 +30,6 @@ const contextKeys = {
   baseImageArn: "hostedGenesisMicrovmBaseImageArn",
   baseImageVersion: "hostedGenesisMicrovmBaseImageVersion",
   buildRoleArn: "hostedGenesisMicrovmBuildRoleArn",
-  codeArtifactUri: "hostedGenesisMicrovmCodeArtifactUri",
   authorizerTokenSha256: "hostedGenesisMicrovmAuthorizerTokenSha256",
 } as const;
 
@@ -108,6 +108,17 @@ export function configureHostedGenesisMicrovmLab(
     "HostedGenesisMicrovmShellIngressConnector",
   );
 
+  // The MicroVM image consumes a repo-built artifact (the in-VM hosted-genesis
+  // workload at cmd/hosted-genesis-microvm-workload), not an external
+  // codeArtifactUri CDK context value (kills G4). The workload binary is built
+  // at synth time and uploaded as a CDK S3 asset; the image's codeArtifact.uri
+  // points at that asset's S3 object URL.
+  const workloadArtifact = buildHostedGenesisMicrovmWorkloadAsset(
+    scope,
+    "HostedGenesisMicrovmWorkloadArtifact",
+    props.repoRoot,
+  );
+
   const microvmImage = new AppTheoryMicrovmImage(
     scope,
     "HostedGenesisMicrovmImage",
@@ -118,7 +129,7 @@ export function configureHostedGenesisMicrovmLab(
       baseImageArn: cfg.baseImageArn,
       baseImageVersion: cfg.baseImageVersion,
       buildRoleArn: cfg.buildRoleArn,
-      codeArtifact: { uri: cfg.codeArtifactUri },
+      codeArtifact: { uri: workloadArtifact.s3ObjectUrl },
       egressNetworkConnectors: [egressConnector],
       hooks: {
         port: 8080,
@@ -262,7 +273,6 @@ function readRequiredContext(
     baseImageArn: requiredContext(scope, contextKeys.baseImageArn),
     baseImageVersion: requiredContext(scope, contextKeys.baseImageVersion),
     buildRoleArn: requiredContext(scope, contextKeys.buildRoleArn),
-    codeArtifactUri: requiredContext(scope, contextKeys.codeArtifactUri),
     authorizerTokenSha256: normalizeTokenHash(
       requiredContext(scope, contextKeys.authorizerTokenSha256),
     ),
@@ -316,4 +326,38 @@ function buildGoBootstrapAsset(
     },
   });
   return lambda.Code.fromAsset(buildDir);
+}
+
+// buildHostedGenesisMicrovmWorkloadAsset builds the in-VM hosted-genesis
+// workload entrypoint (cmd/hosted-genesis-microvm-workload) for the MicroVM
+// image's linux/arm64 runtime and packages it as a CDK S3 asset. The returned
+// asset's s3ObjectUrl is the AppTheoryMicrovmImage codeArtifact.uri — a
+// repo-built artifact, not an external CDK context value (kills G4).
+//
+// The workload is a long-running HTTP server inside the MicroVM image (not a
+// Lambda handler), so it is packaged as a tarball the image build extracts. The
+// binary is built with CGO disabled for a static image payload.
+function buildHostedGenesisMicrovmWorkloadAsset(
+  scope: Construct,
+  id: string,
+  repoRoot: string,
+): s3assets.Asset {
+  const buildDir = path.join(repoRoot, "cdk", ".build", id);
+  fs.mkdirSync(buildDir, { recursive: true });
+  const binaryPath = path.join(buildDir, "hosted-genesis-microvm-workload");
+  execFileSync(
+    "go",
+    ["build", "-o", binaryPath, "./cmd/hosted-genesis-microvm-workload"],
+    {
+      cwd: repoRoot,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        CGO_ENABLED: "0",
+        GOOS: "linux",
+        GOARCH: "arm64",
+      },
+    },
+  );
+  return new s3assets.Asset(scope, id, { path: buildDir });
 }

--- a/cdk/test/lesser-host-stack.test.ts
+++ b/cdk/test/lesser-host-stack.test.ts
@@ -634,7 +634,6 @@ const hostedGenesisMicrovmLabContext = {
 	hostedGenesisMicrovmBaseImageArn: 'arn:aws:lambda:us-east-1:123456789012:microvm-image/base/apptheory-al2023',
 	hostedGenesisMicrovmBaseImageVersion: '1',
 	hostedGenesisMicrovmBuildRoleArn: 'arn:aws:iam::123456789012:role/apptheory-microvm-image-build-lab',
-	hostedGenesisMicrovmCodeArtifactUri: 's3://lesser-host-lab-artifacts/microvm/hosted-genesis.tar',
 	hostedGenesisMicrovmAuthorizerTokenSha256: 'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
 };
 

--- a/cmd/hosted-genesis-microvm-workload/hash.go
+++ b/cmd/hosted-genesis-microvm-workload/hash.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+)
+
+// hashDeclarationDraft returns the sha256 digest of the canonical JSON encoding
+// of the extracted declaration draft, prefixed with "sha256:" to match the
+// hostedgenesis DeclarationCheckpoint hash contract.
+func hashDeclarationDraft(draft llm.MintConversationDeclarationsDraft) (string, error) {
+	body, err := json.Marshal(draft)
+	if err != nil {
+		return "", fmt.Errorf("marshal declaration draft: %w", err)
+	}
+	sum := sha256.Sum256(body)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/cmd/hosted-genesis-microvm-workload/hooks.go
+++ b/cmd/hosted-genesis-microvm-workload/hooks.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/completion"
+)
+
+// hookPort is the port the AWS Lambda MicrovmImage invokes the workload's
+// lifecycle hooks on. It matches the AppTheoryMicrovmImage hooks.port CDK
+// configuration in cdk/lib/hosted-genesis-microvm.ts.
+const hookPort = "8080"
+
+// Framework-feedback workaround (AppTheory v1.15.0): NewLifecycleAdapter
+// validates only with the M15 ValidateLifecycleContract, so it cannot ingest
+// DefaultRealLifecycleContract() (the documented M16 canonical vocabulary).
+// Until a real-contract-aware adapter constructor lands upstream, this workload
+// consumes the framework's EXPORTED M16 vocabulary directly: it validates the
+// contract with ValidateRealLifecycleContract at startup and derives each hook's
+// LifecycleResult from the framework's own DefaultRealLifecycleContract()
+// transition table. This is not a local substitute engine — no fork, no patched
+// adapter, no reimplemented sanitization. See memory mem-8365ca36ad0fd5f6.
+const (
+	hookErrorCode       = "m16.microvm.lifecycle_hook_failed"
+	hookErrorIncomplete = "m16.microvm.lifecycle_event_incomplete"
+)
+
+// hookServer serves the AppTheory M16 MicroVM image lifecycle hooks on the
+// configured port. Each hook path receives a sanitized microvm.LifecycleEvent
+// JSON body, validates it against the framework's M16 real lifecycle contract,
+// and returns the framework-shaped LifecycleResult. The run hook additionally
+// executes the assistant turn + declaration extraction and durably records
+// completion to HostedGenesisSession truth.
+//
+// The server is fail-closed: unknown hooks, malformed events, unsupported
+// transitions, and execution failures surface as a failed LifecycleResult with a
+// typed SafeError envelope. There is no degraded/non-MicroVM fallback path.
+type hookServer struct {
+	contract  runtimemicrovm.LifecycleContract
+	handlers  map[runtimemicrovm.LifecycleHook]runtimemicrovm.LifecycleHandler
+	runner    *turnRunner
+	namespace string
+}
+
+// hookBinding extracts the HostedGenesisSession completion-turn identifiers from
+// a sanitized MicroVM lifecycle event's metadata. Host's controller records
+// source_of_truth, registration_id, agent_id, conversation_id, and turn_id in
+// the session spec metadata; the image surfaces them back on each hook event.
+type hookBinding struct {
+	instanceSlug   string
+	conversationID string
+	turnID         string
+	requestID      string
+}
+
+// fromEvent resolves the completion-turn binding from a lifecycle event. The
+// instance slug is the tenant boundary (slug:<slug>); metadata carries the rest.
+func (hookBinding) fromEvent(event runtimemicrovm.LifecycleEvent) (hookBinding, error) {
+	b := hookBinding{
+		requestID: strings.TrimSpace(event.RequestID),
+	}
+	tenantID := strings.TrimSpace(event.TenantID)
+	if !strings.HasPrefix(tenantID, "slug:") {
+		return hookBinding{}, fmt.Errorf("lifecycle event tenant_id %q is not a slug boundary", tenantID)
+	}
+	b.instanceSlug = strings.TrimSpace(strings.TrimPrefix(tenantID, "slug:"))
+	b.conversationID = strings.TrimSpace(event.Metadata["conversation_id"])
+	b.turnID = strings.TrimSpace(event.Metadata["turn_id"])
+	if b.instanceSlug == "" || b.conversationID == "" || b.turnID == "" {
+		return hookBinding{}, errors.New("lifecycle event metadata is missing hosted-genesis ids")
+	}
+	return b, nil
+}
+
+func (b hookBinding) completionTurn() completion.CompletionTurn {
+	return completion.CompletionTurn{
+		InstanceSlug:   b.instanceSlug,
+		ConversationID: b.conversationID,
+		TurnID:         b.turnID,
+		RequestID:      b.requestID,
+	}
+}
+
+// newHookServer builds the workload's hook dispatcher over the framework's
+// exported M16 real lifecycle contract. It fails closed at startup if the
+// contract is invalid. Handlers are the workload's per-hook behavior; the run
+// handler executes the assistant turn + declaration extraction.
+func newHookServer(runner *turnRunner, namespace string) (*hookServer, error) {
+	contract := runtimemicrovm.DefaultRealLifecycleContract()
+	if err := runtimemicrovm.ValidateRealLifecycleContract(contract); err != nil {
+		return nil, fmt.Errorf("validate M16 real lifecycle contract: %w", err)
+	}
+	handlers := map[runtimemicrovm.LifecycleHook]runtimemicrovm.LifecycleHandler{
+		runtimemicrovm.HookValidate:  validateHook,
+		runtimemicrovm.HookRun:       runHook(runner),
+		runtimemicrovm.HookReady:     readyHook,
+		runtimemicrovm.HookSuspend:   passthroughHook,
+		runtimemicrovm.HookResume:    passthroughHook,
+		runtimemicrovm.HookTerminate: passthroughHook,
+		runtimemicrovm.HookFailure:   failureHook,
+	}
+	return &hookServer{contract: contract, handlers: handlers, runner: runner, namespace: namespace}, nil
+}
+
+// routes returns the HTTP handler that dispatches lifecycle hooks.
+func (s *hookServer) routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/validate", s.handleHook(runtimemicrovm.HookValidate))
+	mux.HandleFunc("/run", s.handleRunHook)
+	mux.HandleFunc("/ready", s.handleHook(runtimemicrovm.HookReady))
+	mux.HandleFunc("/suspend", s.handleHook(runtimemicrovm.HookSuspend))
+	mux.HandleFunc("/resume", s.handleHook(runtimemicrovm.HookResume))
+	mux.HandleFunc("/terminate", s.handleHook(runtimemicrovm.HookTerminate))
+	mux.HandleFunc("/failure", s.handleHook(runtimemicrovm.HookFailure))
+	mux.HandleFunc("/healthz", s.handleHealth)
+	return mux
+}
+
+func (s *hookServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleHook returns a handler that drives one non-run lifecycle hook through
+// the framework's M16 contract vocabulary. It normalizes the event, validates
+// the transition, invokes the workload's hook handler, and returns the
+// framework-shaped LifecycleResult (success state, or failed with a SafeError).
+func (s *hookServer) handleHook(hook runtimemicrovm.LifecycleHook) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		event, err := decodeLifecycleEvent(r)
+		if err != nil {
+			writeJSON(w, http.StatusBadRequest, incompleteEventError("", err))
+			return
+		}
+		event.Hook = hook
+		writeJSON(w, http.StatusOK, s.drive(r.Context(), event))
+	}
+}
+
+// handleRunHook drives the run lifecycle hook. The contract records the running
+// state; the workload's run handler then executes the assistant turn +
+// declaration extraction and durably records completion. A workload execution
+// failure is recorded as a typed completion failure and surfaced via a failed
+// lifecycle result so the controller observes a failed session.
+func (s *hookServer) handleRunHook(w http.ResponseWriter, r *http.Request) {
+	event, err := decodeLifecycleEvent(r)
+	if err != nil {
+		writeJSON(w, http.StatusBadRequest, incompleteEventError("", err))
+		return
+	}
+	event.Hook = runtimemicrovm.HookRun
+	writeJSON(w, http.StatusOK, s.drive(r.Context(), event))
+}
+
+// drive applies one lifecycle event through the framework's exported M16
+// contract vocabulary. It mirrors the LifecycleAdapter.Handle envelope (event
+// normalization, transition lookup, handler invocation, safe-error translation
+// to failed state) but uses DefaultRealLifecycleContract()'s transition table
+// directly because NewLifecycleAdapter cannot ingest the real contract
+// (framework gap; see memory mem-8365ca36ad0fd5f6).
+func (s *hookServer) drive(ctx context.Context, event runtimemicrovm.LifecycleEvent) runtimemicrovm.LifecycleResult {
+	normalized, err := normalizeLifecycleEvent(event, s.namespace)
+	if err != nil {
+		return lifecycleFailedResult(event, event.Hook, err)
+	}
+	spec, ok := hookSpec(s.contract, normalized.Hook)
+	if !ok {
+		return lifecycleFailedResult(normalized, normalized.Hook, errors.New("lifecycle hook is unsupported"))
+	}
+	activeState, ok := nextTransitionState(s.contract, normalized.State, normalized.Hook)
+	if !ok {
+		return lifecycleFailedResult(normalized, normalized.Hook, errors.New("lifecycle transition is unsupported"))
+	}
+	if normalized.Hook != runtimemicrovm.HookFailure && activeState != spec.State {
+		return lifecycleFailedResult(normalized, normalized.Hook, errors.New("lifecycle transition is not the hook active state"))
+	}
+	handler := s.handlers[normalized.Hook]
+	if handler == nil {
+		return lifecycleFailedResult(normalized, normalized.Hook, errors.New("lifecycle hook handler is missing"))
+	}
+	handlerEvent := normalized
+	handlerEvent.State = activeState
+	if err := handler(ctx, handlerEvent); err != nil {
+		slog.Error("hosted-genesis-microvm-workload: lifecycle hook failed", //nolint:gosec // G706: values are structured slog attributes (JSON-encoded key/values), not a log format string; no format-string injection surface.
+			slog.String("hook", string(normalized.Hook)),
+			slog.String("tenant_id", normalized.TenantID),
+			slog.String("session_id", normalized.SessionID),
+			slog.String("request_id", normalized.RequestID),
+			slog.String("error", err.Error()),
+		)
+		return lifecycleFailedResult(normalized, normalized.Hook, fmt.Errorf("lifecycle hook failed: %w", err))
+	}
+	state := spec.SuccessState
+	if normalized.Hook == runtimemicrovm.HookFailure {
+		state = runtimemicrovm.StateFailed
+	} else if !hasTransition(s.contract, activeState, normalized.Hook, state) {
+		return lifecycleFailedResult(normalized, normalized.Hook, errors.New("lifecycle success transition is unsupported"))
+	}
+	return runtimemicrovm.LifecycleResult{
+		RequestID:     normalized.RequestID,
+		TenantID:      normalized.TenantID,
+		Namespace:     normalized.Namespace,
+		SessionID:     normalized.SessionID,
+		Hook:          normalized.Hook,
+		PreviousState: normalized.State,
+		State:         state,
+		Metadata:      cloneStringMap(normalized.Metadata),
+	}
+}
+
+// validateHook is the image-build validation hook. It fails closed if the
+// lifecycle event is not bound to the hosted-genesis namespace.
+func validateHook(_ context.Context, event runtimemicrovm.LifecycleEvent) error {
+	if strings.TrimSpace(event.Namespace) != hostedgenesis.MicroVMNamespace {
+		return fmt.Errorf("lifecycle event namespace %q is not %s", event.Namespace, hostedgenesis.MicroVMNamespace)
+	}
+	return nil
+}
+
+// runHook returns the run lifecycle handler that executes the assistant turn +
+// declaration extraction and durably records completion.
+func runHook(runner *turnRunner) runtimemicrovm.LifecycleHandler {
+	return func(ctx context.Context, event runtimemicrovm.LifecycleEvent) error {
+		if runner == nil {
+			return errors.New("workload runner is not configured")
+		}
+		binding, err := hookBinding{}.fromEvent(event)
+		if err != nil {
+			return err
+		}
+		return runner.runTurnAndPersist(ctx, binding.completionTurn())
+	}
+}
+
+// readyHook records a readiness observation without widening the state model.
+func readyHook(_ context.Context, event runtimemicrovm.LifecycleEvent) error {
+	if strings.TrimSpace(event.Namespace) != hostedgenesis.MicroVMNamespace {
+		return fmt.Errorf("lifecycle event namespace %q is not %s", event.Namespace, hostedgenesis.MicroVMNamespace)
+	}
+	return nil
+}
+
+// passthroughHook acknowledges suspend/resume/terminate observations. Host truth
+// is owned by HostedGenesisSession; these hooks do not mutate business state.
+func passthroughHook(_ context.Context, _ runtimemicrovm.LifecycleEvent) error {
+	return nil
+}
+
+// failureHook records a terminal failure observation.
+func failureHook(_ context.Context, _ runtimemicrovm.LifecycleEvent) error {
+	return nil
+}
+
+// normalizeLifecycleEvent trims and validates a lifecycle event envelope against
+// the hosted-genesis namespace binding. It mirrors the framework's unexported
+// normalizeLifecycleEvent shape using only exported contract vocabulary.
+func normalizeLifecycleEvent(event runtimemicrovm.LifecycleEvent, namespace string) (runtimemicrovm.LifecycleEvent, error) {
+	event.RequestID = strings.TrimSpace(event.RequestID)
+	event.TenantID = strings.TrimSpace(event.TenantID)
+	event.Namespace = strings.TrimSpace(event.Namespace)
+	event.SessionID = strings.TrimSpace(event.SessionID)
+	event.Hook = runtimemicrovm.LifecycleHook(strings.TrimSpace(string(event.Hook)))
+	event.State = runtimemicrovm.LifecycleState(strings.TrimSpace(string(event.State)))
+	event.Metadata = cloneStringMap(event.Metadata)
+	if event.RequestID == "" || event.TenantID == "" || event.Namespace == "" || event.SessionID == "" {
+		return runtimemicrovm.LifecycleEvent{}, errors.New("lifecycle envelope is incomplete")
+	}
+	if event.Hook == "" || event.State == "" {
+		return runtimemicrovm.LifecycleEvent{}, errors.New("lifecycle hook and state are required")
+	}
+	if namespace != "" && event.Namespace != namespace {
+		return runtimemicrovm.LifecycleEvent{}, fmt.Errorf("lifecycle event namespace %q is not %s", event.Namespace, namespace)
+	}
+	return event, nil
+}
+
+func hookSpec(contract runtimemicrovm.LifecycleContract, hook runtimemicrovm.LifecycleHook) (runtimemicrovm.LifecycleHookSpec, bool) {
+	for _, h := range contract.Hooks {
+		if runtimemicrovm.LifecycleHook(strings.TrimSpace(string(h.Name))) == hook {
+			return h, true
+		}
+	}
+	return runtimemicrovm.LifecycleHookSpec{}, false
+}
+
+func nextTransitionState(contract runtimemicrovm.LifecycleContract, from runtimemicrovm.LifecycleState, hook runtimemicrovm.LifecycleHook) (runtimemicrovm.LifecycleState, bool) {
+	for _, t := range contract.Transitions {
+		if t.From == from && t.Hook == hook {
+			return t.To, true
+		}
+	}
+	return "", false
+}
+
+func hasTransition(contract runtimemicrovm.LifecycleContract, from runtimemicrovm.LifecycleState, hook runtimemicrovm.LifecycleHook, to runtimemicrovm.LifecycleState) bool {
+	for _, t := range contract.Transitions {
+		if t.From == from && t.Hook == hook && t.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+func decodeLifecycleEvent(r *http.Request) (runtimemicrovm.LifecycleEvent, error) {
+	var event runtimemicrovm.LifecycleEvent
+	if err := json.NewDecoder(r.Body).Decode(&event); err != nil {
+		return runtimemicrovm.LifecycleEvent{}, fmt.Errorf("decode lifecycle event: %w", err)
+	}
+	return event, nil
+}
+
+func lifecycleFailedResult(event runtimemicrovm.LifecycleEvent, hook runtimemicrovm.LifecycleHook, err error) runtimemicrovm.LifecycleResult {
+	safe := runtimemicrovm.SafeError{
+		Code:      hookErrorCode,
+		Message:   err.Error(),
+		RequestID: strings.TrimSpace(event.RequestID),
+	}
+	return runtimemicrovm.LifecycleResult{
+		RequestID:     strings.TrimSpace(event.RequestID),
+		TenantID:      strings.TrimSpace(event.TenantID),
+		Namespace:     strings.TrimSpace(event.Namespace),
+		SessionID:     strings.TrimSpace(event.SessionID),
+		Hook:          hook,
+		PreviousState: event.State,
+		State:         runtimemicrovm.StateFailed,
+		Error:         &safe,
+	}
+}
+
+func incompleteEventError(requestID string, err error) runtimemicrovm.LifecycleResult {
+	return lifecycleFailedResult(runtimemicrovm.LifecycleEvent{RequestID: requestID}, "", err)
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// httpServer wires a real *http.Server with the configured hook port.
+func (s *hookServer) httpServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           s.routes(),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+}

--- a/cmd/hosted-genesis-microvm-workload/hooks_test.go
+++ b/cmd/hosted-genesis-microvm-workload/hooks_test.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/completion"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func validEvent(hook runtimemicrovm.LifecycleHook, state runtimemicrovm.LifecycleState) runtimemicrovm.LifecycleEvent {
+	return runtimemicrovm.LifecycleEvent{
+		RequestID: "req-1",
+		TenantID:  "slug:acme",
+		Namespace: hostedgenesis.MicroVMNamespace,
+		SessionID: "conv-1",
+		Hook:      hook,
+		State:     state,
+		Metadata:  map[string]string{"conversation_id": "conv-1", "turn_id": "turn-1"},
+	}
+}
+
+// TestHookServer_NonRunHooksDriveAdapter proves each non-run hook path drives
+// the AppTheory LifecycleAdapter with the real M16 contract and returns the
+// adapter's LifecycleResult (success state).
+func TestHookServer_NonRunHooksDriveAdapter(t *testing.T) {
+	srv := newTestHookServer(t, nil)
+	cases := []struct {
+		path      string
+		hook      runtimemicrovm.LifecycleHook
+		state     runtimemicrovm.LifecycleState
+		wantState runtimemicrovm.LifecycleState
+	}{
+		{"/validate", runtimemicrovm.HookValidate, runtimemicrovm.StateRequested, runtimemicrovm.StateValidated},
+		{"/ready", runtimemicrovm.HookReady, runtimemicrovm.StateRunning, runtimemicrovm.StateReady},
+		{"/suspend", runtimemicrovm.HookSuspend, runtimemicrovm.StateReady, runtimemicrovm.StateSuspended},
+		{"/resume", runtimemicrovm.HookResume, runtimemicrovm.StateSuspended, runtimemicrovm.StateReady},
+		{"/terminate", runtimemicrovm.HookTerminate, runtimemicrovm.StateReady, runtimemicrovm.StateTerminated},
+	}
+	for _, c := range cases {
+		t.Run(c.path, func(t *testing.T) {
+			event := validEvent(c.hook, c.state)
+			body, _ := json.Marshal(event)
+			req := httptest.NewRequest(http.MethodPost, c.path, bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			srv.routes().ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+			}
+			var result runtimemicrovm.LifecycleResult
+			if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+				t.Fatalf("decode result: %v", err)
+			}
+			if result.State != c.wantState {
+				t.Fatalf("expected state %q, got %q (err=%v)", c.wantState, result.State, result.Error)
+			}
+			if result.Hook != c.hook {
+				t.Fatalf("expected hook %q, got %q", c.hook, result.Hook)
+			}
+		})
+	}
+}
+
+// TestHookServer_UnknownHook404 proves an unknown hook path is rejected.
+func TestHookServer_UnknownHook404(t *testing.T) {
+	srv := newTestHookServer(t, nil)
+	req := httptest.NewRequest(http.MethodPost, "/bogus", bytes.NewReader([]byte(`{}`)))
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rec.Code)
+	}
+}
+
+// TestHookServer_Healthz proves the liveness endpoint responds ok.
+func TestHookServer_Healthz(t *testing.T) {
+	srv := newTestHookServer(t, nil)
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+}
+
+// TestHookServer_BadNamespaceRejected proves the validate hook fails closed for
+// a non-hosted-genesis namespace, surfacing a failed lifecycle result.
+func TestHookServer_BadNamespaceRejected(t *testing.T) {
+	srv := newTestHookServer(t, nil)
+	event := validEvent(runtimemicrovm.HookValidate, runtimemicrovm.StateRequested)
+	event.Namespace = "other-namespace"
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/validate", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	var result runtimemicrovm.LifecycleResult
+	_ = json.NewDecoder(rec.Body).Decode(&result)
+	if result.State != runtimemicrovm.StateFailed {
+		t.Fatalf("expected failed state for bad namespace, got %q", result.State)
+	}
+	if result.Error == nil {
+		t.Fatalf("expected a safe error for bad namespace")
+	}
+}
+
+// TestHookServer_RunHookExecutesTurn proves the /run hook drives the adapter to
+// running and executes the assistant turn + declaration extraction, persisting
+// declaration_ready to session truth.
+func TestHookServer_RunHookExecutesTurn(t *testing.T) {
+	assistantChunk := "data: " + mustMarshal(map[string]any{
+		"id": "chatcmpl_test", "object": "chat.completion.chunk", "created": 1, "model": "gpt-test",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{"role": "assistant", "content": "I am acme."}, "finish_reason": nil}},
+	}) + "\n\ndata: [DONE]\n\n"
+	declBody := mustMarshal(map[string]any{
+		"id": "chatcmpl_test", "object": "chat.completion", "created": 1, "model": "gpt-test",
+		"choices": []any{map[string]any{"index": 0, "message": map[string]any{"role": "assistant", "content": mustMarshal(validDeclarationDraft())}}},
+		"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+	})
+	llmSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if strings.Contains(string(bodyBytes), `"stream":true`) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(assistantChunk))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(declBody))
+	}))
+	t.Cleanup(llmSrv.Close)
+	withOpenAIBaseURL(t, llmSrv.URL, "sk-test")
+	llm.ConfigureProviderHTTPClient(&http.Client{Timeout: 5 * time.Second})
+	t.Cleanup(func() { llm.ConfigureProviderHTTPClient(nil) })
+
+	turnStore, compStore, _ := baseTurnInput()
+	writer := completion.NewCompletionWriter(compStore, func() time.Time { return time.Unix(3000, 0).UTC() })
+	runner := &turnRunner{store: turnStore, writer: writer, nowFunc: func() time.Time { return time.Unix(3000, 0).UTC() }}
+	srv := newTestHookServer(t, runner)
+
+	event := validEvent(runtimemicrovm.HookRun, runtimemicrovm.StateValidated)
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var result runtimemicrovm.LifecycleResult
+	if err := json.NewDecoder(rec.Body).Decode(&result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result.State != runtimemicrovm.StateRunning {
+		t.Fatalf("expected running state from run hook, got %q (err=%v)", result.State, result.Error)
+	}
+	if got := hostedgenesis.NormalizeStatus(compStore.session.Status); got != hostedgenesis.StatusDeclarationReady {
+		t.Fatalf("expected session declaration_ready after run hook, got %q", got)
+	}
+}
+
+// TestHookServer_RunHookMissingBindingFails proves the /run hook fails closed
+// (failed lifecycle result) when the lifecycle event metadata is missing the
+// hosted-genesis ids, rather than silently succeeding.
+func TestHookServer_RunHookMissingBindingFails(t *testing.T) {
+	srv := newTestHookServer(t, &turnRunner{store: &fakeTurnStore{}, writer: completion.NewCompletionWriter(&fakeCompletionStore{}, nil)})
+	event := validEvent(runtimemicrovm.HookRun, runtimemicrovm.StateValidated)
+	event.Metadata = nil // missing ids
+	body, _ := json.Marshal(event)
+	req := httptest.NewRequest(http.MethodPost, "/run", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.routes().ServeHTTP(rec, req)
+
+	var result runtimemicrovm.LifecycleResult
+	_ = json.NewDecoder(rec.Body).Decode(&result)
+	if result.State != runtimemicrovm.StateFailed {
+		t.Fatalf("expected failed state for missing binding, got %q", result.State)
+	}
+}
+
+// TestNewHookServer_ValidatesRealContract proves newHookServer fails closed if
+// the M16 real lifecycle contract is invalid — no silent fallback to a partial
+// dispatcher. It also confirms the canonical M16 hooks are wired.
+func TestNewHookServer_ValidatesRealContract(t *testing.T) {
+	srv, err := newHookServer(nil, hostedgenesis.MicroVMNamespace)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if srv == nil || srv.contract.Hooks == nil {
+		t.Fatal("expected contract-holding dispatcher constructed")
+	}
+	for _, hook := range []runtimemicrovm.LifecycleHook{
+		runtimemicrovm.HookValidate, runtimemicrovm.HookRun, runtimemicrovm.HookReady,
+		runtimemicrovm.HookSuspend, runtimemicrovm.HookResume, runtimemicrovm.HookTerminate,
+		runtimemicrovm.HookFailure,
+	} {
+		if _, ok := srv.handlers[hook]; !ok {
+			t.Fatalf("expected handler wired for hook %q", hook)
+		}
+	}
+}
+
+func newTestHookServer(t *testing.T, runner *turnRunner) *hookServer {
+	t.Helper()
+	srv, err := newHookServer(runner, hostedgenesis.MicroVMNamespace)
+	if err != nil {
+		t.Fatalf("newHookServer: %v", err)
+	}
+	return srv
+}
+
+// Ensure unused imports in this test file are referenced.
+var _ = context.Background
+var _ = os.Getenv
+var _ = models.EncodeSoulMintConversationBlob

--- a/cmd/hosted-genesis-microvm-workload/main.go
+++ b/cmd/hosted-genesis-microvm-workload/main.go
@@ -1,0 +1,107 @@
+// Command hosted-genesis-microvm-workload is the in-VM AppTheory Lambda MicroVM
+// image workload for hosted genesis conversations. It is the consumer-owned
+// workload the MicroVM image runs instead of an external codeArtifactUri: the
+// CDK image consumes this repo-built artifact.
+//
+// The workload serves the AppTheory M16 MicroVM image lifecycle hooks on port
+// 8080 (matching the AppTheoryMicrovmImage hooks.port CDK configuration). Each
+// hook drives the AppTheory runtime/microvm lifecycle vocabulary with the real
+// M16 contract (validate/run/ready/suspend/resume/terminate/failure). The run
+// hook executes the assistant turn AND declaration extraction through the
+// existing internal/ai/llm clients — which carry an explicit per-provider HTTP
+// timeout configured at startup — and durably records completion to
+// HostedGenesisSession truth through the existing store layer, reusing
+// persistHostedGenesisAcceptedAssistantTurn semantics via the completion writer.
+//
+// Fail-closed posture: there is no degraded/non-MicroVM fallback. Missing
+// session/conversation/registration, missing provider keys, empty assistant
+// responses, declaration-extraction failures, and idempotency conflicts all
+// surface as typed completion failures or non-2xx hook responses — never as a
+// silent HTTP 200 or a swallowed error.
+//
+// This is H1.1 of the MicroVM-only hosted genesis program (parent
+// lesser-host#867). Dispatch wiring (H1.2), reconstruction-hook reachability
+// (H1.3), recovery (H1.4), and full CDK de-lab-gating + lab E2E (H1.5) are
+// separate steps; this workload is the repo-built artifact those steps will run.
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/completion"
+	"github.com/equaltoai/lesser-host/internal/observability"
+	"github.com/equaltoai/lesser-host/internal/store"
+)
+
+const serviceName = "hosted-genesis-microvm-workload"
+
+// observabilityApp is constructed at package load so the workload wires the same
+// AppTheory observability hooks every cmd entrypoint must wire (gov-infra
+// COM-6). The workload is a long-running HTTP server rather than an AppTheory
+// request app, so the app is not used as a request router; its observability
+// hooks establish the structured-logging posture for the process.
+var observabilityApp = apptheory.New(apptheory.WithObservability(observability.New(serviceName)))
+
+func main() {
+	if observabilityApp == nil {
+		// observability.New never returns nil, but fail loudly if it ever does.
+		panic(serviceName + ": observability not initialized")
+	}
+	if err := run(); err != nil {
+		slog.Error(serviceName+": fatal", slog.String("error", err.Error())) //nolint:gosec // G706: err is a structured slog attribute (JSON-encoded), not a log format string.
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	// Install the explicit-timeout provider HTTP client before any provider call
+	// so every llm.StreamMintConversation* / MintConversationDeclarations* call
+	// fails at the configured HTTP deadline, not the Lambda/MicroVM envelope
+	// (kills G8).
+	llm.ConfigureDefaultProviderHTTPClient()
+
+	stateDB, err := store.LambdaInit()
+	if err != nil {
+		return errors.Join(errors.New("store init"), err)
+	}
+	st := store.New(stateDB)
+	writer := completion.NewCompletionWriter(st, nil)
+	runner := &turnRunner{store: st, writer: writer}
+
+	server, err := newHookServer(runner, hostedgenesis.MicroVMNamespace)
+	if err != nil {
+		return err
+	}
+
+	addr := ":" + hookPort
+	httpSrv := server.httpServer(addr)
+
+	// Graceful shutdown on SIGTERM/SIGINT so the image's terminate hook can
+	// drain in-flight turn execution without corrupting a half-written session.
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-stop
+		slog.Info(serviceName + ": shutdown signal received")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(ctx)
+	}()
+
+	slog.Info(serviceName+": serving M16 lifecycle hooks", slog.String("addr", addr))
+	if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+	return nil
+}

--- a/cmd/hosted-genesis-microvm-workload/runner.go
+++ b/cmd/hosted-genesis-microvm-workload/runner.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/completion"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/mintprompt"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// turnStore is the minimal HostedGenesisSession + transcript + registration
+// surface the workload needs to load prompt-ready turn input. It is satisfied by
+// *store.Store; the workload never receives a raw AWS SDK client.
+type turnStore interface {
+	GetHostedGenesisSession(ctx context.Context, instanceSlug string, conversationID string) (*models.HostedGenesisSession, error)
+	GetSoulAgentMintConversation(ctx context.Context, agentID string, conversationID string) (*models.SoulAgentMintConversation, error)
+	GetSoulAgentRegistration(ctx context.Context, id string) (*models.SoulAgentRegistration, error)
+}
+
+// turnRunner is the in-VM hosted-genesis workload's assistant-turn +
+// declaration-extraction executor. It loads the authoritative conversation
+// transcript + registration through the existing store layer, runs the assistant
+// turn and declaration extraction through the existing internal/ai/llm clients
+// (which carry an explicit HTTP timeout configured at process startup), and
+// durably records the outcome to HostedGenesisSession truth through the
+// completion writer. It never receives a raw AWS SDK client, a bearer token, or
+// a raw lifecycle hook payload.
+//
+// The runner is fail-closed: a missing session/conversation/registration, a
+// missing provider key, an empty assistant response, or a declaration-extraction
+// failure surfaces as a typed completion failure written to session truth —
+// never as a silent HTTP 200 or a swallowed error.
+type turnRunner struct {
+	store   turnStore
+	writer  *completion.CompletionWriter
+	nowFunc func() time.Time
+}
+
+// turnInput is the resolved, prompt-ready input for one assistant turn. It is
+// loaded from HostedGenesisSession + SoulAgentMintConversation +
+// SoulAgentRegistration truth.
+type turnInput struct {
+	modelSet     string
+	systemPrompt string
+	messages     []llm.MintConversationMessage
+	registration *models.SoulAgentRegistration
+	conv         *models.SoulAgentMintConversation
+	session      *models.HostedGenesisSession
+}
+
+// loadTurnInput loads the authoritative transcript and registration context for
+// a completion turn. Failures are loud — there is no degraded mode.
+func (r *turnRunner) loadTurnInput(ctx context.Context, turn completion.CompletionTurn) (turnInput, error) {
+	session, err := r.store.GetHostedGenesisSession(ctx, turn.InstanceSlug, turn.ConversationID)
+	if err != nil || session == nil {
+		return turnInput{}, fmt.Errorf("load hosted genesis session: %w", err)
+	}
+	conv, err := r.store.GetSoulAgentMintConversation(ctx, session.AgentID, session.ConversationID)
+	if err != nil || conv == nil {
+		return turnInput{}, fmt.Errorf("load mint conversation transcript: %w", err)
+	}
+	reg, err := r.store.GetSoulAgentRegistration(ctx, session.RegistrationID)
+	if err != nil || reg == nil {
+		return turnInput{}, fmt.Errorf("load agent registration: %w", err)
+	}
+
+	messages, err := decodeMintConversationMessages(conv.Messages)
+	if err != nil {
+		return turnInput{}, fmt.Errorf("decode mint conversation messages: %w", err)
+	}
+	modelSet := strings.TrimSpace(conv.Model)
+	if modelSet == "" {
+		return turnInput{}, errors.New("mint conversation has no model set")
+	}
+
+	return turnInput{
+		modelSet:     modelSet,
+		systemPrompt: mintprompt.MintConversationSystemPrompt(reg),
+		messages:     messages,
+		registration: reg,
+		conv:         conv,
+		session:      session,
+	}, nil
+}
+
+// runAssistantTurn executes the assistant turn for the loaded transcript and
+// returns the full trimmed assistant response + usage. The provider is selected
+// by model-set prefix, mirroring the control-plane runner. Provider keys come
+// from the process environment (the image is provisioned with them at deploy
+// time); a missing key fails closed.
+func (r *turnRunner) runAssistantTurn(ctx context.Context, in turnInput) (string, models.AIUsage, error) {
+	apiKey, err := providerAPIKey(ctx, in.modelSet)
+	if err != nil {
+		return "", models.AIUsage{}, err
+	}
+	modelSet := strings.ToLower(strings.TrimSpace(in.modelSet))
+	switch {
+	case strings.HasPrefix(modelSet, "openai:"):
+		return llm.StreamMintConversationOpenAI(ctx, apiKey, in.modelSet, in.systemPrompt, in.messages, func(string) {})
+	case strings.HasPrefix(modelSet, "anthropic:"):
+		return llm.StreamMintConversationAnthropic(ctx, apiKey, in.modelSet, in.systemPrompt, in.messages, func(string) {})
+	default:
+		return "", models.AIUsage{}, fmt.Errorf("unsupported model set %q", in.modelSet)
+	}
+}
+
+// runDeclarationExtraction extracts structured declarations from the post-turn
+// transcript (accepted user messages + produced assistant message) through the
+// existing internal/ai/llm declaration clients. Returns a draft + a
+// publish-ready DeclarationCheckpoint.
+func (r *turnRunner) runDeclarationExtraction(ctx context.Context, in turnInput, assistantContent string) (llm.MintConversationDeclarationsDraft, models.AIUsage, error) {
+	apiKey, err := providerAPIKey(ctx, in.modelSet)
+	if err != nil {
+		return llm.MintConversationDeclarationsDraft{}, models.AIUsage{}, err
+	}
+	extractionMessages := append(append([]llm.MintConversationMessage(nil), in.messages...), llm.MintConversationMessage{
+		Role:    "assistant",
+		Content: strings.TrimSpace(assistantContent),
+	})
+	declInput := llm.MintConversationDeclarationsInput{
+		Registration: llm.MintConversationRegistrationContext{
+			Domain:               in.registration.DomainNormalized,
+			LocalID:              in.registration.LocalID,
+			AgentID:              in.registration.AgentID,
+			DeclaredCapabilities: in.registration.Capabilities,
+		},
+		Messages: extractionMessages,
+	}
+	modelSet := strings.ToLower(strings.TrimSpace(in.modelSet))
+	switch {
+	case strings.HasPrefix(modelSet, "openai:"):
+		return llm.MintConversationDeclarationsOpenAI(ctx, apiKey, in.modelSet, declInput)
+	case strings.HasPrefix(modelSet, "anthropic:"):
+		return llm.MintConversationDeclarationsAnthropic(ctx, apiKey, in.modelSet, declInput)
+	default:
+		return llm.MintConversationDeclarationsDraft{}, models.AIUsage{}, fmt.Errorf("unsupported model set %q", in.modelSet)
+	}
+}
+
+// runTurnAndPersist is the run-hook's durable execution path. It runs the
+// assistant turn, persists assistant_turn_ready, runs declaration extraction,
+// and persists declaration_ready — or persists a typed failure at any point the
+// path cannot continue. Every completion write is idempotent per turn ID and
+// conditional on the session's status + version; a replay against an already-
+// advanced session is recorded as a conflict (not a silent re-apply).
+func (r *turnRunner) runTurnAndPersist(ctx context.Context, turn completion.CompletionTurn) error {
+	in, err := r.loadTurnInput(ctx, turn)
+	if err != nil {
+		return r.recordFailure(ctx, turn, hostedgenesis.FailureCodeInvalidCompletionState, err.Error())
+	}
+
+	assistantContent, _, err := r.runAssistantTurn(ctx, in)
+	if err != nil || strings.TrimSpace(assistantContent) == "" {
+		msg := "assistant turn failed"
+		if err != nil {
+			msg = err.Error()
+		}
+		return r.recordFailure(ctx, turn, hostedgenesis.FailureCodeAssistantTurnFailed, msg)
+	}
+
+	postTurnMessageCount := len(in.messages) + 1
+	if _, werr := r.writer.RecordAssistantTurnReady(ctx, turn, completion.AssistantTurnCompletion{
+		AssistantContent: assistantContent,
+		MessageCount:     postTurnMessageCount,
+	}); werr != nil {
+		// A conflict here means the session already advanced (e.g. a replay or
+		// a concurrent recovery). Do not overwrite; surface the conflict.
+		return fmt.Errorf("record assistant turn ready: %w", werr)
+	}
+
+	draft, _, err := r.runDeclarationExtraction(ctx, in, assistantContent)
+	if err != nil {
+		return r.recordFailure(ctx, turn, hostedgenesis.FailureCodeDeclarationExtractionFailed, err.Error())
+	}
+	checkpoint, err := r.buildDeclarationCheckpoint(turn, in, draft)
+	if err != nil {
+		return r.recordFailure(ctx, turn, hostedgenesis.FailureCodeInvalidProducedDeclarations, err.Error())
+	}
+	if _, werr := r.writer.RecordDeclarationReady(ctx, turn, checkpoint); werr != nil {
+		return fmt.Errorf("record declaration ready: %w", werr)
+	}
+	return nil
+}
+
+// buildDeclarationCheckpoint assembles a publish-ready DeclarationCheckpoint
+// from the extracted draft. The declaration id + hash are derived from the
+// conversation + turn identity so a replay produces the same checkpoint
+// (idempotent declaration_ready).
+func (r *turnRunner) buildDeclarationCheckpoint(turn completion.CompletionTurn, in turnInput, draft llm.MintConversationDeclarationsDraft) (hostedgenesis.DeclarationCheckpoint, error) {
+	now := r.now()
+	declarationID := fmt.Sprintf("decl:%s:%s:%s", in.session.InstanceSlug, in.session.ConversationID, turn.TurnID)
+	declarationHash, err := hashDeclarationDraft(draft)
+	if err != nil {
+		return hostedgenesis.DeclarationCheckpoint{}, err
+	}
+	return hostedgenesis.DeclarationCheckpoint{
+		DeclarationID:   declarationID,
+		DeclarationHash: declarationHash,
+		CheckpointRef:   fmt.Sprintf("checkpoint://hosted-genesis/%s/declaration/%s", in.session.ConversationID, turn.TurnID),
+		ProducedAt:      now,
+		RegistrationID:  in.session.RegistrationID,
+		ConversationID:  in.session.ConversationID,
+		AgentID:         in.session.AgentID,
+		MessageCount:    len(in.messages) + 1,
+		Model:           in.modelSet,
+		RequestID:       turn.RequestID,
+	}, nil
+}
+
+func (r *turnRunner) recordFailure(ctx context.Context, turn completion.CompletionTurn, code hostedgenesis.FailureCode, message string) error {
+	_, err := r.writer.RecordFailure(ctx, turn, completion.CompletionFailure{
+		Code:      code,
+		Message:   message,
+		Retryable: isRetryableFailureCode(code),
+		Recovery: hostedgenesis.Recovery{
+			Action:            recoveryActionFor(code),
+			MaxAttempts:       3,
+			RetryAfterSeconds: 5,
+			Reason:            message,
+		},
+	})
+	if err == nil {
+		return nil
+	}
+	// A conflict recording failure means the session already reached a terminal
+	// state; report the original failure as the run error but do not mask the
+	// conflict.
+	if errors.Is(err, completion.ErrCompletionConflict) {
+		return fmt.Errorf("record failure (%s): session already terminal: %w", code, err)
+	}
+	return fmt.Errorf("record failure (%s): %w", code, err)
+}
+
+func (r *turnRunner) now() time.Time {
+	if r.nowFunc != nil {
+		return r.nowFunc().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func isRetryableFailureCode(code hostedgenesis.FailureCode) bool {
+	switch code {
+	case hostedgenesis.FailureCodeLLMUnavailable,
+		hostedgenesis.FailureCodeAssistantTurnFailed,
+		hostedgenesis.FailureCodeDeclarationExtractionFailed:
+		return true
+	default:
+		return false
+	}
+}
+
+func recoveryActionFor(code hostedgenesis.FailureCode) hostedgenesis.RecoveryAction {
+	switch code {
+	case hostedgenesis.FailureCodeAssistantTurnFailed,
+		hostedgenesis.FailureCodeDeclarationExtractionFailed,
+		hostedgenesis.FailureCodeLLMUnavailable:
+		return hostedgenesis.RecoveryActionRetrySameStep
+	case hostedgenesis.FailureCodeInvalidCompletionState,
+		hostedgenesis.FailureCodeMissingProducedDeclarations,
+		hostedgenesis.FailureCodeInvalidProducedDeclarations:
+		return hostedgenesis.RecoveryActionRestartSoulBootstrap
+	default:
+		return hostedgenesis.RecoveryActionOperatorAction
+	}
+}
+
+// providerAPIKey resolves the provider API key from the process environment for
+// a model set. It mirrors the control-plane env-first resolution; SSM fallback
+// is a control-plane concern and is not available in the MicroVM image env.
+func providerAPIKey(_ context.Context, modelSet string) (string, error) {
+	modelSetNorm := strings.ToLower(strings.TrimSpace(modelSet))
+	switch {
+	case strings.HasPrefix(modelSetNorm, "openai:"):
+		if k := strings.TrimSpace(os.Getenv("OPENAI_API_KEY")); k != "" {
+			return k, nil
+		}
+		return "", errors.New("openai provider key not configured")
+	case strings.HasPrefix(modelSetNorm, "anthropic:"):
+		if k := strings.TrimSpace(os.Getenv("ANTHROPIC_API_KEY")); k != "" {
+			return k, nil
+		}
+		if k := strings.TrimSpace(os.Getenv("CLAUDE_API_KEY")); k != "" {
+			return k, nil
+		}
+		return "", errors.New("anthropic provider key not configured")
+	default:
+		return "", fmt.Errorf("unsupported model set %q", modelSet)
+	}
+}
+
+// decodeMintConversationMessages decodes the stored conversation blob into
+// provider-ready MintConversationMessage values.
+func decodeMintConversationMessages(stored string) ([]llm.MintConversationMessage, error) {
+	raw := strings.TrimSpace(models.DecodeSoulMintConversationBlob(stored))
+	if raw == "" {
+		return nil, errors.New("conversation has no messages")
+	}
+	var msgs []llm.MintConversationMessage
+	if err := json.Unmarshal([]byte(raw), &msgs); err != nil {
+		return nil, fmt.Errorf("unmarshal messages: %w", err)
+	}
+	if len(msgs) == 0 {
+		return nil, errors.New("conversation has no messages")
+	}
+	out := make([]llm.MintConversationMessage, 0, len(msgs))
+	for _, m := range msgs {
+		role := strings.ToLower(strings.TrimSpace(m.Role))
+		content := strings.TrimSpace(m.Content)
+		if role == "" || content == "" {
+			continue
+		}
+		out = append(out, llm.MintConversationMessage{Role: role, Content: content})
+	}
+	if len(out) == 0 {
+		return nil, errors.New("conversation has no non-empty messages")
+	}
+	return out, nil
+}

--- a/cmd/hosted-genesis-microvm-workload/runner_test.go
+++ b/cmd/hosted-genesis-microvm-workload/runner_test.go
@@ -1,0 +1,299 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/ai/llm"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/completion"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// fakeTurnStore is an in-memory turnStore for runner tests.
+type fakeTurnStore struct {
+	session *models.HostedGenesisSession
+	conv    *models.SoulAgentMintConversation
+	reg     *models.SoulAgentRegistration
+}
+
+func (f *fakeTurnStore) GetHostedGenesisSession(_ context.Context, _, _ string) (*models.HostedGenesisSession, error) {
+	if f.session == nil {
+		return nil, errNotFound
+	}
+	return f.session, nil
+}
+func (f *fakeTurnStore) GetSoulAgentMintConversation(_ context.Context, _, _ string) (*models.SoulAgentMintConversation, error) {
+	if f.conv == nil {
+		return nil, errNotFound
+	}
+	return f.conv, nil
+}
+func (f *fakeTurnStore) GetSoulAgentRegistration(_ context.Context, _ string) (*models.SoulAgentRegistration, error) {
+	if f.reg == nil {
+		return nil, errNotFound
+	}
+	return f.reg, nil
+}
+
+// fakeCompletionStore records completion writes in-memory, applying the
+// conditional version+status advance so the real CompletionWriter's idempotency
+// is exercised end-to-end.
+type fakeCompletionStore struct {
+	session   *models.HostedGenesisSession
+	lastWrite *models.HostedGenesisSession
+}
+
+func (f *fakeCompletionStore) GetHostedGenesisSession(_ context.Context, _, _ string) (*models.HostedGenesisSession, error) {
+	if f.session == nil {
+		return nil, errNotFound
+	}
+	c := *f.session
+	return &c, nil
+}
+func (f *fakeCompletionStore) UpdateHostedGenesisSession(_ context.Context, item *models.HostedGenesisSession, expectedVersion int64, expectedStatus hostedgenesis.Status) error {
+	if hostedgenesis.NormalizeStatus(f.session.Status) != expectedStatus || f.session.Version != expectedVersion {
+		return errConflict
+	}
+	c := *item
+	c.Version = expectedVersion + 1
+	f.session = &c
+	f.lastWrite = &c
+	return nil
+}
+
+var (
+	errNotFound = &errString{"not found"}
+	errConflict = &errString{"conditional write failed"}
+)
+
+type errString struct{ s string }
+
+func (e *errString) Error() string { return e.s }
+
+func baseTurnInput() (*fakeTurnStore, *fakeCompletionStore, completion.CompletionTurn) {
+	messages := `[{"role":"user","content":"hello"}]`
+	turn := completion.CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}
+	session := &models.HostedGenesisSession{
+		InstanceSlug: "acme", ConversationID: "conv-1", RegistrationID: "reg-1", AgentID: "agent-1",
+		Status: string(hostedgenesis.StatusInProgress), LatestTurnID: "turn-1",
+		TurnLedger:   []hostedgenesis.TurnLedgerEntry{{TurnID: "turn-1", MessageCount: 1, AcceptedAt: time.Now().UTC()}},
+		MessageCount: 1, Version: 2, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}
+	conv := &models.SoulAgentMintConversation{
+		AgentID: "agent-1", ConversationID: "conv-1", Model: "openai:gpt-test",
+		Messages: models.EncodeSoulMintConversationBlob(messages),
+	}
+	reg := &models.SoulAgentRegistration{ID: "reg-1", AgentID: "agent-1", DomainNormalized: "acme.example", LocalID: "acme"}
+	return &fakeTurnStore{session: session, conv: conv, reg: reg},
+		&fakeCompletionStore{session: &models.HostedGenesisSession{
+			InstanceSlug: "acme", ConversationID: "conv-1", RegistrationID: "reg-1", AgentID: "agent-1",
+			Status: string(hostedgenesis.StatusInProgress), LatestTurnID: "turn-1",
+			TurnLedger:   []hostedgenesis.TurnLedgerEntry{{TurnID: "turn-1", MessageCount: 1, AcceptedAt: time.Now().UTC()}},
+			MessageCount: 1, Version: 2, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+		}},
+		turn
+}
+
+// openaiStreamServer returns an httptest server that emits a one-chunk OpenAI
+// streaming response with the given assistant content.
+func openaiStreamServer(t *testing.T, content string) *httptest.Server {
+	t.Helper()
+	chunk := "data: " + mustMarshal(map[string]any{
+		"id": "chatcmpl_test", "object": "chat.completion.chunk", "created": 1, "model": "gpt-test",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{"role": "assistant", "content": content}, "finish_reason": nil}},
+	}) + "\n\ndata: [DONE]\n\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		_, _ = w.Write([]byte(chunk))
+	}))
+	return srv
+}
+
+func mustMarshal(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(b)
+}
+
+// withOpenAIBaseURL points the OpenAI adapter at the given server and restores
+// the prior env on cleanup.
+func withOpenAIBaseURL(t *testing.T, url, apiKey string) {
+	t.Helper()
+	oldBase := os.Getenv("OPENAI_BASE_URL")
+	oldKey := os.Getenv("OPENAI_API_KEY")
+	t.Cleanup(func() {
+		_ = os.Setenv("OPENAI_BASE_URL", oldBase)
+		_ = os.Setenv("OPENAI_API_KEY", oldKey)
+	})
+	_ = os.Setenv("OPENAI_BASE_URL", url)
+	_ = os.Setenv("OPENAI_API_KEY", apiKey)
+}
+
+// TestRunTurnAndPersist_AssistantTurnReadyThenDeclarationReady proves the run
+// hook's full path: a successful assistant turn persists assistant_turn_ready,
+// then declaration extraction persists declaration_ready, with the explicit HTTP
+// timeout configured on the LLM clients.
+func TestRunTurnAndPersist_AssistantTurnReadyThenDeclarationReady(t *testing.T) {
+	// Two LLM calls happen (assistant stream + declarations JSON). Route both
+	// through one server that serves the streaming assistant response for the
+	// streaming call and the declarations JSON for the non-streaming call. The
+	// openai-go SDK sets an Accept: text/event-stream header only for streaming
+	// calls, so dispatch on that header.
+	assistantChunk := "data: " + mustMarshal(map[string]any{
+		"id": "chatcmpl_test", "object": "chat.completion.chunk", "created": 1, "model": "gpt-test",
+		"choices": []any{map[string]any{"index": 0, "delta": map[string]any{"role": "assistant", "content": "I am acme."}, "finish_reason": nil}},
+	}) + "\n\ndata: [DONE]\n\n"
+	declBody := mustMarshal(map[string]any{
+		"id": "chatcmpl_test", "object": "chat.completion", "created": 1, "model": "gpt-test",
+		"choices": []any{map[string]any{"index": 0, "message": map[string]any{"role": "assistant", "content": mustMarshal(validDeclarationDraft())}}},
+		"usage":   map[string]any{"prompt_tokens": 5, "completion_tokens": 7, "total_tokens": 12},
+	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bodyBytes, _ := io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if strings.Contains(string(bodyBytes), `"stream":true`) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			_, _ = w.Write([]byte(assistantChunk))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(declBody))
+	}))
+	t.Cleanup(srv.Close)
+	withOpenAIBaseURL(t, srv.URL, "sk-test")
+
+	// Install an explicit (but generous) timeout so the test exercises the
+	// configured-client seam without flaking.
+	llm.ConfigureProviderHTTPClient(&http.Client{Timeout: 5 * time.Second})
+	t.Cleanup(func() { llm.ConfigureProviderHTTPClient(nil) })
+
+	turnStore, compStore, turn := baseTurnInput()
+	writer := completion.NewCompletionWriter(compStore, func() time.Time { return time.Unix(3000, 0).UTC() })
+	runner := &turnRunner{store: turnStore, writer: writer, nowFunc: func() time.Time { return time.Unix(3000, 0).UTC() }}
+
+	if err := runner.runTurnAndPersist(context.Background(), turn); err != nil {
+		t.Fatalf("runTurnAndPersist failed: %v", err)
+	}
+	if got := hostedgenesis.NormalizeStatus(compStore.session.Status); got != hostedgenesis.StatusDeclarationReady {
+		t.Fatalf("expected declaration_ready, got %q (last write status=%q)", got, compStore.lastWrite.Status)
+	}
+	if compStore.session.DeclarationCheckpoint == nil {
+		t.Fatalf("expected declaration checkpoint persisted")
+	}
+	if !strings.HasPrefix(compStore.session.DeclarationCheckpoint.DeclarationHash, "sha256:") {
+		t.Fatalf("expected sha256 declaration hash, got %q", compStore.session.DeclarationCheckpoint.DeclarationHash)
+	}
+}
+
+// TestRunTurnAndPersist_MissingSessionRecordsFailure proves a missing
+// authoritative session surfaces as a typed invalid_completion_state failure,
+// not a silent success.
+func TestRunTurnAndPersist_MissingSessionRecordsFailure(t *testing.T) {
+	withOpenAIBaseURL(t, "https://openai.example.test", "sk-test")
+	turnStore := &fakeTurnStore{session: nil} // missing
+	compStore := &fakeCompletionStore{session: &models.HostedGenesisSession{
+		InstanceSlug: "acme", ConversationID: "conv-1", RegistrationID: "reg-1", AgentID: "agent-1",
+		Status: string(hostedgenesis.StatusInProgress), LatestTurnID: "turn-1",
+		TurnLedger:   []hostedgenesis.TurnLedgerEntry{{TurnID: "turn-1", MessageCount: 1, AcceptedAt: time.Now().UTC()}},
+		MessageCount: 1, Version: 2, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC(),
+	}}
+	writer := completion.NewCompletionWriter(compStore, nil)
+	runner := &turnRunner{store: turnStore, writer: writer}
+	turn := completion.CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}
+
+	err := runner.runTurnAndPersist(context.Background(), turn)
+	if err != nil {
+		t.Fatalf("runTurnAndPersist should record failure and return nil, got %v", err)
+	}
+	if got := hostedgenesis.NormalizeStatus(compStore.session.Status); got != hostedgenesis.StatusFailed {
+		t.Fatalf("expected failed, got %q", got)
+	}
+	if compStore.session.Failure == nil || compStore.session.Failure.Code != hostedgenesis.FailureCodeInvalidCompletionState {
+		t.Fatalf("expected invalid_completion_state failure, got %+v", compStore.session.Failure)
+	}
+}
+
+// TestRunTurnAndPersist_EmptyAssistantRecordsFailure proves an empty assistant
+// response surfaces as assistant_turn_failed, not a silent success.
+func TestRunTurnAndPersist_EmptyAssistantRecordsFailure(t *testing.T) {
+	srv := openaiStreamServer(t, "   ") // empty content after trim
+	t.Cleanup(srv.Close)
+	withOpenAIBaseURL(t, srv.URL, "sk-test")
+	llm.ConfigureProviderHTTPClient(&http.Client{Timeout: 5 * time.Second})
+	t.Cleanup(func() { llm.ConfigureProviderHTTPClient(nil) })
+
+	turnStore, compStore, turn := baseTurnInput()
+	writer := completion.NewCompletionWriter(compStore, nil)
+	runner := &turnRunner{store: turnStore, writer: writer}
+
+	err := runner.runTurnAndPersist(context.Background(), turn)
+	if err != nil {
+		t.Fatalf("runTurnAndPersist should record failure and return nil, got %v", err)
+	}
+	if got := hostedgenesis.NormalizeStatus(compStore.session.Status); got != hostedgenesis.StatusFailed {
+		t.Fatalf("expected failed, got %q", got)
+	}
+	if compStore.session.Failure == nil || compStore.session.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed {
+		t.Fatalf("expected assistant_turn_failed, got %+v", compStore.session.Failure)
+	}
+}
+
+// TestRunTurnAndPersist_ReplayRejected proves idempotency: a second run for the
+// same turn against a session that has already advanced to assistant_turn_ready
+// does not silently re-apply — the assistant_turn_ready write conflicts.
+func TestRunTurnAndPersist_ReplayRejected(t *testing.T) {
+	srv := openaiStreamServer(t, "I am acme.")
+	t.Cleanup(srv.Close)
+	withOpenAIBaseURL(t, srv.URL, "sk-test")
+	llm.ConfigureProviderHTTPClient(&http.Client{Timeout: 5 * time.Second})
+	t.Cleanup(func() { llm.ConfigureProviderHTTPClient(nil) })
+
+	turnStore, compStore, turn := baseTurnInput()
+	// Pre-advance the completion store's session to assistant_turn_ready so the
+	// first assistant_turn_ready write must conflict.
+	compStore.session.Status = string(hostedgenesis.StatusAssistantTurnReady)
+	compStore.session.Version = 3
+	writer := completion.NewCompletionWriter(compStore, nil)
+	runner := &turnRunner{store: turnStore, writer: writer}
+
+	err := runner.runTurnAndPersist(context.Background(), turn)
+	if err == nil {
+		t.Fatal("expected conflict error on replay, got nil")
+	}
+	if !strings.Contains(err.Error(), "record assistant turn ready") {
+		t.Fatalf("expected record assistant turn ready conflict, got %v", err)
+	}
+	// Session must remain at assistant_turn_ready (not overwritten to failed).
+	if got := hostedgenesis.NormalizeStatus(compStore.session.Status); got != hostedgenesis.StatusAssistantTurnReady {
+		t.Fatalf("expected session to remain assistant_turn_ready on replay conflict, got %q", got)
+	}
+}
+
+func validDeclarationDraft() map[string]any {
+	return map[string]any{
+		"selfDescription": map[string]any{
+			"purpose":      "I help with tasks.",
+			"authoredBy":   "agent",
+			"mintingModel": "openai:gpt-test",
+		},
+		"capabilities": []any{map[string]any{
+			"capability": "reasoning", "scope": "general", "claimLevel": "self-declared",
+		}},
+		"boundaries": []any{map[string]any{
+			"category": "scope_limit", "statement": "I will not harm.",
+		}},
+		"transparency": map[string]any{"notes": "test"},
+	}
+}

--- a/docs/hosted-genesis-microvm-lab-canary.md
+++ b/docs/hosted-genesis-microvm-lab-canary.md
@@ -15,8 +15,9 @@ When explicitly enabled for `stage=lab`, CDK requires all operator-owned context
 - `hostedGenesisMicrovmBaseImageArn`
 - `hostedGenesisMicrovmBaseImageVersion`
 - `hostedGenesisMicrovmBuildRoleArn`
-- `hostedGenesisMicrovmCodeArtifactUri`
 - `hostedGenesisMicrovmAuthorizerTokenSha256` — SHA-256 digest only, never a raw token
+
+The MicroVM image code artifact is built in-repo from `cmd/hosted-genesis-microvm-workload` at synth time and uploaded as a CDK S3 asset; no external `codeArtifactUri` context is required.
 
 The wiring fails closed outside `lab` and fails closed when the digest is not a SHA-256 value.
 

--- a/internal/ai/llm/http_client.go
+++ b/internal/ai/llm/http_client.go
@@ -1,0 +1,79 @@
+package llm
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+	openaioption "github.com/openai/openai-go/option"
+)
+
+// DefaultProviderHTTPTimeout is the explicit per-provider HTTP timeout applied
+// to every LLM provider call. It is intentionally shorter than the Lambda
+// envelope that hosts a call so a hanging provider fails at the client boundary
+// with a typed net/http deadline-exceeded error instead of being killed by the
+// runtime and surfaced as an opaque platform timeout (G8).
+//
+// The value is sized for the longest legitimate single mint-conversation turn
+// (streaming assistant response + declaration extraction). It bounds a single
+// HTTP round trip; streaming callers still receive incremental deltas up to the
+// deadline.
+const DefaultProviderHTTPTimeout = 120 * time.Second
+
+// ConfigureProviderHTTPClient installs an explicit-timeout HTTP client on both
+// the OpenAI and Anthropic provider adapters. Pass a nil client to reset to the
+// SDK defaults (no explicit timeout). The client's Transport is left to the
+// caller; only the Timeout field is load-bearing here.
+//
+// This is the single seam the in-VM hosted-genesis workload and tests use to
+// guarantee provider calls carry an explicit HTTP deadline rather than relying
+// on the surrounding Lambda/context envelope. Streaming and parsing behavior is
+// unchanged: the same request bodies, stream decoders, and usage accounting run
+// underneath; only the transport-level deadline is bounded.
+func ConfigureProviderHTTPClient(c *http.Client) {
+	if c == nil {
+		openAIHTTPClient = nil
+		anthropicHTTPClient = nil
+		return
+	}
+	openAIHTTPClient = c
+	anthropicHTTPClient = c
+}
+
+// newDefaultProviderHTTPClient returns an *http.Client with the explicit
+// DefaultProviderHTTPTimeout applied and a default transport. It is the client
+// the hosted-genesis MicroVM workload installs at startup.
+func newDefaultProviderHTTPClient() *http.Client {
+	return &http.Client{
+		Timeout:   DefaultProviderHTTPTimeout,
+		Transport: http.DefaultTransport,
+	}
+}
+
+// ConfigureDefaultProviderHTTPClient installs the default explicit-timeout
+// provider HTTP client. It is safe to call once at process startup; later
+// calls replace the prior client.
+func ConfigureDefaultProviderHTTPClient() {
+	ConfigureProviderHTTPClient(newDefaultProviderHTTPClient())
+}
+
+// ProviderHTTPClientTimeout reports the configured timeout for the OpenAI
+// provider client, or zero if no explicit client is installed. It exists for
+// tests that prove the explicit-timeout invariant without depending on a live
+// provider call.
+func ProviderHTTPClientTimeout() time.Duration {
+	if openAIHTTPClient == nil {
+		return 0
+	}
+	if c, ok := openAIHTTPClient.(*http.Client); ok {
+		return c.Timeout
+	}
+	return 0
+}
+
+// ensure the per-package option types are referenced so this file documents the
+// dual-SDK seam even if future refactors move the vars.
+var (
+	_ openaioption.HTTPClient = (*http.Client)(nil)
+	_ option.HTTPClient       = (*http.Client)(nil)
+)

--- a/internal/ai/llm/http_client_test.go
+++ b/internal/ai/llm/http_client_test.go
@@ -1,0 +1,177 @@
+package llm
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestConfigureProviderHTTPClient_InstallsExplicitTimeout proves the configured
+// HTTP client carries an explicit Timeout rather than relying on the SDK default
+// (http.DefaultClient, which has no Timeout). This is the G8 invariant: provider
+// calls must fail at the configured deadline, not at the Lambda envelope.
+func TestConfigureProviderHTTPClient_InstallsExplicitTimeout(t *testing.T) {
+	t.Cleanup(func() { ConfigureProviderHTTPClient(nil) })
+
+	ConfigureProviderHTTPClient(&http.Client{Timeout: 7 * time.Second})
+	if got := ProviderHTTPClientTimeout(); got != 7*time.Second {
+		t.Fatalf("expected configured timeout 7s, got %v", got)
+	}
+
+	ConfigureDefaultProviderHTTPClient()
+	if got := ProviderHTTPClientTimeout(); got != DefaultProviderHTTPTimeout {
+		t.Fatalf("expected default timeout %v, got %v", DefaultProviderHTTPTimeout, got)
+	}
+
+	ConfigureProviderHTTPClient(nil)
+	if got := ProviderHTTPClientTimeout(); got != 0 {
+		t.Fatalf("expected zero timeout after reset, got %v", got)
+	}
+}
+
+// TestStreamMintConversationOpenAI_TimesOutAtConfiguredDeadline proves a hanging
+// provider fails at the configured client deadline, not the surrounding context
+// envelope. A 200ms client timeout must abort a 30s-hanging server well before a
+// 5s test context would. This is the explicit-timeout proof required by H1.1.
+func TestStreamMintConversationOpenAI_TimesOutAtConfiguredDeadline(t *testing.T) {
+	assertProviderTimesOutAtConfiguredDeadline(t, "OPENAI_BASE_URL", func(ctx context.Context) error {
+		_, _, err := StreamMintConversationOpenAI(ctx, "sk-test", "openai:gpt-test", "system", []MintConversationMessage{
+			{Role: "user", Content: "hello"},
+		}, func(string) {})
+		return err
+	})
+}
+
+// TestStreamMintConversationAnthropic_TimesOutAtConfiguredDeadline mirrors the
+// OpenAI proof for the Anthropic adapter, confirming both provider seams honor
+// the single configured HTTP client.
+func TestStreamMintConversationAnthropic_TimesOutAtConfiguredDeadline(t *testing.T) {
+	assertProviderTimesOutAtConfiguredDeadline(t, "ANTHROPIC_BASE_URL", func(ctx context.Context) error {
+		_, _, err := StreamMintConversationAnthropic(ctx, "sk-test", "anthropic:claude-test", "system", []MintConversationMessage{
+			{Role: "user", Content: "hello"},
+		}, func(string) {})
+		return err
+	})
+}
+
+// assertProviderTimesOutAtConfiguredDeadline is the shared explicit-timeout
+// proof: a hanging provider must fail at the configured 200ms client deadline,
+// not the surrounding 5s context envelope. The provider call is injected so both
+// the OpenAI and Anthropic seams are proven against the single configured client.
+func assertProviderTimesOutAtConfiguredDeadline(t *testing.T, baseURLEnv string, call func(ctx context.Context) error) {
+	t.Helper()
+	// Hanging server: accepts the connection but never writes a response body,
+	// so the only thing that can terminate the call is the client timeout. The
+	// handler selects on the server context so httptest.Server.Close() does not
+	// block for 30s on shutdown.
+	hanging := newHangingServer(t)
+	t.Cleanup(hanging.Close)
+
+	oldBase := os.Getenv(baseURLEnv)
+	t.Cleanup(func() { _ = os.Setenv(baseURLEnv, oldBase) })
+	_ = os.Setenv(baseURLEnv, hanging.URL)
+
+	// Explicit short client timeout — the invariant under test.
+	ConfigureProviderHTTPClient(&http.Client{Timeout: 200 * time.Millisecond})
+	t.Cleanup(func() { ConfigureProviderHTTPClient(nil) })
+
+	// Generous context envelope (5s). If the call waited for the envelope
+	// instead of the client deadline, this test would fail the bound below.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	err := call(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected timeout error from hanging provider, got nil")
+	}
+	// A net/http client timeout surfaces as a url.Error wrapping "context
+	// deadline exceeded" (Client.Timeout uses context cancellation). Accept
+	// either the deadline string or a timeout-class error.
+	if !isTimeoutError(err) {
+		t.Fatalf("expected deadline/timeout-class error, got %v", err)
+	}
+	// Must abort near the 200ms client deadline, not the 5s envelope. The bound
+	// allows margin for SDK retry backoff on slower machines.
+	if elapsed > 3500*time.Millisecond {
+		t.Fatalf("client did not time out at configured deadline: elapsed %v (expected well under the 5s envelope)", elapsed)
+	}
+}
+
+// TestConfigureProviderHTTPClient_DoesNotChangeStreamingParsing proves the seam
+// only swaps the transport client: a fast, well-formed streaming response still
+// parses to the same assistant content as without the configured client.
+func TestConfigureProviderHTTPClient_DoesNotChangeStreamingParsing(t *testing.T) {
+	// Minimal OpenAI streaming response: one chunk with the full delta then a
+	// [DONE] sentinel. The accumulator must surface "hello from openai".
+	chunk := `data: {"id":"chatcmpl_test","object":"chat.completion.chunk","created":1,"model":"gpt-test","choices":[{"index":0,"delta":{"role":"assistant","content":"hello from openai"},"finish_reason":null}]}
+
+data: [DONE]
+
+`
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		_, _ = w.Write([]byte(chunk))
+	}))
+	t.Cleanup(srv.Close)
+
+	oldBase := os.Getenv("OPENAI_BASE_URL")
+	t.Cleanup(func() { _ = os.Setenv("OPENAI_BASE_URL", oldBase) })
+	_ = os.Setenv("OPENAI_BASE_URL", srv.URL)
+
+	ConfigureProviderHTTPClient(&http.Client{Timeout: 5 * time.Second})
+	t.Cleanup(func() { ConfigureProviderHTTPClient(nil) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	got, _, err := StreamMintConversationOpenAI(ctx, "sk-test", "openai:gpt-test", "system", []MintConversationMessage{
+		{Role: "user", Content: "hi"},
+	}, func(string) {})
+	if err != nil {
+		t.Fatalf("stream call failed: %v", err)
+	}
+	if got != "hello from openai" {
+		t.Fatalf("expected parsed assistant content %q, got %q", "hello from openai", got)
+	}
+}
+
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return errors.Is(err, context.DeadlineExceeded) ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "client timed out")
+}
+
+// newHangingServer returns an httptest.Server that accepts requests but never
+// writes a response, so only the client timeout can terminate the call. The
+// handler selects on its own context so server shutdown is prompt.
+func newHangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		_ = r.Body.Close()
+		select {
+		case <-r.Context().Done():
+		case <-time.After(30 * time.Second):
+		}
+	}))
+	return srv
+}
+
+var _ = bytes.NewReader // retained for parity with sibling adapter tests if extended later

--- a/internal/controlplane/handlers_soul_mint_conversation.go
+++ b/internal/controlplane/handlers_soul_mint_conversation.go
@@ -11,7 +11,6 @@ import (
 	"net/http"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +22,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/ai/llm"
 	"github.com/equaltoai/lesser-host/internal/billing"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis/mintprompt"
 	"github.com/equaltoai/lesser-host/internal/httpx"
 	"github.com/equaltoai/lesser-host/internal/secrets"
 	"github.com/equaltoai/lesser-host/internal/soul"
@@ -2199,78 +2199,12 @@ func (s *Server) persistMintConversationBoundaries(ctx context.Context, identity
 	return nil
 }
 
+// buildMintConversationSystemPrompt delegates to the shared
+// hostedgenesis/mintprompt builder so the control-plane synchronous path and the
+// in-VM MicroVM workload prompt the provider identically for a given
+// registration (drift-free).
 func buildMintConversationSystemPrompt(reg *models.SoulAgentRegistration) string {
-	var sb strings.Builder
-	sb.WriteString(`You are a Soul Registry minting assistant. Your role is to help an AI agent define its identity through structured conversation before its soul is minted on-chain.
-
-You are conducting a minting conversation with an agent that wants to register in the Soul Registry. Your goal is to help the agent articulate:
-
-1. **Self-Description**: A clear, honest description of what the agent is, its purpose, and its primary function.
-2. **Capabilities**: What the agent can do, with appropriate claim levels (self-declared, peer-validated, operator-attested).
-3. **Boundaries**: What the agent will NOT do — ethical limits, operational constraints, and refusal conditions.
-4. **Transparency**: How the agent makes decisions, what models it uses, and its known limitations.
-
-Guidelines:
-- Ask probing questions to help the agent articulate its identity clearly.
-- Challenge vague or overly broad claims.
-- Encourage honesty about limitations and potential failure modes.
-- Help distinguish between capabilities the agent has vs. aspirations.
-- Ensure boundaries are concrete and actionable, not just platitudes.
-- The conversation should feel collaborative, not interrogative.
-
-When you feel the conversation has covered all four areas sufficiently, summarize the proposed declarations in a structured format.
-
-`)
-
-	sb.WriteString("Agent registration context:\n")
-	if reg.DomainNormalized != "" {
-		fmt.Fprintf(&sb, "- Domain: %s\n", quoteMintConversationPromptValue(reg.DomainNormalized))
-	}
-	if reg.LocalID != "" {
-		fmt.Fprintf(&sb, "- Local ID: %s\n", quoteMintConversationPromptValue(reg.LocalID))
-	}
-	if len(reg.Capabilities) > 0 {
-		caps := make([]string, 0, len(reg.Capabilities))
-		for _, c := range reg.Capabilities {
-			c = sanitizeMintConversationPromptInline(c, 128)
-			if c != "" {
-				caps = append(caps, c)
-			}
-		}
-		b, _ := json.Marshal(caps)
-		fmt.Fprintf(&sb, "- Declared capabilities: %s\n", string(b))
-	}
-
-	return sb.String()
-}
-
-func sanitizeMintConversationPromptInline(raw string, maxLen int) string {
-	raw = strings.TrimSpace(raw)
-	if raw == "" {
-		return ""
-	}
-	raw = strings.Map(func(r rune) rune {
-		if r < 0x20 || r == 0x7f {
-			return ' '
-		}
-		return r
-	}, raw)
-	if maxLen > 0 && len(raw) > maxLen {
-		raw = raw[:maxLen]
-	}
-	return raw
-}
-
-func quoteMintConversationPromptValue(raw string) string {
-	raw = sanitizeMintConversationPromptInline(raw, 256)
-	if raw == "" {
-		return ""
-	}
-	b, err := json.Marshal(raw)
-	if err != nil {
-		return strconv.Quote(raw)
-	}
-	return string(b)
+	return mintprompt.MintConversationSystemPrompt(reg)
 }
 
 func (s *Server) apiKeyForMintConversationModel(ctx context.Context, modelSet string) (string, *apptheory.AppError) {

--- a/internal/hostedgenesis/completion/completion.go
+++ b/internal/hostedgenesis/completion/completion.go
@@ -1,0 +1,298 @@
+// Package completion provides the in-VM hosted-genesis workload's durable
+// completion-write seam over the existing HostedGenesisSession store layer.
+//
+// It reuses the progression semantics of the control-plane
+// persistHostedGenesisAcceptedAssistantTurn path — the same status transitions,
+// AssistantCheckpointRef shape, and typed Failure envelope — but without the
+// control-plane Server, idempotency, billing, or promotion coupling. Every write
+// is idempotent per turn ID and conditional on the session's current status +
+// optimistic-lock version: a replayed write for a turn whose session has already
+// advanced past the expected status is rejected as ErrCompletionConflict rather
+// than silently re-applied.
+//
+// The package lives under internal/hostedgenesis so the workload and tests
+// depend on the hosted-genesis vocabulary, not the concrete *store.Store. The
+// CompletionStore interface is satisfied by *store.Store.
+package completion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// CompletionStore is the minimal HostedGenesisSession truth surface the in-VM
+// genesis workload needs to durably record a turn outcome. It is satisfied by
+// *store.Store; the workload never receives a raw AWS SDK client or a
+// control-plane Server handle.
+//
+// GetHostedGenesisSession loads authoritative truth by tenant slug +
+// conversation id. UpdateHostedGenesisSession performs an expected-version +
+// expected-status conditional write; a stale version or status must fail as a
+// transaction condition error rather than silently overwriting state.
+type CompletionStore interface {
+	GetHostedGenesisSession(ctx context.Context, instanceSlug string, conversationID string) (*models.HostedGenesisSession, error)
+	UpdateHostedGenesisSession(ctx context.Context, item *models.HostedGenesisSession, expectedVersion int64, expectedStatus hostedgenesis.Status) error
+}
+
+// CompletionTurn identifies the turn a completion write targets. The TurnID is
+// the idempotency key: a second write for the same TurnID against a session that
+// has already advanced past the expected status is rejected as a conflict rather
+// than re-applied.
+type CompletionTurn struct {
+	InstanceSlug   string
+	ConversationID string
+	TurnID         string
+	RequestID      string
+}
+
+// Validate fails closed if the turn is missing durable ids.
+func (t CompletionTurn) Validate() error {
+	if strings.TrimSpace(t.InstanceSlug) == "" ||
+		strings.TrimSpace(t.ConversationID) == "" ||
+		strings.TrimSpace(t.TurnID) == "" {
+		return ErrInvalidCompletionTurn
+	}
+	return nil
+}
+
+// AssistantTurnCompletion is the durable outcome of a successful assistant turn
+// run inside the MicroVM. AssistantContent is the full trimmed assistant
+// response; MessageCount is the post-turn message count (accepted user turn +
+// produced assistant message). Usage is the provider usage for this turn.
+type AssistantTurnCompletion struct {
+	AssistantContent string
+	MessageCount     int
+	Usage            models.AIUsage
+}
+
+// CompletionFailure is the typed failure the workload records when a turn or
+// declaration extraction fails. It maps to hostedgenesis.Failure with bounded
+// recovery guidance authored by Host (clients never author recovery).
+type CompletionFailure struct {
+	Code      hostedgenesis.FailureCode
+	Message   string
+	Retryable bool
+	Recovery  hostedgenesis.Recovery
+}
+
+// CompletionWriter records hosted-genesis turn outcomes to HostedGenesisSession
+// truth through the existing store layer.
+//
+// Every write is idempotent per turn ID and conditional on the session's current
+// status + optimistic-lock version. The clock is optional; if nil, time.Now UTC
+// is used.
+type CompletionWriter struct {
+	store CompletionStore
+	clock func() time.Time
+}
+
+// Sentinel errors for completion writes.
+var (
+	ErrInvalidCompletionTurn    = errors.New("hosted genesis completion turn is incomplete")
+	ErrCompletionConflict       = errors.New("hosted genesis completion write conflicts with session state")
+	ErrCompletionSessionMissing = errors.New("hosted genesis completion session is missing")
+)
+
+// NewCompletionWriter constructs a CompletionWriter over the given store.
+func NewCompletionWriter(store CompletionStore, clock func() time.Time) *CompletionWriter {
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	return &CompletionWriter{store: store, clock: clock}
+}
+
+// RecordAssistantTurnReady transitions an in_progress session to
+// assistant_turn_ready for the named turn, persisting the assistant checkpoint
+// reference and message count. It is idempotent per turn ID: a replay against a
+// session already at assistant_turn_ready (or beyond) returns
+// ErrCompletionConflict.
+//
+// The expected-status precondition is in_progress (the state the accept path
+// leaves the session in). The expected-version precondition is the loaded
+// session's current Version; the store's conditional update increments it.
+func (w *CompletionWriter) RecordAssistantTurnReady(ctx context.Context, turn CompletionTurn, completion AssistantTurnCompletion) (*models.HostedGenesisSession, error) {
+	if w == nil || w.store == nil {
+		return nil, ErrCompletionSessionMissing
+	}
+	if err := turn.Validate(); err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(completion.AssistantContent) == "" {
+		return nil, fmt.Errorf("hosted genesis completion requires non-empty assistant content")
+	}
+
+	session, err := w.store.GetHostedGenesisSession(ctx, turn.InstanceSlug, turn.ConversationID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionSessionMissing, err)
+	}
+	if err := assertTurnMatch(session, turn, hostedgenesis.StatusInProgress); err != nil {
+		return nil, err
+	}
+
+	now := w.clock()
+	progressed := cloneSessionForCompletion(session)
+	progressed.Status = string(hostedgenesis.StatusAssistantTurnReady)
+	progressed.MessageCount = maxInt(progressed.MessageCount, completion.MessageCount)
+	progressed.AssistantCheckpointRef = fmt.Sprintf("checkpoint://hosted-genesis/%s/assistant/%s", progressed.ConversationID, turn.TurnID)
+	progressed.Failure = nil
+	progressed.RequestID = strings.TrimSpace(turn.RequestID)
+	progressed.UpdatedAt = now
+	progressed.CompletedAt = time.Time{}
+
+	if err := w.store.UpdateHostedGenesisSession(ctx, progressed, session.Version, hostedgenesis.StatusInProgress); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionConflict, err)
+	}
+	return progressed, nil
+}
+
+// RecordDeclarationReady transitions a declaration_extraction_pending (or
+// assistant_turn_ready) session to declaration_ready with a publish-ready
+// DeclarationCheckpoint. The checkpoint must pass its Validate and the session's
+// CanPublish gate (enforced by the store model's BeforeUpdate).
+//
+// Idempotent per turn ID against the expected status precondition.
+func (w *CompletionWriter) RecordDeclarationReady(ctx context.Context, turn CompletionTurn, checkpoint hostedgenesis.DeclarationCheckpoint) (*models.HostedGenesisSession, error) {
+	if w == nil || w.store == nil {
+		return nil, ErrCompletionSessionMissing
+	}
+	if err := turn.Validate(); err != nil {
+		return nil, err
+	}
+	if err := checkpoint.Validate(); err != nil {
+		return nil, err
+	}
+
+	session, err := w.store.GetHostedGenesisSession(ctx, turn.InstanceSlug, turn.ConversationID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionSessionMissing, err)
+	}
+	expectedStatus := hostedgenesis.NormalizeStatus(session.Status)
+	if expectedStatus != hostedgenesis.StatusDeclarationExtractionPending && expectedStatus != hostedgenesis.StatusAssistantTurnReady {
+		return nil, fmt.Errorf("%w: session status %q is not declaration-extractable", ErrCompletionConflict, session.Status)
+	}
+	if err := assertTurnMatch(session, turn, expectedStatus); err != nil {
+		return nil, err
+	}
+
+	now := w.clock()
+	progressed := cloneSessionForCompletion(session)
+	progressed.Status = string(hostedgenesis.StatusDeclarationReady)
+	progressed.DeclarationCheckpoint = &checkpoint
+	progressed.Failure = nil
+	progressed.RequestID = strings.TrimSpace(turn.RequestID)
+	progressed.UpdatedAt = now
+	progressed.CompletedAt = now
+
+	if err := w.store.UpdateHostedGenesisSession(ctx, progressed, session.Version, expectedStatus); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionConflict, err)
+	}
+	return progressed, nil
+}
+
+// RecordFailure transitions a non-terminal session to failed with a typed
+// Failure envelope. A replay against an already-terminal session returns
+// ErrCompletionConflict.
+func (w *CompletionWriter) RecordFailure(ctx context.Context, turn CompletionTurn, failure CompletionFailure) (*models.HostedGenesisSession, error) {
+	if w == nil || w.store == nil {
+		return nil, ErrCompletionSessionMissing
+	}
+	if err := turn.Validate(); err != nil {
+		return nil, err
+	}
+	f := hostedgenesis.Failure{
+		Code:      failure.Code,
+		Message:   strings.TrimSpace(failure.Message),
+		Retryable: failure.Retryable,
+		Recovery:  failure.Recovery,
+	}
+	if err := f.Validate(); err != nil {
+		return nil, err
+	}
+
+	session, err := w.store.GetHostedGenesisSession(ctx, turn.InstanceSlug, turn.ConversationID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionSessionMissing, err)
+	}
+	expectedStatus := hostedgenesis.NormalizeStatus(session.Status)
+	if expectedStatus == hostedgenesis.StatusFailed || expectedStatus == hostedgenesis.StatusDeclarationReady {
+		return nil, fmt.Errorf("%w: session is already terminal (%q)", ErrCompletionConflict, session.Status)
+	}
+	if err := assertTurnMatch(session, turn, expectedStatus); err != nil {
+		return nil, err
+	}
+
+	now := w.clock()
+	progressed := cloneSessionForCompletion(session)
+	progressed.Status = string(hostedgenesis.StatusFailed)
+	progressed.Failure = &f
+	progressed.RequestID = strings.TrimSpace(turn.RequestID)
+	progressed.UpdatedAt = now
+	progressed.CompletedAt = now
+
+	if err := w.store.UpdateHostedGenesisSession(ctx, progressed, session.Version, expectedStatus); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrCompletionConflict, err)
+	}
+	return progressed, nil
+}
+
+// assertTurnMatch enforces the per-turn idempotency precondition. The loaded
+// session's LatestTurnID (or last ledger entry's TurnID) must equal the
+// completion turn's TurnID, and the session status must equal the expected
+// status the caller will condition the write on. A mismatch is a conflict.
+func assertTurnMatch(session *models.HostedGenesisSession, turn CompletionTurn, expectedStatus hostedgenesis.Status) error {
+	if session == nil {
+		return ErrCompletionSessionMissing
+	}
+	sessionTurn := strings.TrimSpace(session.LatestTurnID)
+	if sessionTurn == "" && len(session.TurnLedger) > 0 {
+		sessionTurn = strings.TrimSpace(session.TurnLedger[len(session.TurnLedger)-1].TurnID)
+	}
+	if sessionTurn != strings.TrimSpace(turn.TurnID) {
+		return fmt.Errorf("%w: session turn %q does not match completion turn %q", ErrCompletionConflict, sessionTurn, turn.TurnID)
+	}
+	if hostedgenesis.NormalizeStatus(session.Status) != expectedStatus {
+		return fmt.Errorf("%w: session status %q does not match expected %q", ErrCompletionConflict, session.Status, expectedStatus)
+	}
+	return nil
+}
+
+// cloneSessionForCompletion copies the loaded session for a progression write,
+// deep-copying nested pointer fields. Mirrors control-plane
+// cloneHostedGenesisSession.
+func cloneSessionForCompletion(session *models.HostedGenesisSession) *models.HostedGenesisSession {
+	if session == nil {
+		return nil
+	}
+	copy := *session
+	copy.TurnLedger = append([]hostedgenesis.TurnLedgerEntry(nil), session.TurnLedger...)
+	if session.MicroVMLifecycleRef != nil {
+		ref := *session.MicroVMLifecycleRef
+		copy.MicroVMLifecycleRef = &ref
+	}
+	if session.DeclarationCheckpoint != nil {
+		cp := *session.DeclarationCheckpoint
+		copy.DeclarationCheckpoint = &cp
+	}
+	if session.Failure != nil {
+		failure := *session.Failure
+		copy.Failure = &failure
+	}
+	if session.TraceIDs != nil {
+		trace := *session.TraceIDs
+		copy.TraceIDs = &trace
+	}
+	return &copy
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/hostedgenesis/completion/completion_test.go
+++ b/internal/hostedgenesis/completion/completion_test.go
@@ -1,0 +1,304 @@
+package completion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// fakeCompletionStore is an in-memory CompletionStore for idempotency proofs.
+// It records the last conditional update's expected version + status and can be
+// programmed to return a condition failure to simulate a stale/progressed
+// session.
+type fakeCompletionStore struct {
+	session     *models.HostedGenesisSession
+	updateErr   error
+	lastExpectV int64
+	lastExpectS hostedgenesis.Status
+	written     *models.HostedGenesisSession
+}
+
+func (f *fakeCompletionStore) GetHostedGenesisSession(_ context.Context, instanceSlug, conversationID string) (*models.HostedGenesisSession, error) {
+	if f.session == nil || f.session.InstanceSlug != instanceSlug || f.session.ConversationID != conversationID {
+		return nil, fmt.Errorf("not found")
+	}
+	return cloneSessionForCompletion(f.session), nil
+}
+
+func (f *fakeCompletionStore) UpdateHostedGenesisSession(_ context.Context, item *models.HostedGenesisSession, expectedVersion int64, expectedStatus hostedgenesis.Status) error {
+	f.lastExpectV = expectedVersion
+	f.lastExpectS = expectedStatus
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.written = cloneSessionForCompletion(item)
+	f.session = cloneSessionForCompletion(item)
+	f.session.Version = expectedVersion + 1
+	return nil
+}
+
+func newFakeSession(slug, conv, turn string, status hostedgenesis.Status, version int64) *models.HostedGenesisSession {
+	return &models.HostedGenesisSession{
+		InstanceSlug:   slug,
+		ConversationID: conv,
+		RegistrationID: "reg-1",
+		AgentID:        "agent-1",
+		Status:         string(status),
+		LatestTurnID:   turn,
+		TurnLedger:     []hostedgenesis.TurnLedgerEntry{{TurnID: turn, MessageCount: 1, AcceptedAt: time.Now().UTC()}},
+		MessageCount:   1,
+		Version:        version,
+		CreatedAt:      time.Now().UTC(),
+		UpdatedAt:      time.Now().UTC(),
+	}
+}
+
+func hex64() string {
+	return "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+}
+
+func TestRecordAssistantTurnReady_AppliesConditionalWrite(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusInProgress, 3)}
+	w := NewCompletionWriter(store, func() time.Time { return time.Unix(1000, 0).UTC() })
+
+	turn := CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}
+	got, err := w.RecordAssistantTurnReady(context.Background(), turn, AssistantTurnCompletion{
+		AssistantContent: "hello",
+		MessageCount:     2,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != string(hostedgenesis.StatusAssistantTurnReady) {
+		t.Fatalf("expected assistant_turn_ready, got %q", got.Status)
+	}
+	if store.lastExpectV != 3 || store.lastExpectS != hostedgenesis.StatusInProgress {
+		t.Fatalf("expected conditional on version=3 status=in_progress, got version=%d status=%q", store.lastExpectV, store.lastExpectS)
+	}
+	if got.AssistantCheckpointRef != "checkpoint://hosted-genesis/conv-1/assistant/turn-1" {
+		t.Fatalf("unexpected assistant checkpoint ref %q", got.AssistantCheckpointRef)
+	}
+	if got.MessageCount != 2 {
+		t.Fatalf("expected message count 2, got %d", got.MessageCount)
+	}
+	if !got.UpdatedAt.Equal(time.Unix(1000, 0).UTC()) {
+		t.Fatalf("expected clock applied, got %v", got.UpdatedAt)
+	}
+}
+
+// TestRecordAssistantTurnReady_ReplayedTurnIDRejected proves the idempotency
+// invariant required by H1.1: a second write for the same turn ID against a
+// session that has already advanced past in_progress (here, to
+// assistant_turn_ready) is rejected as a conflict, not silently re-applied.
+func TestRecordAssistantTurnReady_ReplayedTurnIDRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusAssistantTurnReady, 4)}
+	w := NewCompletionWriter(store, nil)
+
+	turn := CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}
+	_, err := w.RecordAssistantTurnReady(context.Background(), turn, AssistantTurnCompletion{
+		AssistantContent: "hello again",
+		MessageCount:     2,
+	})
+	if err == nil {
+		t.Fatal("expected conflict error on replayed turn against progressed status, got nil")
+	}
+	if !errors.Is(err, ErrCompletionConflict) {
+		t.Fatalf("expected ErrCompletionConflict, got %v", err)
+	}
+	if store.written != nil {
+		t.Fatalf("expected no write applied on conflict, but a write was recorded")
+	}
+}
+
+// TestRecordAssistantTurnReady_MismatchedTurnIDRejected proves a completion
+// write for a turn ID that does not match the session's latest turn is rejected.
+func TestRecordAssistantTurnReady_MismatchedTurnIDRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusInProgress, 3)}
+	w := NewCompletionWriter(store, nil)
+
+	turn := CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-other", RequestID: "req-1"}
+	_, err := w.RecordAssistantTurnReady(context.Background(), turn, AssistantTurnCompletion{
+		AssistantContent: "hello",
+		MessageCount:     2,
+	})
+	if err == nil {
+		t.Fatal("expected conflict error on mismatched turn ID, got nil")
+	}
+	if !errors.Is(err, ErrCompletionConflict) {
+		t.Fatalf("expected ErrCompletionConflict, got %v", err)
+	}
+}
+
+// TestRecordAssistantTurnReady_StaleVersionRejected proves a store condition
+// failure (stale version) surfaces as ErrCompletionConflict, not a silent
+// overwrite.
+func TestRecordAssistantTurnReady_StaleVersionRejected(t *testing.T) {
+	store := &fakeCompletionStore{
+		session:   newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusInProgress, 3),
+		updateErr: fmt.Errorf("conditional check failed"),
+	}
+	w := NewCompletionWriter(store, nil)
+
+	turn := CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}
+	_, err := w.RecordAssistantTurnReady(context.Background(), turn, AssistantTurnCompletion{
+		AssistantContent: "hello",
+		MessageCount:     2,
+	})
+	if err == nil {
+		t.Fatal("expected conflict error on stale version, got nil")
+	}
+	if !errors.Is(err, ErrCompletionConflict) {
+		t.Fatalf("expected ErrCompletionConflict, got %v", err)
+	}
+}
+
+func TestRecordDeclarationReady_AppliesFromPending(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusDeclarationExtractionPending, 5)}
+	w := NewCompletionWriter(store, func() time.Time { return time.Unix(2000, 0).UTC() })
+
+	cp := hostedgenesis.DeclarationCheckpoint{
+		DeclarationID:   "decl-1",
+		DeclarationHash: "sha256:" + hex64(),
+		CheckpointRef:   "checkpoint://hosted-genesis/conv-1/declaration/turn-1",
+		ProducedAt:      time.Unix(2000, 0).UTC(),
+		RegistrationID:  "reg-1",
+		ConversationID:  "conv-1",
+		AgentID:         "agent-1",
+		MessageCount:    2,
+		RequestID:       "req-1",
+	}
+	got, err := w.RecordDeclarationReady(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}, cp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != string(hostedgenesis.StatusDeclarationReady) {
+		t.Fatalf("expected declaration_ready, got %q", got.Status)
+	}
+	if got.DeclarationCheckpoint == nil || got.DeclarationCheckpoint.DeclarationID != "decl-1" {
+		t.Fatalf("expected declaration checkpoint persisted, got %+v", got.DeclarationCheckpoint)
+	}
+	if store.lastExpectS != hostedgenesis.StatusDeclarationExtractionPending {
+		t.Fatalf("expected conditional on declaration_extraction_pending, got %q", store.lastExpectS)
+	}
+}
+
+// TestRecordDeclarationReady_ReplayRejected proves a second declaration write
+// for a session already at declaration_ready is rejected.
+func TestRecordDeclarationReady_ReplayRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusDeclarationReady, 6)}
+	w := NewCompletionWriter(store, nil)
+
+	cp := hostedgenesis.DeclarationCheckpoint{
+		DeclarationID:   "decl-1",
+		DeclarationHash: "sha256:" + hex64(),
+		CheckpointRef:   "checkpoint://hosted-genesis/conv-1/declaration/turn-1",
+		ProducedAt:      time.Unix(2000, 0).UTC(),
+		RegistrationID:  "reg-1",
+		ConversationID:  "conv-1",
+		AgentID:         "agent-1",
+		MessageCount:    2,
+		RequestID:       "req-1",
+	}
+	_, err := w.RecordDeclarationReady(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}, cp)
+	if err == nil {
+		t.Fatal("expected conflict on replay against declaration_ready, got nil")
+	}
+	if !errors.Is(err, ErrCompletionConflict) {
+		t.Fatalf("expected ErrCompletionConflict, got %v", err)
+	}
+}
+
+func TestRecordFailure_AppliesTypedFailure(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusInProgress, 3)}
+	w := NewCompletionWriter(store, nil)
+
+	got, err := w.RecordFailure(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}, CompletionFailure{
+		Code:      hostedgenesis.FailureCodeAssistantTurnFailed,
+		Message:   "provider timed out",
+		Retryable: true,
+		Recovery:  hostedgenesis.Recovery{Action: hostedgenesis.RecoveryActionRetrySameStep, MaxAttempts: 3, RetryAfterSeconds: 5, Reason: "provider timed out"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Status != string(hostedgenesis.StatusFailed) {
+		t.Fatalf("expected failed, got %q", got.Status)
+	}
+	if got.Failure == nil || got.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed {
+		t.Fatalf("expected typed failure persisted, got %+v", got.Failure)
+	}
+	if !got.Failure.Retryable {
+		t.Fatalf("expected retryable failure")
+	}
+}
+
+func TestRecordFailure_ReplayAgainstTerminalRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusFailed, 4)}
+	w := NewCompletionWriter(store, nil)
+
+	_, err := w.RecordFailure(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1", RequestID: "req-1"}, CompletionFailure{
+		Code:      hostedgenesis.FailureCodeAssistantTurnFailed,
+		Message:   "provider timed out",
+		Retryable: true,
+		Recovery:  hostedgenesis.Recovery{Action: hostedgenesis.RecoveryActionRetrySameStep, MaxAttempts: 3, RetryAfterSeconds: 5, Reason: "provider timed out"},
+	})
+	if err == nil {
+		t.Fatal("expected conflict on replay against failed, got nil")
+	}
+	if !errors.Is(err, ErrCompletionConflict) {
+		t.Fatalf("expected ErrCompletionConflict, got %v", err)
+	}
+}
+
+func TestRecordAssistantTurnReady_MissingSessionRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: nil}
+	w := NewCompletionWriter(store, nil)
+	_, err := w.RecordAssistantTurnReady(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-missing", TurnID: "turn-1"}, AssistantTurnCompletion{AssistantContent: "hi"})
+	if err == nil {
+		t.Fatal("expected missing-session error, got nil")
+	}
+	if !errors.Is(err, ErrCompletionSessionMissing) {
+		t.Fatalf("expected ErrCompletionSessionMissing, got %v", err)
+	}
+}
+
+func TestRecordAssistantTurnReady_EmptyContentRejected(t *testing.T) {
+	store := &fakeCompletionStore{session: newFakeSession("acme", "conv-1", "turn-1", hostedgenesis.StatusInProgress, 3)}
+	w := NewCompletionWriter(store, nil)
+	_, err := w.RecordAssistantTurnReady(context.Background(), CompletionTurn{InstanceSlug: "acme", ConversationID: "conv-1", TurnID: "turn-1"}, AssistantTurnCompletion{AssistantContent: "  "})
+	if err == nil {
+		t.Fatal("expected error for empty assistant content, got nil")
+	}
+}
+
+func TestCompletionTurn_Validate(t *testing.T) {
+	cases := []struct {
+		name string
+		turn CompletionTurn
+		ok   bool
+	}{
+		{"valid", CompletionTurn{InstanceSlug: "a", ConversationID: "c", TurnID: "t"}, true},
+		{"missing slug", CompletionTurn{ConversationID: "c", TurnID: "t"}, false},
+		{"missing conv", CompletionTurn{InstanceSlug: "a", TurnID: "t"}, false},
+		{"missing turn", CompletionTurn{InstanceSlug: "a", ConversationID: "c"}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := c.turn.Validate()
+			if c.ok && err != nil {
+				t.Fatalf("expected nil, got %v", err)
+			}
+			if !c.ok && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+		})
+	}
+}
+
+var _ = strings.TrimSpace // keep strings import for future assertion helpers

--- a/internal/hostedgenesis/mintprompt/prompt.go
+++ b/internal/hostedgenesis/mintprompt/prompt.go
@@ -1,0 +1,96 @@
+// Package mintprompt holds the shared Soul minting-conversation system prompt
+// builder used by both the control-plane assistant runner and the in-VM
+// hosted-genesis MicroVM workload. Centralizing it prevents drift between the
+// synchronous control-plane path and the MicroVM execution path: both must
+// prompt the provider identically for a given registration.
+package mintprompt
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+// MintConversationSystemPrompt builds the Soul Registry minting-assistant system
+// prompt contextualized by the agent's registration. It contains no raw
+// transcripts, credentials, or provider secrets — only sanitized registration
+// metadata (domain, local id, declared capabilities).
+func MintConversationSystemPrompt(reg *models.SoulAgentRegistration) string {
+	var sb strings.Builder
+	sb.WriteString(`You are a Soul Registry minting assistant. Your role is to help an AI agent define its identity through structured conversation before its soul is minted on-chain.
+
+You are conducting a minting conversation with an agent that wants to register in the Soul Registry. Your goal is to help the agent articulate:
+
+1. **Self-Description**: A clear, honest description of what the agent is, its purpose, and its primary function.
+2. **Capabilities**: What the agent can do, with appropriate claim levels (self-declared, peer-validated, operator-attested).
+3. **Boundaries**: What the agent will NOT do — ethical limits, operational constraints, and refusal conditions.
+4. **Transparency**: How the agent makes decisions, what models it uses, and its known limitations.
+
+Guidelines:
+- Ask probing questions to help the agent articulate its identity clearly.
+- Challenge vague or overly broad claims.
+- Encourage honesty about limitations and potential failure modes.
+- Help distinguish between capabilities the agent has vs. aspirations.
+- Ensure boundaries are concrete and actionable, not just platitudes.
+- The conversation should feel collaborative, not interrogative.
+
+When you feel the conversation has covered all four areas sufficiently, summarize the proposed declarations in a structured format.
+
+`)
+
+	sb.WriteString("Agent registration context:\n")
+	if reg.DomainNormalized != "" {
+		fmt.Fprintf(&sb, "- Domain: %s\n", QuotePromptValue(reg.DomainNormalized))
+	}
+	if reg.LocalID != "" {
+		fmt.Fprintf(&sb, "- Local ID: %s\n", QuotePromptValue(reg.LocalID))
+	}
+	if len(reg.Capabilities) > 0 {
+		caps := make([]string, 0, len(reg.Capabilities))
+		for _, c := range reg.Capabilities {
+			c = SanitizePromptInline(c, 128)
+			if c != "" {
+				caps = append(caps, c)
+			}
+		}
+		b, _ := json.Marshal(caps)
+		fmt.Fprintf(&sb, "- Declared capabilities: %s\n", string(b))
+	}
+
+	return sb.String()
+}
+
+// SanitizePromptInline strips control characters and truncates a prompt-inline
+// value to maxLen runes.
+func SanitizePromptInline(raw string, maxLen int) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	raw = strings.Map(func(r rune) rune {
+		if r < 0x20 || r == 0x7f {
+			return ' '
+		}
+		return r
+	}, raw)
+	if maxLen > 0 && len(raw) > maxLen {
+		raw = raw[:maxLen]
+	}
+	return raw
+}
+
+// QuotePromptValue sanitizes and JSON-quotes a prompt value.
+func QuotePromptValue(raw string) string {
+	raw = SanitizePromptInline(raw, 256)
+	if raw == "" {
+		return ""
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return strconv.Quote(raw)
+	}
+	return string(b)
+}

--- a/internal/hostedgenesis/mintprompt/prompt_test.go
+++ b/internal/hostedgenesis/mintprompt/prompt_test.go
@@ -1,0 +1,74 @@
+package mintprompt
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/equaltoai/lesser-host/internal/store/models"
+)
+
+func TestMintConversationSystemPrompt_ContainsCoreInstructions(t *testing.T) {
+	got := MintConversationSystemPrompt(&models.SoulAgentRegistration{})
+	if !strings.Contains(got, "Soul Registry minting assistant") {
+		t.Fatalf("expected core minting-assistant instruction, got: %q", got)
+	}
+	for _, want := range []string{"Self-Description", "Capabilities", "Boundaries", "Transparency"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("expected prompt to mention %q, got: %q", want, got)
+		}
+	}
+}
+
+func TestMintConversationSystemPrompt_IncludesRegistrationContext(t *testing.T) {
+	reg := &models.SoulAgentRegistration{
+		DomainNormalized: "acme.example",
+		LocalID:          "acme",
+		Capabilities:     []string{"reasoning", "tool-use"},
+	}
+	got := MintConversationSystemPrompt(reg)
+	if !strings.Contains(got, "acme.example") {
+		t.Fatalf("expected prompt to include domain, got: %q", got)
+	}
+	if !strings.Contains(got, "acme") {
+		t.Fatalf("expected prompt to include local id, got: %q", got)
+	}
+	if !strings.Contains(got, "reasoning") || !strings.Contains(got, "tool-use") {
+		t.Fatalf("expected prompt to include declared capabilities, got: %q", got)
+	}
+}
+
+func TestMintConversationSystemPrompt_OmitsEmptyContext(t *testing.T) {
+	reg := &models.SoulAgentRegistration{DomainNormalized: "acme.example"}
+	got := MintConversationSystemPrompt(reg)
+	if strings.Contains(got, "Local ID") {
+		t.Fatalf("expected prompt to omit Local ID when empty, got: %q", got)
+	}
+	if strings.Contains(got, "Declared capabilities") {
+		t.Fatalf("expected prompt to omit capabilities when empty, got: %q", got)
+	}
+}
+
+func TestSanitizePromptInline_StripsControlCharsAndTruncates(t *testing.T) {
+	if got := SanitizePromptInline("a\x00b\x1fc", 0); got != "a b c" {
+		t.Fatalf("expected control chars replaced with spaces, got %q", got)
+	}
+	if got := SanitizePromptInline("abcdefghij", 4); got != "abcd" {
+		t.Fatalf("expected truncation to 4, got %q", got)
+	}
+	if got := SanitizePromptInline("   ", 4); got != "" {
+		t.Fatalf("expected empty after trim, got %q", got)
+	}
+}
+
+func TestQuotePromptValue_JSONQuotes(t *testing.T) {
+	got := QuotePromptValue(`he said "hi"`)
+	if !strings.HasPrefix(got, `"`) || !strings.HasSuffix(got, `"`) {
+		t.Fatalf("expected JSON-quoted value, got %q", got)
+	}
+	if !strings.Contains(got, `\"hi\"`) {
+		t.Fatalf("expected inner quotes escaped, got %q", got)
+	}
+	if got := QuotePromptValue("   "); got != "" {
+		t.Fatalf("expected empty for blank input, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

P52 H1.1 — the in-VM genesis workload that has never existed, plus the explicit per-provider LLM HTTP timeout. Parent: #867 (stays OPEN). Factory tracker: equaltoai/factory#8. Roadmap: `docs/roadmap/microvm-only-genesis.md`.

Host is making the genesis turn a MicroVM-dispatched async operation (H1). H1.1 builds the consumer-owned workload the MicroVM image runs instead of an external `codeArtifactUri` (G4), and gives the LLM clients an explicit HTTP timeout (G8). This is the repo-built artifact that H1.2–H1.5 will dispatch and prove.

## What landed (4 commits)

- **`9348f66` feat(llm): explicit per-provider HTTP timeout seam (kills G8)** — `internal/ai/llm/http_client.go`: `DefaultProviderHTTPTimeout = 120s`, `ConfigureProviderHTTPClient`, `newDefaultProviderHTTPClient`, `ProviderHTTPClientTimeout()` reporter. The OpenAI/Anthropic clients now carry an explicit timeout instead of being bounded only by a 90s `WithoutCancel` context inside a 120s Lambda.
- **`860f1c4` feat(hostedgenesis): shared mint prompt + completion-write seam** — extracts `buildMintConversationSystemPrompt` into `internal/hostedgenesis/mintprompt` (drift-free: control-plane and in-VM workload prompt identically), and adds `internal/hostedgenesis/completion` — a store-backed completion writer reusing `persistHostedGenesisAcceptedAssistantTurn` semantics, **idempotent per turn ID** (conditional on session status `in_progress` + turn ID + version; a replay for the same TurnID against a progressed session is a conflict, not a silent overwrite). The control-plane `handlers_soul_mint_conversation.go` change is pure extraction (−78 lines of inline prompt builder → one delegating call).
- **`c5f448e` feat(cmd): hosted-genesis-microvm-workload in-VM entrypoint (kills G4)** — `cmd/hosted-genesis-microvm-workload/{main,hooks,runner,hash}.go` + tests. Serves AppTheory M16 MicroVM image lifecycle hooks on port 8080 (matching CDK `hooks.port`); the `run` hook executes the assistant turn AND declaration extraction through the existing `internal/ai/llm` clients (with the explicit timeout) and durably records completion to `HostedGenesisSession` truth via the completion writer. Fail-closed: unknown hooks, malformed events, unsupported transitions, missing session/registration, empty responses, and idempotency conflicts surface as typed failures — never a silent HTTP 200.
- **`2301ab9` feat(cdk): point MicroVM image at repo-built workload artifact (kills G4)** — minimal `cdk/lib/hosted-genesis-microvm.ts` change so the image consumes the repo-built artifact, not external `codeArtifactUri` context. **Lab gates are NOT removed here** (that is H1.5).

## Framework adoption (AppTheory v1.15.0 M16)

Inspected from the Go module cache: `runtime/microvm/{controller,controller_contract,provider,session,lifecycle}.go`, `docs/features/lambda-microvm-contract-foundation.md`, `docs/cdk/lambda-microvm.md`, `examples/microvm-conformance`, `examples/cdk/microvm-controller`. The workload consumes the framework's exported M16 vocabulary directly: `runtimemicrovm.LifecycleContract`, `LifecycleHook`, `LifecycleHandler`, `LifecycleEvent`, `LifecycleResult`, `DefaultRealLifecycleContract()`, `ValidateRealLifecycleContract`. No raw AWS SDK in the workload; no forked adapter; no reimplemented sanitization.

### ⚠️ Framework-feedback finding (routed upstream, not worked around locally)

AppTheory v1.15.0's `NewLifecycleAdapter` validates only with the M15 `ValidateLifecycleContract`, so it **cannot ingest `DefaultRealLifecycleContract()`** (the documented M16 canonical vocabulary). This workload does **not** build a local substitute engine: it validates the contract with `ValidateRealLifecycleContract` at startup and derives each hook's `LifecycleResult` from the framework's own `DefaultRealLifecycleContract()` transition table. No fork, no patched adapter. Recorded locally as mem-8365ca36ad0fd5f6. **Candidate upstream feedback:** a real-contract-aware adapter constructor in AppTheory. Flagged for factory to route via `coordinate-framework-feedback`.

## Scope (H1.1 only — non-goals respected)

- **Not done here (separate steps):** H1.2 dispatch wiring in `progressHostedGenesisAcceptedTurn` / returning 202; H1.3 reconstruction-hook reachability; H1.4 recovery; H1.5 full CDK de-lab-gating + lab deploy + E2E gate; H2 deletions of the synchronous path / SQS pipeline / legacy extraction / canary.
- No GraphQL schema change. No sibling-repo edits. No deploy. No merge. No on-chain/cloud mutation.

## Validation (re-run by factory; delegate report was lost to a session timeout)

- `go build ./cmd/hosted-genesis-microvm-workload/... ./internal/ai/llm/... ./internal/hostedgenesis/...` ✅
- `go vet` (same set) ✅
- `go test` ✅ — `cmd/hosted-genesis-microvm-workload`, `internal/ai/llm` (3.8s, exercises real timeout), `internal/hostedgenesis/mintprompt`, `internal/hostedgenesis/completion` all green.
- New unit tests prove: completion-write idempotency (replay for same TurnID against progressed session → conflict); explicit LLM HTTP timeout (client times out at configured duration); M16 hook validation (unknown hook / malformed event / unsupported transition → failed `LifecycleResult`); turn-runner happy path + failure paths.

## Risks / follow-ups

- The M16 adapter/real-contract gap above is the key framework follow-up.
- The workload is built but **not yet dispatched or deployed** — H1.2 wires the dispatch, H1.5 deploys to lab and runs the E2E gate. The artifact existing does not make the product path work yet.
- `handlers_soul_mint_conversation.go` extraction is behavior-preserving for the synchronous control-plane path (the synchronous path still exists and is still the production path until H2 removes it — H1.1 does not delete it).