### PR TITLE
P52 H1.3: MicroVM reconstruction reachability + VM-serviced declaration extraction

### DIFF
--- a/internal/controlplane/handlers_soul_instance_bootstrap.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap.go
@@ -24,10 +24,18 @@ const (
 	soulInstanceBootstrapCodeConflict           = "soul_instance.conflict"
 	soulInstanceBootstrapCodeNotFound           = "soul_instance.not_found"
 	soulInstanceBootstrapCodeInternal           = "soul_instance.internal"
+	soulInstanceBootstrapCodeMicroVMUnavailable = "soul_instance.microvm_unavailable"
 	soulInstanceBootstrapMessageUnauthorized    = "unauthorized"
 	soulInstanceBootstrapMessageBoundary        = "resource is outside the authenticated instance boundary"
 	soulInstanceBootstrapBoundaryInstanceDomain = "instance_domain"
 )
+
+// appErrCodeMicroVMUnavailable is the control-plane AppError code emitted when
+// the hosted genesis accept path cannot dispatch the M16 MicroVM controller
+// run. It maps to a loud 5xx at every public surface so MicroVM-unavailable is
+// never confused with a generic internal error or silently downgraded to a
+// synchronous control-plane LLM call.
+const appErrCodeMicroVMUnavailable = "app.microvm_unavailable"
 
 type soulInstanceBootstrapContext struct {
 	key          *models.InstanceKey
@@ -665,6 +673,8 @@ func soulInstanceBootstrapErrorFromAppError(appErr *apptheory.AppError) *apptheo
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeBoundaryViolation, appErr.Message, http.StatusForbidden, nil)
 	case soulMintAppErrCodeNotFound:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeNotFound, appErr.Message, http.StatusNotFound, nil)
+	case appErrCodeMicroVMUnavailable:
+		return soulInstanceBootstrapError(soulInstanceBootstrapCodeMicroVMUnavailable, appErr.Message, http.StatusServiceUnavailable, nil)
 	default:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}
@@ -700,6 +710,8 @@ func soulInstanceBootstrapConversationErrorFromAppError(appErr *apptheory.AppErr
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeConflict, appErr.Message, http.StatusConflict, nil)
 	case soulMintAppErrCodeNotFound:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeNotFound, appErr.Message, http.StatusNotFound, nil)
+	case appErrCodeMicroVMUnavailable:
+		return soulInstanceBootstrapError(soulInstanceBootstrapCodeMicroVMUnavailable, appErr.Message, http.StatusServiceUnavailable, nil)
 	default:
 		return soulInstanceBootstrapError(soulInstanceBootstrapCodeInternal, "internal error", http.StatusInternalServerError, nil)
 	}

--- a/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
@@ -1056,49 +1056,6 @@ func TestSoulInstanceCompleteMintConversation_PersistsDeclarationsAndFinalizeRea
 	tdb.qLifecycle.AssertCalled(t, "Create")
 }
 
-func TestSoulInstanceCompleteMintConversation_AssistantReadyWithoutDeclarationsDoesNotQueueExtraction(t *testing.T) {
-	tdb := newMintConversationTestDB()
-	s := newMintConversationServer(tdb)
-	reg := mintConversationHandleReg()
-	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
-		t.Fatalf("user-visible declaration extraction handoff must not enqueue SQS authority: %#v", msg)
-		return nil
-	}
-	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
-	stubMintConversationRegistration(t, tdb, reg)
-	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
-	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
-		AgentID:        reg.AgentID,
-		ConversationID: mintConversationTestConversationID,
-		Model:          "anthropic:claude-sonnet-4-6",
-		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"describe yourself"},{"role":"assistant","content":"ready"}]`),
-		Status:         models.SoulMintConversationStatusAssistantTurnReady,
-		LatestTurnID:   "turn-ready",
-		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
-	})
-	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
-	expectSoulInstanceMintConversationExtractionDebit(t, tdb)
-
-	resp, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
-		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
-		nil,
-		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
-	))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
-	}
-	if resp.Status != http.StatusAccepted {
-		t.Fatalf("expected 202, got %#v", resp)
-	}
-	var out hostedGenesisConversationResponse
-	if err := json.Unmarshal(resp.Body, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationExtractionPending || out.Conversation.ProducedDeclarations != nil {
-		t.Fatalf("expected declaration extraction progress without terminal declarations, got %#v", out)
-	}
-}
-
 func TestSoulInstanceCompleteMintConversation_ReturnsCompletedConversationReplay(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_internal_test.go
@@ -695,7 +695,7 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("user-visible hosted genesis start must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -707,7 +707,7 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
 	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -717,9 +717,12 @@ func TestSoulInstanceMintConversation_StartReturnsJSONWithoutQueueAuthority(t *t
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	out := assertSoulInstanceMintConversationDispatchedResponse(t, resp)
 	if out.Conversation.RegistrationID != reg.ID {
 		t.Fatalf("expected durable session authority for registration %s, got %#v", reg.ID, out.Conversation)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one MicroVM controller run dispatch, got %d", dispatcher.calls)
 	}
 	tdb.qLifecycle.AssertCalled(t, "Create")
 }
@@ -729,7 +732,8 @@ func TestSoulInstanceMintConversation_AssistantFailurePersistsTypedFailure(t *te
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "", errors.New("provider unavailable"))
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
+	dispatcher.dispatchErr = errors.New("microvm controller run rejected")
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("failed hosted genesis turn must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -748,25 +752,15 @@ func TestSoulInstanceMintConversation_AssistantFailurePersistsTypedFailure(t *te
 		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: soulInstanceBootstrapTestIdempotencyKey, CorrelationID: "corr-1"}),
 		map[string]string{"id": reg.ID},
 	))
-	if err != nil {
-		t.Fatalf("unexpected err: %v", err)
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure, got response %#v", resp)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected JSON 200 failed response, got %#v", resp)
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulInstanceBootstrapCodeMicroVMUnavailable || appErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected typed microvm-unavailable 503 error, got %#v", appErr)
 	}
-	var out hostedGenesisConversationResponse
-	if err := json.Unmarshal(resp.Body, &out); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil {
-		t.Fatalf("expected typed failed status, got %#v", out.Conversation)
-	}
-	if out.Conversation.Failure.Code != hostedGenesisFailureAssistantTurnFailed || out.Conversation.Failure.Recovery.Action != hostedGenesisRecoveryRetrySameStep {
-		t.Fatalf("expected retryable assistant failure, got %#v", out.Conversation.Failure)
-	}
-	if strings.Contains(string(resp.Body), soulInstanceBootstrapTestConversationMessage) ||
-		strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
-		t.Fatalf("failure response leaked transcript or credential material: %s", string(resp.Body))
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected dispatch to be attempted before loud failure, got %d calls", dispatcher.calls)
 	}
 }
 
@@ -775,7 +769,7 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant retry reply", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("idempotent replay must not enqueue duplicate user-visible execution: %#v", msg)
 		return nil
@@ -830,7 +824,7 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 		dest := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
 		*dest = session
 	}).Once()
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -840,18 +834,25 @@ func TestSoulInstanceMintConversation_IdempotentRetryDoesNotDebitOrAppend(t *tes
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200 progressed replay, got %#v", resp)
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched replay, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
 	if out.Conversation.ConversationID != mintConversationTestConversationID ||
-		out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
-		out.Conversation.MessageCount != 2 ||
+		out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
 		out.Conversation.TraceIDs.IdempotencyKey != idemKey {
-		t.Fatalf("expected idempotent progression without duplicate user message, got %#v", out)
+		t.Fatalf("expected idempotent in_progress dispatched replay, got %#v", out)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("idempotent replay must not append an inline assistant message: %#v", out.Conversation.Messages)
+		}
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected one MicroVM dispatch on replay progression, got %d", dispatcher.calls)
 	}
 	tdb.db.AssertNumberOfCalls(t, "TransactWrite", 1)
 	tdb.qBudget.AssertNumberOfCalls(t, "First", 0)
@@ -891,7 +892,7 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "second assistant", nil)
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("continued user-visible hosted genesis turn must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -911,7 +912,7 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, false)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -921,15 +922,25 @@ func TestSoulInstanceMintConversation_ContinueUsesStoredModelAndMessages(t *test
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200, got %#v", resp)
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady || out.Conversation.MessageCount != 4 {
-		t.Fatalf("expected progressed assistant turn, got %#v", out)
+	if out.Conversation.ConversationID != mintConversationTestConversationID || out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress dispatched continuation, got %#v", out)
+	}
+	if len(out.Conversation.Messages) == 0 {
+		t.Fatalf("expected projected transcript, got empty messages")
+	}
+	last := out.Conversation.Messages[len(out.Conversation.Messages)-1]
+	if last.Role != hostedGenesisTranscriptRoleUser || last.Content != "second" {
+		t.Fatalf("continued dispatched turn must end on the accepted user turn, not an inline assistant message: %#v", out.Conversation.Messages)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected one MicroVM dispatch on continuation, got %d", dispatcher.calls)
 	}
 }
 
@@ -1988,20 +1999,15 @@ func expectSoulInstanceMintConversationProgression(t *testing.T, tdb *mintConver
 		if hostedgenesis.NormalizeStatus(session.Status) != wantStatus {
 			t.Fatalf("expected hosted genesis progression status %s, got %#v", wantStatus, session)
 		}
-		switch wantStatus {
-		case hostedgenesis.StatusAssistantTurnReady:
-			if session.AssistantCheckpointRef == "" || session.MessageCount < 2 || session.Failure != nil {
-				t.Fatalf("assistant-ready session must carry checkpoint/message count and no failure: %#v", session)
-			}
-		case hostedgenesis.StatusFailed:
-			if session.Failure == nil || session.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed || !session.Failure.Retryable {
-				t.Fatalf("failed session must carry retryable assistant failure: %#v", session)
-			}
-		}
+		assertHostedGenesisProgressedSession(t, session, wantStatus)
 	})
 	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
 	tb.On("Execute").Return(nil).Once()
 }
+
+// assertHostedGenesisProgressedSession is in
+// handlers_soul_mint_conversation_async_internal_test.go (kept there to stay
+// under the gov-infra MAI-1 Go file budget for this file).
 
 func expectSoulInstanceMintConversationExtractionDebit(t *testing.T, tdb *mintConversationTestDB) {
 	t.Helper()
@@ -2237,6 +2243,10 @@ func assertSoulInstanceMintConversationAcceptedResponse(t *testing.T, resp *appt
 	assertSoulInstanceMintConversationAcceptedTranscript(t, out, resp.Body)
 	return out
 }
+
+// assertSoulInstanceMintConversationDispatchedResponse is in
+// handlers_soul_mint_conversation_async_internal_test.go (kept there to stay
+// under the gov-infra MAI-1 Go file budget for this file).
 
 func assertSoulInstanceMintConversationAcceptedTranscript(t *testing.T, out hostedGenesisConversationResponse, body []byte) {
 	t.Helper()

--- a/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_recovery_internal_test.go
@@ -20,20 +20,7 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 	s := newMintConversationServer(tdb)
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	runnerCalled := false
-	s.hostedGenesisAssistantRunner = func(_ context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
-		runnerCalled = true
-		if len(in.messages) != 1 || in.messages[0].Role != hostedGenesisTranscriptRoleUser || in.messages[0].Content != "stuck user turn" {
-			t.Fatalf("recovery must replay existing accepted messages without appending a duplicate turn: %#v", in.messages)
-		}
-		if strings.Contains(in.systemPrompt, mintConversationInstanceReadTestRawKey) {
-			t.Fatalf("recovery prompt leaked instance key")
-		}
-		return hostedGenesisAssistantRunResult{
-			fullResponse: "recovered assistant turn",
-			usage:        models.AIUsage{Provider: "test", Model: in.modelSet, InputTokens: 1, OutputTokens: 2, TotalTokens: 3},
-		}, nil
-	}
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
 
 	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
 	stubMintConversationRegistration(t, tdb, reg)
@@ -48,7 +35,7 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
 	})
 	stubSoulInstanceRecoverySession(t, tdb, hostedGenesisRecoverySessionFixture(t, reg, hostedgenesis.StatusInProgress, ""))
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -58,21 +45,26 @@ func TestSoulInstanceRecoverMintConversation_RetriggersStuckTurn(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected recovery err: %v", err)
 	}
-	if !runnerCalled {
-		t.Fatalf("expected recovery to rerun the assistant turn")
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected recovery to redispatch the stuck turn via the MicroVM controller, got %d dispatch calls", dispatcher.calls)
 	}
-	if resp.Status != http.StatusOK {
-		t.Fatalf("expected 200 recovery response, got %#v", resp)
+	if dispatcher.lastBinding.ConversationID != mintConversationTestConversationID {
+		t.Fatalf("expected recovery dispatch bound to the stuck conversation, got %#v", dispatcher.lastBinding)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 dispatched recovery response, got %#v", resp)
 	}
 	var out hostedGenesisConversationResponse
 	if err := json.Unmarshal(resp.Body, &out); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady ||
-		out.Conversation.MessageCount != 2 ||
-		len(out.Conversation.Messages) != 2 ||
-		out.Conversation.Messages[1].Content != "recovered assistant turn" {
-		t.Fatalf("expected recovered assistant-ready response with transcript, got %#v", out.Conversation)
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress dispatched recovery, got %#v", out.Conversation)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("recovery dispatch must not append an inline assistant message: %#v", out.Conversation.Messages)
+		}
 	}
 	if strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
 		t.Fatalf("recovery response leaked credential material: %s", string(resp.Body))

--- a/internal/controlplane/handlers_soul_instance_bootstrap_registry_gate_internal_test.go
+++ b/internal/controlplane/handlers_soul_instance_bootstrap_registry_gate_internal_test.go
@@ -56,7 +56,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	s.cfg.SoulRegistryContractAddress = ""
 	reg := mintConversationHandleReg()
 	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
-	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	stubHostedGenesisMicroVMDispatcher(t, s)
 	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
 		t.Fatalf("hosted/off-chain mint conversation must not enqueue SQS authority: %#v", msg)
 		return nil
@@ -68,7 +68,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
 	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
 	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
-	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusInProgress)
 
 	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
 		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
@@ -78,7 +78,7 @@ func TestSoulInstanceHostedOffchainMintConversation_DoesNotRequireRegistryContra
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
 	}
-	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	out := assertSoulInstanceMintConversationDispatchedResponse(t, resp)
 	if out.Conversation.RegistrationID != reg.ID || out.Conversation.AgentID != reg.AgentID {
 		t.Fatalf("expected hosted session for registration/agent, got %#v", out.Conversation)
 	}

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -21,8 +21,17 @@ import (
 )
 
 const (
+	// hostedGenesisAcceptedTurnRunTimeout bounds the synchronous assistant
+	// runner retained for non-production/test seams. H2.1 deletes that path; the
+	// production accept path dispatches the MicroVM and returns 202 well under
+	// this budget.
 	hostedGenesisAcceptedTurnRunTimeout = 90 * time.Second
-	hostedGenesisProviderUnknown        = "unknown"
+	// hostedGenesisAcceptedTurnDispatchTimeout bounds the M16 controller run
+	// dispatch on the production accept path. The accept path returns 202
+	// accepted-pending; the assistant turn itself runs inside the MicroVM and is
+	// not bounded by this timeout.
+	hostedGenesisAcceptedTurnDispatchTimeout = 10 * time.Second
+	hostedGenesisProviderUnknown             = "unknown"
 )
 
 type hostedGenesisTurnSession struct {
@@ -160,6 +169,60 @@ func (s *Server) progressHostedGenesisAcceptedTurn(ctx context.Context, regCtx m
 	if session.session == nil || conv == nil {
 		return nil, nil, 0, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
+	// H1.2: the production accept path dispatches the AppTheory M16 MicroVM
+	// controller run command and returns 202 accepted-pending. The control plane
+	// never makes a synchronous LLM HTTP call on this path; the assistant turn
+	// runs inside the MicroVM and completion is reconstructed from Host truth.
+	// The synchronous assistant runner is retained only behind an explicit
+	// non-production/test guard (hostedGenesisSyncAssistantFallbackEnabled) until
+	// H2.1 deletes it; production never sets that guard.
+	if s.hostedGenesisMicroVMDispatcher == nil {
+		if s.hostedGenesisSyncAssistantFallbackEnabled && s.hostedGenesisAssistantRunner != nil {
+			return s.progressHostedGenesisAcceptedTurnSync(ctx, regCtx, session, conv, acceptedMessages, apiKey, requestID)
+		}
+		log.Printf("controlplane: hosted genesis microvm dispatcher unavailable agent_hash=%s conversation_hash=%s", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID))
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch is unavailable"}
+	}
+
+	binding := session.session.MicroVMSessionBinding()
+	if err := binding.Validate(); err != nil {
+		log.Printf("controlplane: hosted genesis microvm binding invalid agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID), err)
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch is unavailable"}
+	}
+
+	runCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx), hostedGenesisAcceptedTurnDispatchTimeout)
+	defer cancel()
+	dispatch, dispatchErr := s.hostedGenesisMicroVMDispatcher.DispatchMicroVMRun(runCtx, strings.TrimSpace(requestID), binding)
+	if dispatchErr != nil {
+		log.Printf("controlplane: hosted genesis microvm dispatch failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(regCtx.agentIDHex), soulMintInstanceReadAuditHash(session.conversationID), dispatchErr)
+		failedSession, failedConv, appErr := s.persistHostedGenesisAcceptedTurnFailure(ctx, session, conv, acceptedMessages, hostedGenesisFailureMicroVMUnavailable, requestID, time.Now().UTC())
+		if appErr != nil {
+			return nil, nil, 0, appErr
+		}
+		return failedSession, failedConv, http.StatusOK, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution dispatch failed"}
+	}
+
+	progressedSession, progressedConv, appErr := s.persistHostedGenesisAcceptedMicroVMDispatch(ctx, session, conv, acceptedMessages, dispatch, requestID, time.Now().UTC())
+	if appErr != nil {
+		return nil, nil, 0, appErr
+	}
+	return progressedSession, progressedConv, http.StatusAccepted, nil
+}
+
+// progressHostedGenesisAcceptedTurnSync is the retained non-production/test-only
+// synchronous assistant turn path. It is reachable only when
+// hostedGenesisSyncAssistantFallbackEnabled is explicitly true AND no MicroVM
+// dispatcher is wired; production never sets that guard. H2.1 deletes this path
+// and the hostedGenesisAssistantRunner field.
+func (s *Server) progressHostedGenesisAcceptedTurnSync(ctx context.Context, regCtx mintConversationRegistrationContext, session hostedGenesisTurnSession, conv *models.SoulAgentMintConversation, acceptedMessages []soulMintConversationMessage, apiKey string, requestID string) (*models.HostedGenesisSession, *models.SoulAgentMintConversation, int, *apptheory.AppError) {
 	runCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx), hostedGenesisAcceptedTurnRunTimeout)
 	defer cancel()
 
@@ -183,6 +246,33 @@ func (s *Server) progressHostedGenesisAcceptedTurn(ctx context.Context, regCtx m
 		return nil, nil, 0, appErr
 	}
 	return progressedSession, progressedConv, http.StatusOK, nil
+}
+
+// persistHostedGenesisAcceptedMicroVMDispatch records the durable in_progress
+// HostedGenesisSession after a successful M16 controller run dispatch, applying
+// the non-authoritative MicroVM execution/cache lifecycle ref via
+// ApplyMicroVMLifecycleRef so the three MicroVM fields
+// (MicroVMExecutionID/ExecutionStateRef/MicroVMLifecycleRef) are populated on
+// the authoritative Host row. The conversation stays in_progress with no inline
+// assistant message: the turn is pending inside the MicroVM and completion is
+// reconstructed from Host truth by the recovery/stuck-turn path.
+func (s *Server) persistHostedGenesisAcceptedMicroVMDispatch(ctx context.Context, session hostedGenesisTurnSession, conv *models.SoulAgentMintConversation, acceptedMessages []soulMintConversationMessage, dispatch hostedgenesis.MicroVMDispatchResult, requestID string, now time.Time) (*models.HostedGenesisSession, *models.SoulAgentMintConversation, *apptheory.AppError) {
+	progressedSession := cloneHostedGenesisSession(session.session)
+	progressedConv := cloneSoulAgentMintConversation(conv)
+	if err := progressedSession.ApplyMicroVMLifecycleRef(dispatch.LifecycleRef); err != nil {
+		log.Printf("controlplane: hosted genesis microvm lifecycle ref rejected agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(conv.AgentID), soulMintInstanceReadAuditHash(conv.ConversationID), err)
+		return nil, nil, &apptheory.AppError{Code: "app.internal", Message: "failed to record microvm dispatch"}
+	}
+	progressedSession.Status = string(hostedgenesis.StatusInProgress)
+	progressedSession.RequestID = strings.TrimSpace(requestID)
+	progressedSession.UpdatedAt = now
+	progressedSession.CompletedAt = time.Time{}
+	progressedConv.RequestID = strings.TrimSpace(requestID)
+	progressedConv.UpdatedAt = now
+	if appErr := s.persistHostedGenesisProgression(ctx, session, progressedSession, progressedConv, string(progressedConv.Messages), "", progressedConv.Usage, now); appErr != nil {
+		return nil, nil, appErr
+	}
+	return progressedSession, progressedConv, nil
 }
 
 func (s *Server) runHostedGenesisAcceptedAssistant(ctx context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -898,53 +898,119 @@ func (s *Server) startHostedGenesisDeclarationExtraction(ctx *apptheory.Context,
 		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
 	}
 	now := time.Now().UTC()
-	if hostedgenesis.NormalizeStatus(convCtx.session.Status) != hostedgenesis.StatusDeclarationExtractionPending {
-		expectedVersion := convCtx.session.Version
-		expectedStatus := hostedgenesis.NormalizeStatus(convCtx.session.Status)
-		convCtx.session.Status = string(hostedgenesis.StatusDeclarationExtractionPending)
-		convCtx.session.RequestID = strings.TrimSpace(ctx.RequestID)
-		convCtx.session.UpdatedAt = now
-		creditsDebited, appErr := s.debitSoulMintConversationCredits(
-			ctx.Context(),
-			convCtx.inst,
-			soulMintConversationExtractModule,
-			convCtx.conversationID,
-			firstNonEmpty(convCtx.conv.IdempotencyKey, ctx.RequestID),
-			soulMintConversationExtractBaseCredits,
-			now,
-			func(tx core.TransactionBuilder, creditsRequested int64) error {
-				if err := addHostedGenesisSessionWrite(tx, convCtx.session, false, expectedVersion, expectedStatus); err != nil {
-					return err
-				}
-				if convCtx.conv != nil {
-					update := &models.SoulAgentMintConversation{AgentID: convCtx.agentIDHex, ConversationID: convCtx.conversationID}
-					_ = update.UpdateKeys()
-					tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
-						ub.Add("ChargedCredits", creditsRequested)
-						ub.Set("Status", models.SoulMintConversationStatusDeclarationExtractionPending)
-						ub.Set("StatusReason", "")
-						ub.Set("RequestID", strings.TrimSpace(ctx.RequestID))
-						ub.Set("UpdatedAt", now)
-						return nil
-					}, tabletheory.IfExists())
-				}
-				return nil
-			},
-		)
-		if appErr != nil {
-			return appErr
-		}
-		if convCtx.conv != nil {
-			convCtx.conv.ChargedCredits += creditsDebited
-			convCtx.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
-			convCtx.conv.StatusReason = ""
-			convCtx.conv.RequestID = strings.TrimSpace(ctx.RequestID)
-			convCtx.conv.UpdatedAt = now
-		}
+	// H1.3 (kills G7): the pending extraction is serviced by dispatching a
+	// follow-on M16 controller run command on the same MicroVM session via the
+	// MicroVMDispatcher seam. The dispatch fires exactly once, on the transition
+	// into declaration_extraction_pending (the debit/persist block below). An
+	// already-pending session has already dispatched its extraction; re-entry is
+	// a no-op here and the recover path reconciles the in-VM extraction. The
+	// pending status is no longer a permanent trap: the VM services the
+	// extraction or the session fails loudly. An unwired dispatcher is
+	// fail-closed and loud; there is no silent fallback to a non-MicroVM
+	// extraction path. M4 demotes hosted-genesis SQS to operator/backfill
+	// recovery only; this path does not rely on queue delivery, DLQ state, or
+	// AI-worker liveness.
+	transitioned := hostedgenesis.NormalizeStatus(convCtx.session.Status) != hostedgenesis.StatusDeclarationExtractionPending
+	if !transitioned {
+		return nil
 	}
-	// M4 demotes hosted-genesis SQS to operator/backfill recovery only. The
-	// user-visible complete path records the durable pending state and returns
-	// the HostedGenesisSession projection; it does not rely on queue delivery,
-	// DLQ state, or AI-worker liveness to make status/finalize decisions.
+	expectedVersion := convCtx.session.Version
+	expectedStatus := hostedgenesis.NormalizeStatus(convCtx.session.Status)
+	convCtx.session.Status = string(hostedgenesis.StatusDeclarationExtractionPending)
+	convCtx.session.RequestID = strings.TrimSpace(ctx.RequestID)
+	convCtx.session.UpdatedAt = now
+	creditsDebited, appErr := s.debitSoulMintConversationCredits(
+		ctx.Context(),
+		convCtx.inst,
+		soulMintConversationExtractModule,
+		convCtx.conversationID,
+		firstNonEmpty(convCtx.conv.IdempotencyKey, ctx.RequestID),
+		soulMintConversationExtractBaseCredits,
+		now,
+		func(tx core.TransactionBuilder, creditsRequested int64) error {
+			if err := addHostedGenesisSessionWrite(tx, convCtx.session, false, expectedVersion, expectedStatus); err != nil {
+				return err
+			}
+			if convCtx.conv != nil {
+				update := &models.SoulAgentMintConversation{AgentID: convCtx.agentIDHex, ConversationID: convCtx.conversationID}
+				_ = update.UpdateKeys()
+				tx.UpdateWithBuilder(update, func(ub core.UpdateBuilder) error {
+					ub.Add("ChargedCredits", creditsRequested)
+					ub.Set("Status", models.SoulMintConversationStatusDeclarationExtractionPending)
+					ub.Set("StatusReason", "")
+					ub.Set("RequestID", strings.TrimSpace(ctx.RequestID))
+					ub.Set("UpdatedAt", now)
+					return nil
+				}, tabletheory.IfExists())
+			}
+			return nil
+		},
+	)
+	if appErr != nil {
+		return appErr
+	}
+	if convCtx.conv != nil {
+		convCtx.conv.ChargedCredits += creditsDebited
+		convCtx.conv.Status = models.SoulMintConversationStatusDeclarationExtractionPending
+		convCtx.conv.StatusReason = ""
+		convCtx.conv.RequestID = strings.TrimSpace(ctx.RequestID)
+		convCtx.conv.UpdatedAt = now
+	}
+	return s.dispatchHostedGenesisDeclarationExtraction(ctx, convCtx, now)
+}
+
+// dispatchHostedGenesisDeclarationExtraction issues the follow-on M16
+// controller run command that services a declaration_extraction_pending session
+// inside the MicroVM. It refreshes the non-authoritative lifecycle ref on the
+// authoritative HostedGenesisSession so the recover path can reconstruct the
+// extraction. It fails closed and loudly when the dispatcher is unwired or the
+// dispatch is rejected; it never falls back to a synchronous control-plane
+// extraction path.
+func (s *Server) dispatchHostedGenesisDeclarationExtraction(ctx *apptheory.Context, convCtx soulInstanceBootstrapConversationContext, now time.Time) error {
+	if s.hostedGenesisMicroVMDispatcher == nil {
+		log.Printf("controlplane: hosted genesis extraction dispatch unavailable agent_hash=%s conversation_hash=%s", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID))
+		return &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM extraction dispatch is unavailable"}
+	}
+	binding := convCtx.session.MicroVMSessionBinding()
+	if err := binding.Validate(); err != nil {
+		log.Printf("controlplane: hosted genesis extraction binding invalid agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), err)
+		return &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM extraction binding is invalid"}
+	}
+	runCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx.Context()), hostedGenesisAcceptedTurnDispatchTimeout)
+	defer cancel()
+	dispatch, dispatchErr := s.hostedGenesisMicroVMDispatcher.DispatchMicroVMRun(runCtx, strings.TrimSpace(ctx.RequestID), binding)
+	if dispatchErr != nil {
+		log.Printf("controlplane: hosted genesis extraction dispatch failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), dispatchErr)
+		return &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM extraction dispatch failed"}
+	}
+	progressedSession := cloneHostedGenesisSession(convCtx.session)
+	if err := progressedSession.ApplyMicroVMLifecycleRef(dispatch.LifecycleRef); err != nil {
+		log.Printf("controlplane: hosted genesis extraction lifecycle ref rejected agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), err)
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to record microvm extraction dispatch"}
+	}
+	progressedSession.RequestID = strings.TrimSpace(ctx.RequestID)
+	progressedSession.UpdatedAt = now
+	if err := s.persistHostedGenesisExtractionDispatch(ctx.Context(), convCtx.session, progressedSession, convCtx.session.Version, now); err != nil {
+		return err
+	}
+	convCtx.session = progressedSession
+	return nil
+}
+
+// persistHostedGenesisExtractionDispatch records the refreshed MicroVM
+// lifecycle ref on the authoritative HostedGenesisSession after the follow-on
+// extraction run dispatch. The durable status stays
+// declaration_extraction_pending; only the non-authoritative execution/cache
+// ref is refreshed under expected-version/expected-status optimistic locking.
+func (s *Server) persistHostedGenesisExtractionDispatch(ctx context.Context, accepted *models.HostedGenesisSession, progressed *models.HostedGenesisSession, expectedVersion int64, now time.Time) *apptheory.AppError {
+	if s == nil || s.store == nil || s.store.DB == nil || accepted == nil || progressed == nil {
+		return &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	if err := s.store.DB.TransactWrite(ctx, func(tx core.TransactionBuilder) error {
+		return addHostedGenesisSessionWrite(tx, progressed, false, expectedVersion, hostedgenesis.StatusDeclarationExtractionPending)
+	}); err != nil {
+		log.Printf("controlplane: hosted genesis extraction dispatch persist failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(progressed.AgentID), soulMintInstanceReadAuditHash(progressed.ConversationID), err)
+		return &apptheory.AppError{Code: "app.internal", Message: "failed to persist microvm extraction dispatch"}
+	}
 	return nil
 }

--- a/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
@@ -1,0 +1,317 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	apptheory "github.com/theory-cloud/apptheory/runtime"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// TestH1_2_AcceptPathDispatchesControllerRunAndReturns202 proves the production
+// hosted genesis accept path dispatches the AppTheory M16 MicroVM controller
+// run command through the MicroVMDispatcher seam and returns HTTP 202
+// accepted-pending with the durable session in_progress (no synchronous control
+// plane LLM call).
+func TestH1_2_AcceptPathDispatchesControllerRunAndReturns202(t *testing.T) {
+	tdb, s, reg, dispatcher := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	h1d2ExpectAcceptPathProgression(t, tdb, hostedgenesis.StatusInProgress)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202 accepted-pending, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected in_progress durable status, got %#v", out.Conversation)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one M16 controller run dispatch, got %d", dispatcher.calls)
+	}
+	if dispatcher.lastBinding.ConversationID == "" || dispatcher.lastBinding.RegistrationID != reg.ID {
+		t.Fatalf("expected dispatch bound to the accepted turn's session, got %#v", dispatcher.lastBinding)
+	}
+}
+
+// TestH1_2_AcceptPathPopulatesThreeMicroVMFieldsViaApplyLifecycleRef proves a
+// successful dispatch populates MicroVMExecutionID, ExecutionStateRef, and
+// MicroVMLifecycleRef on the authoritative HostedGenesisSession via
+// ApplyMicroVMLifecycleRef (the lifecycle ref is validated against the binding).
+func TestH1_2_AcceptPathPopulatesThreeMicroVMFieldsViaApplyLifecycleRef(t *testing.T) {
+	tdb, s, reg, dispatcher := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	var captured *models.HostedGenesisSession
+	h1d2ExpectAcceptPathProgressionCapture(t, tdb, &captured)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %#v", resp)
+	}
+	if captured == nil {
+		t.Fatalf("expected persisted in_progress session capture")
+	}
+	if captured.MicroVMExecutionID == "" || captured.ExecutionStateRef == "" || captured.MicroVMLifecycleRef == nil {
+		t.Fatalf("expected all three MicroVM execution/cache refs populated, got %#v", captured)
+	}
+	if !strings.HasPrefix(captured.ExecutionStateRef, "microvm://") {
+		t.Fatalf("expected ExecutionStateRef formatted by FormatMicroVMExecutionStateRef, got %q", captured.ExecutionStateRef)
+	}
+	if captured.MicroVMLifecycleRef.SessionID != dispatcher.lastBinding.ConversationID {
+		t.Fatalf("expected lifecycle ref bound to dispatched session, got %#v", captured.MicroVMLifecycleRef)
+	}
+	if captured.MicroVMLifecycleRef.SourceOfTruth != hostedgenesis.MicroVMSourceOfTruth {
+		t.Fatalf("expected lifecycle ref source of truth, got %#v", captured.MicroVMLifecycleRef)
+	}
+}
+
+// TestH1_2_MicroVMUnavailableIsLoudFailureNotSyncLLMFallthrough proves that
+// when the MicroVM dispatcher is unwired (the production misconfiguration
+// case), the accept path fails closed and loudly with a typed 503
+// microvm-unavailable error and persists a retryable failed session, rather
+// than silently falling back to a synchronous control-plane LLM call.
+func TestH1_2_MicroVMUnavailableIsLoudFailureNotSyncLLMFallthrough(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	// No dispatcher wired: production must not fall back to sync LLM.
+	s.hostedGenesisMicroVMDispatcher = nil
+	syncLLMCalled := false
+	s.hostedGenesisAssistantRunner = func(_ context.Context, _ hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		syncLLMCalled = true
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+	h1d2ExpectAcceptPathProgression(t, tdb, hostedgenesis.StatusFailed)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure, got response %#v", resp)
+	}
+	appErr := requireAppTheoryError(t, err)
+	if appErr.Code != soulInstanceBootstrapCodeMicroVMUnavailable || appErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected typed microvm-unavailable 503, got %#v", appErr)
+	}
+	if syncLLMCalled {
+		t.Fatalf("accept path must not fall back to synchronous LLM when MicroVM dispatch is unavailable")
+	}
+}
+
+// TestH1_2_NonProductionSyncFallbackGuard proves the retained synchronous
+// assistant runner stays reachable ONLY through the explicit non-production
+// guard (hostedGenesisSyncAssistantFallbackEnabled). This keeps the sync path
+// referenced and covered until H2.1 deletes it; production never sets the guard
+// so production cannot reach this branch.
+func TestH1_2_NonProductionSyncFallbackGuard(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	// No dispatcher wired, but the non-production sync fallback guard is set.
+	s.hostedGenesisMicroVMDispatcher = nil
+	s.hostedGenesisSyncAssistantFallbackEnabled = true
+	stubHostedGenesisAssistantRunner(t, s, "assistant reply", nil)
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusAssistantTurnReady)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	out := assertSoulInstanceMintConversationAcceptedResponse(t, resp)
+	if out.Conversation.Status != models.SoulMintConversationStatusAssistantTurnReady {
+		t.Fatalf("expected sync fallback to reach assistant_turn_ready, got %#v", out.Conversation)
+	}
+}
+
+// TestH1_2_NonProductionSyncFallbackFailurePersistsTypedFailure covers the
+// non-production sync fallback's failure branch (provider error) so the
+// retained sync path's failure handling and provider-name logging stay covered
+// until H2.1 deletes the path.
+func TestH1_2_NonProductionSyncFallbackFailurePersistsTypedFailure(t *testing.T) {
+	tdb, s, reg, _ := h1d2AcceptPathFixture(t)
+	s.hostedGenesisMicroVMDispatcher = nil
+	s.hostedGenesisSyncAssistantFallbackEnabled = true
+	stubHostedGenesisAssistantRunner(t, s, "", errors.New("provider unavailable"))
+	expectSoulInstanceMintConversationProgression(t, tdb, hostedgenesis.StatusFailed)
+
+	resp, err := s.handleSoulInstanceMintConversation(h1d2AcceptPathRequest(t, reg))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 failed sync fallback response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil {
+		t.Fatalf("expected typed failed status, got %#v", out.Conversation)
+	}
+	if out.Conversation.Failure.Code != hostedGenesisFailureAssistantTurnFailed {
+		t.Fatalf("expected assistant_turn_failed, got %#v", out.Conversation.Failure)
+	}
+}
+
+// h1d2AcceptPathFixture builds the shared mock scaffolding for a fresh hosted
+// genesis accept turn and returns a stub dispatcher not yet wired onto the
+// server (callers wire it to control the dispatch outcome).
+func h1d2AcceptPathFixture(t *testing.T) (*mintConversationTestDB, *Server, models.SoulAgentRegistration, *stubMicroVMDispatcher) {
+	t.Helper()
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		t.Fatalf("accept path must not enqueue SQS authority: %#v", msg)
+		return nil
+	}
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	tdb.qMintIdem.On("First", mock.AnythingOfType("*models.SoulMintConversationIdempotency")).Return(theoryErrors.ErrItemNotFound).Once()
+	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, true)
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	return tdb, s, reg, dispatcher
+}
+
+func h1d2AcceptPathRequest(t *testing.T, reg models.SoulAgentRegistration) *apptheory.Context {
+	t.Helper()
+	return newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, soulMintConversationRequest{Model: "anthropic:claude-sonnet-4-6", Message: soulInstanceBootstrapTestConversationMessage, IdempotencyKey: soulInstanceBootstrapTestIdempotencyKey, CorrelationID: "corr-1"}),
+		map[string]string{"id": reg.ID},
+	)
+}
+
+func h1d2ExpectAcceptPathProgression(t *testing.T, tdb *mintConversationTestDB, wantStatus hostedgenesis.Status) {
+	t.Helper()
+	expectSoulInstanceMintConversationProgression(t, tdb, wantStatus)
+}
+
+func h1d2ExpectAcceptPathProgressionCapture(t *testing.T, tdb *mintConversationTestDB, captured **models.HostedGenesisSession) {
+	t.Helper()
+	tb, _ := tdb.db.TransactWriteBuilder.(*ttmocks.MockTransactionBuilder)
+	if tb == nil {
+		tb = new(ttmocks.MockTransactionBuilder)
+		tdb.db.TransactWriteBuilder = tb
+	}
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.HostedGenesisSession"), mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		*captured = testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		if hostedgenesis.NormalizeStatus((*captured).Status) != hostedgenesis.StatusInProgress {
+			t.Fatalf("expected in_progress dispatched session, got %#v", *captured)
+		}
+	})
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
+	tb.On("Execute").Return(nil).Once()
+}
+
+// assertHostedGenesisProgressedSession asserts the persisted progressed session
+// matches the expected H1.2 status shape (dispatched in_progress carries the
+// three MicroVM refs; failed carries a retryable assistant/microvm failure).
+func assertHostedGenesisProgressedSession(t *testing.T, session *models.HostedGenesisSession, wantStatus hostedgenesis.Status) {
+	t.Helper()
+	switch wantStatus {
+	case hostedgenesis.StatusAssistantTurnReady:
+		assertHostedGenesisAssistantReadySession(t, session)
+	case hostedgenesis.StatusInProgress:
+		assertHostedGenesisDispatchedSession(t, session)
+	case hostedgenesis.StatusFailed:
+		assertHostedGenesisFailedSession(t, session)
+	}
+}
+
+func assertHostedGenesisAssistantReadySession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.AssistantCheckpointRef == "" || session.MessageCount < 2 || session.Failure != nil {
+		t.Fatalf("assistant-ready session must carry checkpoint/message count and no failure: %#v", session)
+	}
+}
+
+func assertHostedGenesisDispatchedSession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.MicroVMExecutionID == "" || session.ExecutionStateRef == "" || session.MicroVMLifecycleRef == nil {
+		t.Fatalf("in_progress dispatched session must carry the three MicroVM execution/cache refs: %#v", session)
+	}
+	if session.AssistantCheckpointRef != "" || session.Failure != nil {
+		t.Fatalf("in_progress dispatched session must not carry an assistant checkpoint or failure: %#v", session)
+	}
+}
+
+func assertHostedGenesisFailedSession(t *testing.T, session *models.HostedGenesisSession) {
+	t.Helper()
+	if session.Failure == nil || !session.Failure.Retryable {
+		t.Fatalf("failed session must carry retryable failure: %#v", session)
+	}
+	if session.Failure.Code != hostedgenesis.FailureCodeAssistantTurnFailed && session.Failure.Code != hostedgenesis.FailureCodeMicroVMUnavailable {
+		t.Fatalf("failed session must carry assistant or microvm-unavailable failure: %#v", session)
+	}
+}
+
+// assertSoulInstanceMintConversationDispatchedResponse asserts the H1.2 accept
+// path returned 202 accepted-pending with the durable session in_progress and
+// no inline assistant message (the turn runs inside the MicroVM).
+func assertSoulInstanceMintConversationDispatchedResponse(t *testing.T, resp *apptheory.Response) hostedGenesisConversationResponse {
+	t.Helper()
+	if resp.Status != http.StatusAccepted || !strings.Contains(resp.Headers["content-type"][0], "application/json") {
+		t.Fatalf("expected JSON 202 dispatched response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.ConversationID == "" ||
+		out.Conversation.Status != models.SoulMintConversationStatusInProgress ||
+		out.Conversation.RequestID != "req-instance-bootstrap" {
+		t.Fatalf("expected in_progress dispatched durable status, got %#v", out)
+	}
+	if out.Conversation.TraceIDs == nil ||
+		out.Conversation.TraceIDs.IdempotencyKey != soulInstanceBootstrapTestIdempotencyKey ||
+		out.Conversation.TraceIDs.CorrelationID != "corr-1" {
+		t.Fatalf("expected trace ids, got %#v", out.Conversation.TraceIDs)
+	}
+	for _, msg := range out.Conversation.Messages {
+		if msg.Role == hostedGenesisTranscriptRoleAssistant {
+			t.Fatalf("dispatched 202 response must not carry an inline assistant message: %#v", out.Conversation.Messages)
+		}
+	}
+	if strings.Contains(string(resp.Body), mintConversationInstanceReadTestRawKey) {
+		t.Fatalf("response leaked credential material: %s", string(resp.Body))
+	}
+	return out
+}
+
+func TestHostedGenesisProviderName(t *testing.T) {
+	cases := map[string]string{
+		"openai:gpt-5.4":                 "openai",
+		"  Anthropic:claude-sonnet-4-6 ": "anthropic",
+		"unknown:foo":                    hostedGenesisProviderUnknown,
+		"":                               hostedGenesisProviderUnknown,
+	}
+	for in, want := range cases {
+		if got := hostedGenesisProviderName(in); got != want {
+			t.Fatalf("hostedGenesisProviderName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestHostedGenesisMaxInt(t *testing.T) {
+	if hostedGenesisMaxInt(1, 2) != 2 || hostedGenesisMaxInt(3, 2) != 3 || hostedGenesisMaxInt(5, 5) != 5 {
+		t.Fatalf("hostedGenesisMaxInt returned unexpected value")
+	}
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_h1d3_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_h1d3_internal_test.go
@@ -1,0 +1,542 @@
+package controlplane
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
+	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
+
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
+	"github.com/equaltoai/lesser-host/internal/store/models"
+	"github.com/equaltoai/lesser-host/internal/testutil"
+)
+
+// hostedGenesisH1D3RecoveryFixture builds the shared mock scaffolding for an
+// H1.3 recovery/reconciliation test: a hosted genesis session sitting in a
+// MicroVM-serviced pending state (in_progress or declaration_extraction_pending)
+// with a populated MicroVMLifecycleRef, plus a stub dispatcher whose reconcile
+// behavior the caller controls via observedState/reconcileErr.
+func hostedGenesisH1D3RecoveryFixture(t *testing.T, status hostedgenesis.Status) (*mintConversationTestDB, *Server, models.SoulAgentRegistration, *stubMicroVMDispatcher) {
+	t.Helper()
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubSoulInstanceRecoveryConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"stuck user turn"}]`),
+		Status:         string(status),
+		LatestTurnID:   "turn-stuck",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubSoulInstanceRecoverySession(t, tdb, hostedGenesisH1D3RecoverySessionFixture(t, reg, status))
+	return tdb, s, reg, dispatcher
+}
+
+// hostedGenesisH1D3RecoverySessionFixture builds a recovery session in a
+// MicroVM-serviced pending state with the three MicroVM execution/cache refs
+// populated (the shape the H1.2 accept path or H1.3 extraction dispatch records
+// so the H1.3 recover path can reach production reconstruction).
+func hostedGenesisH1D3RecoverySessionFixture(t *testing.T, reg models.SoulAgentRegistration, status hostedgenesis.Status) models.HostedGenesisSession {
+	t.Helper()
+	session := hostedGenesisRecoverySessionFixture(t, reg, status, "")
+	binding := session.MicroVMSessionBinding()
+	if err := binding.Validate(); err != nil {
+		t.Fatalf("h1.3 recovery session binding invalid: %v", err)
+	}
+	resp := runtimemicrovm.ControllerResponse{
+		Command:           runtimemicrovm.CommandRun,
+		RequestID:         "req-original",
+		TenantID:          binding.TenantID(),
+		Namespace:         hostedgenesis.MicroVMNamespace,
+		SessionID:         binding.ConversationID,
+		State:             runtimemicrovm.StateRunning,
+		DesiredState:      runtimemicrovm.StateRunning,
+		LifecycleState:    runtimemicrovm.StateRunning,
+		MicroVMID:         "mv-h1d3-" + binding.ConversationID,
+		ProviderMicroVMID: "mv-h1d3-" + binding.ConversationID,
+		LastAction:        runtimemicrovm.CommandRun,
+		LastTransition:    time.Date(2026, 3, 7, 12, 0, 5, 0, time.UTC),
+		RegistryVersion:   2,
+	}
+	ref, err := hostedgenesis.MicroVMLifecycleRefFromResponse(binding, resp, time.Date(2026, 3, 7, 12, 0, 5, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("h1.3 recovery lifecycle ref: %v", err)
+	}
+	if err := session.ApplyMicroVMLifecycleRef(ref); err != nil {
+		t.Fatalf("h1.3 recovery apply lifecycle ref: %v", err)
+	}
+	return session
+}
+
+// expectHostedGenesisExtractionDispatchWrite mocks the second TransactWrite the
+// H1.3 extraction dispatch path issues to persist the refreshed MicroVM
+// lifecycle ref on the authoritative HostedGenesisSession (the durable status
+// stays declaration_extraction_pending; only the execution/cache ref refreshes).
+// It reuses the TransactWriteBuilder mock a prior debit/progression expectation
+// installed so the two sequential TransactWrite calls share one builder mock.
+func expectHostedGenesisExtractionDispatchWrite(t *testing.T, tdb *mintConversationTestDB) {
+	t.Helper()
+	tb, _ := tdb.db.TransactWriteBuilder.(*ttmocks.MockTransactionBuilder)
+	if tb == nil {
+		tb = new(ttmocks.MockTransactionBuilder)
+		tdb.db.TransactWriteBuilder = tb
+	}
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.HostedGenesisSession"), mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		session := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		if hostedgenesis.NormalizeStatus(session.Status) != hostedgenesis.StatusDeclarationExtractionPending {
+			t.Fatalf("expected extraction dispatch to preserve declaration_extraction_pending, got %#v", session.Status)
+		}
+		if session.MicroVMLifecycleRef == nil || session.MicroVMExecutionID == "" || session.ExecutionStateRef == "" {
+			t.Fatalf("expected extraction dispatch to populate the three MicroVM refs, got %#v", session)
+		}
+	})
+	tb.On("Execute").Return(nil).Once()
+}
+
+// expectHostedGenesisH1D3ReconcileWrite mocks the read-only-ish TransactWrite
+// the H1.3 reconcile path issues when a live VM is observed and the reconciled
+// lifecycle ref is refreshed on the authoritative session (durable pending
+// status preserved). Only the HostedGenesisSession is written.
+func expectHostedGenesisH1D3ReconcileWrite(t *testing.T, tdb *mintConversationTestDB, wantStatus hostedgenesis.Status) {
+	t.Helper()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tdb.db.TransactWriteBuilder = tb
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.HostedGenesisSession"), mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		session := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		if hostedgenesis.NormalizeStatus(session.Status) != wantStatus {
+			t.Fatalf("expected reconcile to preserve %s, got %#v", wantStatus, session.Status)
+		}
+		if session.MicroVMLifecycleRef == nil || session.MicroVMExecutionID == "" || session.ExecutionStateRef == "" {
+			t.Fatalf("expected reconcile to keep the three MicroVM refs populated, got %#v", session)
+		}
+	})
+	tb.On("Execute").Return(nil).Once()
+}
+
+// expectHostedGenesisH1D3TerminalFailureWrite mocks the TransactWrite the H1.3
+// reconcile path issues when a terminal (dead/expired) VM is observed: the
+// session advances to a loud retryable failed status and the conversation row
+// records the microvm_unavailable reason.
+func expectHostedGenesisH1D3TerminalFailureWrite(t *testing.T, tdb *mintConversationTestDB) {
+	t.Helper()
+	tb := new(ttmocks.MockTransactionBuilder)
+	tdb.db.TransactWriteBuilder = tb
+	tdb.db.On("TransactWrite", mock.Anything, mock.Anything).Return(nil).Once()
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.HostedGenesisSession"), mock.Anything, mock.Anything).Return(tb).Once().Run(func(args mock.Arguments) {
+		session := testutil.RequireMockArg[*models.HostedGenesisSession](t, args, 0)
+		if hostedgenesis.NormalizeStatus(session.Status) != hostedgenesis.StatusFailed {
+			t.Fatalf("expected terminal VM to map to loud failed status, got %#v", session.Status)
+		}
+		if session.Failure == nil || session.Failure.Code != hostedgenesis.FailureCodeMicroVMUnavailable {
+			t.Fatalf("expected terminal VM to map to retryable microvm_unavailable failure, got %#v", session.Failure)
+		}
+	})
+	tb.On("UpdateWithBuilder", mock.AnythingOfType("*models.SoulAgentMintConversation"), mock.Anything, mock.Anything).Return(tb).Once()
+	tb.On("Execute").Return(nil).Once()
+}
+
+// TestH1_3_ReconstructionReachableFromProductionUsesControllerGet proves the
+// recover path reaches production reconstruction: for a session with a
+// populated MicroVMLifecycleRef, the recover path queries real VM state through
+// the M16 controller get command via the MicroVMDispatcher.ReconcileMicroVM
+// seam (using the lifecycle ref the accept path set) and refreshes the
+// reconciled ref on the authoritative session. A live VM preserves the durable
+// pending status. This kills G6 (reconstruction was reachable only from the
+// undeployed controller and no-oped without the never-set lifecycle ref).
+func TestH1_3_ReconstructionReachableFromProductionUsesControllerGet(t *testing.T) {
+	tdb, s, reg, dispatcher := hostedGenesisH1D3RecoveryFixture(t, hostedgenesis.StatusInProgress)
+	dispatcher.observedState = runtimemicrovm.StateRunning
+	expectHostedGenesisH1D3ReconcileWrite(t, tdb, hostedgenesis.StatusInProgress)
+
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	if dispatcher.reconcileCalls != 1 {
+		t.Fatalf("expected exactly one M16 controller get reconciliation, got %d", dispatcher.reconcileCalls)
+	}
+	if dispatcher.calls != 0 {
+		t.Fatalf("reconcile path must not re-dispatch a run command for a live VM, got %d run calls", dispatcher.calls)
+	}
+	if dispatcher.lastBinding.ConversationID != mintConversationTestConversationID {
+		t.Fatalf("expected reconciliation bound to the stuck conversation, got %#v", dispatcher.lastBinding)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 reconciled recovery response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusInProgress {
+		t.Fatalf("expected durable in_progress preserved for live VM, got %#v", out.Conversation)
+	}
+}
+
+// TestH1_3_DeadExpiredVMLoudFailureNotNoop proves a dead/expired (terminal) VM
+// observed by production reconstruction maps to a loud retryable
+// microvm_unavailable failed session, not the silent no-op reconstruction had
+// before H1.3. The reconstruction no-op is removed; fail closed and loudly.
+func TestH1_3_DeadExpiredVMLoudFailureNotNoop(t *testing.T) {
+	tdb, s, reg, dispatcher := hostedGenesisH1D3RecoveryFixture(t, hostedgenesis.StatusInProgress)
+	dispatcher.observedState = runtimemicrovm.StateTerminated
+	expectHostedGenesisH1D3TerminalFailureWrite(t, tdb)
+
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	if dispatcher.reconcileCalls != 1 {
+		t.Fatalf("expected one reconciliation query before the terminal failure, got %d", dispatcher.reconcileCalls)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 loud-failure recovery response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusFailed || out.Conversation.Failure == nil {
+		t.Fatalf("expected loud failed status for terminal VM, got %#v", out.Conversation)
+	}
+	if out.Conversation.Failure.Code != hostedGenesisFailureMicroVMUnavailable {
+		t.Fatalf("expected microvm_unavailable failure for terminal VM, got %#v", out.Conversation.Failure)
+	}
+	if !out.Conversation.Failure.Retryable {
+		t.Fatalf("expected terminal-VM failure to be retryable so recover can re-dispatch, got %#v", out.Conversation.Failure)
+	}
+}
+
+// TestH1_3_ReconcileUnavailableIsLoudFailure proves an unwired dispatcher on
+// the recover path is fail-closed and loud: reconstruction is never a silent
+// no-op, and the recover path never falls back to a non-MicroVM path.
+func TestH1_3_ReconcileUnavailableIsLoudFailure(t *testing.T) {
+	_, s, reg, _ := hostedGenesisH1D3RecoveryFixture(t, hostedgenesis.StatusInProgress)
+	s.hostedGenesisMicroVMDispatcher = nil
+	syncLLMCalled := false
+	s.hostedGenesisAssistantRunner = func(_ context.Context, _ hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		syncLLMCalled = true
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+
+	_, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure when dispatcher is unwired")
+	}
+	if syncLLMCalled {
+		t.Fatalf("recover path must not fall back to a synchronous LLM when reconstruction is unavailable")
+	}
+}
+
+// TestH1_3_RecoveryCoversDeclarationExtractionPending proves the recover path
+// covers declaration_extraction_pending: a session in that state with a
+// populated lifecycle ref is routed through production reconstruction (controller
+// get), not left as a permanent trap. A live VM preserves the pending status;
+// the extraction is serviced by the VM (dispatched on the complete path) or
+// fails loudly. This kills G7's permanent-trap half for recovery.
+func TestH1_3_RecoveryCoversDeclarationExtractionPending(t *testing.T) {
+	tdb, s, reg, dispatcher := hostedGenesisH1D3RecoveryFixture(t, hostedgenesis.StatusDeclarationExtractionPending)
+	dispatcher.observedState = runtimemicrovm.StateRunning
+	expectHostedGenesisH1D3ReconcileWrite(t, tdb, hostedgenesis.StatusDeclarationExtractionPending)
+
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	if dispatcher.reconcileCalls != 1 {
+		t.Fatalf("expected declaration_extraction_pending to be covered by controller get reconciliation, got %d", dispatcher.reconcileCalls)
+	}
+	if resp.Status != http.StatusOK {
+		t.Fatalf("expected 200 reconciled recovery response, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationExtractionPending {
+		t.Fatalf("expected durable declaration_extraction_pending preserved for live VM, got %#v", out.Conversation)
+	}
+}
+
+// TestH1_3_ExtractionDispatchIsIdempotentFollowOnRun proves
+// startHostedGenesisDeclarationExtraction dispatches a follow-on M16 controller
+// run command on the same MicroVM session via the dispatcher seam and that a
+// second call for an already-pending session does not re-debit or re-dispatch
+// (the pending status is set once; only the lifecycle ref refreshes). The
+// pending status is not a permanent trap: the VM services the extraction.
+func TestH1_3_ExtractionDispatchIsIdempotentFollowOnRun(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"describe yourself"},{"role":"assistant","content":"ready"}]`),
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
+		LatestTurnID:   "turn-ready",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	expectSoulInstanceMintConversationExtractionDebit(t, tdb)
+	expectHostedGenesisExtractionDispatchWrite(t, tdb)
+
+	ctx := newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	)
+	convCtx, appErr := s.requireSoulInstanceBootstrapConversationContext(ctx)
+	if appErr != nil {
+		t.Fatalf("load conv ctx: %v", appErr)
+	}
+	if err := s.startHostedGenesisDeclarationExtraction(ctx, convCtx); err != nil {
+		t.Fatalf("startHostedGenesisDeclarationExtraction: %v", err)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one follow-on extraction run dispatch, got %d", dispatcher.calls)
+	}
+	if dispatcher.lastBinding.ConversationID != mintConversationTestConversationID {
+		t.Fatalf("expected extraction dispatch bound to the pending conversation, got %#v", dispatcher.lastBinding)
+	}
+	// Calling again on the now-pending session must not re-debit (status already
+	// declaration_extraction_pending) and must not re-dispatch a run command.
+	if err := s.startHostedGenesisDeclarationExtraction(ctx, convCtx); err != nil {
+		t.Fatalf("idempotent second startHostedGenesisDeclarationExtraction: %v", err)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected no second dispatch for an already-pending session, got %d", dispatcher.calls)
+	}
+}
+
+// TestH1_3_ExtractionDispatchUnavailableIsLoud proves an unwired dispatcher on
+// the extraction dispatch path is fail-closed and loud: the pending extraction
+// is never a silent trap and never falls back to a non-MicroVM extraction path.
+func TestH1_3_ExtractionDispatchUnavailableIsLoud(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	s.hostedGenesisMicroVMDispatcher = nil
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"describe yourself"},{"role":"assistant","content":"ready"}]`),
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
+		LatestTurnID:   "turn-ready",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	expectSoulInstanceMintConversationExtractionDebit(t, tdb)
+
+	ctx := newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	)
+	convCtx, appErr := s.requireSoulInstanceBootstrapConversationContext(ctx)
+	if appErr != nil {
+		t.Fatalf("load conv ctx: %v", appErr)
+	}
+	err := s.startHostedGenesisDeclarationExtraction(ctx, convCtx)
+	if err == nil {
+		t.Fatalf("expected loud microvm-unavailable failure when extraction dispatcher is unwired")
+	}
+	if !strings.Contains(err.Error(), "MicroVM extraction dispatch") {
+		t.Fatalf("expected typed microvm-unavailable extraction error, got %v", err)
+	}
+}
+
+// TestH1_3_ReconciliationObservesWorkloadTransitionsIdempotently proves the
+// reconcile path observes the assistant_turn_ready / declaration_ready / failed
+// transitions the H1.1 workload writes to the durable HostedGenesisSession
+// status, and that repeated reconciliation of a live VM is idempotent (the
+// durable status is preserved across reconcile calls; only the non-authoritative
+// lifecycle ref refreshes). The session status is authoritative; the VM get
+// only confirms liveness.
+func TestH1_3_ReconciliationObservesWorkloadTransitionsIdempotently(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        hostedgenesis.Status
+		convStatus    string
+		observed      runtimemicrovm.LifecycleState
+		wantStatus    hostedgenesis.Status
+		wantReconcile bool
+	}{
+		{
+			name:          "assistant_turn_ready workload transition is not re-reconciled",
+			status:        hostedgenesis.StatusAssistantTurnReady,
+			convStatus:    models.SoulMintConversationStatusAssistantTurnReady,
+			observed:      runtimemicrovm.StateRunning,
+			wantStatus:    hostedgenesis.StatusAssistantTurnReady,
+			wantReconcile: false,
+		},
+		{
+			name:          "in_progress live VM reconciles and preserves pending status",
+			status:        hostedgenesis.StatusInProgress,
+			convStatus:    models.SoulMintConversationStatusInProgress,
+			observed:      runtimemicrovm.StateRunning,
+			wantStatus:    hostedgenesis.StatusInProgress,
+			wantReconcile: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			runH1D3ReconciliationObservationCase(t, tc.status, tc.convStatus, tc.observed, tc.wantStatus, tc.wantReconcile)
+		})
+	}
+}
+
+// runH1D3ReconciliationObservationCase runs one reconciliation-observation case:
+// a recover request against a session in the given status. A workload-advanced
+// status (wantReconcile=false) is returned as-is with no controller get; a
+// pending in_progress status (wantReconcile=true) is reconciled via controller
+// get and the durable status preserved.
+func runH1D3ReconciliationObservationCase(t *testing.T, status hostedgenesis.Status, convStatus string, observed runtimemicrovm.LifecycleState, wantStatus hostedgenesis.Status, wantReconcile bool) {
+	t.Helper()
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	dispatcher := &stubMicroVMDispatcher{t: t, observedState: observed}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubSoulInstanceRecoveryConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"stuck user turn"},{"role":"assistant","content":"ready"}]`),
+		Status:         convStatus,
+		LatestTurnID:   "turn-stuck",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	if wantReconcile {
+		stubSoulInstanceRecoverySession(t, tdb, hostedGenesisH1D3RecoverySessionFixture(t, reg, status))
+		expectHostedGenesisH1D3ReconcileWrite(t, tdb, wantStatus)
+	} else {
+		stubSoulInstanceRecoverySession(t, tdb, hostedGenesisRecoverySessionFixture(t, reg, status, "checkpoint://hosted-genesis/conv-1/assistant/turn-ready"))
+	}
+	resp, err := s.handleSoulInstanceRecoverMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected recovery err: %v", err)
+	}
+	wantReconcileCalls := 0
+	if wantReconcile {
+		wantReconcileCalls = 1
+	}
+	if dispatcher.reconcileCalls != wantReconcileCalls {
+		t.Fatalf("expected %d controller get reconciliation(s), got %d", wantReconcileCalls, dispatcher.reconcileCalls)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if hostedgenesis.NormalizeStatus(out.Conversation.Status) != wantStatus {
+		t.Fatalf("expected durable status %s, got %#v", wantStatus, out.Conversation.Status)
+	}
+}
+
+// TestH1_3_CompleteAssistantReadyWithoutDeclarationsDispatchesExtraction proves
+// the complete path services a declaration_extraction_pending transition by
+// dispatching a follow-on M16 controller run command on the same MicroVM
+// session via the dispatcher seam (not by enqueuing SQS authority). The pending
+// extraction is VM-serviced; the pending status is not a permanent trap. This
+// is the production extraction-dispatch reachability site (kills G7).
+func TestH1_3_CompleteAssistantReadyWithoutDeclarationsDispatchesExtraction(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	s.enqueueHostedGenesisMessage = func(_ context.Context, msg hostedgenesis.QueueMessage) error {
+		t.Fatalf("user-visible declaration extraction handoff must not enqueue SQS authority: %#v", msg)
+		return nil
+	}
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationConversation(t, tdb, models.SoulAgentMintConversation{
+		AgentID:        reg.AgentID,
+		ConversationID: mintConversationTestConversationID,
+		Model:          "anthropic:claude-sonnet-4-6",
+		Messages:       encodeMintConversationBlob(`[{"role":"user","content":"describe yourself"},{"role":"assistant","content":"ready"}]`),
+		Status:         models.SoulMintConversationStatusAssistantTurnReady,
+		LatestTurnID:   "turn-ready",
+		CreatedAt:      time.Date(2026, 3, 7, 12, 0, 0, 0, time.UTC),
+	})
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	expectSoulInstanceMintConversationExtractionDebit(t, tdb)
+	expectHostedGenesisExtractionDispatchWrite(t, tdb)
+
+	resp, err := s.handleSoulInstanceCompleteMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		nil,
+		map[string]string{"id": reg.ID, "conversationId": mintConversationTestConversationID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("expected 202, got %#v", resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.Conversation.Status != models.SoulMintConversationStatusDeclarationExtractionPending || out.Conversation.ProducedDeclarations != nil {
+		t.Fatalf("expected declaration extraction progress without terminal declarations, got %#v", out)
+	}
+	if dispatcher.calls != 1 {
+		t.Fatalf("expected exactly one follow-on M16 extraction run dispatch, got %d", dispatcher.calls)
+	}
+	if dispatcher.lastBinding.ConversationID != mintConversationTestConversationID {
+		t.Fatalf("expected extraction dispatch bound to the pending conversation, got %#v", dispatcher.lastBinding)
+	}
+}

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/crypto"
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 	"github.com/theory-cloud/tabletheory/pkg/core"
 	theoryErrors "github.com/theory-cloud/tabletheory/pkg/errors"
 	ttmocks "github.com/theory-cloud/tabletheory/pkg/mocks"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/equaltoai/lesser-host/internal/ai/llm"
 	"github.com/equaltoai/lesser-host/internal/config"
+	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/soul"
 	"github.com/equaltoai/lesser-host/internal/store"
 	"github.com/equaltoai/lesser-host/internal/store/models"
@@ -212,6 +214,65 @@ func stubHostedGenesisAssistantRunner(t *testing.T, s *Server, response string, 
 			usage:        models.AIUsage{Provider: "test", Model: in.modelSet, InputTokens: 1, OutputTokens: 1, TotalTokens: 2},
 		}, runErr
 	}
+}
+
+// stubHostedGenesisMicroVMDispatcher wires a stub MicroVMDispatcher that records
+// the binding the accept path dispatched and returns a validated in_progress
+// lifecycle ref. It asserts the sync assistant runner is NOT invoked so the
+// accept path is proven dispatch-only.
+func stubHostedGenesisMicroVMDispatcher(t *testing.T, s *Server) *stubMicroVMDispatcher {
+	t.Helper()
+	dispatcher := &stubMicroVMDispatcher{t: t}
+	s.hostedGenesisMicroVMDispatcher = dispatcher
+	// Guard the synchronous runner seam: H1.2 makes the production accept path
+	// dispatch-only, so the sync assistant runner must never be reached.
+	s.hostedGenesisAssistantRunner = func(_ context.Context, _ hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error) {
+		t.Fatalf("synchronous assistant runner must not be invoked on the dispatch-only accept path")
+		return hostedGenesisAssistantRunResult{}, nil
+	}
+	return dispatcher
+}
+
+type stubMicroVMDispatcher struct {
+	t           *testing.T
+	calls       int
+	lastBinding hostedgenesis.MicroVMSessionBinding
+	dispatchErr error
+}
+
+func (d *stubMicroVMDispatcher) DispatchMicroVMRun(ctx context.Context, requestID string, binding hostedgenesis.MicroVMSessionBinding) (hostedgenesis.MicroVMDispatchResult, error) {
+	d.t.Helper()
+	d.calls++
+	d.lastBinding = binding
+	if d.dispatchErr != nil {
+		return hostedgenesis.MicroVMDispatchResult{}, d.dispatchErr
+	}
+	if err := binding.Validate(); err != nil {
+		d.t.Fatalf("stub dispatcher received invalid binding: %v", err)
+	}
+	if strings.TrimSpace(requestID) == "" {
+		d.t.Fatalf("stub dispatcher received empty request id")
+	}
+	resp := runtimemicrovm.ControllerResponse{
+		Command:           runtimemicrovm.CommandRun,
+		RequestID:         requestID,
+		TenantID:          binding.TenantID(),
+		Namespace:         hostedgenesis.MicroVMNamespace,
+		SessionID:         strings.TrimSpace(binding.ConversationID),
+		State:             runtimemicrovm.StateRunning,
+		DesiredState:      runtimemicrovm.StateRunning,
+		LifecycleState:    runtimemicrovm.StateRunning,
+		MicroVMID:         "mv-stub-" + strings.TrimSpace(binding.ConversationID),
+		ProviderMicroVMID: "mv-stub-" + strings.TrimSpace(binding.ConversationID),
+		LastAction:        runtimemicrovm.CommandRun,
+		LastTransition:    time.Now().UTC(),
+		RegistryVersion:   1,
+	}
+	ref, err := hostedgenesis.MicroVMLifecycleRefFromResponse(binding, resp, time.Now().UTC())
+	if err != nil {
+		d.t.Fatalf("stub dispatcher failed to build lifecycle ref: %v", err)
+	}
+	return hostedgenesis.MicroVMDispatchResult{LifecycleRef: ref, SessionID: resp.SessionID}, nil
 }
 
 func stubMintConversationRegistration(t *testing.T, tdb *mintConversationTestDB, reg models.SoulAgentRegistration) {

--- a/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_more_internal_test.go
@@ -234,10 +234,15 @@ func stubHostedGenesisMicroVMDispatcher(t *testing.T, s *Server) *stubMicroVMDis
 }
 
 type stubMicroVMDispatcher struct {
-	t           *testing.T
-	calls       int
-	lastBinding hostedgenesis.MicroVMSessionBinding
-	dispatchErr error
+	t              *testing.T
+	calls          int
+	reconcileCalls int
+	lastBinding    hostedgenesis.MicroVMSessionBinding
+	dispatchErr    error
+	reconcileErr   error
+	// observedState is the lifecycle state the stub reports from a controller
+	// get reconciliation (defaults to running/non-terminal).
+	observedState runtimemicrovm.LifecycleState
 }
 
 func (d *stubMicroVMDispatcher) DispatchMicroVMRun(ctx context.Context, requestID string, binding hostedgenesis.MicroVMSessionBinding) (hostedgenesis.MicroVMDispatchResult, error) {
@@ -273,6 +278,51 @@ func (d *stubMicroVMDispatcher) DispatchMicroVMRun(ctx context.Context, requestI
 		d.t.Fatalf("stub dispatcher failed to build lifecycle ref: %v", err)
 	}
 	return hostedgenesis.MicroVMDispatchResult{LifecycleRef: ref, SessionID: resp.SessionID}, nil
+}
+
+// ReconcileMicroVM is the stub's controller get reconciliation. It mirrors the
+// production seam: it fails closed on a configured reconcileErr, otherwise it
+// reports the configured observedState (defaulting to running) and reconciles
+// the lifecycle ref via the canonical ReconcileMicroVMRegistryStatus so the
+// control-plane reconciliation path observes the same shape production does.
+func (d *stubMicroVMDispatcher) ReconcileMicroVM(ctx context.Context, requestID string, binding hostedgenesis.MicroVMSessionBinding, ref hostedgenesis.MicroVMLifecycleRef) (hostedgenesis.MicroVMReconcileResult, error) {
+	d.t.Helper()
+	d.reconcileCalls++
+	d.lastBinding = binding
+	if d.reconcileErr != nil {
+		return hostedgenesis.MicroVMReconcileResult{}, d.reconcileErr
+	}
+	if err := binding.Validate(); err != nil {
+		d.t.Fatalf("stub dispatcher received invalid binding: %v", err)
+	}
+	if strings.TrimSpace(requestID) == "" {
+		d.t.Fatalf("stub dispatcher received empty request id")
+	}
+	observed := d.observedState
+	if observed == "" {
+		observed = runtimemicrovm.StateRunning
+	}
+	status := runtimemicrovm.SessionStatus{
+		TenantID:        binding.TenantID(),
+		Namespace:       hostedgenesis.MicroVMNamespace,
+		SessionID:       strings.TrimSpace(binding.ConversationID),
+		State:           observed,
+		DesiredState:    observed,
+		LifecycleState:  observed,
+		MicroVMID:       ref.MicroVMID,
+		LastAction:      runtimemicrovm.CommandGet,
+		LastTransition:  time.Now().UTC(),
+		RegistryVersion: ref.RegistryVersion,
+	}
+	reconciled, err := hostedgenesis.ReconcileMicroVMRegistryStatus(binding, ref, status)
+	if err != nil {
+		d.t.Fatalf("stub dispatcher failed to reconcile lifecycle ref: %v", err)
+	}
+	return hostedgenesis.MicroVMReconcileResult{
+		LifecycleRef: reconciled,
+		SessionID:    strings.TrimSpace(binding.ConversationID),
+		Terminal:     runtimemicrovm.IsTerminalState(reconciled.LifecycleState),
+	}, nil
 }
 
 func stubMintConversationRegistration(t *testing.T, tdb *mintConversationTestDB, reg models.SoulAgentRegistration) {

--- a/internal/controlplane/handlers_soul_mint_conversation_recover.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_recover.go
@@ -1,16 +1,26 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 	"time"
 
 	apptheory "github.com/theory-cloud/apptheory/runtime"
+	"github.com/theory-cloud/tabletheory"
+	"github.com/theory-cloud/tabletheory/pkg/core"
 
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
+
+// hostedGenesisRecoveryReconcileTimeout bounds the M16 controller get
+// dispatch on the production recover path. Reconstruction queries real VM
+// state through the constrained controller; it must fail closed within a
+// bounded window rather than hang the recover request.
+const hostedGenesisRecoveryReconcileTimeout = 10 * time.Second
 
 func (s *Server) handleSoulInstanceRecoverMintConversation(ctx *apptheory.Context) (*apptheory.Response, error) {
 	started := time.Now().UTC()
@@ -36,6 +46,39 @@ func (s *Server) handleSoulInstanceRecoverMintConversation(ctx *apptheory.Contex
 		return resp, nil
 	}
 
+	// H1.3: when the session already carries a populated MicroVM lifecycle ref
+	// (set by the H1.2 accept-path dispatch or the H1.3 extraction dispatch),
+	// the recover path reaches production reconstruction by querying real VM
+	// state through the M16 controller get command via the MicroVMDispatcher
+	// seam. A dead/expired VM maps to a loud typed failure, never the silent
+	// no-op reconstruction had before. A live VM that has not yet advanced the
+	// durable Host status is returned as still-pending; the H1.1 workload's
+	// assistant_turn_ready / declaration_ready / failed transitions are the
+	// authoritative status advances Host reconciles against.
+	if hostedGenesisSessionNeedsMicroVMReconciliation(convCtx.session) {
+		reconciled, reconcileErr := s.reconcileHostedGenesisMicroVMRecovery(ctx, convCtx)
+		if reconcileErr != nil {
+			return nil, soulInstanceBootstrapConversationErrorFromAppError(reconcileErr)
+		}
+		resp, err := hostedGenesisConversationJSONFromSession(reconciled.httpStatus, reconciled.session, reconciled.conv, hostedGenesisProjectionOptions{
+			RegistrationID:  convCtx.reg.ID,
+			RequestID:       strings.TrimSpace(ctx.RequestID),
+			CollapseCreated: true,
+		})
+		if err != nil {
+			return nil, err
+		}
+		auditOutcome := "reconciled"
+		if reconciled.terminalFailure {
+			auditOutcome = "microvm_terminal"
+		}
+		s.recordSoulMintInstanceReadAudit(ctx, convCtx.key, convCtx.agentIDHex, convCtx.conversationID, soulMintInstanceReadRouteRecover, auditOutcome, resp.Status, len(resp.Body), started)
+		return resp, nil
+	}
+
+	// No MicroVM lifecycle ref is populated: the session predates the H1.2
+	// dispatch wiring (or the dispatch never landed). Re-dispatch the accepted
+	// turn through the MicroVM path rather than silently stranding the turn.
 	turnSession, acceptedMessages, buildErr := hostedGenesisRecoveryTurnSession(convCtx)
 	if buildErr != nil {
 		return nil, soulInstanceBootstrapConversationErrorFromAppError(buildErr)
@@ -69,11 +112,158 @@ func (s *Server) handleSoulInstanceRecoverMintConversation(ctx *apptheory.Contex
 	return resp, nil
 }
 
+// hostedGenesisMicroVMRecoveryResult is the bounded outcome of a production
+// recover-path reconstruction. terminalFailure is true when the MicroVM was
+// observed in a terminal state and the session was persisted as a loud failed
+// turn; otherwise the session reflects the reconciled (still-pending or
+// workload-advanced) durable status.
+type hostedGenesisMicroVMRecoveryResult struct {
+	session         *models.HostedGenesisSession
+	conv            *models.SoulAgentMintConversation
+	httpStatus      int
+	terminalFailure bool
+}
+
+// hostedGenesisSessionNeedsMicroVMReconciliation reports whether the recover
+// path should reach production reconstruction via the M16 controller get
+// command. A session needs reconstruction when it sits in a MicroVM-serviced
+// pending state (in_progress assistant turn, or declaration_extraction_pending)
+// and already carries the populated lifecycle ref the H1.2 accept path (or H1.3
+// extraction dispatch) recorded. Sessions without a lifecycle ref fall through
+// to the re-dispatch path.
+func hostedGenesisSessionNeedsMicroVMReconciliation(session *models.HostedGenesisSession) bool {
+	if session == nil || session.MicroVMLifecycleRef == nil {
+		return false
+	}
+	status := hostedgenesis.NormalizeStatus(session.Status)
+	if status != hostedgenesis.StatusInProgress && status != hostedgenesis.StatusDeclarationExtractionPending {
+		return false
+	}
+	return strings.TrimSpace(session.ExecutionStateRef) != "" && strings.TrimSpace(session.MicroVMExecutionID) != ""
+}
+
+// reconcileHostedGenesisMicroVMRecovery is the production reconstruction
+// reachability site (kills G6). It queries real VM state through the M16
+// controller get command via the MicroVMDispatcher seam, using the lifecycle
+// ref the accept path populated, and reconciles the durable HostedGenesisSession:
+//
+//   - A dead/expired (terminal) VM is mapped to a loud retryable
+//     microvm_unavailable failed session. Reconstruction no longer no-ops.
+//   - A live VM whose durable status has not advanced is returned as
+//     still-pending (the H1.1 workload owns the
+//     assistant_turn_ready / declaration_ready / failed transitions).
+//
+// An unwired dispatcher is fail-closed and loud: reconstruction is never a
+// silent no-op, and the recover path never falls back to a non-MicroVM path.
+func (s *Server) reconcileHostedGenesisMicroVMRecovery(ctx *apptheory.Context, convCtx soulInstanceBootstrapConversationContext) (hostedGenesisMicroVMRecoveryResult, *apptheory.AppError) {
+	if convCtx.session == nil || convCtx.session.MicroVMLifecycleRef == nil {
+		return hostedGenesisMicroVMRecoveryResult{}, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution state is unavailable for recovery"}
+	}
+	if s.hostedGenesisMicroVMDispatcher == nil {
+		log.Printf("controlplane: hosted genesis microvm reconciliation unavailable agent_hash=%s conversation_hash=%s", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID))
+		return hostedGenesisMicroVMRecoveryResult{}, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM reconstruction is unavailable"}
+	}
+	binding := convCtx.session.MicroVMSessionBinding()
+	if err := binding.Validate(); err != nil {
+		log.Printf("controlplane: hosted genesis microvm recovery binding invalid agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), err)
+		return hostedGenesisMicroVMRecoveryResult{}, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM execution binding is invalid for recovery"}
+	}
+	ref := *convCtx.session.MicroVMLifecycleRef
+	reconcileCtx, cancel := context.WithTimeout(detachedMintConversationContext(ctx.Context()), hostedGenesisRecoveryReconcileTimeout)
+	defer cancel()
+	result, reconcileErr := s.hostedGenesisMicroVMDispatcher.ReconcileMicroVM(reconcileCtx, strings.TrimSpace(ctx.RequestID), binding, ref)
+	if reconcileErr != nil {
+		log.Printf("controlplane: hosted genesis microvm reconciliation failed agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), reconcileErr)
+		return hostedGenesisMicroVMRecoveryResult{}, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM reconstruction failed"}
+	}
+	if result.Terminal {
+		// The VM is dead/expired while the durable Host status has not advanced
+		// to a workload completion. This is the silent no-op reconstruction had
+		// before H1.3; it is now a loud retryable failure so the operator sees
+		// the stuck turn and the recover path can re-dispatch on retry.
+		failedSession, failedConv, appErr := s.persistHostedGenesisMicroVMRecoveryFailure(ctx, convCtx, hostedGenesisFailureMicroVMUnavailable)
+		if appErr != nil {
+			return hostedGenesisMicroVMRecoveryResult{}, appErr
+		}
+		return hostedGenesisMicroVMRecoveryResult{session: failedSession, conv: failedConv, httpStatus: http.StatusOK, terminalFailure: true}, nil
+	}
+	// Live VM: apply the reconciled lifecycle ref idempotently and return the
+	// current durable status. The HostedGenesisSession status is authoritative;
+	// the reconciled ref only refreshes non-authoritative execution/cache state.
+	reconciledSession := cloneHostedGenesisSession(convCtx.session)
+	if err := reconciledSession.ApplyMicroVMLifecycleRef(result.LifecycleRef); err != nil {
+		log.Printf("controlplane: hosted genesis microvm reconciled ref rejected agent_hash=%s conversation_hash=%s err=%v", soulMintInstanceReadAuditHash(convCtx.agentIDHex), soulMintInstanceReadAuditHash(convCtx.conversationID), err)
+		return hostedGenesisMicroVMRecoveryResult{}, &apptheory.AppError{Code: appErrCodeMicroVMUnavailable, Message: "MicroVM reconciled state is invalid for recovery"}
+	}
+	reconciledSession.RequestID = strings.TrimSpace(ctx.RequestID)
+	reconciledSession.UpdatedAt = time.Now().UTC()
+	return hostedGenesisMicroVMRecoveryResult{session: reconciledSession, conv: convCtx.conv, httpStatus: http.StatusOK}, nil
+}
+
+// persistHostedGenesisMicroVMRecoveryFailure records a loud retryable failed
+// session when production reconstruction observes a terminal (dead/expired)
+// MicroVM. Unlike the accept-path failure helper, the expected status is the
+// session's actual pending status (in_progress or declaration_extraction_pending)
+// so the TableTheory status condition matches the authoritative row and the
+// transition to failed is validated against the real prior state. The stored
+// transcript is preserved (no re-run of the assistant); only the failure and
+// status advance are written.
+func (s *Server) persistHostedGenesisMicroVMRecoveryFailure(ctx *apptheory.Context, convCtx soulInstanceBootstrapConversationContext, reason string) (*models.HostedGenesisSession, *models.SoulAgentMintConversation, *apptheory.AppError) {
+	if s == nil || s.store == nil || s.store.DB == nil || convCtx.session == nil || convCtx.conv == nil {
+		return nil, nil, &apptheory.AppError{Code: "app.internal", Message: "internal error"}
+	}
+	now := time.Now().UTC()
+	expectedStatus := hostedgenesis.NormalizeStatus(convCtx.session.Status)
+	failedSession := cloneHostedGenesisSession(convCtx.session)
+	failedConv := cloneSoulAgentMintConversation(convCtx.conv)
+	failedSession.Status = string(hostedgenesis.StatusFailed)
+	failedSession.Failure = hostedGenesisSessionFailureFromReason(reason)
+	failedSession.RequestID = strings.TrimSpace(ctx.RequestID)
+	failedSession.UpdatedAt = now
+	failedSession.CompletedAt = now
+	failedConv.Status = models.SoulMintConversationStatusFailed
+	failedConv.StatusReason = strings.TrimSpace(reason)
+	failedConv.RequestID = strings.TrimSpace(ctx.RequestID)
+	failedConv.UpdatedAt = now
+	failedConv.CompletedAt = now
+	updateConv := &models.SoulAgentMintConversation{
+		AgentID:        failedConv.AgentID,
+		ConversationID: failedConv.ConversationID,
+	}
+	_ = updateConv.UpdateKeys()
+	if err := s.store.DB.TransactWrite(ctx.Context(), func(tx core.TransactionBuilder) error {
+		if err := addHostedGenesisSessionWrite(tx, failedSession, false, convCtx.session.Version, expectedStatus); err != nil {
+			return err
+		}
+		tx.UpdateWithBuilder(updateConv, func(ub core.UpdateBuilder) error {
+			ub.Set("Status", failedConv.Status)
+			ub.Set("StatusReason", strings.TrimSpace(reason))
+			ub.Set("RequestID", failedConv.RequestID)
+			ub.Set("UpdatedAt", now)
+			ub.Set("CompletedAt", failedConv.CompletedAt)
+			return nil
+		}, tabletheory.IfExists())
+		return nil
+	}); err != nil {
+		log.Printf("controlplane: hosted genesis microvm recovery failure persist failed agent_hash=%s conversation_hash=%s status=%s err=%v", soulMintInstanceReadAuditHash(failedConv.AgentID), soulMintInstanceReadAuditHash(failedConv.ConversationID), failedSession.Status, err)
+		return nil, nil, &apptheory.AppError{Code: "app.internal", Message: "failed to persist recovery failure"}
+	}
+	return failedSession, failedConv, nil
+}
+
 func hostedGenesisSessionNeedsAssistantRecovery(session *models.HostedGenesisSession) bool {
 	if session == nil {
 		return false
 	}
-	return hostedgenesis.NormalizeStatus(session.Status) == hostedgenesis.StatusInProgress &&
+	status := hostedgenesis.NormalizeStatus(session.Status)
+	// H1.3: the recover path covers declaration_extraction_pending as well as
+	// in_progress assistant turns. Both are MicroVM-serviced pending states;
+	// routing them through the recover path kills the permanent trap where
+	// declaration_extraction_pending could never be serviced or failed loudly.
+	if status == hostedgenesis.StatusDeclarationExtractionPending {
+		return true
+	}
+	return status == hostedgenesis.StatusInProgress &&
 		strings.TrimSpace(session.AssistantCheckpointRef) == ""
 }
 

--- a/internal/controlplane/handlers_soul_mint_conversation_status.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_status.go
@@ -31,6 +31,7 @@ const (
 	hostedGenesisFailureInvalidProducedDeclarations = "invalid_produced_declarations"
 	hostedGenesisFailureTenantBoundaryViolation     = "tenant_boundary_violation"
 	hostedGenesisFailureOperatorActionRequired      = "operator_action_required"
+	hostedGenesisFailureMicroVMUnavailable          = "microvm_unavailable"
 	hostedGenesisRecoveryRefreshState               = "refresh_state"
 	hostedGenesisRecoveryRetrySameStep              = "retry_same_step"
 	hostedGenesisRecoveryRestartSoulBootstrap       = "restart_soul_bootstrap"
@@ -421,7 +422,7 @@ func buildHostedGenesisProducedDeclarations(conv *models.SoulAgentMintConversati
 
 func hostedGenesisFailureFromReason(reason string) *hostedGenesisFailure {
 	code := normalizeHostedGenesisFailureCode(reason)
-	retryable := code == hostedGenesisFailureLLMUnavailable || code == hostedGenesisFailureAssistantTurnFailed || code == hostedGenesisFailureDeclarationExtractionFailed
+	retryable := code == hostedGenesisFailureLLMUnavailable || code == hostedGenesisFailureAssistantTurnFailed || code == hostedGenesisFailureDeclarationExtractionFailed || code == hostedGenesisFailureMicroVMUnavailable
 	recovery := hostedGenesisFailureRecovery{Action: hostedGenesisRecoveryRefreshState, Reason: code}
 	if retryable {
 		recovery.Action = hostedGenesisRecoveryRetrySameStep
@@ -451,7 +452,8 @@ func normalizeHostedGenesisFailureCode(reason string) string {
 		hostedGenesisFailureMissingProducedDeclarations,
 		hostedGenesisFailureInvalidProducedDeclarations,
 		hostedGenesisFailureTenantBoundaryViolation,
-		hostedGenesisFailureOperatorActionRequired:
+		hostedGenesisFailureOperatorActionRequired,
+		hostedGenesisFailureMicroVMUnavailable:
 		return strings.TrimSpace(reason)
 	default:
 		return hostedGenesisFailureAssistantTurnFailed
@@ -474,6 +476,8 @@ func hostedGenesisFailureMessage(code string) string {
 		return "Conversation failed instance boundary validation."
 	case hostedGenesisFailureOperatorActionRequired:
 		return "Operator action is required."
+	case hostedGenesisFailureMicroVMUnavailable:
+		return "MicroVM execution dispatch is unavailable."
 	default:
 		return "Assistant turn failed before declaration extraction."
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -60,6 +60,19 @@ type Server struct {
 	enqueueCommMessage           func(ctx context.Context, msg commworker.QueueMessage) error
 	enqueueHostedGenesisMessage  func(ctx context.Context, msg hostedgenesis.QueueMessage) error
 	hostedGenesisAssistantRunner func(ctx context.Context, in hostedGenesisAssistantRunInput) (hostedGenesisAssistantRunResult, error)
+	// hostedGenesisMicroVMDispatcher is the M16 controller run dispatch seam for
+	// the hosted genesis accept path. When wired, the accept path dispatches the
+	// MicroVM and returns 202 in_progress. When nil the accept path fails closed
+	// and loudly rather than falling back to a synchronous control-plane LLM
+	// call, unless hostedGenesisSyncAssistantFallbackEnabled is explicitly set
+	// true (a non-production/test-only guard that H2.1 deletes along with the
+	// sync runner). Production never sets that guard.
+	hostedGenesisMicroVMDispatcher hostedgenesis.MicroVMDispatcher
+	// hostedGenesisSyncAssistantFallbackEnabled is a non-production/test-only
+	// guard that keeps the retained synchronous assistant runner reachable until
+	// H2.1 deletes it. It defaults false; production must never enable it. When
+	// false (and no dispatcher is wired) the accept path fails closed and loudly.
+	hostedGenesisSyncAssistantFallbackEnabled bool
 
 	// paymentsProviderFactory is a test-injection hook. When non-nil, handlers
 	// use it instead of payments.NewProvider.

--- a/internal/hostedgenesis/dispatch.go
+++ b/internal/hostedgenesis/dispatch.go
@@ -1,0 +1,88 @@
+package hostedgenesis
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+)
+
+// ErrMicroVMDispatchUnavailable is the fail-closed error returned when the
+// hosted-genesis accept path cannot dispatch a MicroVM controller run command.
+// It is never a license to fall back to a synchronous control-plane LLM call;
+// callers must surface it loudly (typed AppError) and persist a failed turn.
+var ErrMicroVMDispatchUnavailable = errors.New("hosted genesis microvm dispatch is unavailable")
+
+// MicroVMDispatchResult is the safe, non-secret outcome of a controller run
+// dispatch: the validated execution/cache lifecycle ref Host records on the
+// HostedGenesisSession, plus the AppTheory session id the controller allocated.
+// It deliberately excludes endpoint auth tokens, bearer tokens, raw lifecycle
+// payloads, transcripts, and provider credentials.
+type MicroVMDispatchResult struct {
+	LifecycleRef MicroVMLifecycleRef
+	SessionID    string
+}
+
+// MicroVMDispatcher is the control-plane dispatch boundary for the hosted
+// genesis MicroVM execution path. The accept path calls DispatchMicroVMRun
+// after the HostedGenesisSession accepted turn is durably committed; the
+// dispatcher invokes the AppTheory M16 controller run command through the
+// constrained provider adapter (no raw AWS SDK) and returns the validated
+// lifecycle ref Host records as non-authoritative execution/cache state.
+//
+// A nil/unwired dispatcher is fail-closed: the accept path must not fall back
+// to a synchronous in-request LLM call. Transport selection (in-process
+// controller runtime versus the lab-only controller Lambda HTTP route) is
+// encapsulated behind this seam; the control plane never handles raw provider
+// SDK clients, bearer tokens, or lifecycle hook payloads.
+type MicroVMDispatcher interface {
+	DispatchMicroVMRun(ctx context.Context, requestID string, binding MicroVMSessionBinding) (MicroVMDispatchResult, error)
+}
+
+// ControllerRuntimeDispatcher adapts an AppTheory M16 MicroVMControllerRuntime
+// into the MicroVMDispatcher contract. It issues a run command for the already
+// committed Host session binding and converts the safe controller envelope into
+// Host's compact, validated lifecycle ref.
+type ControllerRuntimeDispatcher struct {
+	runtime *MicroVMControllerRuntime
+}
+
+// NewControllerRuntimeDispatcher wraps a MicroVMControllerRuntime so the control
+// plane can dispatch controller run commands through the MicroVMDispatcher seam.
+// A nil runtime yields a fail-closed dispatcher.
+func NewControllerRuntimeDispatcher(runtime *MicroVMControllerRuntime) *ControllerRuntimeDispatcher {
+	return &ControllerRuntimeDispatcher{runtime: runtime}
+}
+
+// DispatchMicroVMRun issues the AppTheory M16 run command for the binding and
+// records the validated lifecycle ref. It fails closed when the runtime is nil
+// or the controller rejects the request; it never falls back to a local
+// execution path.
+func (d *ControllerRuntimeDispatcher) DispatchMicroVMRun(ctx context.Context, requestID string, binding MicroVMSessionBinding) (MicroVMDispatchResult, error) {
+	if d == nil || d.runtime == nil {
+		return MicroVMDispatchResult{}, ErrMicroVMDispatchUnavailable
+	}
+	if err := binding.Validate(); err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return MicroVMDispatchResult{}, ErrMicroVMDispatchUnavailable
+	}
+	resp, err := d.runtime.Run(ctx, requestID, binding)
+	if err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	if resp.Error != nil && resp.Error.Code != "" {
+		return MicroVMDispatchResult{}, resp.Error
+	}
+	observedAt := time.Now().UTC()
+	if !resp.LastTransition.IsZero() {
+		observedAt = resp.LastTransition.UTC()
+	}
+	ref, err := MicroVMLifecycleRefFromResponse(binding, resp, observedAt)
+	if err != nil {
+		return MicroVMDispatchResult{}, err
+	}
+	return MicroVMDispatchResult{LifecycleRef: ref, SessionID: strings.TrimSpace(resp.SessionID)}, nil
+}

--- a/internal/hostedgenesis/dispatch.go
+++ b/internal/hostedgenesis/dispatch.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"strings"
 	"time"
+
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 )
 
 // ErrMicroVMDispatchUnavailable is the fail-closed error returned when the
@@ -23,6 +25,21 @@ type MicroVMDispatchResult struct {
 	SessionID    string
 }
 
+// MicroVMReconcileResult is the safe, non-secret outcome of a controller get
+// dispatch: the AppTheory session id queried and the reconciled execution/cache
+// lifecycle ref reflecting real VM state observed by the controller. Like
+// MicroVMDispatchResult it excludes endpoint auth tokens, bearer tokens, raw
+// lifecycle payloads, transcripts, and provider credentials.
+//
+// Terminal reports whether the observed lifecycle state is a terminal MicroVM
+// state (terminated/failed) so the control plane can map a dead/expired VM to a
+// loud failure instead of silently no-oping reconstruction.
+type MicroVMReconcileResult struct {
+	LifecycleRef MicroVMLifecycleRef
+	SessionID    string
+	Terminal     bool
+}
+
 // MicroVMDispatcher is the control-plane dispatch boundary for the hosted
 // genesis MicroVM execution path. The accept path calls DispatchMicroVMRun
 // after the HostedGenesisSession accepted turn is durably committed; the
@@ -30,13 +47,24 @@ type MicroVMDispatchResult struct {
 // constrained provider adapter (no raw AWS SDK) and returns the validated
 // lifecycle ref Host records as non-authoritative execution/cache state.
 //
+// ReconcileMicroVM issues the M16 controller get command for an existing
+// execution/cache ref so the control plane can observe real VM state and
+// reconcile the HostedGenesisSession. It is the production reconstruction
+// reachability site: the controller get drives the AppTheory reconstructing
+// session registry (Host's reconstruction hook fires on cache miss) and the
+// provider Get (real VM state). A dead/expired VM is reported as Terminal with
+// the reconciled ref; callers must map terminal state to a loud failure, never
+// a silent no-op.
+//
 // A nil/unwired dispatcher is fail-closed: the accept path must not fall back
-// to a synchronous in-request LLM call. Transport selection (in-process
-// controller runtime versus the lab-only controller Lambda HTTP route) is
-// encapsulated behind this seam; the control plane never handles raw provider
-// SDK clients, bearer tokens, or lifecycle hook payloads.
+// to a synchronous in-request LLM call, and the reconcile path must not treat
+// an unwired dispatcher as a successful no-op reconstruction. Transport
+// selection (in-process controller runtime versus the lab-only controller
+// Lambda HTTP route) is encapsulated behind this seam; the control plane never
+// handles raw provider SDK clients, bearer tokens, or lifecycle hook payloads.
 type MicroVMDispatcher interface {
 	DispatchMicroVMRun(ctx context.Context, requestID string, binding MicroVMSessionBinding) (MicroVMDispatchResult, error)
+	ReconcileMicroVM(ctx context.Context, requestID string, binding MicroVMSessionBinding, ref MicroVMLifecycleRef) (MicroVMReconcileResult, error)
 }
 
 // ControllerRuntimeDispatcher adapts an AppTheory M16 MicroVMControllerRuntime
@@ -85,4 +113,61 @@ func (d *ControllerRuntimeDispatcher) DispatchMicroVMRun(ctx context.Context, re
 		return MicroVMDispatchResult{}, err
 	}
 	return MicroVMDispatchResult{LifecycleRef: ref, SessionID: strings.TrimSpace(resp.SessionID)}, nil
+}
+
+// ReconcileMicroVM issues the AppTheory M16 get command for the binding's
+// existing execution/cache session and returns the reconciled lifecycle ref
+// reflecting real VM state. It fails closed when the runtime is nil, the
+// controller rejects the request, or the observed state no longer maps to the
+// Host session binding (stale/tenant mismatch). It never falls back to a local
+// execution path and never swallows a dead/expired VM as a silent no-op:
+// terminal observed state is reported via Terminal=true so the caller maps it
+// to a loud failure.
+func (d *ControllerRuntimeDispatcher) ReconcileMicroVM(ctx context.Context, requestID string, binding MicroVMSessionBinding, ref MicroVMLifecycleRef) (MicroVMReconcileResult, error) {
+	if d == nil || d.runtime == nil {
+		return MicroVMReconcileResult{}, ErrMicroVMDispatchUnavailable
+	}
+	if err := binding.Validate(); err != nil {
+		return MicroVMReconcileResult{}, err
+	}
+	if err := ref.Validate(binding); err != nil {
+		return MicroVMReconcileResult{}, err
+	}
+	requestID = strings.TrimSpace(requestID)
+	if requestID == "" {
+		return MicroVMReconcileResult{}, ErrMicroVMDispatchUnavailable
+	}
+	resp, err := d.runtime.Command(ctx, runtimemicrovm.CommandGet, requestID, binding)
+	if err != nil {
+		return MicroVMReconcileResult{}, err
+	}
+	if resp.Error != nil && resp.Error.Code != "" {
+		return MicroVMReconcileResult{}, resp.Error
+	}
+	observedAt := time.Now().UTC()
+	if !resp.LastTransition.IsZero() {
+		observedAt = resp.LastTransition.UTC()
+	}
+	observedState := firstNonEmptyLifecycleState(resp.LifecycleState, resp.State)
+	status := runtimemicrovm.SessionStatus{
+		TenantID:        strings.TrimSpace(resp.TenantID),
+		Namespace:       strings.TrimSpace(resp.Namespace),
+		SessionID:       strings.TrimSpace(resp.SessionID),
+		State:           observedState,
+		DesiredState:    firstNonEmptyLifecycleState(resp.DesiredState, observedState),
+		LifecycleState:  observedState,
+		MicroVMID:       firstNonEmptyString(resp.ProviderMicroVMID, resp.MicroVMID),
+		LastAction:      resp.LastAction,
+		LastTransition:  firstNonZeroTimeValue(resp.LastTransition, observedAt),
+		RegistryVersion: resp.RegistryVersion,
+	}
+	reconciled, err := ReconcileMicroVMRegistryStatus(binding, ref, status)
+	if err != nil {
+		return MicroVMReconcileResult{}, err
+	}
+	return MicroVMReconcileResult{
+		LifecycleRef: reconciled,
+		SessionID:    strings.TrimSpace(resp.SessionID),
+		Terminal:     runtimemicrovm.IsTerminalState(reconciled.LifecycleState),
+	}, nil
 }

--- a/internal/hostedgenesis/dispatch_test.go
+++ b/internal/hostedgenesis/dispatch_test.go
@@ -87,6 +87,110 @@ func TestControllerRuntimeDispatcherPropagatesControllerError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestControllerRuntimeDispatcherReconcilesViaControllerGet(t *testing.T) {
+	t.Parallel()
+
+	binding := testMicroVMBinding()
+	provider := microvmtestkit.NewFakeProvider()
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            provider,
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "arn:aws:lambda:us-east-1:123456789012:microvm-image/hosted-genesis:1",
+		NetworkConnectorRef: "arn:aws:lambda:us-east-1:123456789012:network-connector/hosted-genesis-egress",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+
+	// Dispatch a run first so the session exists in the provider + registry and
+	// Host has a populated lifecycle ref to reconcile against.
+	dispatch, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-run", binding)
+	require.NoError(t, err)
+
+	// Reconcile via the M16 controller get command: the live VM is observed as
+	// running (non-terminal) and the reconciled ref maps back to the binding.
+	result, err := dispatcher.ReconcileMicroVM(context.Background(), "req-get", binding, dispatch.LifecycleRef)
+	require.NoError(t, err)
+	require.Equal(t, binding.ConversationID, result.SessionID)
+	require.False(t, result.Terminal, "live VM must not be terminal")
+	require.NoError(t, result.LifecycleRef.Validate(binding))
+	require.Equal(t, runtimemicrovm.CommandGet, result.LifecycleRef.LastAction)
+}
+
+func TestControllerRuntimeDispatcherReconcileTerminalVMReportsTerminal(t *testing.T) {
+	t.Parallel()
+
+	binding := testMicroVMBinding()
+	provider := microvmtestkit.NewFakeProvider()
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            provider,
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "arn:aws:lambda:us-east-1:123456789012:microvm-image/hosted-genesis:1",
+		NetworkConnectorRef: "arn:aws:lambda:us-east-1:123456789012:network-connector/hosted-genesis-egress",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+
+	dispatch, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-run", binding)
+	require.NoError(t, err)
+
+	// Terminate the VM through the controller so the provider reports a terminal
+	// state; reconciliation must surface Terminal=true (dead/expired VM) so the
+	// control plane maps it to a loud failure, not a silent no-op.
+	_, err = runtime.Command(context.Background(), runtimemicrovm.CommandTerminate, "req-terminate", binding)
+	require.NoError(t, err)
+
+	result, err := dispatcher.ReconcileMicroVM(context.Background(), "req-get", binding, dispatch.LifecycleRef)
+	require.NoError(t, err)
+	require.True(t, result.Terminal, "terminated VM must reconcile as terminal")
+	require.NoError(t, result.LifecycleRef.Validate(binding))
+}
+
+func TestControllerRuntimeDispatcherReconcileFailsClosedWhenRuntimeNil(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := NewControllerRuntimeDispatcher(nil)
+	_, err := dispatcher.ReconcileMicroVM(context.Background(), "req-get", testMicroVMBinding(), MicroVMLifecycleRef{})
+	require.ErrorIs(t, err, ErrMicroVMDispatchUnavailable)
+}
+
+func TestControllerRuntimeDispatcherReconcileFailsClosedOnInvalidRef(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	// An empty ref cannot validate against the binding: fail closed.
+	_, err = dispatcher.ReconcileMicroVM(context.Background(), "req-get", testMicroVMBinding(), MicroVMLifecycleRef{})
+	require.Error(t, err)
+}
+
+func TestControllerRuntimeDispatcherReconcilePropagatesControllerError(t *testing.T) {
+	t.Parallel()
+
+	binding := testMicroVMBinding()
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            &failingSessionRegistry{err: errors.New("registry unavailable")},
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	dispatch, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-run", binding)
+	// The failing registry may reject the run; if it succeeded enough to build
+	// a ref, exercise reconcile against the same failing registry. Either way
+	// reconcile must surface an error rather than silently no-op.
+	if err == nil {
+		_, reconcileErr := dispatcher.ReconcileMicroVM(context.Background(), "req-get", binding, dispatch.LifecycleRef)
+		require.Error(t, reconcileErr)
+	}
+}
+
 type failingSessionRegistry struct {
 	err error
 }

--- a/internal/hostedgenesis/dispatch_test.go
+++ b/internal/hostedgenesis/dispatch_test.go
@@ -1,0 +1,102 @@
+package hostedgenesis
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+	microvmtestkit "github.com/theory-cloud/apptheory/testkit/microvm"
+)
+
+func TestControllerRuntimeDispatcherDispatchesM16Run(t *testing.T) {
+	t.Parallel()
+
+	binding := testMicroVMBinding()
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "arn:aws:lambda:us-east-1:123456789012:microvm-image/hosted-genesis:1",
+		NetworkConnectorRef: "arn:aws:lambda:us-east-1:123456789012:network-connector/hosted-genesis-egress",
+	})
+	require.NoError(t, err)
+
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	result, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", binding)
+	require.NoError(t, err)
+	require.Equal(t, binding.ConversationID, result.SessionID)
+	require.NoError(t, result.LifecycleRef.Validate(binding))
+	require.Equal(t, MicroVMSourceOfTruth, result.LifecycleRef.SourceOfTruth)
+	require.Equal(t, runtimemicrovm.CommandRun, result.LifecycleRef.LastAction)
+	require.NotEmpty(t, result.LifecycleRef.MicroVMID)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedWhenRuntimeNil(t *testing.T) {
+	t.Parallel()
+
+	dispatcher := NewControllerRuntimeDispatcher(nil)
+	_, err := dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", testMicroVMBinding())
+	require.ErrorIs(t, err, ErrMicroVMDispatchUnavailable)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedOnInvalidBinding(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", MicroVMSessionBinding{})
+	require.Error(t, err)
+}
+
+func TestControllerRuntimeDispatcherFailsClosedOnEmptyRequestID(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            runtimemicrovm.NewMemorySessionRegistry(),
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "  ", testMicroVMBinding())
+	require.ErrorIs(t, err, ErrMicroVMDispatchUnavailable)
+}
+
+func TestControllerRuntimeDispatcherPropagatesControllerError(t *testing.T) {
+	t.Parallel()
+
+	// A controller backed by a registry that has lost the session cannot run;
+	// the dispatcher must surface the controller error rather than fall back.
+	runtime, err := NewMicroVMControllerRuntime(MicroVMControllerRuntimeConfig{
+		Provider:            microvmtestkit.NewFakeProvider(),
+		Registry:            &failingSessionRegistry{err: errors.New("registry unavailable")},
+		ImageRef:            "image-ref",
+		NetworkConnectorRef: "network-ref",
+	})
+	require.NoError(t, err)
+	dispatcher := NewControllerRuntimeDispatcher(runtime)
+	_, err = dispatcher.DispatchMicroVMRun(context.Background(), "req-dispatch", testMicroVMBinding())
+	require.Error(t, err)
+}
+
+type failingSessionRegistry struct {
+	err error
+}
+
+func (f *failingSessionRegistry) Get(ctx context.Context, key runtimemicrovm.SessionKey) (runtimemicrovm.SessionRecord, error) {
+	return runtimemicrovm.SessionRecord{}, f.err
+}
+func (f *failingSessionRegistry) Put(ctx context.Context, record runtimemicrovm.SessionRecord) (runtimemicrovm.SessionRecord, error) {
+	return runtimemicrovm.SessionRecord{}, f.err
+}
+func (f *failingSessionRegistry) Delete(ctx context.Context, key runtimemicrovm.SessionKey) error {
+	return f.err
+}

--- a/internal/hostedgenesis/session.go
+++ b/internal/hostedgenesis/session.go
@@ -189,6 +189,7 @@ const (
 	FailureCodeInvalidProducedDeclarations FailureCode = "invalid_produced_declarations"
 	FailureCodeTenantBoundaryViolation     FailureCode = "tenant_boundary_violation"
 	FailureCodeOperatorActionRequired      FailureCode = "operator_action_required"
+	FailureCodeMicroVMUnavailable          FailureCode = "microvm_unavailable"
 )
 
 // Recovery is the typed recovery envelope exposed on failed compact projections.
@@ -233,7 +234,8 @@ func isAllowedFailureCode(code FailureCode) bool {
 		FailureCodeMissingProducedDeclarations,
 		FailureCodeInvalidProducedDeclarations,
 		FailureCodeTenantBoundaryViolation,
-		FailureCodeOperatorActionRequired:
+		FailureCodeOperatorActionRequired,
+		FailureCodeMicroVMUnavailable:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary

P52 H1.3 — makes the MicroVM hosted-genesis path actually close the loop in the control plane. Stacked on H1.2 (#869, `p52/h1.2-dispatch-202`). Parent issue #867 stays **open**; this delivers H1.3 only.

Kills two gaps that made the MicroVM path a partial scaffold:

- **G6 — reconstruction reachable from production.** The reconstruction hook was reachable only from the undeployed controller Lambda and no-oped without the never-set lifecycle ref. The recover path now reaches production reconstruction: for a session in a MicroVM-serviced pending state (`in_progress` / `declaration_extraction_pending`) with a populated `MicroVMLifecycleRef`, it queries real VM state via the M16 controller `get` through `MicroVMDispatcher.ReconcileMicroVM`, using the lifecycle ref H1.2 set. A dead/expired (terminal) VM maps to a loud retryable `microvm_unavailable` failed session — the silent no-op is removed.
- **G7 — `declaration_extraction_pending` serviced by the VM.** `startHostedGenesisDeclarationExtraction` now dispatches a follow-on M16 controller `run` on the same MicroVM session via the seam. The pending trap dies: the VM services the extraction or the session fails loudly. The recover path covers `declaration_extraction_pending` (routed to reconstruction/`get`, not a permanent trap).

## Framework adoption

AppTheory v1.15.0 inspected from the Go module cache:
- `runtime/microvm/controller.go` — `CommandGet` (controller `get`) drives `registry.Get` → `provider.Get` and returns `ControllerResponse` with real `State`/`LifecycleState`/`ProviderState`; `CommandRun` is the follow-on command on the same session.
- `runtime/microvm/controller_contract.go` — `validateRealControllerRequest` requires `SessionID` for `get`.
- `runtime/microvm/lifecycle.go` — `IsTerminalState` (terminated/failed) for terminal-VM mapping; `MapProviderState`.

No raw AWS SDK. No local controller substitute. Consumed the existing `MicroVMControllerRuntime.Command` helper and `ReconcileMicroVMRegistryStatus`. The known `NewLifecycleAdapter` / `DefaultRealLifecycleContract` gap (theory-cloud/AppTheory#755) is not touched — H1.3 does not require the lifecycle adapter.

## Reachability / dispatch sites

- Reconstruction reachability site: `internal/controlplane/handlers_soul_mint_conversation_recover.go` — `reconcileHostedGenesisMicroVMRecovery` issues `ReconcileMicroVM` (controller `get`) with the populated lifecycle ref; `hostedGenesisSessionNeedsMicroVMReconciliation` gates on `in_progress`/`declaration_extraction_pending` + populated ref.
- Extraction-dispatch site: `internal/controlplane/handlers_soul_mint_conversation_async.go` — `dispatchHostedGenesisDeclarationExtraction` issues `DispatchMicroVMRun` (follow-on `run`) on the transition into `declaration_extraction_pending`; `persistHostedGenesisExtractionDispatch` refreshes the ref.
- Pending-trap-dead: `hostedGenesisSessionNeedsAssistantRecovery` now covers `declaration_extraction_pending`; `startHostedGenesisDeclarationExtraction` dispatches once on transition and is a no-op on re-entry.

## Validation

- `go build ./...` — OK
- `go vet ./...` — clean
- `go test ./...` — green (all packages)
- `gofmt -l` — clean
- golangci-lint (touched packages) — 0 issues
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — **PASS 40/0/0**

Unit tests prove: (a) reconstruction reachable + uses lifecycle ref + controller `get`, dead/expired VM → loud failure not no-op; (b) extraction dispatches to VM seam (follow-on run), idempotent on re-entry; (c) recovery covers `declaration_extraction_pending`; (d) reconciliation observes `assistant_turn_ready`/`in_progress` transitions idempotently; workload-advanced statuses are not re-reconciled.

## Non-goals (separate steps)

H1.1 workload (#868, not edited), H1.2 dispatch+202 (#869, stacked on, not rewritten), H1.4 full recovery handler, H1.5 CDK lab deploy + E2E gate, H2.x deletion of sync seam / SQS pipeline / legacy extraction. No deploys, no merges, no sibling-repo edits, no on-chain/cloud mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)