### PR TITLE
chore(cdk): harden Hosted Genesis MicroVM boundaries

### DIFF
--- a/cdk/lib/hosted-genesis-microvm.ts
+++ b/cdk/lib/hosted-genesis-microvm.ts
@@ -18,6 +18,10 @@ import type { Construct } from "constructs";
 export const HOSTED_GENESIS_MICROVM_NAMESPACE = "hosted-genesis" as const;
 export const HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH =
   "host-dynamodb-hosted-genesis-session" as const;
+export const HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS = 300 as const;
+export const HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS = 300 as const;
+export const HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS = 1800 as const;
+export const HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED = false as const;
 
 // P52 H1 step 2 (F1): the AWS-managed base MicroVM image ARN. This is the
 // foundation the entire MicroVM-only genesis program sits on — H1.1–H1.5 merged
@@ -392,6 +396,18 @@ export function configureHostedGenesisMicrovm(
           HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH:
             HOSTED_GENESIS_MICROVM_SOURCE_OF_TRUTH,
           HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SHA256: authTokenSha256,
+          HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS: String(
+            HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS,
+          ),
+          HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS: String(
+            HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
+          ),
+          HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS: String(
+            HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
+          ),
+          HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED: String(
+            HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
+          ),
           STATE_TABLE_NAME: props.stateTable.tableName,
         },
       },
@@ -577,9 +593,28 @@ function grantFunctionMicroVMDispatch(
   // reads: the governed controller endpoint, the auth-token SSM param name
   // (the raw token is fetched at runtime, never committed), and the non-secret
   // image/network-connector refs the control plane sends in the POST /microvms
-  // run body. addEnvironment is the CDK-supported way to append env vars to a
-  // Function constructed elsewhere.
+  // run body. The lifetime values are the explicit AppTheory ProviderRunInput
+  // MaximumDurationSeconds + ProviderIdlePolicy boundary from ADR 0010; Host
+  // does not create a local scheduler or provider step machine for human gaps.
+  // addEnvironment is the CDK-supported way to append env vars to a Function
+  // constructed elsewhere.
   fn.addEnvironment("HOSTED_GENESIS_MICROVM_ENABLED", "true");
+  fn.addEnvironment(
+    "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS",
+    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
+  );
+  fn.addEnvironment(
+    "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS",
+    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
+  );
+  fn.addEnvironment(
+    "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS",
+    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
+  );
+  fn.addEnvironment(
+    "HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED",
+    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
+  );
   fn.addEnvironment(
     "APPTHEORY_MICROVM_CONTROLLER_ENDPOINT",
     controllerEndpoint,

--- a/cdk/test/lesser-host-stack-microvm.test.ts
+++ b/cdk/test/lesser-host-stack-microvm.test.ts
@@ -17,7 +17,13 @@ import {
   webLookupContext,
   webStackEnv,
 } from "./_lesser-host-test-helpers";
-import { HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN } from "../lib/hosted-genesis-microvm";
+import {
+  HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN,
+  HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
+  HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
+  HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
+  HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS,
+} from "../lib/hosted-genesis-microvm";
 
 import assert from "node:assert/strict";
 import * as fs from "node:fs";
@@ -417,6 +423,26 @@ test("hosted genesis AppTheory MicroVM deployed-stage wiring uses AppTheory cons
   assert.equal(
     controllerEnv.APPTHEORY_MICROVM_CONTROLLER_OPERATIONS,
     "run,get,list,suspend,resume,terminate,invoke,auth-token,shell-auth-token",
+  );
+  assert.equal(
+    controllerEnv.HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
+    "expected controller runtime to carry the AppTheory run maximum duration",
+  );
+  assert.equal(
+    controllerEnv.HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
+    "expected controller runtime to carry the AppTheory idle max duration",
+  );
+  assert.equal(
+    controllerEnv.HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
+    "expected controller runtime to carry the AppTheory suspended duration",
+  );
+  assert.equal(
+    controllerEnv.HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
+    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
+    "expected controller runtime to keep provider auto-resume explicit",
   );
   assert.ok(
     String(controllerEnv.APPTHEORY_MICROVM_CONTROLLER_ROUTES ?? "").includes(
@@ -892,6 +918,23 @@ test("P52 H1.5 corrective: host-owned MicroVM execution role propagates to RunMi
     undefined,
     "AWS_REGION must NOT be set in MicroVM image environmentVariables (reserved by the Lambda Microvms service)",
   );
+  const imageEnvKeys = new Set(imageEnv.map((env) => String(env?.Key ?? "")));
+  for (const forbiddenKey of [
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "CLAUDE_API_KEY",
+    "AWS_ACCESS_KEY_ID",
+    "AWS_SECRET_ACCESS_KEY",
+    "AWS_SESSION_TOKEN",
+    "HOSTED_GENESIS_MICROVM_AUTH_TOKEN",
+    "APPTHEORY_MICROVM_AUTHORIZER_TOKEN",
+    "MICROVM_ENDPOINT_TOKEN",
+  ]) {
+    assert.ok(
+      !imageEnvKeys.has(forbiddenKey),
+      `MicroVM image env must not carry raw provider/cloud/bearer/MicroVM endpoint secrets (${forbiddenKey})`,
+    );
+  }
 
   // No raw secret values anywhere in the synthesized template. P52 corrective
   // #873: the auth bearer token is CDK-owned (custom resource), so neither the
@@ -1107,6 +1150,26 @@ test("P52 H1.5: control-plane Lambda receives HTTP dispatch env + SSM auth-token
     "true",
     "expected HOSTED_GENESIS_MICROVM_ENABLED on control-plane Lambda",
   );
+  assert.equal(
+    controlPlaneEnv.HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
+    "expected control-plane dispatch to thread the AppTheory maximum duration onto POST /microvms",
+  );
+  assert.equal(
+    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
+    "expected control-plane dispatch to thread the AppTheory idle max policy onto POST /microvms",
+  );
+  assert.equal(
+    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
+    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
+    "expected control-plane dispatch to thread the AppTheory suspended policy onto POST /microvms",
+  );
+  assert.equal(
+    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
+    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
+    "expected control-plane dispatch auto-resume policy to be explicit",
+  );
   assert.ok(
     controlPlaneEnv.APPTHEORY_MICROVM_CONTROLLER_ENDPOINT,
     "expected APPTHEORY_MICROVM_CONTROLLER_ENDPOINT on control-plane Lambda",
@@ -1151,6 +1214,49 @@ test("P52 H1.5: control-plane Lambda receives HTTP dispatch env + SSM auth-token
     controlPlaneEnv.APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS,
     "expected egress connector refs on control-plane Lambda",
   );
+  const aiWorkerFn = findLambdaEntryByFunctionName(template, "ai-worker");
+  assert.ok(aiWorkerFn, "expected ai-worker Lambda to synthesize");
+  const aiWorkerEnv = lambdaEnvironment(aiWorkerFn[1].Properties ?? {});
+  for (const key of [
+    "HOSTED_GENESIS_MICROVM_ENABLED",
+    "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS",
+    "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS",
+    "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS",
+    "HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED",
+    "APPTHEORY_MICROVM_CONTROLLER_ENDPOINT",
+    "HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM",
+    "APPTHEORY_MICROVM_IMAGE_REF",
+    "APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS",
+    "APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS",
+  ]) {
+    assert.deepEqual(
+      aiWorkerEnv[key],
+      controlPlaneEnv[key],
+      `ai-worker MicroVM dispatch env ${key} must match control-plane dispatch env`,
+    );
+  }
+  for (const [label, env] of [
+    ["control-plane", controlPlaneEnv],
+    ["ai-worker", aiWorkerEnv],
+    ["controller", controllerEnv],
+  ] as const) {
+    for (const forbiddenKey of [
+      "OPENAI_API_KEY",
+      "ANTHROPIC_API_KEY",
+      "CLAUDE_API_KEY",
+      "AWS_ACCESS_KEY_ID",
+      "AWS_SECRET_ACCESS_KEY",
+      "AWS_SESSION_TOKEN",
+      "HOSTED_GENESIS_MICROVM_AUTH_TOKEN",
+      "APPTHEORY_MICROVM_AUTHORIZER_TOKEN",
+      "MICROVM_ENDPOINT_TOKEN",
+    ]) {
+      assert.ok(
+        !(forbiddenKey in env),
+        `${label} Lambda env must not carry raw provider/cloud/bearer/MicroVM endpoint secrets (${forbiddenKey})`,
+      );
+    }
+  }
   // The control plane must NOT receive session-registry table env: it does
   // not touch the registry directly (the controller Lambda owns it).
   assert.ok(

--- a/cmd/hosted-genesis-microvm-controller/main.go
+++ b/cmd/hosted-genesis-microvm-controller/main.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	apptheory "github.com/theory-cloud/apptheory/runtime"
 	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 
+	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/observability"
 	"github.com/equaltoai/lesser-host/internal/store"
@@ -155,6 +157,14 @@ func newRuntimeController(ctx context.Context, getenv getenvFunc) (*hostedgenesi
 		ControllerID:             hostedgenesis.MicroVMControllerID,
 		SessionTTL:               hostedgenesis.MicroVMRegistryReconstructionTTL,
 		ReconstructionStaleAfter: 5 * time.Minute,
+		MaximumDurationSeconds: microVMInt32Env(
+			getenv,
+			"HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS",
+			config.HostedGenesisMicroVMDefaultMaximumDurationSeconds,
+			0,
+			3600,
+		),
+		IdlePolicy: microVMIdlePolicyFromEnv(getenv),
 	}
 	return hostedgenesis.NewMicroVMControllerRuntime(cfg)
 }
@@ -248,6 +258,44 @@ func csv(value string) []string {
 		}
 	}
 	return out
+}
+
+func microVMIdlePolicyFromEnv(getenv getenvFunc) *runtimemicrovm.ProviderIdlePolicy {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	return &runtimemicrovm.ProviderIdlePolicy{
+		AutoResumeEnabled:        microVMBoolEnv(getenv, "HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED"),
+		MaxIdleDurationSeconds:   microVMInt32Env(getenv, "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", config.HostedGenesisMicroVMDefaultIdleMaxSeconds, 1, 3600),
+		SuspendedDurationSeconds: microVMInt32Env(getenv, "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", config.HostedGenesisMicroVMDefaultIdleSuspendedSeconds, 1, 3600),
+	}
+}
+
+func microVMInt32Env(getenv getenvFunc, key string, fallback int32, minValue int32, maxValue int32) int32 {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	raw := strings.TrimSpace(getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	parsed, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || parsed < int64(minValue) || parsed > int64(maxValue) {
+		return fallback
+	}
+	return int32(parsed)
+}
+
+func microVMBoolEnv(getenv getenvFunc, key string) bool {
+	if getenv == nil {
+		getenv = os.Getenv
+	}
+	switch strings.ToLower(strings.TrimSpace(getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
 }
 
 func safeFailure(command runtimemicrovm.Command, requestID string, code string, message string) runtimemicrovm.ControllerResponse {

--- a/cmd/hosted-genesis-microvm-controller/main_test.go
+++ b/cmd/hosted-genesis-microvm-controller/main_test.go
@@ -15,8 +15,11 @@ import (
 	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 	microvmtestkit "github.com/theory-cloud/apptheory/testkit/microvm"
 
+	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 )
+
+const controllerTestTrue = "true"
 
 func TestControllerEventFailsClosedWhenDisabled(t *testing.T) {
 	t.Parallel()
@@ -76,7 +79,7 @@ func TestControllerEventGateNoLongerLabOnly(t *testing.T) {
 	if strings.Contains(src, `getenv("STAGE")) != "lab"`) {
 		t.Fatalf("H1.5 regression: controller still lab-gates on STAGE != \"lab\"; the runtime lab gate should be removed (fail-closed auth preserved)")
 	}
-	if !strings.Contains(src, `getenv("APPTHEORY_MICROVM_CONTROLLER_AUTH_REQUIRED")) != "true"`) {
+	if !strings.Contains(src, `getenv("APPTHEORY_MICROVM_CONTROLLER_AUTH_REQUIRED")) != "`+controllerTestTrue+`"`) {
 		t.Fatalf("H1.5 regression: fail-closed AUTH_REQUIRED check missing from controller gate")
 	}
 	if !strings.Contains(src, `getenv("APPTHEORY_MICROVM_CONTROLLER_AUTH_DEFAULT")) != runtimemicrovm.ControllerAuthDefaultDeny`) {
@@ -100,6 +103,11 @@ func TestRuntimeControllerUsesHostOwnedMicroVMRegistry(t *testing.T) {
 	}
 	if !strings.Contains(src, "HostedGenesisMicroVMReconstructionHook") {
 		t.Fatalf("expected missing/stale MicroVM registry cache to reconstruct from Host HostedGenesisSession truth")
+	}
+	if !strings.Contains(src, "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS") ||
+		!strings.Contains(src, "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS") ||
+		!strings.Contains(src, "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS") {
+		t.Fatalf("expected controller runtime to read Host-configured AppTheory MicroVM lifetime policy env")
 	}
 }
 
@@ -278,6 +286,55 @@ func TestControllerCSVAndFirstStringNormalize(t *testing.T) {
 	}
 }
 
+func TestControllerLifetimePolicyEnvParsesAppTheoryRunPolicy(t *testing.T) {
+	t.Parallel()
+
+	getenv := func(key string) string {
+		switch key {
+		case "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS":
+			return "450"
+		case "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS":
+			return "240"
+		case "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS":
+			return "1200"
+		case "HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED":
+			return controllerTestTrue
+		default:
+			return ""
+		}
+	}
+	if got := microVMInt32Env(getenv, "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", config.HostedGenesisMicroVMDefaultMaximumDurationSeconds, 0, 3600); got != 450 {
+		t.Fatalf("maximum duration parse = %d, want 450", got)
+	}
+	policy := microVMIdlePolicyFromEnv(getenv)
+	if policy == nil {
+		t.Fatalf("expected idle policy")
+	}
+	if !policy.AutoResumeEnabled || policy.MaxIdleDurationSeconds != 240 || policy.SuspendedDurationSeconds != 1200 {
+		t.Fatalf("unexpected idle policy: %#v", policy)
+	}
+	if err := runtimemicrovm.ValidateProviderRunInput(runtimemicrovm.ProviderRunInput{
+		RequestID:              "req",
+		TenantID:               "slug:demo",
+		Namespace:              hostedgenesis.MicroVMNamespace,
+		SessionID:              "conv",
+		AuthContext:            runtimemicrovm.AuthContext{Subject: hostedgenesis.MicroVMAuthSubject, TenantID: "slug:demo", Namespace: hostedgenesis.MicroVMNamespace},
+		ImageRef:               "image-ref",
+		NetworkConnectorRef:    "network-ref",
+		IdlePolicy:             policy,
+		MaximumDurationSeconds: 450,
+	}); err != nil {
+		t.Fatalf("configured AppTheory run policy should validate: %v", err)
+	}
+
+	defaultPolicy := microVMIdlePolicyFromEnv(func(string) string { return "" })
+	if defaultPolicy.AutoResumeEnabled ||
+		defaultPolicy.MaxIdleDurationSeconds != config.HostedGenesisMicroVMDefaultIdleMaxSeconds ||
+		defaultPolicy.SuspendedDurationSeconds != config.HostedGenesisMicroVMDefaultIdleSuspendedSeconds {
+		t.Fatalf("unexpected default idle policy: %#v", defaultPolicy)
+	}
+}
+
 func testControllerApp(t *testing.T) interface {
 	ServeAPIGatewayV2(context.Context, events.APIGatewayV2HTTPRequest) events.APIGatewayV2HTTPResponse
 } {
@@ -291,6 +348,11 @@ func testControllerApp(t *testing.T) interface {
 			"ingress-ref",
 		},
 		EgressNetworkConnectorRefs: []string{"egress-ref"},
+		MaximumDurationSeconds:     config.HostedGenesisMicroVMDefaultMaximumDurationSeconds,
+		IdlePolicy: &runtimemicrovm.ProviderIdlePolicy{
+			MaxIdleDurationSeconds:   config.HostedGenesisMicroVMDefaultIdleMaxSeconds,
+			SuspendedDurationSeconds: config.HostedGenesisMicroVMDefaultIdleSuspendedSeconds,
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewMicroVMControllerRuntime: %v", err)

--- a/docs/adr/0010-hosted-genesis-conversation-lifetime-microvm.md
+++ b/docs/adr/0010-hosted-genesis-conversation-lifetime-microvm.md
@@ -145,6 +145,18 @@ The configured idle values are deployment policy, not business truth. They must 
 long enough to cover the operator-approved lab human-gap canary. If provider limits force shorter durations than real
 human conversations, the actor contract still holds through checkpoint/relaunch/replay.
 
+M11 deployment policy chooses the following Host defaults for the CDK-deployed AppTheory controller and Host dispatchers:
+
+- `MaximumDurationSeconds=300`: one active provider/declaration step has five minutes to complete bounded work;
+- `IdlePolicy.MaxIdleDurationSeconds=300`: a ready conversation actor may be suspended after five minutes of ready idle;
+- `IdlePolicy.SuspendedDurationSeconds=1800`: suspended execution/cache state is allowed for up to thirty minutes,
+  intentionally below Host's one-hour AppTheory registry reconstruction TTL;
+- `IdlePolicy.AutoResumeEnabled=false`: Host keeps resume explicit through AppTheory `Get` / `Resume` / `Invoke` until
+  #941's live lab proof validates provider auto-resume semantics.
+
+Longer human gaps therefore recover from safe checkpoints and `HostedGenesisSession` truth instead of preserving process
+memory by policy.
+
 ### Checkpoint / relaunch / replay expectations
 
 Host and the in-VM runtime must assume process memory is an optimization, not a recovery source. Before any human wait,

--- a/docs/contracts/hosted-genesis-conversation.md
+++ b/docs/contracts/hosted-genesis-conversation.md
@@ -84,6 +84,19 @@ execution details. They do not determine user-visible progress, retry, finalize 
 delivery or MicroVM cache is missing or stale, status remains the compact `HostedGenesisSession` projection and
 retry/finalize decisions continue to fail closed from that Host row.
 
+### M11 billing policy for actor-path declaration extraction
+
+Project 48 M11 keeps billing at the Host accepted-turn boundary. The Lesser instance-key path's final affirmation is
+charged as the ordinary paid accepted user turn described above. If the AppTheory MicroVM actor then decides that this
+accepted turn should extract/finalize declarations, that in-VM extraction rides the same accepted-turn ledger entry and
+does **not** create a second Host extraction debit, second idempotency row, or Host-owned extraction step machine.
+
+The retained `declaration_extraction_pending` compatibility/recovery seam is only for historical or explicitly routed
+legacy lanes that had already entered the pre-M11 extraction state. Active M11 actor-path traffic must remain:
+persist/debit/idempotency on accepted turn → MicroVM actor decides ask/wait/revise/extract/finalize/fail → Host guarded
+finalization/publish. Host may record safe provider usage/telemetry metadata, but it must not bill another credit debit
+for the actor's declaration extraction work unless a future ADR explicitly changes this policy.
+
 ### Hosted instance-trust declarations and restart recovery
 
 For the instance-key hosted/off-chain authority model, an agent may complete a valid genesis conversation without

--- a/docs/hosted-genesis-microvm-lab-canary.md
+++ b/docs/hosted-genesis-microvm-lab-canary.md
@@ -67,8 +67,9 @@ This PR does **not** deploy, run a cloud canary, mutate SSM/Secrets, sign transa
 
 The existing non-deploying canary and `scripts/hosted-genesis-microvm-e2e-gate.sh` prove AppTheory M16 route coverage,
 happy-path Hosted Genesis execution, kill-VM recovery behavior, metadata-only reads, and `MaximumDurationSeconds`
-wiring. They do **not** prove whether AWS Lambda MicroVM suspend/resume preserves process memory across a human-scale
-idle interval.
+wiring plus the CDK-deployed AppTheory `IdlePolicy` shape (`MaxIdleDurationSeconds=300`,
+`SuspendedDurationSeconds=1800`, `AutoResumeEnabled=false`). They do **not** prove whether AWS Lambda MicroVM
+suspend/resume preserves process memory across a human-scale idle interval.
 
 #941 acceptance requires a separate lab evidence record before the issue can be closed. If a live lab run is delegated,
 the operator-approved run must use only an explicit allowed AWS profile (`Lesser` or `TheoryLive`) and the normal Host

--- a/internal/aiworker/hosted_genesis_internal_test.go
+++ b/internal/aiworker/hosted_genesis_internal_test.go
@@ -474,6 +474,10 @@ func TestNewHostedGenesisWorkerMicroVMDispatcherConfigPaths(t *testing.T) {
 		IngressConnectorRefs:   []string{"ingress:test"},
 		EgressConnectorRefs:    []string{"egress:test"},
 		MaximumDurationSeconds: 60,
+		IdlePolicy: config.HostedGenesisMicroVMIdlePolicyConfig{
+			MaxIdleDurationSeconds:   300,
+			SuspendedDurationSeconds: 1800,
+		},
 	}
 	if got := newHostedGenesisWorkerMicroVMDispatcher(context.Background(), cfg, nil, hostedGenesisWorkerMicroVMDispatcherOptions{}); got != nil {
 		t.Fatalf("missing token getter must fail closed, got %#v", got)

--- a/internal/aiworker/hosted_genesis_microvm.go
+++ b/internal/aiworker/hosted_genesis_microvm.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 	"github.com/equaltoai/lesser-host/internal/secrets"
@@ -84,15 +86,28 @@ func newHostedGenesisWorkerMicroVMDispatcher(ctx context.Context, cfg config.Con
 		IngressConnectorRefs: append([]string(nil), microvmCfg.IngressConnectorRefs...),
 		EgressConnectorRefs:  append([]string(nil), microvmCfg.EgressConnectorRefs...),
 		MaxDurationSeconds:   microvmCfg.MaximumDurationSeconds,
+		IdlePolicy:           workerMicroVMIdlePolicyFromConfig(microvmCfg.IdlePolicy),
 		HTTPClient:           httpClient,
 	})
 	if err != nil {
 		log.Printf("aiworker: hosted genesis microvm dispatcher unavailable (http dispatcher construction failed) err=%v", err)
 		return nil
 	}
-	log.Printf("aiworker: hosted genesis microvm dispatcher wired stage=%s endpoint=%s image_ref=%s max_duration_seconds=%d",
-		strings.TrimSpace(cfg.Stage), microvmCfg.ControllerEndpoint, microvmCfg.ImageRef, microvmCfg.MaximumDurationSeconds)
+	log.Printf("aiworker: hosted genesis microvm dispatcher wired stage=%s endpoint=%s image_ref=%s max_duration_seconds=%d idle_max_seconds=%d idle_suspended_seconds=%d idle_auto_resume=%t",
+		strings.TrimSpace(cfg.Stage), microvmCfg.ControllerEndpoint, microvmCfg.ImageRef, microvmCfg.MaximumDurationSeconds,
+		microvmCfg.IdlePolicy.MaxIdleDurationSeconds, microvmCfg.IdlePolicy.SuspendedDurationSeconds, microvmCfg.IdlePolicy.AutoResumeEnabled)
 	return dispatcher
+}
+
+func workerMicroVMIdlePolicyFromConfig(policy config.HostedGenesisMicroVMIdlePolicyConfig) *runtimemicrovm.ProviderIdlePolicy {
+	if !policy.Complete() {
+		return nil
+	}
+	return &runtimemicrovm.ProviderIdlePolicy{
+		AutoResumeEnabled:        policy.AutoResumeEnabled,
+		MaxIdleDurationSeconds:   policy.MaxIdleDurationSeconds,
+		SuspendedDurationSeconds: policy.SuspendedDurationSeconds,
+	}
 }
 
 func (s *Server) processHostedGenesisMicroVMDispatch(ctx context.Context, workerRequestID string, msg hostedgenesis.QueueMessage) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -164,6 +164,40 @@ type Config struct {
 	HostedGenesisMicroVM HostedGenesisMicroVMConfig
 }
 
+const (
+	// HostedGenesisMicroVMDefaultMaximumDurationSeconds caps one active
+	// AppTheory MicroVM run for the longest provider turn plus in-VM
+	// declaration extraction. Human wait time is handled by the explicit
+	// ProviderIdlePolicy below, not by stretching the active-run ceiling.
+	HostedGenesisMicroVMDefaultMaximumDurationSeconds int32 = 300
+	// HostedGenesisMicroVMDefaultIdleMaxSeconds is the ready-idle interval
+	// before the provider may suspend the conversation actor. It is long enough
+	// for normal poll/retry jitter and short enough to force the lab human-gap
+	// canary through the AppTheory suspend/resume/relaunch contract.
+	HostedGenesisMicroVMDefaultIdleMaxSeconds int32 = 300
+	// HostedGenesisMicroVMDefaultIdleSuspendedSeconds is deliberately shorter
+	// than Host's one-hour AppTheory registry cache TTL so a suspended provider
+	// session is not treated as durable business truth after Host's
+	// HostedGenesisSession/reconstruction boundary would have to revalidate it.
+	HostedGenesisMicroVMDefaultIdleSuspendedSeconds int32 = 1800
+)
+
+// HostedGenesisMicroVMIdlePolicyConfig is Host's env-friendly representation of
+// AppTheory runtime/microvm.ProviderIdlePolicy. The dispatcher converts it at
+// the controller boundary so config never carries raw provider SDK state.
+type HostedGenesisMicroVMIdlePolicyConfig struct {
+	AutoResumeEnabled        bool
+	MaxIdleDurationSeconds   int32
+	SuspendedDurationSeconds int32
+}
+
+// Complete reports whether the idle policy can be passed to AppTheory's
+// ProviderIdlePolicy. AppTheory v1.17.0 rejects partial idle policies; Host
+// treats a missing policy as incomplete deployed MicroVM config.
+func (p HostedGenesisMicroVMIdlePolicyConfig) Complete() bool {
+	return p.MaxIdleDurationSeconds > 0 && p.SuspendedDurationSeconds > 0
+}
+
 // HostedGenesisMicroVMConfig groups the AppTheory M16 MicroVM controller HTTP
 // transport inputs controlplane.NewServer uses to construct the production
 // dispatcher. ControllerEndpoint is the governed AppTheoryMicrovmController
@@ -173,7 +207,9 @@ type Config struct {
 // IngressConnectorRefs / EgressConnectorRefs are non-secret refs the control
 // plane sends in the POST /microvms run body (the HTTP route handler does not
 // fill them from env the way the in-process runtime did). MaximumDurationSeconds
-// caps each dispatched run session duration.
+// caps each dispatched run session duration. IdlePolicy is the explicit
+// AppTheory human-gap policy for ready/suspended lifetime; Host does not
+// emulate it with a local scheduler or step machine.
 type HostedGenesisMicroVMConfig struct {
 	Enabled                bool
 	ControllerEndpoint     string
@@ -183,6 +219,7 @@ type HostedGenesisMicroVMConfig struct {
 	IngressConnectorRefs   []string
 	EgressConnectorRefs    []string
 	MaximumDurationSeconds int32
+	IdlePolicy             HostedGenesisMicroVMIdlePolicyConfig
 }
 
 // Complete reports whether the MicroVM dispatch config has the minimum required
@@ -192,7 +229,7 @@ type HostedGenesisMicroVMConfig struct {
 // parameter named here; Complete only requires the parameter name. A missing or
 // empty token at fetch time fails the dispatcher construction loudly.
 func (c HostedGenesisMicroVMConfig) Complete() bool {
-	return c.Enabled && c.ControllerEndpoint != "" && c.AuthTokenSSMParam != "" && c.ImageRef != "" && c.NetworkConnectorRef != ""
+	return c.Enabled && c.ControllerEndpoint != "" && c.AuthTokenSSMParam != "" && c.ImageRef != "" && c.NetworkConnectorRef != "" && c.IdlePolicy.Complete()
 }
 
 // Load reads environment variables and returns a Config with defaults applied.
@@ -280,14 +317,22 @@ func Load() Config {
 		}
 	}
 	// MaximumDurationSeconds is sized for the longest LLM turn plus in-VM
-	// declaration extraction (decision 7): default 300s, bounded to the M16
-	// provider's int32 range [0,3600]. A non-positive config disables the cap
-	// and lets the provider/default apply (still fail-closed; never a sync
-	// fallback). The bound keeps the int64->int32 narrowing safe (gosec G115).
-	microvmMaxDurationRaw := envInt64Bounded("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", 300, 0, 3600)
-	microvmMaxDuration := int32(0)
-	if microvmMaxDurationRaw > 0 && microvmMaxDurationRaw <= 3600 {
-		microvmMaxDuration = int32(microvmMaxDurationRaw)
+	// declaration extraction (ADR 0010 decision 7): default 300s, bounded to
+	// the M16 provider's int32 range [0,3600]. A non-positive config disables
+	// the cap and lets the provider/default apply (still fail-closed; never a
+	// sync fallback). The bound keeps the int64->int32 narrowing safe (gosec
+	// G115).
+	microvmMaxDuration := envInt32Bounded("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", HostedGenesisMicroVMDefaultMaximumDurationSeconds, 0, 3600)
+	// IdlePolicy is the AppTheory-provider human-gap boundary. Defaults are
+	// explicit even when the operator does not override env, so deployed
+	// control-plane and worker dispatches do not silently omit idle behavior.
+	// The suspended duration is bounded below Host's current one-hour
+	// MicroVMRegistryReconstructionTTL; longer human gaps must recover through
+	// Host checkpoints and AppTheory relaunch/replay, not unbounded VM lifetime.
+	microvmIdlePolicy := HostedGenesisMicroVMIdlePolicyConfig{
+		AutoResumeEnabled:        envBoolOn("HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED"),
+		MaxIdleDurationSeconds:   envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", HostedGenesisMicroVMDefaultIdleMaxSeconds, 1, 3600),
+		SuspendedDurationSeconds: envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", HostedGenesisMicroVMDefaultIdleSuspendedSeconds, 1, 3600),
 	}
 	microvmCfg := HostedGenesisMicroVMConfig{
 		Enabled:                envBoolOn("HOSTED_GENESIS_MICROVM_ENABLED"),
@@ -298,6 +343,7 @@ func Load() Config {
 		IngressConnectorRefs:   parseCSV(envString("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS")),
 		EgressConnectorRefs:    microvmEgressRefs,
 		MaximumDurationSeconds: microvmMaxDuration,
+		IdlePolicy:             microvmIdlePolicy,
 	}
 
 	portalHost := envStringDefault("WEBAUTHN_RP_ID", "lesser.host")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,6 +93,61 @@ func TestLoad_Defaults(t *testing.T) {
 	}
 }
 
+func TestLoad_HostedGenesisMicroVMDefaultLifetimePolicy(t *testing.T) {
+	cfg := Load()
+
+	if got := cfg.HostedGenesisMicroVM.MaximumDurationSeconds; got != HostedGenesisMicroVMDefaultMaximumDurationSeconds {
+		t.Fatalf("expected hosted genesis microvm default max duration %d, got %d", HostedGenesisMicroVMDefaultMaximumDurationSeconds, got)
+	}
+	if !cfg.HostedGenesisMicroVM.IdlePolicy.Complete() {
+		t.Fatalf("expected default hosted genesis microvm idle policy to be complete: %#v", cfg.HostedGenesisMicroVM.IdlePolicy)
+	}
+	if cfg.HostedGenesisMicroVM.IdlePolicy.AutoResumeEnabled {
+		t.Fatalf("expected default hosted genesis microvm idle auto-resume disabled until lab proof explicitly validates it")
+	}
+	if got := cfg.HostedGenesisMicroVM.IdlePolicy.MaxIdleDurationSeconds; got != HostedGenesisMicroVMDefaultIdleMaxSeconds {
+		t.Fatalf("expected default hosted genesis microvm idle max %d, got %d", HostedGenesisMicroVMDefaultIdleMaxSeconds, got)
+	}
+	if got := cfg.HostedGenesisMicroVM.IdlePolicy.SuspendedDurationSeconds; got != HostedGenesisMicroVMDefaultIdleSuspendedSeconds {
+		t.Fatalf("expected default hosted genesis microvm suspended duration %d, got %d", HostedGenesisMicroVMDefaultIdleSuspendedSeconds, got)
+	}
+}
+
+func TestLoad_HostedGenesisMicroVMLifetimePolicy(t *testing.T) {
+	t.Setenv("HOSTED_GENESIS_MICROVM_ENABLED", "true")
+	t.Setenv("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT", " https://controller.example/microvms ")
+	t.Setenv("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM", " /lesser-host/lab/hosted-genesis/microvm/auth-token ")
+	t.Setenv("APPTHEORY_MICROVM_IMAGE_REF", " image-ref ")
+	t.Setenv("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS", " egress-1, egress-2 ")
+	t.Setenv("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS", " ingress-1 ")
+	t.Setenv("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", "450")
+	t.Setenv("HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", "240")
+	t.Setenv("HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", "1200")
+	t.Setenv("HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED", "true")
+
+	cfg := Load()
+
+	if !cfg.HostedGenesisMicroVM.Complete() {
+		t.Fatalf("expected complete hosted genesis microvm config: %#v", cfg.HostedGenesisMicroVM)
+	}
+	if cfg.HostedGenesisMicroVM.ControllerEndpoint != "https://controller.example/microvms" {
+		t.Fatalf("unexpected controller endpoint: %q", cfg.HostedGenesisMicroVM.ControllerEndpoint)
+	}
+	if cfg.HostedGenesisMicroVM.NetworkConnectorRef != "egress-1" {
+		t.Fatalf("expected first egress connector as network connector ref, got %q", cfg.HostedGenesisMicroVM.NetworkConnectorRef)
+	}
+	if cfg.HostedGenesisMicroVM.MaximumDurationSeconds != 450 {
+		t.Fatalf("expected maximum duration 450, got %d", cfg.HostedGenesisMicroVM.MaximumDurationSeconds)
+	}
+	if !cfg.HostedGenesisMicroVM.IdlePolicy.AutoResumeEnabled {
+		t.Fatalf("expected explicit idle auto resume opt-in")
+	}
+	if cfg.HostedGenesisMicroVM.IdlePolicy.MaxIdleDurationSeconds != 240 ||
+		cfg.HostedGenesisMicroVM.IdlePolicy.SuspendedDurationSeconds != 1200 {
+		t.Fatalf("unexpected idle policy: %#v", cfg.HostedGenesisMicroVM.IdlePolicy)
+	}
+}
+
 func TestLoad_ENSGatewayDefaultStageConfig(t *testing.T) {
 	t.Setenv("STAGE", "")
 	t.Setenv("ENS_GATEWAY_CHAIN_ID", "")

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -42,6 +42,18 @@ func envInt64Bounded(key string, fallback int64, minValue int64, maxValue int64)
 	return n
 }
 
+func envInt32Bounded(key string, fallback int32, minValue int32, maxValue int32) int32 {
+	raw := envString(key)
+	if raw == "" {
+		return fallback
+	}
+	n, err := strconv.ParseInt(raw, 10, 32)
+	if err != nil || n < int64(minValue) || n > int64(maxValue) {
+		return fallback
+	}
+	return int32(n) //nolint:gosec // G115: ParseInt bitSize=32 plus explicit bounds above constrain the narrowing.
+}
+
 func envInt64Positive(key string, fallback int64) int64 {
 	raw := envString(key)
 	if raw == "" {

--- a/internal/controlplane/handlers_soul_mint_conversation_async.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async.go
@@ -1088,8 +1088,9 @@ func addHostedGenesisSessionWrite(tx core.TransactionBuilder, session *models.Ho
 // compatibility/recovery seam for sessions that are already in the legacy
 // declaration_extraction_pending lane or explicit #944/#945 follow-up work. The
 // Project 48 M11 accepted-turn path must not call it to decide final
-// affirmation or to create a follow-on extraction job: current Hosted Genesis
-// turns are delivered to the AppTheory MicroVM actor, and that actor owns the
+// affirmation, create a follow-on extraction job, or debit a second extraction
+// charge: current Hosted Genesis turns are delivered to the AppTheory MicroVM
+// actor through the ordinary paid accepted turn, and that actor owns the
 // ask/wait/revise/extract/finalize/fail decision under Host status/version
 // guards.
 func (s *Server) startHostedGenesisDeclarationExtraction(ctx *apptheory.Context, convCtx soulInstanceBootstrapConversationContext) error {

--- a/internal/controlplane/hosted_genesis_microvm_dispatch.go
+++ b/internal/controlplane/hosted_genesis_microvm_dispatch.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
+
 	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 )
@@ -116,15 +118,28 @@ func newHostedGenesisMicroVMDispatcher(ctx context.Context, cfg config.Config, s
 		IngressConnectorRefs: append([]string(nil), microvmCfg.IngressConnectorRefs...),
 		EgressConnectorRefs:  append([]string(nil), microvmCfg.EgressConnectorRefs...),
 		MaxDurationSeconds:   microvmCfg.MaximumDurationSeconds,
+		IdlePolicy:           microVMIdlePolicyFromConfig(microvmCfg.IdlePolicy),
 		HTTPClient:           httpClient,
 	})
 	if err != nil {
 		log.Printf("controlplane: hosted genesis microvm dispatcher unavailable (http dispatcher construction failed) err=%v", err)
 		return nil
 	}
-	log.Printf("controlplane: hosted genesis microvm dispatcher wired stage=%s endpoint=%s image_ref=%s max_duration_seconds=%d",
-		strings.TrimSpace(cfg.Stage), microvmCfg.ControllerEndpoint, microvmCfg.ImageRef, microvmCfg.MaximumDurationSeconds)
+	log.Printf("controlplane: hosted genesis microvm dispatcher wired stage=%s endpoint=%s image_ref=%s max_duration_seconds=%d idle_max_seconds=%d idle_suspended_seconds=%d idle_auto_resume=%t",
+		strings.TrimSpace(cfg.Stage), microvmCfg.ControllerEndpoint, microvmCfg.ImageRef, microvmCfg.MaximumDurationSeconds,
+		microvmCfg.IdlePolicy.MaxIdleDurationSeconds, microvmCfg.IdlePolicy.SuspendedDurationSeconds, microvmCfg.IdlePolicy.AutoResumeEnabled)
 	return dispatcher
+}
+
+func microVMIdlePolicyFromConfig(policy config.HostedGenesisMicroVMIdlePolicyConfig) *runtimemicrovm.ProviderIdlePolicy {
+	if !policy.Complete() {
+		return nil
+	}
+	return &runtimemicrovm.ProviderIdlePolicy{
+		AutoResumeEnabled:        policy.AutoResumeEnabled,
+		MaxIdleDurationSeconds:   policy.MaxIdleDurationSeconds,
+		SuspendedDurationSeconds: policy.SuspendedDurationSeconds,
+	}
 }
 
 // resolveMicroVMAuthToken fetches the authorizer bearer token from SSM. The

--- a/internal/controlplane/hosted_genesis_microvm_dispatch_internal_test.go
+++ b/internal/controlplane/hosted_genesis_microvm_dispatch_internal_test.go
@@ -19,8 +19,8 @@ import (
 
 // microVMWiringTestConfig returns a complete HTTP-transport MicroVM config for
 // NewServer wiring tests. The ControllerEndpoint + AuthTokenSSMParam +
-// ImageRef/NetworkConnectorRef satisfy Complete(); tests inject an httptest
-// stub controller URL + a stub SSM getter so no AWS or SSM is called.
+// ImageRef/NetworkConnectorRef/IdlePolicy satisfy Complete(); tests inject an
+// httptest stub controller URL + a stub SSM getter so no AWS or SSM is called.
 func microVMWiringTestConfig() config.Config {
 	return config.Config{
 		Stage: "lab",
@@ -33,6 +33,10 @@ func microVMWiringTestConfig() config.Config {
 			IngressConnectorRefs:   []string{"arn:aws:lambda::network-connector/all-ingress:test"},
 			EgressConnectorRefs:    []string{"arn:aws:lambda::network-connector/egress:test"},
 			MaximumDurationSeconds: 300,
+			IdlePolicy: config.HostedGenesisMicroVMIdlePolicyConfig{
+				MaxIdleDurationSeconds:   300,
+				SuspendedDurationSeconds: 1800,
+			},
 		},
 	}
 }
@@ -82,6 +86,11 @@ func (s *stubControllerServer) handleRun(w http.ResponseWriter, r *http.Request)
 	var payload struct {
 		SessionID              string `json:"session_id"`
 		MaximumDurationSeconds int32  `json:"maximum_duration_seconds"`
+		IdlePolicy             struct {
+			AutoResumeEnabled        bool  `json:"auto_resume_enabled"`
+			MaxIdleDurationSeconds   int32 `json:"max_idle_duration_seconds"`
+			SuspendedDurationSeconds int32 `json:"suspended_duration_seconds"`
+		} `json:"idle_policy"`
 	}
 	_ = readJSONBody(r, &payload)
 	sessionID := strings.TrimSpace(payload.SessionID)

--- a/internal/controlplane/hosted_genesis_microvm_e2e_internal_test.go
+++ b/internal/controlplane/hosted_genesis_microvm_e2e_internal_test.go
@@ -167,15 +167,20 @@ func h1_5KillVMRecoveryArc(t *testing.T, dispatcher hostedgenesis.MicroVMDispatc
 	}
 }
 
-// TestH1_5_E2E_MaximumDurationSecondsWired proves the H1.5 timeout-budget
-// wiring: the dispatcher-sized MaximumDurationSeconds (config, decision 7) is
-// set on the dispatched POST /microvms run body so the MicroVM session is
-// bounded for the longest LLM turn plus in-VM extraction. The stub controller
-// records the value it received on the run body.
+// TestH1_5_E2E_MaximumDurationSecondsWired proves the H1.5/M11 timeout-budget
+// wiring: the dispatcher-sized MaximumDurationSeconds and AppTheory
+// ProviderIdlePolicy are set on the dispatched POST /microvms run body so the
+// active provider step and human-gap behavior stay in the AppTheory substrate
+// instead of a Host-owned step machine. The stub controller records the values
+// it received on the run body.
 func TestH1_5_E2E_MaximumDurationSecondsWired(t *testing.T) {
 	cfg := microVMWiringTestConfig()
 	const wantMaxDuration = int32(300)
+	const wantIdleMax = int32(300)
+	const wantIdleSuspended = int32(1800)
 	cfg.HostedGenesisMicroVM.MaximumDurationSeconds = wantMaxDuration
+	cfg.HostedGenesisMicroVM.IdlePolicy.MaxIdleDurationSeconds = wantIdleMax
+	cfg.HostedGenesisMicroVM.IdlePolicy.SuspendedDurationSeconds = wantIdleSuspended
 
 	stub := newMaxDurationCapturingControllerServer(t, "stub-bearer")
 	controllerSrv := httptest.NewServer(stub.handler())
@@ -202,14 +207,25 @@ func TestH1_5_E2E_MaximumDurationSecondsWired(t *testing.T) {
 	if got := stub.capturedMaxDuration(); got != wantMaxDuration {
 		t.Fatalf("expected MaximumDurationSeconds=%d on the run request, got %d", wantMaxDuration, got)
 	}
+	idle := stub.capturedIdlePolicy()
+	if idle == nil {
+		t.Fatalf("expected AppTheory IdlePolicy on the run request")
+	}
+	if idle.AutoResumeEnabled {
+		t.Fatalf("expected Host default auto-resume disabled until lab proof, got %#v", idle)
+	}
+	if idle.MaxIdleDurationSeconds != wantIdleMax || idle.SuspendedDurationSeconds != wantIdleSuspended {
+		t.Fatalf("unexpected idle policy on run request: %#v", idle)
+	}
 }
 
 // maxDurationCapturingControllerServer wraps the stub controller and captures
-// the maximum_duration_seconds passed in the POST /microvms run body so the E2E
-// harness can assert the timeout-budget wiring without calling AWS.
+// the lifetime policy passed in the POST /microvms run body so the E2E harness
+// can assert timeout-budget wiring without calling AWS.
 type maxDurationCapturingControllerServer struct {
 	inner    *stubControllerServer
 	captured *int32
+	idle     *runtimemicrovm.ProviderIdlePolicy
 }
 
 func newMaxDurationCapturingControllerServer(t *testing.T, token string) *maxDurationCapturingControllerServer {
@@ -228,10 +244,12 @@ func (s *maxDurationCapturingControllerServer) handler() http.Handler {
 			_ = r.Body.Close()
 			if err == nil {
 				var payload struct {
-					MaximumDurationSeconds int32 `json:"maximum_duration_seconds"`
+					MaximumDurationSeconds int32                              `json:"maximum_duration_seconds"`
+					IdlePolicy             *runtimemicrovm.ProviderIdlePolicy `json:"idle_policy"`
 				}
 				_ = json.Unmarshal(body, &payload)
 				*s.captured = payload.MaximumDurationSeconds
+				s.idle = payload.IdlePolicy
 			}
 			r.Body = io.NopCloser(bytes.NewReader(body))
 		}
@@ -241,6 +259,10 @@ func (s *maxDurationCapturingControllerServer) handler() http.Handler {
 
 func (s *maxDurationCapturingControllerServer) capturedMaxDuration() int32 { return *s.captured }
 
+func (s *maxDurationCapturingControllerServer) capturedIdlePolicy() *runtimemicrovm.ProviderIdlePolicy {
+	return s.idle
+}
+
 // TestH1_5_E2E_HarnessConfigCompleteGuard is a lightweight guard that the
 // harness's wiring-test config satisfies config.HostedGenesisMicroVMConfig.Complete
 // (the gate NewServer uses to decide between wiring the real dispatcher and
@@ -249,7 +271,7 @@ func (s *maxDurationCapturingControllerServer) capturedMaxDuration() int32 { ret
 func TestH1_5_E2E_HarnessConfigCompleteGuard(t *testing.T) {
 	cfg := microVMWiringTestConfig()
 	if !cfg.HostedGenesisMicroVM.Complete() {
-		t.Fatalf("E2E harness config must be Complete (enabled + endpoint + auth token + image + egress), got %#v", cfg.HostedGenesisMicroVM)
+		t.Fatalf("E2E harness config must be Complete (enabled + endpoint + auth token + image + egress + idle policy), got %#v", cfg.HostedGenesisMicroVM)
 	}
 	if !strings.HasPrefix(cfg.HostedGenesisMicroVM.ImageRef, "arn:") {
 		t.Fatalf("E2E harness config image ref drifted: %q", cfg.HostedGenesisMicroVM.ImageRef)

--- a/internal/hostedgenesis/contract_docs_test.go
+++ b/internal/hostedgenesis/contract_docs_test.go
@@ -18,6 +18,42 @@ func TestFiveBodyContractDocsPinSchemaGuidanceVersions(t *testing.T) {
 	assertFiveBodyContractMarkdown(t)
 }
 
+func TestHostedGenesisConversationContractCodifiesM11ActorPathBilling(t *testing.T) {
+	contractBody, readErr := os.ReadFile(filepath.Join("..", "..", "docs", "contracts", "hosted-genesis-conversation.md"))
+	if readErr != nil {
+		t.Fatalf("read hosted-genesis conversation contract: %v", readErr)
+	}
+	contract := string(contractBody)
+	for _, want := range []string{
+		"M11 billing policy for actor-path declaration extraction",
+		"does **not** create a second Host extraction debit",
+		"Active M11 actor-path traffic",
+		"finalization/publish",
+	} {
+		if !strings.Contains(contract, want) {
+			t.Fatalf("hosted-genesis conversation contract missing M11 billing policy phrase %q", want)
+		}
+	}
+
+	asyncBody, readErr := os.ReadFile(filepath.Join("..", "controlplane", "handlers_soul_mint_conversation_async.go"))
+	if readErr != nil {
+		t.Fatalf("read async mint conversation source: %v", readErr)
+	}
+	asyncSrc := string(asyncBody)
+	progressBody, ok := between(asyncSrc, "func (s *Server) progressHostedGenesisAcceptedTurn", "func (s *Server) progressHostedGenesisAcceptedTurnSync")
+	if !ok {
+		t.Fatalf("could not locate progressHostedGenesisAcceptedTurn body")
+	}
+	if strings.Contains(progressBody, "startHostedGenesisDeclarationExtraction") ||
+		strings.Contains(progressBody, "soulMintConversationExtractModule") {
+		t.Fatalf("active M11 accepted-turn path must not call Host-owned extraction/debit machinery")
+	}
+	if !strings.Contains(asyncSrc, "startHostedGenesisDeclarationExtraction") ||
+		!strings.Contains(asyncSrc, "compatibility/recovery seam") {
+		t.Fatalf("legacy extraction seam must remain explicit and documented as compatibility/recovery only")
+	}
+}
+
 func assertFiveBodyContractSchemaCore(t *testing.T, schema map[string]any) {
 	t.Helper()
 	props := requireJSONMap(t, schema, "properties")
@@ -150,6 +186,19 @@ func requiredHas(required []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func between(body string, start string, end string) (string, bool) {
+	startIdx := strings.Index(body, start)
+	if startIdx < 0 {
+		return "", false
+	}
+	tail := body[startIdx:]
+	endIdx := strings.Index(tail[len(start):], end)
+	if endIdx < 0 {
+		return "", false
+	}
+	return tail[:len(start)+endIdx], true
 }
 
 func compileContractSchema(t *testing.T, name string) *jsonschema.Schema {

--- a/internal/hostedgenesis/dispatch.go
+++ b/internal/hostedgenesis/dispatch.go
@@ -87,17 +87,18 @@ type MicroVMDispatcher interface {
 // (runtime/microvm/controller_routes.go controllerRoutePayload). The route
 // handler fixes the command to "run", derives tenant_id from x-tenant-id /
 // query, and namespace from x-namespace-id; only the session + image/network
-// fields + the duration cap are caller-supplied in the body. AuthContext is
-// populated by the controller authorizer, not the body.
+// fields + AppTheory lifetime controls are caller-supplied in the body.
+// AuthContext is populated by the controller authorizer, not the body.
 type microvmRunRequestPayload struct {
-	SessionID                   string                     `json:"session_id,omitempty"`
-	ImageRef                    string                     `json:"image_ref"`
-	ImageVersion                string                     `json:"image_version,omitempty"`
-	NetworkConnectorRef         string                     `json:"network_connector_ref"`
-	IngressNetworkConnectorRefs []string                   `json:"ingress_network_connector_refs,omitempty"`
-	EgressNetworkConnectorRefs  []string                   `json:"egress_network_connector_refs,omitempty"`
-	SessionSpec                 runtimemicrovm.SessionSpec `json:"session_spec,omitempty"`
-	MaximumDurationSeconds      int32                      `json:"maximum_duration_seconds,omitempty"`
+	SessionID                   string                             `json:"session_id,omitempty"`
+	ImageRef                    string                             `json:"image_ref"`
+	ImageVersion                string                             `json:"image_version,omitempty"`
+	NetworkConnectorRef         string                             `json:"network_connector_ref"`
+	IngressNetworkConnectorRefs []string                           `json:"ingress_network_connector_refs,omitempty"`
+	EgressNetworkConnectorRefs  []string                           `json:"egress_network_connector_refs,omitempty"`
+	SessionSpec                 runtimemicrovm.SessionSpec         `json:"session_spec,omitempty"`
+	IdlePolicy                  *runtimemicrovm.ProviderIdlePolicy `json:"idle_policy,omitempty"`
+	MaximumDurationSeconds      int32                              `json:"maximum_duration_seconds,omitempty"`
 }
 
 // HTTPControllerDispatcher adapts the governed AppTheoryMicrovmController HTTP
@@ -122,6 +123,7 @@ type HTTPControllerDispatcher struct {
 	ingressConnRefs []string
 	egressConnRefs  []string
 	maxDuration     int32
+	idlePolicy      *runtimemicrovm.ProviderIdlePolicy
 	httpClient      *http.Client
 }
 
@@ -130,7 +132,9 @@ type HTTPControllerDispatcher struct {
 // is the authorizer bearer token presented in the Authorization header (a
 // credential — never committed or logged); the image/network refs are the
 // non-secret refs sent in the POST /microvms run body. MaxDurationSeconds caps
-// each run session; zero lets the controller/provider default apply.
+// each active run session; zero lets the controller/provider default apply.
+// IdlePolicy is passed through AppTheory's v1.17.0 ProviderIdlePolicy contract
+// for human-gap ready/suspended lifetime instead of a Host-owned step machine.
 type HTTPControllerDispatcherConfig struct {
 	Endpoint             string
 	AuthToken            string //nolint:gosec // G117: name describes the authorizer bearer token; in-process config struct, never JSON-serialized over an untrusted wire.
@@ -139,6 +143,7 @@ type HTTPControllerDispatcherConfig struct {
 	IngressConnectorRefs []string
 	EgressConnectorRefs  []string
 	MaxDurationSeconds   int32
+	IdlePolicy           *runtimemicrovm.ProviderIdlePolicy
 	HTTPClient           *http.Client
 }
 
@@ -158,6 +163,13 @@ func NewHTTPControllerDispatcher(cfg HTTPControllerDispatcherConfig) (*HTTPContr
 	if cfg.HTTPClient == nil {
 		return nil, ErrMicroVMDispatchUnavailable
 	}
+	if cfg.MaxDurationSeconds < 0 {
+		return nil, ErrMicroVMDispatchUnavailable
+	}
+	idlePolicy, err := cloneAndValidateProviderIdlePolicy(cfg.IdlePolicy)
+	if err != nil {
+		return nil, err
+	}
 	return &HTTPControllerDispatcher{
 		endpoint:        strings.TrimRight(endpoint, "/"),
 		authToken:       authToken,
@@ -166,8 +178,31 @@ func NewHTTPControllerDispatcher(cfg HTTPControllerDispatcherConfig) (*HTTPContr
 		ingressConnRefs: normalizeStringSlice(cfg.IngressConnectorRefs),
 		egressConnRefs:  normalizeStringSlice(cfg.EgressConnectorRefs),
 		maxDuration:     cfg.MaxDurationSeconds,
+		idlePolicy:      idlePolicy,
 		httpClient:      cfg.HTTPClient,
 	}, nil
+}
+
+func cloneAndValidateProviderIdlePolicy(policy *runtimemicrovm.ProviderIdlePolicy) (*runtimemicrovm.ProviderIdlePolicy, error) {
+	cloned := cloneProviderIdlePolicy(policy)
+	if cloned == nil {
+		return nil, nil
+	}
+	if cloned.MaxIdleDurationSeconds <= 0 || cloned.SuspendedDurationSeconds <= 0 {
+		return nil, ErrMicroVMDispatchUnavailable
+	}
+	return cloned, nil
+}
+
+func cloneProviderIdlePolicy(policy *runtimemicrovm.ProviderIdlePolicy) *runtimemicrovm.ProviderIdlePolicy {
+	if policy == nil {
+		return nil
+	}
+	return &runtimemicrovm.ProviderIdlePolicy{
+		AutoResumeEnabled:        policy.AutoResumeEnabled,
+		MaxIdleDurationSeconds:   policy.MaxIdleDurationSeconds,
+		SuspendedDurationSeconds: policy.SuspendedDurationSeconds,
+	}
 }
 
 // StartMicroVMRun POSTs /microvms to the governed controller API for the
@@ -197,6 +232,7 @@ func (d *HTTPControllerDispatcher) StartMicroVMRun(ctx context.Context, requestI
 			Metadata: binding.Metadata(),
 		},
 		MaximumDurationSeconds: d.maxDuration,
+		IdlePolicy:             cloneProviderIdlePolicy(d.idlePolicy),
 	}
 	resp, err := d.doControllerRequest(ctx, http.MethodPost, d.endpoint, requestID, binding, payload)
 	if err != nil {
@@ -345,6 +381,7 @@ func (d *HTTPControllerDispatcher) DispatchMicroVMRun(ctx context.Context, reque
 			Metadata: binding.Metadata(),
 		},
 		MaximumDurationSeconds: d.maxDuration,
+		IdlePolicy:             cloneProviderIdlePolicy(d.idlePolicy),
 	}
 	resp, err := d.doControllerRequest(ctx, http.MethodPost, d.endpoint, requestID, binding, payload)
 	if err != nil {

--- a/internal/hostedgenesis/dispatch_test.go
+++ b/internal/hostedgenesis/dispatch_test.go
@@ -3,6 +3,7 @@ package hostedgenesis
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -35,6 +36,8 @@ type stubControllerServer struct {
 	runState      runtimemicrovm.LifecycleState
 	getState      runtimemicrovm.LifecycleState
 	invokeFailure *runtimemicrovm.SafeError
+	runPayloads   []microvmRunRequestPayload
+	runBodies     []string
 }
 
 func newStubControllerServer(t *testing.T, token string) *stubControllerServer {
@@ -91,13 +94,21 @@ func (s *stubControllerServer) handleRun(w http.ResponseWriter, r *http.Request)
 		})
 		return
 	}
-	var payload microvmRunRequestPayload
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+	body, readErr := io.ReadAll(r.Body)
+	if readErr != nil {
 		writeControllerJSON(w, http.StatusBadRequest, runtimemicrovm.ControllerResponse{
 			Error: &runtimemicrovm.SafeError{Code: "m15.microvm.invalid_controller_request", Message: "malformed"},
 		})
 		return
 	}
+	var payload microvmRunRequestPayload
+	if err := json.Unmarshal(body, &payload); err != nil {
+		writeControllerJSON(w, http.StatusBadRequest, runtimemicrovm.ControllerResponse{
+			Error: &runtimemicrovm.SafeError{Code: "m15.microvm.invalid_controller_request", Message: "malformed"},
+		})
+		return
+	}
+	s.recordRunPayload(payload, string(body))
 	sessionID := strings.TrimSpace(payload.SessionID)
 	if sessionID == "" {
 		sessionID = "stub-session"
@@ -127,6 +138,13 @@ func (s *stubControllerServer) handleRun(w http.ResponseWriter, r *http.Request)
 	s.sessions[sessionID] = resp
 	s.mu.Unlock()
 	writeControllerJSON(w, http.StatusOK, resp)
+}
+
+func (s *stubControllerServer) recordRunPayload(payload microvmRunRequestPayload, body string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.runPayloads = append(s.runPayloads, payload)
+	s.runBodies = append(s.runBodies, body)
 }
 
 func (s *stubControllerServer) handleGet(w http.ResponseWriter, r *http.Request) {
@@ -357,6 +375,15 @@ func (s *stubControllerServer) resumeCount() int {
 	return s.resumes
 }
 
+func (s *stubControllerServer) lastRunPayload() (microvmRunRequestPayload, string, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.runPayloads) == 0 {
+		return microvmRunRequestPayload{}, "", false
+	}
+	return s.runPayloads[len(s.runPayloads)-1], s.runBodies[len(s.runBodies)-1], true
+}
+
 func writeControllerJSON(w http.ResponseWriter, status int, resp runtimemicrovm.ControllerResponse) {
 	w.Header().Set("content-type", "application/json")
 	w.WriteHeader(status)
@@ -377,7 +404,11 @@ func testHTTPDispatcher(t *testing.T, endpoint, token string) *HTTPControllerDis
 		ImageRef:            "arn:aws:lambda:us-east-1:123456789012:microvm-image/hosted-genesis:1",
 		NetworkConnectorRef: "arn:aws:lambda:us-east-1:123456789012:network-connector/hosted-genesis-egress",
 		MaxDurationSeconds:  300,
-		HTTPClient:          &http.Client{Timeout: 5 * time.Second},
+		IdlePolicy: &runtimemicrovm.ProviderIdlePolicy{
+			MaxIdleDurationSeconds:   300,
+			SuspendedDurationSeconds: 1800,
+		},
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
 	})
 	require.NoError(t, err)
 	return d
@@ -400,6 +431,58 @@ func TestHTTPControllerDispatcherDispatchesRunViaPOST(t *testing.T) {
 	require.NotEmpty(t, result.LifecycleRef.MicroVMID)
 	require.Equal(t, runtimemicrovm.StateRunning, result.LifecycleRef.LifecycleState)
 	require.Equal(t, 1, stub.invokeCount(), "dispatch must invoke the hosted-genesis turn through AppTheory's canonical controller invoke route")
+}
+
+func TestHTTPControllerDispatcherPassesAppTheoryLifetimePolicyWithoutSecrets(t *testing.T) {
+	t.Parallel()
+	stub := newStubControllerServer(t, "stub-bearer")
+	srv := httptest.NewServer(stub.handler())
+	t.Cleanup(srv.Close)
+
+	binding := testMicroVMBinding()
+	dispatcher := testHTTPDispatcher(t, srv.URL+"/microvms", stub.token)
+	_, err := dispatcher.StartMicroVMRun(context.Background(), "req-lifetime", binding)
+	require.NoError(t, err)
+
+	payload, rawBody, ok := stub.lastRunPayload()
+	require.True(t, ok, "expected stub controller to capture the run payload")
+	require.Equal(t, binding.ConversationID, payload.SessionID)
+	require.Equal(t, int32(300), payload.MaximumDurationSeconds)
+	require.NotNil(t, payload.IdlePolicy)
+	require.False(t, payload.IdlePolicy.AutoResumeEnabled, "default Host M11 policy must not opt into provider auto-resume before lab proof")
+	require.Equal(t, int32(300), payload.IdlePolicy.MaxIdleDurationSeconds)
+	require.Equal(t, int32(1800), payload.IdlePolicy.SuspendedDurationSeconds)
+	require.NoError(t, runtimemicrovm.ValidateProviderRunInput(runtimemicrovm.ProviderRunInput{
+		RequestID:                   "req-lifetime",
+		TenantID:                    binding.TenantID(),
+		Namespace:                   MicroVMNamespace,
+		SessionID:                   binding.ConversationID,
+		AuthContext:                 authContext(binding),
+		ImageRef:                    payload.ImageRef,
+		NetworkConnectorRef:         payload.NetworkConnectorRef,
+		IngressNetworkConnectorRefs: payload.IngressNetworkConnectorRefs,
+		EgressNetworkConnectorRefs:  payload.EgressNetworkConnectorRefs,
+		SessionSpec:                 payload.SessionSpec,
+		IdlePolicy:                  payload.IdlePolicy,
+		MaximumDurationSeconds:      payload.MaximumDurationSeconds,
+	}))
+	rawLower := strings.ToLower(rawBody)
+	for _, forbidden := range []string{
+		"stub-bearer",
+		"authorization",
+		"bearer_token",
+		"provider_key",
+		"provider_secret",
+		"aws_secret_access_key",
+		"aws_access_key_id",
+		"instance_api_key",
+		"microvm_endpoint_token",
+		"transcript",
+		"messages",
+		"prompt",
+	} {
+		require.NotContains(t, rawLower, forbidden, "controller run body must carry only AppTheory run metadata/lifetime policy")
+	}
 }
 
 func TestHTTPControllerDispatcherRecordsReadyGETResponseAfterValidatingRun(t *testing.T) {
@@ -542,6 +625,8 @@ func TestHTTPControllerDispatcherConstructionFailsClosedOnMissingConfig(t *testi
 		{"missing image ref", HTTPControllerDispatcherConfig{Endpoint: "https://example/microvms", AuthToken: "tok", NetworkConnectorRef: "net", HTTPClient: client}},
 		{"missing network ref", HTTPControllerDispatcherConfig{Endpoint: "https://example/microvms", AuthToken: "tok", ImageRef: "img", HTTPClient: client}},
 		{"nil http client", HTTPControllerDispatcherConfig{Endpoint: "https://example/microvms", AuthToken: "tok", ImageRef: "img", NetworkConnectorRef: "net"}},
+		{"negative maximum duration", HTTPControllerDispatcherConfig{Endpoint: "https://example/microvms", AuthToken: "tok", ImageRef: "img", NetworkConnectorRef: "net", MaxDurationSeconds: -1, HTTPClient: client}},
+		{"partial idle policy", HTTPControllerDispatcherConfig{Endpoint: "https://example/microvms", AuthToken: "tok", ImageRef: "img", NetworkConnectorRef: "net", IdlePolicy: &runtimemicrovm.ProviderIdlePolicy{MaxIdleDurationSeconds: 300}, HTTPClient: client}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/hostedgenesis/microvm_controller.go
+++ b/internal/hostedgenesis/microvm_controller.go
@@ -40,6 +40,9 @@ type MicroVMControllerRuntime struct {
 	// extraction). Zero/positive-only; a non-positive value lets the AppTheory
 	// provider default apply. It is set on the run request envelope only.
 	maximumDurationSeconds int32
+	// idlePolicy is the AppTheory ProviderIdlePolicy applied to run requests
+	// when the caller omitted an explicit idle policy.
+	idlePolicy *runtimemicrovm.ProviderIdlePolicy
 }
 
 // MicroVMControllerRuntimeConfig configures the AppTheory M16 controller
@@ -63,6 +66,11 @@ type MicroVMControllerRuntimeConfig struct {
 	// sized for the longest LLM turn plus in-VM declaration extraction (P52 H1.5
 	// decision 7). Non-positive leaves the AppTheory provider default in place.
 	MaximumDurationSeconds int32
+	// IdlePolicy is the AppTheory ProviderIdlePolicy Host passes on run
+	// commands for human-gap ready/suspended lifetime. It is execution/cache
+	// policy only; Host checkpoints/relaunches from HostedGenesisSession truth
+	// when the provider cannot preserve process memory.
+	IdlePolicy *runtimemicrovm.ProviderIdlePolicy
 }
 
 // NewMicroVMControllerRuntime creates the AppTheory M16 real controller Host
@@ -98,6 +106,10 @@ func NewMicroVMControllerRuntime(cfg MicroVMControllerRuntimeConfig) (*MicroVMCo
 	if cfg.SessionTTL > 0 {
 		opts = append(opts, runtimemicrovm.WithControllerSessionTTL(cfg.SessionTTL))
 	}
+	idlePolicy, idleErr := cloneAndValidateProviderIdlePolicy(cfg.IdlePolicy)
+	if idleErr != nil {
+		return nil, ErrMicroVMControllerIncomplete
+	}
 	opts = append(opts, runtimemicrovm.WithControllerDeploymentDefaults(runtimemicrovm.ControllerDeploymentDefaults{
 		ImageRef:                    imageRef,
 		NetworkConnectorRef:         networkConnectorRef,
@@ -115,6 +127,7 @@ func NewMicroVMControllerRuntime(cfg MicroVMControllerRuntimeConfig) (*MicroVMCo
 		ingressNetworkConnectorRefs: normalizeStringSlice(cfg.IngressNetworkConnectorRefs),
 		egressNetworkConnectorRefs:  normalizeStringSlice(cfg.EgressNetworkConnectorRefs),
 		maximumDurationSeconds:      cfg.MaximumDurationSeconds,
+		idlePolicy:                  idlePolicy,
 	}, nil
 }
 
@@ -153,6 +166,9 @@ func (r *MicroVMControllerRuntime) Handle(ctx context.Context, req runtimemicrov
 		// leaves the AppTheory provider default in place.
 		if req.MaximumDurationSeconds <= 0 && r.maximumDurationSeconds > 0 {
 			req.MaximumDurationSeconds = r.maximumDurationSeconds
+		}
+		if req.IdlePolicy == nil && r.idlePolicy != nil {
+			req.IdlePolicy = cloneProviderIdlePolicy(r.idlePolicy)
 		}
 	}
 	if req.Command == runtimemicrovm.CommandAuthToken && len(req.AllowedPortScope) == 0 {

--- a/scripts/hosted-genesis-microvm-canary.sh
+++ b/scripts/hosted-genesis-microvm-canary.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-go test ./internal/hostedgenesis -run 'TestMicroVMLabCanaryHarnessExercisesM16LifecycleAndSecretChecks|TestMicroVMControllerRuntimeExercisesAppTheoryM16Commands|TestMicroVMControllerRuntimeUsesAppTheoryM16WithoutLocalAdapter' -count=1
-go test ./cmd/hosted-genesis-microvm-controller -run 'TestControllerAppRegistersAppTheoryM16Routes|TestControllerAuthHookRequiresHashedBearerAndTenantHeaders|TestControllerEventFailsClosedWhenDisabled' -count=1
+go test ./internal/hostedgenesis -run 'TestMicroVMLabCanaryHarnessExercisesM16LifecycleAndSecretChecks|TestMicroVMControllerRuntimeExercisesAppTheoryM16Commands|TestMicroVMControllerRuntimeUsesAppTheoryM16WithoutLocalAdapter|TestHTTPControllerDispatcherPassesAppTheoryLifetimePolicyWithoutSecrets' -count=1
+go test ./cmd/hosted-genesis-microvm-controller -run 'TestControllerAppRegistersAppTheoryM16Routes|TestControllerAuthHookRequiresHashedBearerAndTenantHeaders|TestControllerEventFailsClosedWhenDisabled|TestControllerLifetimePolicyEnvParsesAppTheoryRunPolicy' -count=1

--- a/scripts/hosted-genesis-microvm-e2e-gate.sh
+++ b/scripts/hosted-genesis-microvm-e2e-gate.sh
@@ -17,8 +17,8 @@
 #      httptest.Server-backed stub controller serving the governed
 #      AppTheoryMicrovmController HTTP routes (POST /microvms to run, GET
 #      /microvms/{session_id} to reconcile). Proves the happy path, kill-VM
-#      recovery, and the MaximumDurationSeconds timeout-budget wiring. This is
-#      the proof that runs in CI; it does NOT call AWS. It needs NO
+#      recovery, and the MaximumDurationSeconds + IdlePolicy timeout-budget
+#      wiring. This is the proof that runs in CI; it does NOT call AWS. It needs NO
 #      configuration — in-memory HTTP stubs only.
 #   2. LAB DEPLOY GATE (runs only with --stage lab): drives the deployed lab
 #      control-plane endpoints. ALL configuration is SYSTEM-SOURCED — no
@@ -47,6 +47,10 @@
 #     in-VM extraction (HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS, default
 #     300s) — set on the CDK control-plane Lambda env and threaded onto the
 #     dispatched run request (verified by the stub gate).
+#   - the AppTheory ProviderIdlePolicy is explicit (default max idle 300s,
+#     suspended duration 1800s, auto-resume false) and is threaded onto the same
+#     dispatched run request; longer human gaps recover through checkpoint /
+#     relaunch / replay, not a Host-owned conversation step machine.
 #   - controller Lambda stays at 30s (lifecycle only); the assistant turn runs
 #     inside the MicroVM, not the controller Lambda.
 #


### PR DESCRIPTION
## Milestone
Project 48 Legend M11 — Hosted Genesis MicroVM conversation actor, issue #945 boundary hardening.

## Classification
operational-reliability / security / tenant-isolation / billing-accounting / framework-adoption / CDK-runtime-boundary

## Summary
- Thread AppTheory v1.17.0 `ProviderRunInput` lifetime controls through Host CDK/config/runtime dispatch: `MaximumDurationSeconds=300` plus explicit `ProviderIdlePolicy` (`max_idle_duration_seconds=300`, `suspended_duration_seconds=1800`, `auto_resume_enabled=false`).
- Preserve fail-closed controller auth and tenant-bound MicroVM run dispatch while testing that run bodies, CDK env, logs/docs/checkpoints carry only approved metadata/hashes and not raw provider keys, bearer tokens, AWS credentials, MicroVM endpoint tokens, or transcript data.
- Codify the M11 billing policy: actor-path declaration extraction rides the ordinary paid accepted turn; Host must not create a second extraction debit or reintroduce a Host-owned extraction step machine. The legacy extraction seam remains documented as compatibility/recovery only.

## Inspected framework/source evidence
- `go.mod`: confirmed `github.com/theory-cloud/apptheory v1.17.0` is preserved.
- AppTheory v1.17.0 sources inspected under `/home/aron/go/pkg/mod/github.com/theory-cloud/apptheory@v1.17.0/`:
  - `docs/cdk/lambda-microvm.md` — golden path requires `AppTheoryMicrovmNetworkConnector`, `AppTheoryMicrovmImage`, and `AppTheoryMicrovmController`; do not bypass controller auth/lifecycle/registry/token safety.
  - `runtime/microvm/provider.go` / `aws_provider.go` — exposes `MaximumDurationSeconds` and `ProviderIdlePolicy` and maps both into provider run input.
  - `runtime/microvm/controller.go` / `controller_routes.go` — controller request/payload carries `maximum_duration_seconds` and `idle_policy`.
  - `runtime/microvm/session.go` — session/token metadata excludes plaintext token material.
  - `cdk/lib/microvm-controller.ts` — fail-closed authorizer env, protected routes, session table, and execution-role pass-through.
- Host staging sources inspected before editing:
  - `docs/adr/0010-hosted-genesis-conversation-lifetime-microvm.md`.
  - `docs/contracts/hosted-genesis-conversation.md`.
  - Current Host CDK constructs plus MicroVM controller/workload/authorizer/session/recovery/billing paths.

## Surfaces affected
- CDK MicroVM controller/workload env + tests.
- Hosted Genesis runtime config and dispatch payload validation.
- Control-plane and ai-worker dispatcher wiring/logging tests.
- Controller runtime lifetime defaults.
- Billing/contract docs and policy tests.
- Local Hosted Genesis MicroVM canary/e2e gate scripts.

## Specialist walks referenced
- Framework: AppTheory v1.17.0 MicroVM contracts adopted directly; no Host-owned framework substitute or local provider-runtime replacement.
- Trust/security boundary: fail-closed controller auth preserved; no raw secret/transcript/token persistence added.
- Tenant isolation: session dispatch remains tenant/session scoped; Host remains durable gateway/finalization/billing/checkpoint authority.
- Governance: gov-infra verifier passed locally.

## Validation
- `go test ./...` — PASS.
- `./scripts/hosted-genesis-microvm-canary.sh` — PASS.
- `go vet ./...` — PASS.
- `files=$(git ls-files '*.go'); test -z "$(gofmt -l $files)"` — PASS.
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (`Pass: 41`, `Fail: 0`, `Blocked: 0`).
- `cd cdk && npm test` — PASS (`67` pass, `0` fail).
- `cd cdk && npm run synth -- -c stage=lab --quiet` — PASS.
- `git diff --check` — PASS.

## Boundary notes
- No AWS/cloud/SSM/secrets/signing/on-chain mutation was performed; no AWS profile was used.
- No sibling repo edits.
- No deployment, publishing, or signing.
- No framework fork/substitute; conversation decisions remain in the AppTheory MicroVM actor.
- #941 remains open for live lab proof.

Closes #945
