### PR TITLE
feat(hostedgenesis): dispatch M16 MicroVM run on accept path, return 202 (H1.2)

### DIFF
--- a/internal/controlplane/handlers_soul_instance_bootstrap.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap.go
@@ -24,10 +24,18 @@ const (
 	soulInstanceBootstrapCodeConflict           = "soul_instance.conflict"
 	soulInstanceBootstrapCodeNotFound           = "soul_instance.not_found"
 	soulInstanceBootstrapCodeInternal           = "soul_instance.internal"
+	soulInstanceBootstrapCodeMicroVMUnavailable = "soul_instance.microvm_unavailable"
 	soulInstanceBootstrapMessageUnauthorized    = "unauthorized"
 	soulInstanceBootstrapMessageBoundary        = "resource is outside the authenticated instance boundary"
 	soulInstanceBootstrapBoundaryInstanceDomain = "instance_domain"
 )
+
+// appErrCodeMicroVMUnavailable is the control-plane AppError code emitted when
+// the hosted genesis accept path cannot dispatch the M16 MicroVM controller
+// run. It maps to a loud 5xx at every public surface so MicroVM-unavailable is
+// never confused with a generic internal error or silently downgraded to a
+// synchronous control-plane LLM call.
+const appErrCodeMicroVMUnavailable = "app.microvm_unavailable"
 
 type soulInstanceBootstrapContext struct {
 	key          *models.InstanceKey
@@ -665,6 +673,8 @@ func soulInstanceBootstrapErrorFromAppError(appErr *apptheory.AppError) *apptheo
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeBoundaryViolation, appErr.Message, http.StatusForbidden, nil)
 	case soulMintAppErrCodeNotFound:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeNotFound, appErr.Message, http.StatusNotFound, nil)
+	case appErrCodeMicroVMUnavailable:
+		return soulInstanceBootstrapError(soulInstanceBootstrapCodeMicroVMUnavailable, appErr.Message, http.StatusServiceUnavailable, nil)
 	default:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}
@@ -700,6 +710,8 @@ func soulInstanceBootstrapConversationErrorFromAppError(appErr *apptheory.AppErr
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeConflict, appErr.Message, http.StatusConflict, nil)
 	case soulMintAppErrCodeNotFound:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeNotFound, appErr.Message, http.StatusNotFound, nil)
+	case appErrCodeMicroVMUnavailable:
+		return soulInstanceBootstrapError(soulInstanceBootstrapCodeMicroVMUnavailable, appErr.Message, http.StatusServiceUnavailable, nil)
 	default:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}

--- a/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
@@ -695,7 +695,7 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("user-visible hosted genesis start must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -707,7 +707,7 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
 	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -717,9 +717,12 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	out := assertSoulInstanceMintConversationDispatchedResponse(t, resp)
 	if out.Conversation.RegistrationID != reg.ID {
 		t.Fatalf("expected durable session authority for registration %s, got %#v", reg.ID, out.Conversation)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one MicroVM controller run dispatch, got %d", dispatcher.calls)
 	}
 	tdb.qLifecycle.AssertCalled(t, "Create")
 }
@@ -729,7 +732,8 @@ func TestSoulInstanceMintConversation_AssistantFailurePersistsTypedFailure(t *te
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "", errors.New("provider unavailable"))
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
+	dispatcher.dispatchErr = errors.New("microvm controller run rejected")
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("failed hosted genesis turn must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -748,25 +752,15 @@ func TestSoulInstanceMintConversation_AssistantFailurePersistsTypedFailure(t *te
 		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: soulInstanceBootstrapTestIdempotencyKey, CorrelationID: "corr-1"}),
 		map[string]string{"id": reg.ID},
 	))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure, got response %#v", resp)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected JSON 200 failed response, got %#v", resp)
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulInstanceBootstrapCodeMicroVMUnavailable || appErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected typed microvm-unavailable 503 error, got %#v", appErr)
 	}
-	var out hostedGenesisConversationResponse
-	if err := json.Unmarshal(resp.Body, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil {
-		t.Fatalf("expected typed failed status, got %#v", out.Conversation)
-	}
-	if out.Conversation.Failure.Code != hostedGenesisFailureAssistantTurnFailed || out.Conversation.Failure.Recovery.Action != hostedGenesisRecoveryRetrySameStep {
-		t.Fatalf("expected retryable assistant failure, got %#v", out.Conversation.Failure)
-	}
-	if strings.Contains(string(resp.Body), soulInstanceBootstrapTestConversationMessage) ||
-		strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
-		t.Fatalf("failure response leaked transcript or credential material: %s", string(resp.Body))
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected dispatch to be attempted before loud failure, got %d calls", dispatcher.calls)
 	}
 }
 
@@ -775,7 +769,7 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant retry reply", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("idempotent replay must not enqueue duplicate user-visible execution: %#v", msg)
 		return nil
@@ -830,7 +824,7 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 		dest := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
 		*dest = session
 	}).Once()
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -840,18 +834,25 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200 progressed replay, got %#v", resp)
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched replay, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.Conversation.ConversationID != mintConversationTestConversationID ||
-		out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
-		out.Conversation.MessageCount != 2 ||
+		out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
 		out.Conversation.TraceIDs.IdempotencyKey != idemKey {
-		t.Fatalf("expected idempotent progression without duplicate user message, got %#v", out)
+		t.Fatalf("expected idempotent in_progress dispatched replay, got %#v", out)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("idempotent replay must not append an inline assistant message: %#v", out.Conversation.Messages)
+		}
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected one MicroVM dispatch on replay progression, got %d", dispatcher.calls)
 	}
 	tdb.db.AssertNumberOfCalls(t, "TransactWrite", 1)
 	tdb.qBudget.AssertNumberOfCalls(t, "First", 0)
@@ -891,7 +892,7 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "second assistant", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("continued user-visible hosted genesis turn must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -911,7 +912,7 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, false)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -921,15 +922,25 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200, got %#v", resp)
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady || out.Conversation.MessageCount != 4 {
-		t.Fatalf("expected progressed assistant turn, got %#v", out)
+	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress dispatched continuation, got %#v", out)
+	}
+	if len(out.Conversation.Messages) == 0 {
+		t.Fatalf("expected projected transcript, got empty messages")
+	}
+	last := out.Conversation.Messages[len(out.Conversation.Messages)-1]
+	if last.Role != hostedGenesisTranscriptRoleUser || last.Content != "second" {
+		t.Fatalf("continued dispatched turn must end on the accepted user turn, not an inline assistant message: %#v", out.Conversation.Messages)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected one MicroVM dispatch on continuation, got %d", dispatcher.calls)
 	}
 }
 
@@ -1988,20 +1999,15 @@ func expectSoulInstanceMintConversationProgression(t *testing.T, tdb *mintConver
 		if hostedgenesis.NormalizeStatus(session.Status) != wantStatus {
 			t.Fatalf("expected hosted genesis progression status %s, got %#v", wantStatus, session)
 		}
-		switch wantStatus {
-		case hostedgenesis.StatusAssistantTurnReady:
-			if session.AssistantCheckpointRef == "" || session.MessageCount < 2 || session.Failure != nil {
-				t.Fatalf("assistant-ready session must carry checkpoint/message count and no failure: %#v", session)
-			}
-		case hostedgenesis.StatusFailed:
-			if session.Failure == nil || session.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed || !session.Failure.Retryable {
-				t.Fatalf("failed session must carry retryable assistant failure: %#v", session)
-			}
-		}
+		assertHostedGenesisProgressedSession(t, session, wantStatus)
 	})
 	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
 	tb.On("Execute").Return(nil).Once()
 }
+
+// assertHostedGenesisProgressedSession is in
+// handlers_soul_mint_conversation_async_internal_test.go (kept there to stay
+// under the gov-infra MAI-1 Go file budget for this file).
 
 func expectSoulInstanceMintConversationExtractionDebit(t *testing.T, tdb *mintConversationTestDB) {
 	t.Helper()
@@ -2237,6 +2243,10 @@ func assertSoulInstanceMintConversationAcceptedResponse(t *testing.T, resp *appt
 	assertSoulInstanceMintConversationAcceptedTranscript(t, out, resp.Body)
 	return out
 }
+
+// assertSoulInstanceMintConversationDispatchedResponse is in
+// handlers_soul_mint_conversation_async_internal_test.go (kept there to stay
+// under the gov-infra MAI-1 Go file budget for this file).
 
 func assertSoulInstanceMintConversationAcceptedTranscript(t *testing.T, out hostedGenesisConversationResponse, body []byte) {
 	t.Helper()

--- a/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
@@ -20,20 +20,7 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	runnerCalled := false
-	s.hostedGenesisAssistantRunner = func(_ context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
-		runnerCalled = true
-		if len(in.messages) != 1 || in.messages[0].Role != hostedGenesisTranscriptRoleUser || in.messages[0].Content != "stuck user turn" {
-			t.Fatalf("recovery must replay existing accepted messages without appending a duplicate turn: %#v", in.messages)
-		}
-		if strings.Contains(in.systemPrompt, mintConversationInstanceReadTestRawKey) {
-			t.Fatalf("recovery prompt leaked instance key")
-		}
-		return hostedGenesisAssistantRunResult{
-			fullResponse: "recovered assistant turn",
-			usage:        models.AIUsage{Provider: "test", Model: in.modelSet, InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
-		}, nil
-	}
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 
 	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
 	stubMintConversationRegistration(t, tdb, reg)
@@ -48,7 +35,7 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
 	stubSoulInstanceRecoverySession(t, tdb, hostedGenesisRecoverySessionFixture(t, reg, hostedgenesis.StatusInProgress, ""))
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -58,21 +45,26 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected recovery err: %v", err)
 	}
-	if !runnerCalled {
-		t.Fatalf("expected recovery to rerun the assistant turn")
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected recovery to redispatch the stuck turn via the MicroVM controller, got %d dispatch calls", dispatcher.calls)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200 recovery response, got %#v", resp)
+	if dispatcher.lastBinding.ConversationID != mintConversationTestConversationID {
+		t.Fatalf("expected recovery dispatch bound to the stuck conversation, got %#v", dispatcher.lastBinding)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched recovery response, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
-		out.Conversation.MessageCount != 2 ||
-		len(out.Conversation.Messages) != 2 ||
-		out.Conversation.Messages[1].Content != "recovered assistant turn" {
-		t.Fatalf("expected recovered assistant-ready response with transcript, got %#v", out.Conversation)
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress dispatched recovery, got %#v", out.Conversation)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("recovery dispatch must not append an inline assistant message: %#v", out.Conversation.Messages)
+		}
 	}
 	if strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
 		t.Fatalf("recovery response leaked credential material: %s", string(resp.Body))

--- a/internal/controlplane/handlers_soul_instance_bootstrap_registry_gate_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_registry_gate_internal_test.go
@@ -56,7 +56,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	s.cfg.SoulRegistryContractAddress = ""
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("hosted/off-chain mint conversation must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -68,7 +68,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
 	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -78,7 +78,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	out := assertSoulInstanceMintConversationDispatchedResponse(t, resp)
 	if out.Conversation.RegistrationID != reg.ID || out.Conversation.AgentID != reg.AgentID {
 		t.Fatalf("expected hosted session for registration/agent, got %#v", out.Conversation)
 	}

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -21,8 +21,17 @@ import (
 )
 
 const (
+	// hostedGenesisAcceptedTurnRunTimeout bounds the synchronous assistant
+	// runner retained for non-production/test seams. H2.1 deletes that path; the
+	// production accept path dispatches the MicroVM and returns 202 well under
+	// this budget.
 	hostedGenesisAcceptedTurnRunTimeout = 90 * time.Second
-	hostedGenesisProviderUnknown        = "unknown"
+	// hostedGenesisAcceptedTurnDispatchTimeout bounds the M16 controller run
+	// dispatch on the production accept path. The accept path returns 202
+	// accepted-pending; the assistant turn itself runs inside the MicroVM and is
+	// not bounded by this timeout.
+	hostedGenesisAcceptedTurnDispatchTimeout = 10 * time.Second
+	hostedGenesisProviderUnknown             = "unknown"
 )
 
 type hostedGenesisTurnSession struct {
@@ -160,6 +169,60 @@ func (s *Server) progressHostedGenesisAcceptedTurn(ctx context.Context, regCtx m
 	if session.session == nil || conv == nil {
 		return nil, nil, 0, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	// H1.2: the production accept path dispatches the AppTheory M16 MicroVM
+	// controller run command and returns 202 accepted-pending. The control plane
+	// never makes a synchronous LLM HTTP call on this path; the assistant turn
+	// runs inside the MicroVM and completion is reconstructed from Host truth.
+	// The synchronous assistant runner is retained only behind an explicit
+	// non-production/test guard (hostedGenesisSyncAssistantFallbackEnabled) until
+	// H2.1 deletes it; production never sets that guard.
+	if s.hostedGenesisMicroVMDispatcher == nil {
+		if s.hostedGenesisSyncAssistantFallbackEnabled && s.hostedGenesisAssistantRunner != nil {
+			return s.progressHostedGenesisAcceptedTurnSync(ctx, regCtx, session, conv, acceptedMessages, apiKey, requestID)
+		}
+		log.Printf("controlplane: hosted genesis microvm dispatcher unavailable agent_hash=%s conversation_hash=%s", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID))
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch is unavailable"}
+	}
+
+	binding := session.session.MicroVMSessionBinding()
+	if err := binding.Validate(); err != nil {
+		log.Printf("controlplane: hosted genesis microvm binding invalid agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID), err)
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch is unavailable"}
+	}
+
+	runCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx), hostedGenesisAcceptedTurnDispatchTimeout)
+	defer cancel()
+	dispatch, dispatchErr := s.hostedGenesisMicroVMDispatcher.DispatchMicroVMRun(runCtx, strings.TrimSpace(requestID), binding)
+	if dispatchErr != nil {
+		log.Printf("controlplane: hosted genesis microvm dispatch failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID), dispatchErr)
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch failed"}
+	}
+
+	progressedSession, progressedConv, appErr := s.persistHostedGenesisAcceptedMicroVMDispatch(ctx, session, conv, acceptedMessages, dispatch, requestID, time.Now().UTC())
+	if appErr != nil {
+		return nil, nil, 0, appErr
+	}
+	return progressedSession, progressedConv, http.StatusAccepted, nil
+}
+
+// progressHostedGenesisAcceptedTurnSync is the retained non-production/test-only
+// synchronous assistant turn path. It is reachable only when
+// hostedGenesisSyncAssistantFallbackEnabled is explicitly true AND no MicroVM
+// dispatcher is wired; production never sets that guard. H2.1 deletes this path
+// and the hostedGenesisAssistantRunner field.
+func (s *Server) progressHostedGenesisAcceptedTurnSync(ctx context.Context, regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, conv *models.SoulAgentMintConversation, acceptedMessages []soulMintConversationMessage, apiKey string, requestID string) (*models.HostedGenesisSession, *models.SoulAgentMintConversation, int, *apptheory.AppError) {
 	runCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx), hostedGenesisAcceptedTurnRunTimeout)
 	defer cancel()
 
@@ -183,6 +246,33 @@ func (s *Server) progressHostedGenesisAcceptedTurn(ctx context.Context, regCtx m
 		return nil, nil, 0, appErr
 	}
 	return progressedSession, progressedConv, http.StatusOK, nil
+}
+
+// persistHostedGenesisAcceptedMicroVMDispatch records the durable in_progress
+// HostedGenesisSession after a successful M16 controller run dispatch, applying
+// the non-authoritative MicroVM execution/cache lifecycle ref via
+// ApplyMicroVMLifecycleRef so the three MicroVM fields
+// (MicroVMExecutionID/ExecutionStateRef/MicroVMLifecycleRef) are populated on
+// the authoritative Host row. The conversation stays in_progress with no inline
+// assistant message: the turn is pending inside the MicroVM and completion is
+// reconstructed from Host truth by the recovery/stuck-turn path.
+func (s *Server) persistHostedGenesisAcceptedMicroVMDispatch(ctx context.Context, session hostedGenesisTurnSession, conv *models.SoulAgentMintConversation, acceptedMessages []soulMintConversationMessage, dispatch hostedgenesis.MicroVMDispatchResult, requestID string, now time.Time) (*models.HostedGenesisSession, *models.SoulAgentMintConversation, *apptheory.AppError) {
+	progressedSession := cloneHostedGenesisSession(session.session)
+	progressedConv := cloneSoulAgentMintConversation(conv)
+	if err := progressedSession.ApplyMicroVMLifecycleRef(dispatch.LifecycleRef); err != nil {
+		log.Printf("controlplane: hosted genesis microvm lifecycle ref rejected agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(conv.AgentID), soulMintInstanceReadAuditHash(conv.ConversationID), err)
+		return nil, nil, &apptheory.AppError{Code: "app.internal", Message: "failed to record microvm dispatch"}
+	}
+	progressedSession.Status = string(hostedgenesis.StatusInProgress)
+	progressedSession.RequestID = strings.TrimSpace(requestID)
+	progressedSession.UpdatedAt = now
+	progressedSession.CompletedAt = time.Time{}
+	progressedConv.RequestID = strings.TrimSpace(requestID)
+	progressedConv.UpdatedAt = now
+	if appErr := s.persistHostedGenesisProgression(ctx, session, progressedSession, progressedConv, string(progressedConv.Messages), "", progressedConv.Usage, now); appErr != nil {
+		return nil, nil, appErr
+	}
+	return progressedSession, progressedConv, nil
 }
 
 func (s *Server) runHostedGenesisAcceptedAssistant(ctx context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {

--- a/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
@@ -1,0 +1,317 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// TestH1_2_AcceptPathDispatchesControllerRunAndReturns202 proves the production
+// hosted genesis accept path dispatches the AppTheory M16 MicroVM controller
+// run command through the MicroVMDispatcher seam and returns HTTP 202
+// accepted-pending with the durable session in_progress (no synchronous control
+// plane LLM call).
+func TestH1_2_AcceptPathDispatchesControllerRunAndReturns202(t *testing.T) {
+	tdb, s, reg, dispatcher := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	h1d2ExpectAcceptPathProgression(t, tdb, hostedgenesis.StatusInProgress)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 accepted-pending, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress durable status, got %#v", out.Conversation)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one M16 controller run dispatch, got %d", dispatcher.calls)
+	}
+	if dispatcher.lastBinding.ConversationID == "" || dispatcher.lastBinding.RegistrationID != reg.ID {
+		t.Fatalf("expected dispatch bound to the accepted turn's session, got %#v", dispatcher.lastBinding)
+	}
+}
+
+// TestH1_2_AcceptPathPopulatesThreeMicroVMFieldsViaApplyLifecycleRef proves a
+// successful dispatch populates MicroVMExecutionID, ExecutionStateRef, and
+// MicroVMLifecycleRef on the authoritative HostedGenesisSession via
+// ApplyMicroVMLifecycleRef (the lifecycle ref is validated against the binding).
+func TestH1_2_AcceptPathPopulatesThreeMicroVMFieldsViaApplyLifecycleRef(t *testing.T) {
+	tdb, s, reg, dispatcher := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	var captured *models.HostedGenesisSession
+	h1d2ExpectAcceptPathProgressionCapture(t, tdb, &captured)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %#v", resp)
+	}
+	if captured == nil {
+		t.Fatalf("expected persisted in_progress session capture")
+	}
+	if captured.MicroVMExecutionID == "" || captured.ExecutionStateRef == "" || captured.MicroVMLifecycleRef == nil {
+		t.Fatalf("expected all three MicroVM execution/cache refs populated, got %#v", captured)
+	}
+	if !strings.HasPrefix(captured.ExecutionStateRef, "microvm://") {
+		t.Fatalf("expected ExecutionStateRef formatted by FormatMicroVMExecutionStateRef, got %q", captured.ExecutionStateRef)
+	}
+	if captured.MicroVMLifecycleRef.SessionID != dispatcher.lastBinding.ConversationID {
+		t.Fatalf("expected lifecycle ref bound to dispatched session, got %#v", captured.MicroVMLifecycleRef)
+	}
+	if captured.MicroVMLifecycleRef.SourceOfTruth != hostedgenesis.MicroVMSourceOfTruth {
+		t.Fatalf("expected lifecycle ref source of truth, got %#v", captured.MicroVMLifecycleRef)
+	}
+}
+
+// TestH1_2_MicroVMUnavailableIsLoudFailureNotSyncLLMFallthrough proves that
+// when the MicroVM dispatcher is unwired (the production misconfiguration
+// case), the accept path fails closed and loudly with a typed 503
+// microvm-unavailable error and persists a retryable failed session, rather
+// than silently falling back to a synchronous control-plane LLM call.
+func TestH1_2_MicroVMUnavailableIsLoudFailureNotSyncLLMFallthrough(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	// No dispatcher wired: production must not fall back to sync LLM.
+	s.hostedGenesisMicroVMDispatcher = nil
+	syncLLMCalled := false
+	s.hostedGenesisAssistantRunner = func(_ context.Context, _ hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		syncLLMCalled = true
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+	h1d2ExpectAcceptPathProgression(t, tdb, hostedgenesis.StatusFailed)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure, got response %#v", resp)
+	}
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulInstanceBootstrapCodeMicroVMUnavailable || appErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected typed microvm-unavailable 503, got %#v", appErr)
+	}
+	if syncLLMCalled {
+		t.Fatalf("accept path must not fall back to synchronous LLM when MicroVM dispatch is unavailable")
+	}
+}
+
+// TestH1_2_NonProductionSyncFallbackGuard proves the retained synchronous
+// assistant runner stays reachable ONLY through the explicit non-production
+// guard (hostedGenesisSyncAssistantFallbackEnabled). This keeps the sync path
+// referenced and covered until H2.1 deletes it; production never sets the guard
+// so production cannot reach this branch.
+func TestH1_2_NonProductionSyncFallbackGuard(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	// No dispatcher wired, but the non-production sync fallback guard is set.
+	s.hostedGenesisMicroVMDispatcher = nil
+	s.hostedGenesisSyncAssistantFallbackEnabled = true
+	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady {
+		t.Fatalf("expected sync fallback to reach assistant_turn_ready, got %#v", out.Conversation)
+	}
+}
+
+// TestH1_2_NonProductionSyncFallbackFailurePersistsTypedFailure covers the
+// non-production sync fallback's failure branch (provider error) so the
+// retained sync path's failure handling and provider-name logging stay covered
+// until H2.1 deletes the path.
+func TestH1_2_NonProductionSyncFallbackFailurePersistsTypedFailure(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = nil
+	s.hostedGenesisSyncAssistantFallbackEnabled = true
+	stubHostedGenesisAssistantRunner(t, s, "", errors.New("provider unavailable"))
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusFailed)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 failed sync fallback response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil {
+		t.Fatalf("expected typed failed status, got %#v", out.Conversation)
+	}
+	if out.Conversation.Failure.Code != hostedGenesisFailureAssistantTurnFailed {
+		t.Fatalf("expected assistant_turn_failed, got %#v", out.Conversation.Failure)
+	}
+}
+
+// h1d2AcceptPathFixture builds the shared mock scaffolding for a fresh hosted
+// genesis accept turn and returns a stub dispatcher not yet wired onto the
+// server (callers wire it to control the dispatch outcome).
+func h1d2AcceptPathFixture(t *testing.T) (*mintConversationTestDB, *Server, models.SoulAgentRegistration, *stubMicroVMDispatcher) {
+	t.Helper()
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		t.Fatalf("accept path must not enqueue SQS authority: %#v", msg)
+		return nil
+	}
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
+	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	return tdb, s, reg, dispatcher
+}
+
+func h1d2AcceptPathRequest(t *testing.T, reg models.SoulAgentRegistration) *apptheory.Context {
+	t.Helper()
+	return newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: soulInstanceBootstrapTestIdempotencyKey, CorrelationID: "corr-1"}),
+		map[string]string{"id": reg.ID},
+	)
+}
+
+func h1d2ExpectAcceptPathProgression(t *testing.T, tdb *mintConversationTestDB, wantStatus hostedgenesis.Status) {
+	t.Helper()
+	expectSoulInstanceMintConversationProgression(t, tdb, wantStatus)
+}
+
+func h1d2ExpectAcceptPathProgressionCapture(t *testing.T, tdb *mintConversationTestDB, captured **models.HostedGenesisSession) {
+	t.Helper()
+	tb, _ := tdb.db.TransactWriteBuilder.(*ttmocks.MockTransactionBuilder)
+	if tb == nil {
+		tb = new(ttmocks.MockTransactionBuilder)
+		tdb.db.TransactWriteBuilder = tb
+	}
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.HostedGenesisSession"), mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		*captured = testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		if hostedgenesis.NormalizeStatus((*captured).Status) != hostedgenesis.StatusInProgress {
+			t.Fatalf("expected in_progress dispatched session, got %#v", *captured)
+		}
+	})
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
+	tb.On("Execute").Return(nil).Once()
+}
+
+// assertHostedGenesisProgressedSession asserts the persisted progressed session
+// matches the expected H1.2 status shape (dispatched in_progress carries the
+// three MicroVM refs; failed carries a retryable assistant/microvm failure).
+func assertHostedGenesisProgressedSession(t *testing.T, session *models.HostedGenesisSession, wantStatus hostedgenesis.Status) {
+	t.Helper()
+	switch wantStatus {
+	case hostedgenesis.StatusAssistantTurnReady:
+		assertHostedGenesisAssistantReadySession(t, session)
+	case hostedgenesis.StatusInProgress:
+		assertHostedGenesisDispatchedSession(t, session)
+	case hostedgenesis.StatusFailed:
+		assertHostedGenesisFailedSession(t, session)
+	}
+}
+
+func assertHostedGenesisAssistantReadySession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.AssistantCheckpointRef == "" || session.MessageCount < 2 || session.Failure != nil {
+		t.Fatalf("assistant-ready session must carry checkpoint/message count and no failure: %#v", session)
+	}
+}
+
+func assertHostedGenesisDispatchedSession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.MicroVMExecutionID == "" || session.ExecutionStateRef == "" || session.MicroVMLifecycleRef == nil {
+		t.Fatalf("in_progress dispatched session must carry the three MicroVM execution/cache refs: %#v", session)
+	}
+	if session.AssistantCheckpointRef != "" || session.Failure != nil {
+		t.Fatalf("in_progress dispatched session must not carry an assistant checkpoint or failure: %#v", session)
+	}
+}
+
+func assertHostedGenesisFailedSession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.Failure == nil || !session.Failure.Retryable {
+		t.Fatalf("failed session must carry retryable failure: %#v", session)
+	}
+	if session.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed && session.Failure.Code != hostedgenesis.FailureCodeMicroVMUnavailable {
+		t.Fatalf("failed session must carry assistant or microvm-unavailable failure: %#v", session)
+	}
+}
+
+// assertSoulInstanceMintConversationDispatchedResponse asserts the H1.2 accept
+// path returned 202 accepted-pending with the durable session in_progress and
+// no inline assistant message (the turn runs inside the MicroVM).
+func assertSoulInstanceMintConversationDispatchedResponse(t *testing.T, resp *apptheory.Response) hostedGenesisConversationResponse {
+	t.Helper()
+	if resp.Status != http.StatusAccepted || !strings.Contains(resp.Headers["content-type"][0], "application/json") {
+		t.Fatalf("expected JSON 202 dispatched response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.ConversationID == "" ||
+		out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
+		out.Conversation.RequestID != "req-instance-bootstrap" {
+		t.Fatalf("expected in_progress dispatched durable status, got %#v", out)
+	}
+	if out.Conversation.TraceIDs == nil ||
+		out.Conversation.TraceIDs.IdempotencyKey != soulInstanceBootstrapTestIdempotencyKey ||
+		out.Conversation.TraceIDs.CorrelationID != "corr-1" {
+		t.Fatalf("expected trace ids, got %#v", out.Conversation.TraceIDs)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("dispatched 202 response must not carry an inline assistant message: %#v", out.Conversation.Messages)
+		}
+	}
+	if strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("response leaked credential material: %s", string(resp.Body))
+	}
+	return out
+}
+
+func TestHostedGenesisProviderName(t *testing.T) {
+	cases := map[string]string{
+		"openai:gpt-5.4":                 "openai",
+		"  Anthropic:claude-sonnet-4-6 ": "anthropic",
+		"unknown:foo":                    hostedGenesisProviderUnknown,
+		"":                               hostedGenesisProviderUnknown,
+	}
+	for in, want := range cases {
+		if got := hostedGenesisProviderName(in); got != want {
+			t.Fatalf("hostedGenesisProviderName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHostedGenesisMaxInt(t *testing.T) {
+	if hostedGenesisMaxInt(1, 2) != 2 || hostedGenesisMaxInt(3, 2) != 3 || hostedGenesisMaxInt(5, 5) != 5 {
+		t.Fatalf("hostedGenesisMaxInt returned unexpected value")
+	}
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/ai/llm"
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -212,6 +214,65 @@ func stubHostedGenesisAssistantRunner(t *testing.T, s *Server, response string, 
 			usage:        models.AIUsage{Provider: "test", Model: in.modelSet, InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		}, runErr
 	}
+}
+
+// stubHostedGenesisMicroVMDispatcher wires a stub MicroVMDispatcher that records
+// the binding the accept path dispatched and returns a validated in_progress
+// lifecycle ref. It asserts the sync assistant runner is NOT invoked so the
+// accept path is proven dispatch-only.
+func stubHostedGenesisMicroVMDispatcher(t *testing.T, s *Server) *stubMicroVMDispatcher {
+	t.Helper()
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	// Guard the synchronous runner seam: H1.2 makes the production accept path
+	// dispatch-only, so the sync assistant runner must never be reached.
+	s.hostedGenesisAssistantRunner = func(_ context.Context, _ hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		t.Fatalf("synchronous assistant runner must not be invoked on the dispatch-only accept path")
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+	return dispatcher
+}
+
+type stubMicroVMDispatcher struct {
+	t           *testing.T
+	calls       int
+	lastBinding hostedgenesis.MicroVMSessionBinding
+	dispatchErr error
+}
+
+func (d *stubMicroVMDispatcher) DispatchMicroVMRun(ctx context.Context, requestID string, binding hostedgenesis.MicroVMSessionBinding) (hostedgenesis.MicroVMDispatchResult, error) {
+	d.t.Helper()
+	d.calls++
+	d.lastBinding = binding
+	if d.dispatchErr != nil {
+		return hostedgenesis.MicroVMDispatchResult{}, d.dispatchErr
+	}
+	if err := binding.Validate(); err != nil {
+		d.t.Fatalf("stub dispatcher received invalid binding: %v", err)
+	}
+	if strings.TrimSpace(requestID) == "" {
+		d.t.Fatalf("stub dispatcher received empty request id")
+	}
+	resp := runtimemicrovm.ControllerResponse{
+		Command:           runtimemicrovm.CommandRun,
+		RequestID:         requestID,
+		TenantID:          binding.TenantID(),
+		Namespace:         hostedgenesis.MicroVMNamespace,
+		SessionID:         strings.TrimSpace(binding.ConversationID),
+		State:             runtimemicrovm.StateRunning,
+		DesiredState:      runtimemicrovm.StateRunning,
+		LifecycleState:    runtimemicrovm.StateRunning,
+		MicroVMID:         "mv-stub-" + strings.TrimSpace(binding.ConversationID),
+		ProviderMicroVMID: "mv-stub-" + strings.TrimSpace(binding.ConversationID),
+		LastAction:        runtimemicrovm.CommandRun,
+		LastTransition:    time.Now().UTC(),
+		RegistryVersion:   1,
+	}
+	ref, err := hostedgenesis.MicroVMLifecycleRefFromResponse(binding, resp, time.Now().UTC())
+	if err != nil {
+		d.t.Fatalf("stub dispatcher failed to build lifecycle ref: %v", err)
+	}
+	return hostedgenesis.MicroVMDispatchResult{LifecycleRef: ref, SessionID: resp.SessionID}, nil
 }
 
 func stubMintConversationRegistration(t *testing.T, tdb *mintConversationTestDB, reg models.SoulAgentRegistration) {

--- a/internal/controlplane/handlers_soul_mint_conversation_status.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_status.go
@@ -31,6 +31,7 @@ const (
 	hostedGenesisFailureInvalidProducedDeclarations = "invalid_produced_declarations"
 	hostedGenesisFailureTenantBoundaryViolation     = "tenant_boundary_violation"
 	hostedGenesisFailureOperatorActionRequired      = "operator_action_required"
+	hostedGenesisFailureMicroVMUnavailable          = "microvm_unavailable"
 	hostedGenesisRecoveryRefreshState               = "refresh_state"
 	hostedGenesisRecoveryRetrySameStep              = "retry_same_step"
 	hostedGenesisRecoveryRestartSoulBootstrap       = "restart_soul_bootstrap"
@@ -421,7 +422,7 @@ func buildHostedGenesisProducedDeclarations(conv *models.SoulAgentMintConversati
 
 func hostedGenesisFailureFromReason(reason string) *hostedGenesisFailure {
 	code := normalizeHostedGenesisFailureCode(reason)
-	retryable := code == hostedGenesisFailureLLMUnavailable || code == hostedGenesisFailureAssistantTurnFailed || code == hostedGenesisFailureDeclarationExtractionFailed
+	retryable := code == hostedGenesisFailureLLMUnavailable || code == hostedGenesisFailureAssistantTurnFailed || code == hostedGenesisFailureDeclarationExtractionFailed || code == hostedGenesisFailureMicroVMUnavailable
 	recovery := hostedGenesisFailureRecovery{Action: hostedGenesisRecoveryRefreshState, Reason: code}
 	if retryable {
 		recovery.Action = hostedGenesisRecoveryRetrySameStep
@@ -451,7 +452,8 @@ func normalizeHostedGenesisFailureCode(reason string) string {
 		hostedGenesisFailureMissingProducedDeclarations,
 		hostedGenesisFailureInvalidProducedDeclarations,
 		hostedGenesisFailureTenantBoundaryViolation,
-		hostedGenesisFailureOperatorActionRequired:
+		hostedGenesisFailureOperatorActionRequired,
+		hostedGenesisFailureMicroVMUnavailable:
 		return strings.TrimSpace(reason)
 	default:
 		return hostedGenesisFailureAssistantTurnFailed
@@ -474,6 +476,8 @@ func hostedGenesisFailureMessage(code string) string {
 		return "Conversation failed instance boundary validation."
 	case hostedGenesisFailureOperatorActionRequired:
 		return "Operator action is required."
+	case hostedGenesisFailureMicroVMUnavailable:
+		return "MicroVM execution dispatch is unavailable."
 	default:
 		return "Assistant turn failed before declaration extraction."
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -60,6 +60,19 @@ type Server struct {
 	enqueueCommMessage           func(ctx context.Context, msg commworker.QueueMessage) error
 	enqueueHostedGenesisMessage  func(ctx context.Context, msg hostedgenesis.QueueMessage) error
 	hostedGenesisAssistantRunner func(ctx context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error)
+	// hostedGenesisMicroVMDispatcher is the M16 controller run dispatch seam for
+	// the hosted genesis accept path. When wired, the accept path dispatches the
+	// MicroVM and returns 202 in_progress. When nil the accept path fails closed
+	// and loudly rather than falling back to a synchronous control-plane LLM
+	// call, unless hostedGenesisSyncAssistantFallbackEnabled is explicitly set
+	// true (a non-production/test-only guard that H2.1 deletes along with the
+	// sync runner). Production never sets that guard.
+	hostedGenesisMicroVMDispatcher hostedgenesis.MicroVMDispatcher
+	// hostedGenesisSyncAssistantFallbackEnabled is a non-production/test-only
+	// guard that keeps the retained synchronous assistant runner reachable until
+	// H2.1 deletes it. It defaults false; production must never enable it. When
+	// false (and no dispatcher is wired) the accept path fails closed and loudly.
+	hostedGenesisSyncAssistantFallbackEnabled bool
 
 	// paymentsProviderFactory is a test-injection hook. When non-nil, handlers
 	// use it instead of payments.NewProvider.

--- a/internal/hostedgenesis/dispatch.go
+++ b/internal/hostedgenesis/dispatch.go
@@ -1,0 +1,88 @@
+package hostedgenesis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrMicroVMDispatchUnavailable is the fail-closed error returned when the
+// hosted-genesis accept path cannot dispatch a MicroVM controller run command.
+// It is never a license to fall back to a synchronous control-plane LLM call;
+// callers must surface it loudly (typed AppError) and persist a failed turn.
+var ErrMicroVMDispatchUnavailable = errors.New("hosted genesis microvm dispatch is unavailable")
+
+// MicroVMDispatchResult is the safe, non-secret outcome of a controller run
+// dispatch: the validated execution/cache lifecycle ref Host records on the
+// HostedGenesisSession, plus the AppTheory session id the controller allocated.
+// It deliberately excludes endpoint auth tokens, bearer tokens, raw lifecycle
+// payloads, transcripts, and provider credentials.
+type MicroVMDispatchResult struct {
+	LifecycleRef MicroVMLifecycleRef
+	SessionID    string
+}
+
+// MicroVMDispatcher is the control-plane dispatch boundary for the hosted
+// genesis MicroVM execution path. The accept path calls DispatchMicroVMRun
+// after the HostedGenesisSession accepted turn is durably committed; the
+// dispatcher invokes the AppTheory M16 controller run command through the
+// constrained provider adapter (no raw AWS SDK) and returns the validated
+// lifecycle ref Host records as non-authoritative execution/cache state.
+//
+// A nil/unwired dispatcher is fail-closed: the accept path must not fall back
+// to a synchronous in-request LLM call. Transport selection (in-process
+// controller runtime versus the lab-only controller Lambda HTTP route) is
+// encapsulated behind this seam; the control plane never handles raw provider
+// SDK clients, bearer tokens, or lifecycle hook payloads.
+type MicroVMDispatcher interface {
+	DispatchMicroVMRun(ctx context.Context, requestID string, binding MicroVMSessionBinding) (MicroVMDispatchResult, error)
+}
+
+// ControllerRuntimeDispatcher adapts an AppTheory M16 MicroVMControllerRuntime
+// into the MicroVMDispatcher contract. It issues a run command for the already
+// committed Host session binding and converts the safe controller envelope into
+// Host's compact, validated lifecycle ref.
+type ControllerRuntimeDispatcher struct {
+	runtime *MicroVMControllerRuntime
+}
+
+// NewControllerRuntimeDispatcher wraps a MicroVMControllerRuntime so the control
+// plane can dispatch controller run commands through the MicroVMDispatcher seam.
+// A nil runtime yields a fail-closed dispatcher.
+func NewControllerRuntimeDispatcher(runtime *MicroVMControllerRuntime) *ControllerRuntimeDispatcher {
+	return &ControllerRuntimeDispatcher{runtime: runtime}
+}
+
+// DispatchMicroVMRun issues the AppTheory M16 run command for the binding and
+// records the validated lifecycle ref. It fails closed when the runtime is nil
+// or the controller rejects the request; it never falls back to a local
+// execution path.
+func (d *ControllerRuntimeDispatcher) DispatchMicroVMRun(ctx context.Context, requestID string, binding MicroVMSessionBinding) (MicroVMDispatchResult, error) {
+	if d == nil || d.runtime == nil {
+		return MicroVMDispatchResult{}, ErrMicroVMDispatchUnavailable
+	}
+	if err := binding.Validate(); err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return MicroVMDispatchResult{}, ErrMicroVMDispatchUnavailable
+	}
+	resp, err := d.runtime.Run(ctx, requestID, binding)
+	if err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	if resp.Error != nil && resp.Error.Code != "" {
+		return MicroVMDispatchResult{}, resp.Error
+	}
+	observedAt := time.Now().UTC()
+	if !resp.LastTransition.IsZero() {
+		observedAt = resp.LastTransition.UTC()
+	}
+	ref, err := MicroVMLifecycleRefFromResponse(binding, resp, observedAt)
+	if err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	return MicroVMDispatchResult{LifecycleRef: ref, SessionID: strings.TrimSpace(resp.SessionID)}, nil
+}

--- a/internal/hostedgenesis/dispatch_test.go
+++ b/internal/hostedgenesis/dispatch_test.go
@@ -1,0 +1,102 @@
+package hostedgenesis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+	microvmtestkit "github.com/theory-cloud/apptheory/testkit/microvm"
+)
+
+func TestControllerRuntimeDispatcherDispatchesM16Run(t *testing.T) {
+	t.Parallel()
+
+	binding := testMicroVMBinding()
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "arn:aws:lambda:us-east-1:123456789012:microvm-image/hosted-genesis:1",
+		NetworkConnectorRef: "arn:aws:lambda:us-east-1:123456789012:network-connector/hosted-genesis-egress",
+	})
+	require.NoError(t, err)
+
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	result, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", binding)
+	require.NoError(t, err)
+	require.Equal(t, binding.ConversationID, result.SessionID)
+	require.NoError(t, result.LifecycleRef.Validate(binding))
+	require.Equal(t, MicroVMSourceOfTruth, result.LifecycleRef.SourceOfTruth)
+	require.Equal(t, runtimemicrovm.CommandRun, result.LifecycleRef.LastAction)
+	require.NotEmpty(t, result.LifecycleRef.MicroVMID)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedWhenRuntimeNil(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := NewControllerRuntimeDispatcher(nil)
+	_, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", testMicroVMBinding())
+	require.ErrorIs(t, err, ErrMicroVMDispatchUnavailable)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedOnInvalidBinding(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", MicroVMSessionBinding{})
+	require.Error(t, err)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedOnEmptyRequestID(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "  ", testMicroVMBinding())
+	require.ErrorIs(t, err, ErrMicroVMDispatchUnavailable)
+}
+
+func TestControllerRuntimeDispatcherPropagatesControllerError(t *testing.T) {
+	t.Parallel()
+
+	// A controller backed by a registry that has lost the session cannot run;
+	// the dispatcher must surface the controller error rather than fall back.
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            &failingSessionRegistry{err: errors.New("registry unavailable")},
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", testMicroVMBinding())
+	require.Error(t, err)
+}
+
+type failingSessionRegistry struct {
+	err error
+}
+
+func (f *failingSessionRegistry) Get(ctx context.Context, key runtimemicrovm.SessionKey) (runtimemicrovm.SessionRecord, error) {
+	return runtimemicrovm.SessionRecord{}, f.err
+}
+func (f *failingSessionRegistry) Put(ctx context.Context, record runtimemicrovm.SessionRecord) (runtimemicrovm.SessionRecord, error) {
+	return runtimemicrovm.SessionRecord{}, f.err
+}
+func (f *failingSessionRegistry) Delete(ctx context.Context, key runtimemicrovm.SessionKey) error {
+	return f.err
+}

--- a/internal/hostedgenesis/session.go
+++ b/internal/hostedgenesis/session.go
@@ -189,6 +189,7 @@ const (
 	FailureCodeInvalidProducedDeclarations FailureCode = "invalid_produced_declarations"
 	FailureCodeTenantBoundaryViolation     FailureCode = "tenant_boundary_violation"
 	FailureCodeOperatorActionRequired      FailureCode = "operator_action_required"
+	FailureCodeMicroVMUnavailable          FailureCode = "microvm_unavailable"
 )
 
 // Recovery is the typed recovery envelope exposed on failed compact projections.
@@ -233,7 +234,8 @@ func isAllowedFailureCode(code FailureCode) bool {
 		FailureCodeMissingProducedDeclarations,
 		FailureCodeInvalidProducedDeclarations,
 		FailureCodeTenantBoundaryViolation,
-		FailureCodeOperatorActionRequired:
+		FailureCodeOperatorActionRequired,
+		FailureCodeMicroVMUnavailable:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## P52 H1.2 — MicroVM dispatch wiring on the hosted genesis accept path

Parent: lesser-host#867 (checklist item H1.2 — **stays open**). Factory tracker: factory#8. Branch off `main`; merges independently of H1.1 (#868).

### Target outcome (met)
`progressHostedGenesisAcceptedTurn` persists the accepted turn, dispatches the AppTheory M16 MicroVM controller `run` using the existing `MicroVMSessionBinding` / `NewMicroVMRunRequest` builders, populates `MicroVMExecutionID` / `ExecutionStateRef` / `MicroVMLifecycleRef` via `ApplyMicroVMLifecycleRef`, and returns **HTTP 202** with the session `in_progress`. The synchronous `llm.StreamMintConversation*` fallthrough is no longer reached on the production accept path. No LLM call in the control plane, ever.

### What changed
- **`internal/hostedgenesis/dispatch.go`** (new): `MicroVMDispatcher` interface + `ControllerRuntimeDispatcher` that wraps `MicroVMControllerRuntime.Run` and converts the safe controller envelope into a validated `MicroVMDispatchResult` (`MicroVMLifecycleRefFromResponse`). Fail-closed `ErrMicroVMDispatchUnavailable`.
- **`internal/controlplane/handlers_soul_mint_conversation_async.go`**: `progressHostedGenesisAcceptedTurn` dispatches + returns 202; new `persistHostedGenesisAcceptedMicroVMDispatch` applies the lifecycle ref and persists the in_progress session. MicroVM-unavailable → loud typed 503. The retained sync path is extracted into `progressHostedGenesisAcceptedTurnSync`, reachable **only** via the explicit non-production guard `Server.hostedGenesisSyncAssistantFallbackEnabled` (defaults false; H2.1 deletes it).
- **`internal/controlplane/server.go`**: `hostedGenesisMicroVMDispatcher` seam + `hostedGenesisSyncAssistantFallbackEnabled` guard fields.
- **`internal/controlplane/handlers_soul_instance_bootstrap.go`**: `appErrCodeMicroVMUnavailable` → typed `soul_instance.microvm_unavailable` 503 mapping in both error mappers.
- **`internal/controlplane/handlers_soul_mint_conversation_status.go`** + **`internal/hostedgenesis/session.go`**: `hostedGenesisFailureMicroVMUnavailable` / `FailureCodeMicroVMUnavailable` (retryable, `retry_same_step`), added to `isAllowedFailureCode`.
- Tests: dedicated H1.2 tests (`handlers_soul_mint_conversation_async_internal_test.go`) + `dispatch_test.go` + re-seamed existing accept/recovery/registry-gate tests to the dispatch + 202 contract.

### Security invariant
Fail closed and loudly. No silent fallback to a synchronous LLM call on the production accept path. MicroVM dispatch unavailable = typed 503 + retryable failed session. No raw AWS SDK — constrained controller adapter only.

### Framework adoption
AppTheory v1.15.0 `runtime/microvm.Controller.Handle(ctx, ControllerRequest{Command: CommandRun, ...})` → `ControllerResponse` (microvm_id/session_id/state/registry_version), invoked through Host's existing `MicroVMControllerRuntime.Run`. No local M16 substitute, no fork. The H1.1 lifecycle-adapter gap (`NewLifecycleAdapter` validates with M15 `ValidateLifecycleContract`) does **not** block H1.2 — H1.2 dispatches via the controller `run`, not the lifecycle adapter.

### Validation
- `go build ./...` ✅
- `go vet` clean on touched packages ✅
- `go test ./...` — 52 packages green ✅
- `gofmt -l` clean ✅
- gov-infra rubric: **PASS 40 / Fail 0 / Blocked 0** ✅
- Unit tests: (1) accept path dispatches controller run → 202 in_progress; (2) three MicroVM fields populated via `ApplyMicroVMLifecycleRef`; (3) MicroVM-unavailable = loud 503, sync LLM not invoked; (4) `ControllerRuntimeDispatcher` success / nil-runtime fail-closed / invalid-binding / empty-request-id / controller-error propagation; (5) non-production sync fallback guard + failure branch.

### Non-goals (not done — separate steps)
H1.1 workload (#868, not edited), H1.3 reconstruction-hook reachability, H1.4 recovery handler, H1.5 CDK de-lab-gating + lab deploy + E2E gate, H2.1 deletion of `hostedGenesisAssistantRunner` + sync LLM call site, H2.2 SQS deletion, H2.3 legacy deletion. No deploy, no merge, no on-chain/cloud mutation, no sibling-repo edits, no schema changes.

### Risks / follow-ups
- The sync path is retained behind a defaulted-false guard (per the brief's explicit allowance) so golangci `unused` stays clean and production stays fail-closed; H2.1 must delete it.
- The production dispatcher transport (in-process controller runtime vs. the lab-only controller Lambda HTTP route) is encapsulated behind the `MicroVMDispatcher` seam; H1.5 wires the CDK/deploy transport.
- Parent lesser-host#867 stays **OPEN** — this PR delivers H1.2 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)