### PR TITLE
fix(llm): strip Anthropic-unsupported declaration schema constraints

### DIFF
--- a/internal/ai/llm/anthropic_helpers.go
+++ b/internal/ai/llm/anthropic_helpers.go
@@ -109,19 +109,47 @@ func anthropicToolInputSchemaFromJSONSchema(schema map[string]any) anthropic.Too
 	return out
 }
 
+// anthropicUnsupportedSchemaKeywords maps a JSON-schema node type to constraint
+// keywords Anthropic strict custom tools reject with a 400 (e.g. "For 'array'
+// type, property 'maxItems' is not supported"). Stripping them only relaxes
+// provider-side validation: Host re-enforces these limits locally after the
+// provider responds (normalizeMintConversationDeclarationsDraft, hostedgenesis
+// five-body normalization/validation).
+const anthropicSchemaTypeObject = "object"
+
+var anthropicUnsupportedSchemaKeywords = map[string][]string{
+	"array":   {"minItems", "maxItems", "uniqueItems", "contains", "minContains", "maxContains"},
+	"string":  {"minLength", "maxLength"},
+	"number":  {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"},
+	"integer": {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"},
+}
+
+func anthropicSchemaKeywordUnsupported(nodeType, keyword string) bool {
+	for _, unsupported := range anthropicUnsupportedSchemaKeywords[nodeType] {
+		if keyword == unsupported {
+			return true
+		}
+	}
+	return false
+}
+
 func sanitizeAnthropicToolSchemaMap(schema map[string]any) map[string]any {
 	if len(schema) == 0 {
 		return nil
 	}
 	out := make(map[string]any, len(schema))
-	objType, _ := schema["type"].(string)
+	rawType, _ := schema["type"].(string)
+	nodeType := strings.ToLower(strings.TrimSpace(rawType))
 	for k, v := range schema {
-		if k == "additionalProperties" && strings.EqualFold(strings.TrimSpace(objType), "object") {
+		if k == "additionalProperties" && nodeType == anthropicSchemaTypeObject {
+			continue
+		}
+		if anthropicSchemaKeywordUnsupported(nodeType, k) {
 			continue
 		}
 		out[k] = sanitizeAnthropicToolSchemaValue(v)
 	}
-	if strings.EqualFold(strings.TrimSpace(objType), "object") {
+	if nodeType == anthropicSchemaTypeObject {
 		if _, ok := out["properties"]; !ok {
 			out["properties"] = map[string]any{}
 		}

--- a/internal/ai/llm/anthropic_helpers.go
+++ b/internal/ai/llm/anthropic_helpers.go
@@ -109,14 +109,14 @@ func anthropicToolInputSchemaFromJSONSchema(schema map[string]any) anthropic.Too
 	return out
 }
 
+const anthropicSchemaTypeObject = "object"
+
 // anthropicUnsupportedSchemaKeywords maps a JSON-schema node type to constraint
 // keywords Anthropic strict custom tools reject with a 400 (e.g. "For 'array'
 // type, property 'maxItems' is not supported"). Stripping them only relaxes
 // provider-side validation: Host re-enforces these limits locally after the
 // provider responds (normalizeMintConversationDeclarationsDraft, hostedgenesis
 // five-body normalization/validation).
-const anthropicSchemaTypeObject = "object"
-
 var anthropicUnsupportedSchemaKeywords = map[string][]string{
 	"array":   {"minItems", "maxItems", "uniqueItems", "contains", "minContains", "maxContains"},
 	"string":  {"minLength", "maxLength"},

--- a/internal/ai/llm/mint_conversation_internal_test.go
+++ b/internal/ai/llm/mint_conversation_internal_test.go
@@ -316,6 +316,19 @@ func TestMintConversationDeclarationsProviderParityUsesStrictAnthropicTool(t *te
 			t.Fatalf("Anthropic strict tool request missing %s: %s", want, anthropicRequest)
 		}
 	}
+	assertProviderParityArrayConstraintHandling(t, openAIRequest, anthropicRequest)
+}
+
+func assertProviderParityArrayConstraintHandling(t *testing.T, openAIRequest, anthropicRequest string) {
+	t.Helper()
+	if !strings.Contains(openAIRequest, `"maxItems"`) {
+		t.Fatalf("OpenAI strict schema request should keep maxItems: %s", openAIRequest)
+	}
+	for _, banned := range []string{`"maxItems"`, `"minItems"`} {
+		if strings.Contains(anthropicRequest, banned) {
+			t.Fatalf("Anthropic strict tool request must strip %s (Anthropic rejects it for custom tools): %s", banned, anthropicRequest)
+		}
+	}
 }
 
 func TestMintConversationDeclarationsAnthropicRejectsTruncatedStopReason(t *testing.T) {
@@ -530,6 +543,98 @@ func TestAnthropicToolInputSchemaSanitizesPermissiveAdditionalProperties(t *test
 
 	selfDescription := requireSchemaMap(t, props, "selfDescription")
 	assertSchemaBool(t, selfDescription, "additionalProperties", false)
+}
+
+func TestAnthropicToolInputSchemaStripsUnsupportedConstraints(t *testing.T) {
+	t.Parallel()
+
+	contract := hostedgenesis.FiveBodyDeclarationContract()
+	for name, schema := range map[string]map[string]any{
+		"v1": mintConversationDeclarationsJSONSchemaV1(),
+		"v2": mintConversationDeclarationsJSONSchemaV2(contract),
+	} {
+		source, err := json.Marshal(schema)
+		if err != nil {
+			t.Fatalf("%s: marshal source schema: %v", name, err)
+		}
+		if !strings.Contains(string(source), `"maxItems"`) {
+			t.Fatalf("%s: expected source schema to keep maxItems for the OpenAI strict path, got %s", name, source)
+		}
+
+		raw, err := json.Marshal(anthropicToolInputSchemaFromJSONSchema(schema))
+		if err != nil {
+			t.Fatalf("%s: marshal anthropic schema: %v", name, err)
+		}
+		for _, keyword := range []string{`"maxItems"`, `"minItems"`, `"maxLength"`, `"minLength"`} {
+			if strings.Contains(string(raw), keyword) {
+				t.Fatalf("%s: expected anthropic schema to strip %s (Anthropic strict custom tools reject it), got %s", name, keyword, raw)
+			}
+		}
+		if !strings.Contains(string(raw), `"additionalProperties":false`) {
+			t.Fatalf("%s: expected anthropic schema to keep additionalProperties=false, got %s", name, raw)
+		}
+
+		after, err := json.Marshal(schema)
+		if err != nil {
+			t.Fatalf("%s: re-marshal source schema: %v", name, err)
+		}
+		if string(after) != string(source) {
+			t.Fatalf("%s: sanitizing must not mutate the shared provider schema:\nbefore=%s\nafter=%s", name, source, after)
+		}
+	}
+}
+
+func TestSanitizeAnthropicToolSchemaMapKeepsConstraintLikePropertyNames(t *testing.T) {
+	t.Parallel()
+
+	schema := map[string]any{
+		"type":                 "object",
+		"additionalProperties": false,
+		"properties": map[string]any{
+			"maxItems":  map[string]any{"type": "integer", "minimum": 0, "maximum": 10},
+			"maxLength": map[string]any{"type": "string", "minLength": 1, "maxLength": 4},
+			"tags": map[string]any{
+				"type":     "array",
+				"minItems": 1,
+				"maxItems": 3,
+				"items":    map[string]any{"type": "string", "maxLength": 12},
+			},
+		},
+		"required": []string{"maxItems", "maxLength", "tags"},
+	}
+
+	out := sanitizeAnthropicToolSchemaMap(schema)
+	props := requireSchemaMap(t, out, "properties")
+
+	maxItemsProp := requireSchemaMap(t, props, "maxItems")
+	for _, stripped := range []string{"minimum", "maximum"} {
+		if _, exists := maxItemsProp[stripped]; exists {
+			t.Fatalf("expected integer constraint %q stripped, got %#v", stripped, maxItemsProp)
+		}
+	}
+
+	maxLengthProp := requireSchemaMap(t, props, "maxLength")
+	for _, stripped := range []string{"minLength", "maxLength"} {
+		if _, exists := maxLengthProp[stripped]; exists {
+			t.Fatalf("expected string constraint %q stripped, got %#v", stripped, maxLengthProp)
+		}
+	}
+
+	tags := requireSchemaMap(t, props, "tags")
+	for _, stripped := range []string{"minItems", "maxItems"} {
+		if _, exists := tags[stripped]; exists {
+			t.Fatalf("expected array constraint %q stripped, got %#v", stripped, tags)
+		}
+	}
+	items := requireSchemaMap(t, tags, "items")
+	if _, exists := items["maxLength"]; exists {
+		t.Fatalf("expected nested string constraint stripped, got %#v", items)
+	}
+
+	required, ok := out["required"].([]string)
+	if !ok || len(required) != 3 {
+		t.Fatalf("expected constraint-like property names preserved in required, got %#v", out["required"])
+	}
 }
 
 func TestExtractJSONObjectFromText(t *testing.T) {


### PR DESCRIPTION
## Summary

- Strip Anthropic-unsupported JSON-schema constraint keywords from the schema sent to Anthropic strict custom tools.
- Preserve OpenAI strict schema behavior and Host-side post-provider validation.
- Add tests for the live `maxItems` failure mode and sanitizer invariants.

Closes #953

## Factory live-failure evidence

A fresh `juniper-sol` hosted genesis on 2026-07-20 failed with `declaration_extraction_failed` after the MicroVM turn completed. Factory replayed the declaration extraction shape locally without recording transcript/key material and reproduced:

```text
Anthropic 400: tools.0.custom: For 'array' type, property 'maxItems' is not supported
```

The MicroVM lifecycle was not the failing component; the provider-specific tool schema was.

## Validation

```text
go test ./internal/ai/llm ./cmd/hosted-genesis-microvm-workload
ok  github.com/equaltoai/lesser-host/internal/ai/llm  (cached)
ok  github.com/equaltoai/lesser-host/cmd/hosted-genesis-microvm-workload  (cached)

go test -count=1 ./internal/ai/llm -run 'Test(MintConversationDeclarationsProviderParityUsesStrictAnthropicTool|AnthropicToolInputSchemaStripsUnsupportedConstraints|SanitizeAnthropicToolSchemaMapKeepsConstraintLikePropertyNames|NormalizeMintConversationDeclarationsDraft)'
ok  github.com/equaltoai/lesser-host/internal/ai/llm  0.006s
```

## Safety / non-goals

- No AWS commands or live mutation in this PR.
- No provider secret or raw transcript content committed or logged.
- No deployment.
- No model switch.
- No AppTheory/TableTheory replacement or MicroVM orchestration change.
