### PR TITLE
fix: compact hosted genesis MicroVM dispatch env

### DIFF
--- a/cdk/lib/hosted-genesis-microvm.ts
+++ b/cdk/lib/hosted-genesis-microvm.ts
@@ -22,6 +22,8 @@ export const HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS = 300 as const;
 export const HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS = 300 as const;
 export const HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS = 1800 as const;
 export const HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED = false as const;
+export const HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV =
+  "HOSTED_GENESIS_MICROVM_CONFIG_JSON" as const;
 
 // P52 H1 step 2 (F1): the AWS-managed base MicroVM image ARN. This is the
 // foundation the entire MicroVM-only genesis program sits on — H1.1–H1.5 merged
@@ -593,53 +595,55 @@ function grantFunctionMicroVMDispatch(
     }),
   );
 
-  // Inject the env vars controlplane.NewServer's HTTP dispatcher constructor
-  // reads: the governed controller endpoint, the auth-token SSM param name
-  // (the raw token is fetched at runtime, never committed), and the non-secret
-  // image/network-connector refs the control plane sends in the POST /microvms
-  // run body. The lifetime values are the explicit AppTheory ProviderRunInput
-  // MaximumDurationSeconds + ProviderIdlePolicy boundary from ADR 0010; Host
-  // does not create a local scheduler or provider step machine for human gaps.
+  // Inject one compact config env var read by controlplane.NewServer /
+  // ai-worker. It carries the same AppTheory POST /microvms run inputs the
+  // legacy per-variable env carried — governed controller endpoint, auth-token
+  // SSM param name (raw token fetched at runtime), image ref, ingress/egress
+  // refs, MaximumDurationSeconds, and IdlePolicy — but avoids duplicating long
+  // APPTHEORY_MICROVM_* key names on already-large deployment Lambdas. The
+  // compact field names are Host-private CDK/runtime contract, not a public API.
   // addEnvironment is the CDK-supported way to append env vars to a Function
   // constructed elsewhere.
-  fn.addEnvironment("HOSTED_GENESIS_MICROVM_ENABLED", "true");
   fn.addEnvironment(
-    "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS",
-    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
+    HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV,
+    hostedGenesisMicroVMDispatchConfigJSON(
+      controllerEndpoint,
+      authTokenSSMParamName,
+      imageArn,
+      ingressConnectorArns,
+      egressConnectorArns,
+    ),
   );
-  fn.addEnvironment(
-    "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS",
-    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
-  );
-  fn.addEnvironment(
-    "HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS",
-    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
-  );
-  fn.addEnvironment(
-    "HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED",
-    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
-  );
-  fn.addEnvironment(
-    "APPTHEORY_MICROVM_CONTROLLER_ENDPOINT",
+}
+
+function hostedGenesisMicroVMDispatchConfigJSON(
+  controllerEndpoint: string,
+  authTokenSSMParamName: string,
+  imageArn: string,
+  ingressConnectorArns: string[],
+  egressConnectorArns: string[],
+): string {
+  return cdk.Fn.join("", [
+    '{"v":1,"ep":"',
     controllerEndpoint,
-  );
-  fn.addEnvironment(
-    "HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM",
+    '","ap":"',
     authTokenSSMParamName,
-  );
-  fn.addEnvironment("APPTHEORY_MICROVM_IMAGE_REF", imageArn);
-  fn.addEnvironment(
-    "APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS",
+    '","img":"',
+    imageArn,
+    '","in":"',
     ingressConnectorArns.join(","),
-  );
-  fn.addEnvironment(
-    "APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS",
+    '","eg":"',
     egressConnectorArns.join(","),
-  );
-  fn.addEnvironment(
-    "APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS",
-    egressConnectorArns.join(","),
-  );
+    '","max":',
+    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
+    ',"idle":{"ar":',
+    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
+    ',"max":',
+    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
+    ',"sus":',
+    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
+    "}}",
+  ]);
 }
 
 // ssmParamArn formats the full ARN for an SSM parameter name (the parameter is

--- a/cdk/test/lesser-host-stack-microvm.test.ts
+++ b/cdk/test/lesser-host-stack-microvm.test.ts
@@ -12,6 +12,7 @@ import {
   lambdaEnvironment,
   roleServicePrincipals,
   synthesizeTemplate,
+  type SynthesizedTemplate,
   synthTemplateForStage,
   synthTemplateWithContext,
   webLookupContext,
@@ -19,6 +20,7 @@ import {
 } from "./_lesser-host-test-helpers";
 import {
   HOSTED_GENESIS_MICROVM_BASE_IMAGE_ARN,
+  HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV,
   HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
   HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
   HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
@@ -29,6 +31,38 @@ import assert from "node:assert/strict";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import test from "node:test";
+
+const lambdaEnvTemplateBudgetBytes = 3800;
+
+function lambdaEnvBudgetBytes(env: Record<string, unknown>): number {
+  // Deterministic synthesized-template budget method for #941:
+  // UTF-8 bytes of JSON.stringify(Environment.Variables). This intentionally
+  // includes CloudFormation intrinsic-key overhead instead of trying to predict
+  // live AWS token resolution, so it is a conservative local guard with
+  // headroom below Lambda's 4096-byte deployed env limit.
+  return Buffer.byteLength(JSON.stringify(env), "utf8");
+}
+
+function assertEnvWithinBudget(template: SynthesizedTemplate, logicalId: string): void {
+  const resource = template.Resources?.[logicalId];
+  assert.ok(resource, `expected ${logicalId} to synthesize`);
+  const env = lambdaEnvironment(resource.Properties ?? {});
+  const actual = lambdaEnvBudgetBytes(env);
+  assert.ok(
+    actual <= lambdaEnvTemplateBudgetBytes,
+    `${logicalId} synthesized env budget ${actual} bytes exceeds ${lambdaEnvTemplateBudgetBytes} bytes`,
+  );
+}
+
+function compactMicroVMConfigText(env: Record<string, unknown>): string {
+  const value = env[HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV];
+  assert.ok(value, `expected ${HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV}`);
+  return JSON.stringify(value);
+}
+
+function cfnTextIncludesRuntimeFragment(text: string, fragment: string): boolean {
+  return text.includes(fragment) || text.includes(JSON.stringify(fragment).slice(1, -1));
+}
 
 test("hosted genesis AppTheory MicroVM deployed stages require NO credential-pair context (CDK-owned token)", () => {
   // P52 corrective #873: the authorizer bearer token is CDK-owned (a custom
@@ -1090,20 +1124,23 @@ test("P52 #873: CDK-owned auth-token custom resource generates the bearer token 
     );
   }
 
-  // The control plane still gets the deterministic param name + SSM read grant
-  // (it loads the raw token at runtime). This grant path is unchanged from the
-  // HTTP-transport rework; the param name is now deterministic (CDK-owned)
-  // rather than context-supplied, but the grant shape is identical.
+  // The control plane still gets the deterministic param name inside the
+  // compact dispatch config + the SSM read grant (it loads the raw token at
+  // runtime). This grant path is unchanged from the HTTP-transport rework; the
+  // param name is now deterministic (CDK-owned) rather than context-supplied,
+  // but the grant shape is identical.
   const controlPlaneFn = findLambdaEntryByFunctionName(
     template,
     "control-plane-api",
   );
   assert.ok(controlPlaneFn, "expected control-plane Lambda to synthesize");
   const controlPlaneEnv = lambdaEnvironment(controlPlaneFn[1].Properties ?? {});
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM,
-    "/lesser-host/lab/hosted-genesis/microvm/auth-token",
-    "expected the deterministic auth-token SSM param name on the control-plane Lambda",
+  assert.ok(
+    cfnTextIncludesRuntimeFragment(
+      compactMicroVMConfigText(controlPlaneEnv),
+      "/lesser-host/lab/hosted-genesis/microvm/auth-token",
+    ),
+    "expected the deterministic auth-token SSM param name in the compact control-plane Lambda config",
   );
 
   // grep-proof: no raw token, no literal sha256 of a known test token, no
@@ -1149,83 +1186,68 @@ test("P52 H1.5: control-plane Lambda receives HTTP dispatch env + SSM auth-token
   assert.ok(controllerFn, "expected AppTheory-created controller Lambda");
   const controllerEnv = lambdaEnvironment(controllerFn[1].Properties ?? {});
   // controlplane.NewServer reads these env vars to construct the
-  // HTTPControllerDispatcher (HostedGenesisMicroVM config block). The
-  // controller endpoint + auth-token SSM param name + image/egress refs are
-  // the HTTP-transport inputs; the raw auth token is fetched from SSM at
-  // runtime, never committed.
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_ENABLED,
-    "true",
-    "expected HOSTED_GENESIS_MICROVM_ENABLED on control-plane Lambda",
-  );
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS,
-    String(HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS),
-    "expected control-plane dispatch to thread the AppTheory maximum duration onto POST /microvms",
-  );
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS,
-    String(HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS),
-    "expected control-plane dispatch to thread the AppTheory idle max policy onto POST /microvms",
-  );
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS,
-    String(HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS),
-    "expected control-plane dispatch to thread the AppTheory suspended policy onto POST /microvms",
-  );
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED,
-    String(HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED),
-    "expected control-plane dispatch auto-resume policy to be explicit",
+  // HTTPControllerDispatcher (HostedGenesisMicroVM config block). #941 keeps
+  // these AppTheory run inputs in one compact env value so ControlPlaneApi
+  // stays under Lambda's 4KB environment limit: controller endpoint,
+  // auth-token SSM param name, image ref, ingress/egress refs,
+  // MaximumDurationSeconds, and IdlePolicy. The raw auth token is fetched from
+  // SSM at runtime, never committed.
+  const compactConfig = compactMicroVMConfigText(controlPlaneEnv);
+  assert.ok(
+    cfnTextIncludesRuntimeFragment(compactConfig, '"v"') &&
+      cfnTextIncludesRuntimeFragment(compactConfig, '"ep"'),
+    "expected compact hosted-genesis MicroVM config schema marker + endpoint field",
   );
   assert.ok(
-    controlPlaneEnv.APPTHEORY_MICROVM_CONTROLLER_ENDPOINT,
-    "expected APPTHEORY_MICROVM_CONTROLLER_ENDPOINT on control-plane Lambda",
-  );
-  assert.equal(
-    controlPlaneEnv.HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM,
-    "/lesser-host/lab/hosted-genesis/microvm/auth-token",
-    "expected auth-token SSM param name env on control-plane Lambda",
+    cfnTextIncludesRuntimeFragment(compactConfig, "/lesser-host/lab/hosted-genesis/microvm/auth-token"),
+    "expected compact config to carry the auth-token SSM param name",
   );
   assert.ok(
-    controlPlaneEnv.APPTHEORY_MICROVM_IMAGE_REF,
-    "expected APPTHEORY_MICROVM_IMAGE_REF on control-plane Lambda",
+    cfnTextIncludesRuntimeFragment(compactConfig, '"HostedGenesisMicrovmImage"') &&
+      cfnTextIncludesRuntimeFragment(compactConfig, '"ImageArn"'),
+    "expected compact config to carry the AppTheory MicroVM image ref",
   );
   assert.ok(
-    controlPlaneEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    "expected ingress connector refs on control-plane Lambda",
-  );
-  assert.ok(
-    JSON.stringify(
-      controlPlaneEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    ).includes("aws-network-connector:HTTP_INGRESS"),
+    cfnTextIncludesRuntimeFragment(compactConfig, "aws-network-connector:HTTP_INGRESS"),
     "expected control-plane dispatch to use HTTP_INGRESS for endpoint auth-token compatibility",
   );
   assert.ok(
-    JSON.stringify(
-      controlPlaneEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    ).includes("aws-network-connector:SHELL_INGRESS"),
+    cfnTextIncludesRuntimeFragment(compactConfig, "aws-network-connector:SHELL_INGRESS"),
     "expected control-plane dispatch ingress refs to match the controller deployment-pinned shell ingress ref",
   );
-  assert.deepEqual(
-    controlPlaneEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    controllerEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    "control-plane dispatch ingress refs must match controller deployment-pinned ingress refs",
-  );
   assert.ok(
-    !JSON.stringify(
-      controlPlaneEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS,
-    ).includes("aws-network-connector:ALL_INGRESS"),
+    !cfnTextIncludesRuntimeFragment(compactConfig, "aws-network-connector:ALL_INGRESS"),
     "control-plane dispatch must not use ALL_INGRESS with shell ingress enabled",
   );
   assert.ok(
-    controlPlaneEnv.APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS,
+    cfnTextIncludesRuntimeFragment(compactConfig, "aws-network-connector:INTERNET_EGRESS"),
     "expected egress connector refs on control-plane Lambda",
+  );
+  assert.ok(
+    cfnTextIncludesRuntimeFragment(compactConfig, `"max":${HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS}`),
+    "expected compact config to thread the AppTheory maximum duration onto POST /microvms",
+  );
+  assert.ok(
+    cfnTextIncludesRuntimeFragment(compactConfig, `"ar":${HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED}`) &&
+      cfnTextIncludesRuntimeFragment(compactConfig, `"max":${HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS}`) &&
+      cfnTextIncludesRuntimeFragment(compactConfig, `"sus":${HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS}`),
+    "expected compact config to carry the AppTheory idle policy",
+  );
+  assert.ok(
+    JSON.stringify(controllerEnv.APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS).includes(
+      "aws-network-connector:HTTP_INGRESS",
+    ),
+    "expected compact config ingress assertion to be checked against AppTheory controller deployment env",
   );
   const aiWorkerFn = findLambdaEntryByFunctionName(template, "ai-worker");
   assert.ok(aiWorkerFn, "expected ai-worker Lambda to synthesize");
   const aiWorkerEnv = lambdaEnvironment(aiWorkerFn[1].Properties ?? {});
-  for (const key of [
+  assert.deepEqual(
+    aiWorkerEnv[HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV],
+    controlPlaneEnv[HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV],
+    `ai-worker compact MicroVM dispatch env ${HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV} must match control-plane dispatch env`,
+  );
+  for (const compactedKey of [
     "HOSTED_GENESIS_MICROVM_ENABLED",
     "HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS",
     "HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS",
@@ -1236,11 +1258,15 @@ test("P52 H1.5: control-plane Lambda receives HTTP dispatch env + SSM auth-token
     "APPTHEORY_MICROVM_IMAGE_REF",
     "APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS",
     "APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS",
+    "APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS",
   ]) {
-    assert.deepEqual(
-      aiWorkerEnv[key],
-      controlPlaneEnv[key],
-      `ai-worker MicroVM dispatch env ${key} must match control-plane dispatch env`,
+    assert.ok(
+      !(compactedKey in controlPlaneEnv),
+      `control-plane Lambda env should compact ${compactedKey} into ${HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV}`,
+    );
+    assert.ok(
+      !(compactedKey in aiWorkerEnv),
+      `ai-worker Lambda env should compact ${compactedKey} into ${HOSTED_GENESIS_MICROVM_CONFIG_JSON_ENV}`,
     );
   }
   for (const [label, env] of [
@@ -1345,4 +1371,17 @@ test("P52 H1.5: control-plane Lambda receives HTTP dispatch env + SSM auth-token
     !controlPlanePolicyJson.includes("hosted-genesis-microvm-sessions"),
     "control-plane Lambda must not hold session-registry DynamoDB grants (controller owns the registry)",
   );
+});
+
+test("#941: synthesized lab Lambda env for MicroVM dispatch stays under deploy-safe budget", () => {
+  const template = synthTemplateWithContext(
+    hostedGenesisMicrovmRequiredContext,
+  );
+  for (const logicalId of [
+    "ControlPlaneApi8D3F9AC2",
+    "AiWorker1553A229",
+    "HostedGenesisMicrovmControllerControllerFunctionB458B1F3",
+  ]) {
+    assertEnvWithinBudget(template, logicalId);
+  }
 });

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -165,6 +166,14 @@ type Config struct {
 }
 
 const (
+	// HostedGenesisMicroVMConfigJSONEnv is the compact, CDK-owned dispatcher
+	// config envelope used on deployment Lambdas. It keeps the Lambda
+	// environment below AWS's 4KB limit while still carrying the same AppTheory
+	// run inputs (controller endpoint, auth-token source, image ref, connector
+	// refs, MaximumDurationSeconds, and IdlePolicy). Legacy individual env vars
+	// remain supported for local tests/tools.
+	HostedGenesisMicroVMConfigJSONEnv = "HOSTED_GENESIS_MICROVM_CONFIG_JSON"
+
 	// HostedGenesisMicroVMDefaultMaximumDurationSeconds caps one active
 	// AppTheory MicroVM run for the longest provider turn plus in-VM
 	// declaration extraction. Human wait time is handled by the explicit
@@ -297,54 +306,7 @@ func Load() Config {
 	paymentsProvider := envLowerStringDefault("PAYMENTS_PROVIDER", "none")
 	centsPer1000Credits := envInt64Bounded("PAYMENTS_CENTS_PER_1000_CREDITS", 100, 1, 1_000_000)
 
-	// P52 H1.5: production MicroVM HTTP-transport dispatch config. The
-	// AppTheoryMicrovmController CDK construct exposes the controller endpoint
-	// (HostedGenesisMicrovmControllerEndpoint CfnOutput → control-plane env);
-	// the CDK grants the control-plane Lambda HTTP egress to that endpoint +
-	// ssm:GetParameter on the auth-token SecureString. The control plane never
-	// receives MicroVM IAM or session-registry access — it only speaks HTTP to
-	// the governed controller API with the authorizer bearer token (loaded from
-	// SSM at runtime, never committed or logged).
-	microvmEgressRefs := parseCSV(envString("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS"))
-	if len(microvmEgressRefs) == 0 {
-		microvmEgressRefs = parseCSV(envString("APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS"))
-	}
-	microvmNetworkConnectorRef := ""
-	for _, ref := range microvmEgressRefs {
-		if ref = strings.TrimSpace(ref); ref != "" {
-			microvmNetworkConnectorRef = ref
-			break
-		}
-	}
-	// MaximumDurationSeconds is sized for the longest LLM turn plus in-VM
-	// declaration extraction (ADR 0010 decision 7): default 300s, bounded to
-	// the M16 provider's int32 range [0,3600]. A non-positive config disables
-	// the cap and lets the provider/default apply (still fail-closed; never a
-	// sync fallback). The bound keeps the int64->int32 narrowing safe (gosec
-	// G115).
-	microvmMaxDuration := envInt32Bounded("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", HostedGenesisMicroVMDefaultMaximumDurationSeconds, 0, 3600)
-	// IdlePolicy is the AppTheory-provider human-gap boundary. Defaults are
-	// explicit even when the operator does not override env, so deployed
-	// control-plane and worker dispatches do not silently omit idle behavior.
-	// The suspended duration is bounded below Host's current one-hour
-	// MicroVMRegistryReconstructionTTL; longer human gaps must recover through
-	// Host checkpoints and AppTheory relaunch/replay, not unbounded VM lifetime.
-	microvmIdlePolicy := HostedGenesisMicroVMIdlePolicyConfig{
-		AutoResumeEnabled:        envBoolOn("HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED"),
-		MaxIdleDurationSeconds:   envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", HostedGenesisMicroVMDefaultIdleMaxSeconds, 1, 3600),
-		SuspendedDurationSeconds: envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", HostedGenesisMicroVMDefaultIdleSuspendedSeconds, 1, 3600),
-	}
-	microvmCfg := HostedGenesisMicroVMConfig{
-		Enabled:                envBoolOn("HOSTED_GENESIS_MICROVM_ENABLED"),
-		ControllerEndpoint:     strings.TrimSpace(envString("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT")),
-		AuthTokenSSMParam:      strings.TrimSpace(envString("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM")),
-		ImageRef:               envString("APPTHEORY_MICROVM_IMAGE_REF"),
-		NetworkConnectorRef:    microvmNetworkConnectorRef,
-		IngressConnectorRefs:   parseCSV(envString("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS")),
-		EgressConnectorRefs:    microvmEgressRefs,
-		MaximumDurationSeconds: microvmMaxDuration,
-		IdlePolicy:             microvmIdlePolicy,
-	}
+	microvmCfg := loadHostedGenesisMicroVMConfig()
 
 	portalHost := envStringDefault("WEBAUTHN_RP_ID", "lesser.host")
 	checkoutSuccessURL := envStringDefault(
@@ -466,6 +428,126 @@ func Load() Config {
 
 		HostedGenesisMicroVM: microvmCfg,
 	}
+}
+
+// hostedGenesisMicroVMCompactConfig is the compact JSON shape stored in
+// HOSTED_GENESIS_MICROVM_CONFIG_JSON. The intentionally short JSON field names
+// are a deployment-budget measure, not a public API: CDK owns the producer and
+// this package owns the consumer. Values remain the same AppTheory request
+// inputs the legacy per-variable env carried.
+type hostedGenesisMicroVMCompactConfig struct {
+	Version                int                                 `json:"v"`
+	ControllerEndpoint     string                              `json:"ep"`
+	AuthTokenSSMParam      string                              `json:"ap"`
+	ImageRef               string                              `json:"img"`
+	IngressConnectorRefs   string                              `json:"in"`
+	EgressConnectorRefs    string                              `json:"eg"`
+	MaximumDurationSeconds *int32                              `json:"max"`
+	IdlePolicy             hostedGenesisMicroVMCompactIdleJSON `json:"idle"`
+}
+
+type hostedGenesisMicroVMCompactIdleJSON struct {
+	AutoResumeEnabled        *bool  `json:"ar"`
+	MaxIdleDurationSeconds   *int32 `json:"max"`
+	SuspendedDurationSeconds *int32 `json:"sus"`
+}
+
+func loadHostedGenesisMicroVMConfig() HostedGenesisMicroVMConfig {
+	if raw := envString(HostedGenesisMicroVMConfigJSONEnv); raw != "" {
+		return parseHostedGenesisMicroVMCompactConfig(raw)
+	}
+	return loadHostedGenesisMicroVMLegacyEnvConfig()
+}
+
+func loadHostedGenesisMicroVMLegacyEnvConfig() HostedGenesisMicroVMConfig {
+	// P52 H1.5: production MicroVM HTTP-transport dispatch config. The
+	// AppTheoryMicrovmController CDK construct exposes the controller endpoint;
+	// the CDK grants the control-plane Lambda HTTP egress to that endpoint +
+	// ssm:GetParameter on the auth-token SecureString. The control plane never
+	// receives MicroVM IAM or session-registry access — it only speaks HTTP to
+	// the governed controller API with the authorizer bearer token (loaded from
+	// SSM at runtime, never committed or logged).
+	microvmEgressRefs := parseCSV(envString("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS"))
+	if len(microvmEgressRefs) == 0 {
+		microvmEgressRefs = parseCSV(envString("APPTHEORY_MICROVM_NETWORK_CONNECTOR_REFS"))
+	}
+	return HostedGenesisMicroVMConfig{
+		Enabled:                envBoolOn("HOSTED_GENESIS_MICROVM_ENABLED"),
+		ControllerEndpoint:     strings.TrimSpace(envString("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT")),
+		AuthTokenSSMParam:      strings.TrimSpace(envString("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM")),
+		ImageRef:               envString("APPTHEORY_MICROVM_IMAGE_REF"),
+		NetworkConnectorRef:    firstNonEmpty(microvmEgressRefs),
+		IngressConnectorRefs:   parseCSV(envString("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS")),
+		EgressConnectorRefs:    microvmEgressRefs,
+		MaximumDurationSeconds: envInt32Bounded("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", HostedGenesisMicroVMDefaultMaximumDurationSeconds, 0, 3600),
+		IdlePolicy:             hostedGenesisMicroVMDefaultIdlePolicyFromEnv(),
+	}
+}
+
+func parseHostedGenesisMicroVMCompactConfig(raw string) HostedGenesisMicroVMConfig {
+	cfg := HostedGenesisMicroVMConfig{
+		Enabled:                true,
+		MaximumDurationSeconds: HostedGenesisMicroVMDefaultMaximumDurationSeconds,
+		IdlePolicy:             hostedGenesisMicroVMDefaultIdlePolicy(),
+	}
+	var compact hostedGenesisMicroVMCompactConfig
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &compact); err != nil || compact.Version != 1 {
+		// Fail closed: a present-but-invalid compact env means deployment config
+		// is malformed. Do not silently fall back to legacy variables because
+		// that could mask a broken CDK/runtime boundary.
+		return cfg
+	}
+	cfg.ControllerEndpoint = strings.TrimSpace(compact.ControllerEndpoint)
+	cfg.AuthTokenSSMParam = strings.TrimSpace(compact.AuthTokenSSMParam)
+	cfg.ImageRef = strings.TrimSpace(compact.ImageRef)
+	cfg.IngressConnectorRefs = parseCSV(compact.IngressConnectorRefs)
+	cfg.EgressConnectorRefs = parseCSV(compact.EgressConnectorRefs)
+	cfg.NetworkConnectorRef = firstNonEmpty(cfg.EgressConnectorRefs)
+	cfg.MaximumDurationSeconds = boundedInt32Ptr(compact.MaximumDurationSeconds, HostedGenesisMicroVMDefaultMaximumDurationSeconds, 0, 3600)
+	cfg.IdlePolicy = HostedGenesisMicroVMIdlePolicyConfig{
+		AutoResumeEnabled:        boolPtrValue(compact.IdlePolicy.AutoResumeEnabled, false),
+		MaxIdleDurationSeconds:   boundedInt32Ptr(compact.IdlePolicy.MaxIdleDurationSeconds, HostedGenesisMicroVMDefaultIdleMaxSeconds, 1, 3600),
+		SuspendedDurationSeconds: boundedInt32Ptr(compact.IdlePolicy.SuspendedDurationSeconds, HostedGenesisMicroVMDefaultIdleSuspendedSeconds, 1, 3600),
+	}
+	return cfg
+}
+
+func hostedGenesisMicroVMDefaultIdlePolicyFromEnv() HostedGenesisMicroVMIdlePolicyConfig {
+	return HostedGenesisMicroVMIdlePolicyConfig{
+		AutoResumeEnabled:        envBoolOn("HOSTED_GENESIS_MICROVM_IDLE_AUTO_RESUME_ENABLED"),
+		MaxIdleDurationSeconds:   envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", HostedGenesisMicroVMDefaultIdleMaxSeconds, 1, 3600),
+		SuspendedDurationSeconds: envInt32Bounded("HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", HostedGenesisMicroVMDefaultIdleSuspendedSeconds, 1, 3600),
+	}
+}
+
+func hostedGenesisMicroVMDefaultIdlePolicy() HostedGenesisMicroVMIdlePolicyConfig {
+	return HostedGenesisMicroVMIdlePolicyConfig{
+		MaxIdleDurationSeconds:   HostedGenesisMicroVMDefaultIdleMaxSeconds,
+		SuspendedDurationSeconds: HostedGenesisMicroVMDefaultIdleSuspendedSeconds,
+	}
+}
+
+func boundedInt32Ptr(value *int32, fallback int32, minValue int32, maxValue int32) int32 {
+	if value == nil || *value < minValue || *value > maxValue {
+		return fallback
+	}
+	return *value
+}
+
+func boolPtrValue(value *bool, fallback bool) bool {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}
+
+func firstNonEmpty(values []string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
 }
 
 func defaultENSGatewayChain(stage string) (int64, string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,40 @@
 package config
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
+
+const (
+	testMicroVMControllerEndpoint = "https://controller.example/microvms"
+	testMicroVMAuthTokenParam     = "/lesser-host/lab/hosted-genesis/microvm/auth-token"
+	testMicroVMImageRef           = "image-ref"
+	testMicroVMIngressOne         = "ingress-1"
+	testMicroVMIngressTwo         = "ingress-2"
+	testMicroVMEgressOne          = "egress-1"
+	testMicroVMEgressTwo          = "egress-2"
+)
+
+func assertEqual[T comparable](t *testing.T, label string, got T, want T) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s: expected %#v, got %#v", label, want, got)
+	}
+}
+
+func assertTrue(t *testing.T, label string, got bool) {
+	t.Helper()
+	if !got {
+		t.Fatalf("%s: expected true", label)
+	}
+}
+
+func assertStringSliceEqual(t *testing.T, label string, got []string, want []string) {
+	t.Helper()
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s: expected %#v, got %#v", label, want, got)
+	}
+}
 
 func TestEnvHelpers(t *testing.T) {
 	t.Setenv("X", "  hi ")
@@ -115,11 +149,11 @@ func TestLoad_HostedGenesisMicroVMDefaultLifetimePolicy(t *testing.T) {
 
 func TestLoad_HostedGenesisMicroVMLifetimePolicy(t *testing.T) {
 	t.Setenv("HOSTED_GENESIS_MICROVM_ENABLED", "true")
-	t.Setenv("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT", " https://controller.example/microvms ")
-	t.Setenv("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM", " /lesser-host/lab/hosted-genesis/microvm/auth-token ")
-	t.Setenv("APPTHEORY_MICROVM_IMAGE_REF", " image-ref ")
-	t.Setenv("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS", " egress-1, egress-2 ")
-	t.Setenv("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS", " ingress-1 ")
+	t.Setenv("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT", " "+testMicroVMControllerEndpoint+" ")
+	t.Setenv("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM", " "+testMicroVMAuthTokenParam+" ")
+	t.Setenv("APPTHEORY_MICROVM_IMAGE_REF", " "+testMicroVMImageRef+" ")
+	t.Setenv("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS", " "+testMicroVMEgressOne+", "+testMicroVMEgressTwo+" ")
+	t.Setenv("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS", " "+testMicroVMIngressOne+" ")
 	t.Setenv("HOSTED_GENESIS_MICROVM_MAXIMUM_DURATION_SECONDS", "450")
 	t.Setenv("HOSTED_GENESIS_MICROVM_IDLE_MAX_SECONDS", "240")
 	t.Setenv("HOSTED_GENESIS_MICROVM_IDLE_SUSPENDED_SECONDS", "1200")
@@ -130,10 +164,10 @@ func TestLoad_HostedGenesisMicroVMLifetimePolicy(t *testing.T) {
 	if !cfg.HostedGenesisMicroVM.Complete() {
 		t.Fatalf("expected complete hosted genesis microvm config: %#v", cfg.HostedGenesisMicroVM)
 	}
-	if cfg.HostedGenesisMicroVM.ControllerEndpoint != "https://controller.example/microvms" {
+	if cfg.HostedGenesisMicroVM.ControllerEndpoint != testMicroVMControllerEndpoint {
 		t.Fatalf("unexpected controller endpoint: %q", cfg.HostedGenesisMicroVM.ControllerEndpoint)
 	}
-	if cfg.HostedGenesisMicroVM.NetworkConnectorRef != "egress-1" {
+	if cfg.HostedGenesisMicroVM.NetworkConnectorRef != testMicroVMEgressOne {
 		t.Fatalf("expected first egress connector as network connector ref, got %q", cfg.HostedGenesisMicroVM.NetworkConnectorRef)
 	}
 	if cfg.HostedGenesisMicroVM.MaximumDurationSeconds != 450 {
@@ -145,6 +179,67 @@ func TestLoad_HostedGenesisMicroVMLifetimePolicy(t *testing.T) {
 	if cfg.HostedGenesisMicroVM.IdlePolicy.MaxIdleDurationSeconds != 240 ||
 		cfg.HostedGenesisMicroVM.IdlePolicy.SuspendedDurationSeconds != 1200 {
 		t.Fatalf("unexpected idle policy: %#v", cfg.HostedGenesisMicroVM.IdlePolicy)
+	}
+}
+
+func TestLoad_HostedGenesisMicroVMCompactConfig(t *testing.T) {
+	t.Setenv(HostedGenesisMicroVMConfigJSONEnv, `{
+		"v": 1,
+		"ep": " `+testMicroVMControllerEndpoint+` ",
+		"ap": " `+testMicroVMAuthTokenParam+` ",
+		"img": " `+testMicroVMImageRef+` ",
+		"in": " `+testMicroVMIngressOne+`, `+testMicroVMIngressTwo+` ",
+		"eg": " `+testMicroVMEgressOne+`, `+testMicroVMEgressTwo+` ",
+		"max": 450,
+		"idle": {"ar": true, "max": 240, "sus": 1200}
+	}`)
+	// Legacy per-variable env must not be required when the compact CDK-owned
+	// config is present; the compact value is the deployment env-budget path.
+	t.Setenv("HOSTED_GENESIS_MICROVM_ENABLED", "")
+	t.Setenv("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT", "")
+	t.Setenv("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM", "")
+	t.Setenv("APPTHEORY_MICROVM_IMAGE_REF", "")
+	t.Setenv("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS", "")
+	t.Setenv("APPTHEORY_MICROVM_INGRESS_NETWORK_CONNECTOR_REFS", "")
+
+	cfg := Load()
+
+	assertTrue(t, "compact hosted genesis microvm config complete", cfg.HostedGenesisMicroVM.Complete())
+	assertEqual(t, "compact controller endpoint", cfg.HostedGenesisMicroVM.ControllerEndpoint, testMicroVMControllerEndpoint)
+	assertEqual(t, "compact auth-token param", cfg.HostedGenesisMicroVM.AuthTokenSSMParam, testMicroVMAuthTokenParam)
+	assertEqual(t, "compact image ref", cfg.HostedGenesisMicroVM.ImageRef, testMicroVMImageRef)
+	assertEqual(t, "compact network connector ref", cfg.HostedGenesisMicroVM.NetworkConnectorRef, testMicroVMEgressOne)
+	assertStringSliceEqual(t, "compact ingress refs", cfg.HostedGenesisMicroVM.IngressConnectorRefs, []string{testMicroVMIngressOne, testMicroVMIngressTwo})
+	assertStringSliceEqual(t, "compact egress refs", cfg.HostedGenesisMicroVM.EgressConnectorRefs, []string{testMicroVMEgressOne, testMicroVMEgressTwo})
+	assertEqual(t, "compact maximum duration", cfg.HostedGenesisMicroVM.MaximumDurationSeconds, int32(450))
+	assertEqual(t, "compact idle auto resume", cfg.HostedGenesisMicroVM.IdlePolicy.AutoResumeEnabled, true)
+	assertEqual(t, "compact idle max", cfg.HostedGenesisMicroVM.IdlePolicy.MaxIdleDurationSeconds, int32(240))
+	assertEqual(t, "compact idle suspended", cfg.HostedGenesisMicroVM.IdlePolicy.SuspendedDurationSeconds, int32(1200))
+}
+
+func TestLoad_HostedGenesisMicroVMCompactConfigFailsClosed(t *testing.T) {
+	t.Setenv(HostedGenesisMicroVMConfigJSONEnv, `{"v": 99, "ep": "https://controller.example/microvms"}`)
+	t.Setenv("HOSTED_GENESIS_MICROVM_ENABLED", "true")
+	t.Setenv("APPTHEORY_MICROVM_CONTROLLER_ENDPOINT", "https://legacy.example/microvms")
+	t.Setenv("HOSTED_GENESIS_MICROVM_AUTH_TOKEN_SSM_PARAM", "/legacy/token")
+	t.Setenv("APPTHEORY_MICROVM_IMAGE_REF", "legacy-image")
+	t.Setenv("APPTHEORY_MICROVM_EGRESS_NETWORK_CONNECTOR_REFS", "legacy-egress")
+
+	cfg := Load()
+
+	if !cfg.HostedGenesisMicroVM.Enabled {
+		t.Fatalf("present invalid compact config should leave MicroVM enabled so startup fails closed loudly")
+	}
+	if cfg.HostedGenesisMicroVM.Complete() {
+		t.Fatalf("invalid compact config must not fall back to legacy env: %#v", cfg.HostedGenesisMicroVM)
+	}
+	if cfg.HostedGenesisMicroVM.ControllerEndpoint != "" ||
+		cfg.HostedGenesisMicroVM.AuthTokenSSMParam != "" ||
+		cfg.HostedGenesisMicroVM.ImageRef != "" {
+		t.Fatalf("invalid compact config leaked legacy values: %#v", cfg.HostedGenesisMicroVM)
+	}
+	if !cfg.HostedGenesisMicroVM.IdlePolicy.Complete() {
+		t.Fatalf("invalid compact config should retain safe default idle policy for diagnostics: %#v", cfg.HostedGenesisMicroVM.IdlePolicy)
 	}
 }
 

--- a/internal/controlplane/hosted_genesis_microvm_e2e_internal_test.go
+++ b/internal/controlplane/hosted_genesis_microvm_e2e_internal_test.go
@@ -13,6 +13,7 @@ import (
 
 	runtimemicrovm "github.com/theory-cloud/apptheory/runtime/microvm"
 
+	"github.com/equaltoai/lesser-host/internal/config"
 	"github.com/equaltoai/lesser-host/internal/hostedgenesis"
 )
 
@@ -219,19 +220,89 @@ func TestH1_5_E2E_MaximumDurationSecondsWired(t *testing.T) {
 	}
 }
 
+func TestH1_5_E2E_CompactMicroVMEnvWiresAppTheoryRunRequest(t *testing.T) {
+	stub := newMaxDurationCapturingControllerServer(t, "stub-bearer")
+	controllerSrv := httptest.NewServer(stub.handler())
+	t.Cleanup(controllerSrv.Close)
+
+	t.Setenv(config.HostedGenesisMicroVMConfigJSONEnv, `{
+		"v": 1,
+		"ep": "`+controllerSrv.URL+`/microvms",
+		"ap": "/lesser-host/lab/hosted-genesis/microvm/auth-token",
+		"img": "arn:aws:lambda::microvm-image/hosted-genesis:compact",
+		"in": "arn:aws:lambda::network-connector/http-ingress:compact,arn:aws:lambda::network-connector/shell-ingress:compact",
+		"eg": "arn:aws:lambda::network-connector/internet-egress:compact",
+		"max": 450,
+		"idle": {"ar": true, "max": 240, "sus": 1200}
+	}`)
+	cfg := config.Load()
+
+	dispatcher := newHostedGenesisMicroVMDispatcher(context.Background(), cfg, stubSSMGetter{
+		param: cfg.HostedGenesisMicroVM.AuthTokenSSMParam,
+		token: stub.inner.token,
+	}.GetParameter, hostedGenesisMicroVMDispatcherOptions{})
+	if dispatcher == nil {
+		t.Fatalf("expected dispatcher from compact env config, got nil")
+	}
+	binding := hostedgenesis.MicroVMSessionBinding{
+		InstanceSlug:   "acme",
+		RegistrationID: "reg_compact",
+		AgentID:        "agent_compact",
+		ConversationID: "conv_compact_001",
+		TurnID:         "turn_1",
+	}
+	if _, err := dispatcher.DispatchMicroVMRun(context.Background(), "req_compact", binding); err != nil {
+		t.Fatalf("compact config dispatch failed: %v", err)
+	}
+
+	payload := stub.payload
+	if payload.ImageRef != "arn:aws:lambda::microvm-image/hosted-genesis:compact" {
+		t.Fatalf("compact config image ref did not reach AppTheory run request: %#v", payload)
+	}
+	if payload.NetworkConnectorRef != "arn:aws:lambda::network-connector/internet-egress:compact" {
+		t.Fatalf("compact config network connector did not reach AppTheory run request: %#v", payload)
+	}
+	if len(payload.IngressNetworkConnectorRefs) != 2 ||
+		payload.IngressNetworkConnectorRefs[0] != "arn:aws:lambda::network-connector/http-ingress:compact" ||
+		payload.IngressNetworkConnectorRefs[1] != "arn:aws:lambda::network-connector/shell-ingress:compact" {
+		t.Fatalf("compact config ingress refs did not reach AppTheory run request: %#v", payload)
+	}
+	if len(payload.EgressNetworkConnectorRefs) != 1 ||
+		payload.EgressNetworkConnectorRefs[0] != "arn:aws:lambda::network-connector/internet-egress:compact" {
+		t.Fatalf("compact config egress refs did not reach AppTheory run request: %#v", payload)
+	}
+	if payload.MaximumDurationSeconds != 450 {
+		t.Fatalf("compact config maximum duration did not reach AppTheory run request: %#v", payload)
+	}
+	if payload.IdlePolicy == nil ||
+		!payload.IdlePolicy.AutoResumeEnabled ||
+		payload.IdlePolicy.MaxIdleDurationSeconds != 240 ||
+		payload.IdlePolicy.SuspendedDurationSeconds != 1200 {
+		t.Fatalf("compact config idle policy did not reach AppTheory run request: %#v", payload.IdlePolicy)
+	}
+}
+
 // maxDurationCapturingControllerServer wraps the stub controller and captures
 // the lifetime policy passed in the POST /microvms run body so the E2E harness
 // can assert timeout-budget wiring without calling AWS.
 type maxDurationCapturingControllerServer struct {
-	inner    *stubControllerServer
-	captured *int32
-	idle     *runtimemicrovm.ProviderIdlePolicy
+	inner   *stubControllerServer
+	payload capturedMicroVMRunPayload
 }
 
 func newMaxDurationCapturingControllerServer(t *testing.T, token string) *maxDurationCapturingControllerServer {
 	t.Helper()
 	inner := newStubControllerServer(token)
-	return &maxDurationCapturingControllerServer{inner: inner, captured: new(int32)}
+	return &maxDurationCapturingControllerServer{inner: inner}
+}
+
+type capturedMicroVMRunPayload struct {
+	ImageRef                    string                             `json:"image_ref"`
+	NetworkConnectorRef         string                             `json:"network_connector_ref"`
+	IngressNetworkConnectorRefs []string                           `json:"ingress_network_connector_refs"`
+	EgressNetworkConnectorRefs  []string                           `json:"egress_network_connector_refs"`
+	MaximumDurationSeconds      int32                              `json:"maximum_duration_seconds"`
+	IdlePolicy                  *runtimemicrovm.ProviderIdlePolicy `json:"idle_policy"`
 }
 
 func (s *maxDurationCapturingControllerServer) handler() http.Handler {
@@ -243,13 +314,7 @@ func (s *maxDurationCapturingControllerServer) handler() http.Handler {
 			body, err := io.ReadAll(r.Body)
 			_ = r.Body.Close()
 			if err == nil {
-				var payload struct {
-					MaximumDurationSeconds int32                              `json:"maximum_duration_seconds"`
-					IdlePolicy             *runtimemicrovm.ProviderIdlePolicy `json:"idle_policy"`
-				}
-				_ = json.Unmarshal(body, &payload)
-				*s.captured = payload.MaximumDurationSeconds
-				s.idle = payload.IdlePolicy
+				_ = json.Unmarshal(body, &s.payload)
 			}
 			r.Body = io.NopCloser(bytes.NewReader(body))
 		}
@@ -257,10 +322,12 @@ func (s *maxDurationCapturingControllerServer) handler() http.Handler {
 	})
 }
 
-func (s *maxDurationCapturingControllerServer) capturedMaxDuration() int32 { return *s.captured }
+func (s *maxDurationCapturingControllerServer) capturedMaxDuration() int32 {
+	return s.payload.MaximumDurationSeconds
+}
 
 func (s *maxDurationCapturingControllerServer) capturedIdlePolicy() *runtimemicrovm.ProviderIdlePolicy {
-	return s.idle
+	return s.payload.IdlePolicy
 }
 
 // TestH1_5_E2E_HarnessConfigCompleteGuard is a lightweight guard that the


### PR DESCRIPTION
## Milestone
Project 48 Legend M11 — #941 lab deploy blocker continuation/recovery.

## Classification
operational-reliability / framework-adjacent / bug-fix

## Surfaces affected
- `cdk/lib/hosted-genesis-microvm.ts`
- `cdk/test/lesser-host-stack-microvm.test.ts`
- `internal/config/config.go`
- `internal/config/config_test.go`
- `internal/controlplane/hosted_genesis_microvm_e2e_internal_test.go`

## Specialist walks referenced
- Governance rubric: repo-local gov-rubric run completed PASS (41 pass, 0 fail, 0 blocked).
- Provisioning / managed-update / release verification: none; no Consumer release verification path changed.
- Soul registry: none.
- Trust API / CSP / instance-auth: none.
- Framework: AppTheory v1.17.0 MicroVM CDK/runtime source inspected; this keeps AppTheoryMicrovmController/AppTheoryMicrovmImage plus runtime controller/provider/session lifecycle as substrate and does not add a raw AWS Lambda MicroVM provider/client or Host-local provider fork.

## Multi-tenant isolation impact
No tenant data plane changes. Control plane and ai-worker still receive no MicroVM IAM/session-registry access; they only call the governed AppTheory controller endpoint with the auth token loaded from the CDK-owned SSM SecureString at runtime.

## On-chain impact
None.

## Consumer impact
Allows the operator to retry the lab deploy blocked after PR #951 by reducing deployment Lambda environment size below Lambda's 4KB limit while preserving AppTheory run inputs: controller endpoint/auth source, image ref, ingress/egress connector refs, MaximumDurationSeconds, and IdlePolicy.

## Tasks
- [x] Adopt existing Host dirty patch for #941 lab deploy rollback.
- [x] Restore accidental verifier evidence deletion (`gov-infra/evidence/CMP-4-output.log`) and keep gov evidence out of the implementation diff.
- [x] Verify synthesized lab Lambda environment budgets and HostedGenesisMicrovmImage `STAGE=lab` guest env.

## Validation
- `git diff --check` — PASS
- `git ls-files '*.go' | xargs gofmt -l` — PASS (empty)
- `go test ./...` — PASS
- `go vet ./...` — PASS
- `cd cdk && npm run build && node --test --test-isolation=none dist/test/lesser-host-stack-microvm.test.js && npm run synth -- --context stage=lab` — PASS
- Env-size measurement from `cdk/cdk.out/lesser-host-lab.template.json` via `Buffer.byteLength(JSON.stringify(Environment.Variables), 'utf8')`:
  - `ControlPlaneApi8D3F9AC2`: 3466 bytes
  - `AiWorker1553A229`: 1136 bytes
  - `HostedGenesisMicrovmControllerControllerFunctionB458B1F3`: 2493 bytes
- `bash gov-infra/verifiers/gov-verify-rubric.sh` — PASS (41 pass, 0 fail, 0 blocked)

## Stage rollout plan (handoff after merge)
- [ ] Merge to `staging` after review/CI.
- [ ] Operator retries `theory app up --stage lab --execute` (no timeout).
- [ ] #941 remains open for live lab process-memory-canary proof after this deploy fix merges.

Refs #941
