### PR TITLE
fix(h1): baseImageVersion 1→0 (only available managed version for al2023-1)

### DIFF
--- a/cdk/lib/hosted-genesis-microvm.ts
+++ b/cdk/lib/hosted-genesis-microvm.ts
@@ -238,7 +238,15 @@ export function configureHostedGenesisMicrovm(
   // parameterize the region segment (cdk.Aws.REGION cannot be embedded in a
   // literal ARN string — that is a separate change, out of F1 scope).
   const baseImageArn = HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN;
-  const baseImageVersion = "1";
+  // baseImageVersion "0" is the only AVAILABLE managed version for al2023-1,
+  // verified via `aws lambda-microvms list-managed-microvm-image-versions
+  //   --image-identifier arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1`
+  // (factory, 2026-07-04). The 2026-07-04 lab deploy failed on
+  // HostedGenesisMicrovmImage CREATE_FAILED: "No managed runtime with arn
+  // arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1 and version 1 is
+  // available." — the ARN is correct; "1" was the wrong version. The API
+  // returned only {"imageVersion": "0"} for this image.
+  const baseImageVersion = "0";
 
   const microvmImage = new AppTheoryMicrovmImage(
     scope,

--- a/cdk/test/lesser-host-stack-microvm.test.ts
+++ b/cdk/test/lesser-host-stack-microvm.test.ts
@@ -99,8 +99,10 @@ test('hosted genesis AppTheory MicroVM deployed-stage wiring uses AppTheory cons
 	// exactly. BaseImageArn renders as an Fn::Join (partition is a CFN token), so
 	// stringify before the substring check; `:aws:microvm-image:al2023-1` carries
 	// the load-bearing `aws` literal account, COLON separator, and al2023-1 runtime.
+	// BaseImageVersion "0" is the only available managed version (factory-verified
+	// via list-managed-microvm-image-versions, 2026-07-04); "1" failed the lab deploy.
 	const imageProps = images[0][1].Properties ?? {};
-	assert.equal(imageProps.BaseImageVersion, '1', 'expected deterministic base image version 1');
+	assert.equal(imageProps.BaseImageVersion, '0', 'expected deterministic base image version 0 (only available managed version)');
 	assert.ok(
 		JSON.stringify(imageProps.BaseImageArn ?? '').includes(HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN),
 		`expected BaseImageArn to be the pinned AWS-managed base runtime ARN (${HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN}), not a placeholder or operator-supplied context value`,


### PR DESCRIPTION
## Summary

Fixes the version that failed the 2026-07-04 lab deploy. The AWS-managed base MicroVM image ARN `arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1` is correct; the version `"1"` was wrong.

### Deploy failure
```
HostedGenesisMicrovmImage CREATE_FAILED:
"No managed runtime with arn arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1
 and version 1 is available."
```

### Verification (factory, 2026-07-04)
`aws lambda-microvms list-managed-microvm-image-versions` (awscli v1.45.40) returned only:
```json
{"items": [{"imageArn": "arn:aws:lambda:us-east-1:aws:microvm-image:al2023-1", "imageVersion": "0", ...}]}
```
**`"0"` is the only available managed version for al2023-1.**

## Change
- `cdk/lib/hosted-genesis-microvm.ts`: `baseImageVersion` `"1"` → `"0"` + comment citing the live API verification.
- `cdk/test/lesser-host-stack-microvm.test.ts`: `BaseImageVersion` assertion `'1'` → `'0'`.

**ARN unchanged.** One-line behavior change; no scope creep.

## Validation (local)
- `bash gov-infra/verifiers/gov-verify-rubric.sh` → **Pass: 40 / Fail: 0 / Blocked: 0**
- `cdk`: `npm run build` ✓, `npm test` → 57/57 ✓, `cdk synth --stage lab` (no context) ✓
- Go: `golangci-lint run --timeout=10m ./...` zero findings (rubric run strips node_modules) ✓, `go test ./...` ✓

## Non-goals
No deploy. No ARN change. No merge (factory merges once CI green). Refs lesser-host#867 (do not close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)