### PR TITLE
fix(hosted-genesis): preserve exact candidate edits

### DIFF
--- a/docs/contracts/hosted-genesis-conversation.md
+++ b/docs/contracts/hosted-genesis-conversation.md
@@ -88,7 +88,9 @@ discipline, boundaries, and soul. Accepted tool submissions are normalized and v
 under tenant/session/turn/candidate guards through TableTheory. Invalid submissions return machine-readable
 section/path/code errors and retry only the current section. Every tool payload must repeat the exact current
 `candidateRevision` and `candidateHash`; missing, stale, mismatched, or unknown payload fields fail closed before any
-candidate mutation. The VM actor never rebuilds the candidate from a transcript.
+candidate mutation. Host rejects section fields above their published limits so provider repair can compress the
+current section; it never silently truncates owner-supplied declaration content. The VM actor never rebuilds the
+candidate from a transcript.
 
 The owner review is rendered deterministically as a stable human header plus a byte-counted, delimited copy of the
 exact canonical JSON. The canonical block is reversible byte-for-byte without a provider and losslessly exposes every
@@ -97,7 +99,9 @@ derived boundaries, refusals, and adversarial-review evidence. `candidate_hash` 
 `review_hash` separately authenticates the complete `review_text`. The full lossless payload is authoritative at
 `declaration_candidate.review.review_text`; clients must not substitute a potentially truncated transcript-message
 projection. Structural affirmation binds the candidate revision/hash and review hash; any edit invalidates the prior
-review and affirmation. Finalization revalidates and publishes the exact canonical candidate bytes. **No provider request occurs after affirmation.**
+review and affirmation, advances the revision, and reopens only the selected section. The revised section regenerates
+the deterministic review and bindings; actions from the prior review fail closed. Finalization revalidates and
+publishes the exact canonical candidate bytes. **No provider request occurs after affirmation.**
 The fifth accepted tool also needs no provider-generated review prose: Host projects the stored deterministic review
 directly, including after process/VM recovery from the accepted review checkpoint.
 When the actor finalizes, it advances the same durable conversation to `declaration_ready` with `produced_declarations`

--- a/internal/ai/llm/mint_conversation_phase_tools.go
+++ b/internal/ai/llm/mint_conversation_phase_tools.go
@@ -16,7 +16,15 @@ import (
 	"github.com/equaltoai/lesser-host/internal/store/models"
 )
 
-const maxMintConversationPhaseToolRounds = 4
+const (
+	maxMintConversationPhaseToolRounds        = 4
+	mintConversationPhaseSummaryMaxRunes      = 2400
+	mintConversationPhaseNotesMaxItems        = 8
+	mintConversationPhaseNoteMaxRunes         = 480
+	mintConversationPhaseRefusalsMinItems     = 3
+	mintConversationPhaseRefusalsMaxItems     = 8
+	mintConversationPhaseRefusalFieldMaxRunes = 480
+)
 
 // MintConversationPhaseInput exposes exactly one typed declaration tool for
 // the candidate's current section. Revision/hash are durable preconditions,
@@ -269,6 +277,20 @@ func finishAnthropicMintConversationPhaseText(message *anthropic.Message, text s
 
 func mintConversationPhaseSystemPrompt(in MintConversationPhaseInput) string {
 	toolName, _ := hostedgenesis.DeclarationToolForSection(in.Section)
+	limits := fmt.Sprintf(
+		"summary at most %d Unicode characters; notes at most %d items of at most %d Unicode characters each",
+		mintConversationPhaseSummaryMaxRunes,
+		mintConversationPhaseNotesMaxItems,
+		mintConversationPhaseNoteMaxRunes,
+	)
+	if in.Section == hostedgenesis.DeclarationSectionSoul {
+		limits += fmt.Sprintf(
+			"; refusals %d-%d items with bypass, invariant, and closestSafePath each at most %d Unicode characters",
+			mintConversationPhaseRefusalsMinItems,
+			mintConversationPhaseRefusalsMaxItems,
+			mintConversationPhaseRefusalFieldMaxRunes,
+		)
+	}
 	return strings.TrimSpace(in.SystemPrompt) + fmt.Sprintf(`
 
 Typed declaration construction protocol:
@@ -276,8 +298,10 @@ Typed declaration construction protocol:
 - Current candidate revision: %d.
 - Current candidate hash: %s.
 - Use only %s when the owner's answers support a complete current section, and copy the exact current revision/hash into its candidateRevision/candidateHash fields.
+- Current-section payload limits: %s.
+- Preserve every owner-supplied item for the current section. Compress wording before the tool call when necessary; Host rejects over-limit fields instead of truncating them.
 - The tool result is authoritative. On a machine-readable section/path/code error, revise only this section and call the same tool again.
-- Do not reconstruct accepted sections from the transcript and do not claim finalization.`, in.Section, in.CandidateRevision, in.CandidateHash, toolName)
+- Do not reconstruct accepted sections from the transcript and do not claim finalization.`, in.Section, in.CandidateRevision, in.CandidateHash, toolName, limits)
 }
 
 func openAIMintConversationPhaseTool(section hostedgenesis.DeclarationSection) openai.ChatCompletionToolParam {
@@ -332,7 +356,7 @@ func fiveBodySectionSchema() map[string]any {
 	return map[string]any{
 		"type": "object", "additionalProperties": false,
 		"properties": map[string]any{
-			"summary": map[string]any{"type": "string", "maxLength": 2400},
+			"summary": map[string]any{"type": "string", "maxLength": mintConversationPhaseSummaryMaxRunes},
 			"notes":   fiveBodyNotesSchema(),
 		},
 		"required": []string{"summary", "notes"},
@@ -341,8 +365,8 @@ func fiveBodySectionSchema() map[string]any {
 
 func fiveBodyNotesSchema() map[string]any {
 	return map[string]any{
-		"type": "array", "minItems": 0, "maxItems": 8,
-		"items": map[string]any{"type": "string", "maxLength": 480},
+		"type": "array", "minItems": 0, "maxItems": mintConversationPhaseNotesMaxItems,
+		"items": map[string]any{"type": "string", "maxLength": mintConversationPhaseNoteMaxRunes},
 	}
 }
 
@@ -350,14 +374,14 @@ func soulPhaseSectionSchema() map[string]any {
 	return map[string]any{
 		"type": "object", "additionalProperties": false,
 		"properties": map[string]any{
-			"summary": map[string]any{"type": "string", "maxLength": 2400}, "notes": fiveBodyNotesSchema(),
+			"summary": map[string]any{"type": "string", "maxLength": mintConversationPhaseSummaryMaxRunes}, "notes": fiveBodyNotesSchema(),
 			"refusals": map[string]any{
-				"type": "array", "minItems": 3, "maxItems": 8,
+				"type": "array", "minItems": mintConversationPhaseRefusalsMinItems, "maxItems": mintConversationPhaseRefusalsMaxItems,
 				"items": map[string]any{
 					"type": "object", "additionalProperties": false,
 					"properties": map[string]any{
-						"bypass": map[string]any{"type": "string", "maxLength": 480}, "invariant": map[string]any{"type": "string", "maxLength": 480},
-						"closestSafePath": map[string]any{"type": "string", "maxLength": 480},
+						"bypass": map[string]any{"type": "string", "maxLength": mintConversationPhaseRefusalFieldMaxRunes}, "invariant": map[string]any{"type": "string", "maxLength": mintConversationPhaseRefusalFieldMaxRunes},
+						"closestSafePath": map[string]any{"type": "string", "maxLength": mintConversationPhaseRefusalFieldMaxRunes},
 					}, "required": []string{"bypass", "invariant", "closestSafePath"},
 				},
 			},

--- a/internal/ai/llm/mint_conversation_phase_tools_test.go
+++ b/internal/ai/llm/mint_conversation_phase_tools_test.go
@@ -192,6 +192,58 @@ func TestMintConversationPhaseToolsOpenAIAnthropicParity(t *testing.T) {
 	}
 }
 
+func TestMintConversationPhasePromptRejectsTruncationForBothProviderPaths(t *testing.T) {
+	input := MintConversationPhaseInput{
+		SystemPrompt: "five-body contract", Section: hostedgenesis.DeclarationSectionBoundaries,
+		CandidateRevision: 5, CandidateHash: "sha256:" + strings.Repeat("a", 64), SourceTurnID: "turn-review-edit",
+	}
+	prompt := mintConversationPhaseSystemPrompt(input)
+	for _, required := range []string{
+		"summary at most 2400 Unicode characters",
+		"notes at most 8 items of at most 480 Unicode characters each",
+		"Preserve every owner-supplied item for the current section.",
+		"Host rejects over-limit fields instead of truncating them.",
+		hostedgenesis.DeclarationToolBoundariesPut,
+	} {
+		if !strings.Contains(prompt, required) {
+			t.Fatalf("shared OpenAI/Anthropic section prompt missing %q: %s", required, prompt)
+		}
+	}
+	input.Section = hostedgenesis.DeclarationSectionSoul
+	if prompt := mintConversationPhaseSystemPrompt(input); !strings.Contains(prompt, "refusals 3-8 items") ||
+		!strings.Contains(prompt, "each at most 480 Unicode characters") {
+		t.Fatalf("shared soul prompt omits exact refusal limits: %s", prompt)
+	}
+}
+
+func TestMintConversationPhaseToolSchemaCarriesCanonicalSectionLimits(t *testing.T) {
+	section := mintConversationPhaseToolSchema(hostedgenesis.DeclarationSectionBoundaries)
+	properties := requireSchemaMap(t, section, "properties")
+	body := requireSchemaMap(t, properties, "section")
+	bodyProperties := requireSchemaMap(t, body, "properties")
+	summary := requireSchemaMap(t, bodyProperties, "summary")
+	notes := requireSchemaMap(t, bodyProperties, "notes")
+	note := requireSchemaMap(t, notes, "items")
+	if summary["maxLength"] != mintConversationPhaseSummaryMaxRunes ||
+		notes["maxItems"] != mintConversationPhaseNotesMaxItems ||
+		note["maxLength"] != mintConversationPhaseNoteMaxRunes {
+		t.Fatalf("section tool schema limits drifted: %#v", body)
+	}
+
+	soulSchema := mintConversationPhaseToolSchema(hostedgenesis.DeclarationSectionSoul)
+	soulProperties := requireSchemaMap(t, soulSchema, "properties")
+	soulBody := requireSchemaMap(t, soulProperties, "section")
+	refusals := requireSchemaMap(t, requireSchemaMap(t, soulBody, "properties"), "refusals")
+	refusalProperties := requireSchemaMap(t, requireSchemaMap(t, refusals, "items"), "properties")
+	if refusals["minItems"] != mintConversationPhaseRefusalsMinItems ||
+		refusals["maxItems"] != mintConversationPhaseRefusalsMaxItems ||
+		requireSchemaMap(t, refusalProperties, "bypass")["maxLength"] != mintConversationPhaseRefusalFieldMaxRunes ||
+		requireSchemaMap(t, refusalProperties, "invariant")["maxLength"] != mintConversationPhaseRefusalFieldMaxRunes ||
+		requireSchemaMap(t, refusalProperties, "closestSafePath")["maxLength"] != mintConversationPhaseRefusalFieldMaxRunes {
+		t.Fatalf("soul tool schema limits drifted: %#v", soulBody)
+	}
+}
+
 func assertMintConversationPhaseToolParity(t *testing.T, section hostedgenesis.DeclarationSection) {
 	t.Helper()
 	wantName, ok := hostedgenesis.DeclarationToolForSection(section)

--- a/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
+++ b/internal/controlplane/handlers_soul_mint_conversation_async_internal_test.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -172,6 +173,106 @@ func TestHostedGenesisStructuralAffirmationQueuesProviderFreeFinalizationTurn(t 
 		t.Fatalf("unexpected err: %v", err)
 	}
 	assertProviderFreeFinalizationAccepted(t, resp, dispatcher)
+}
+
+func TestHostedGenesisExactAdvertisedBoundariesEditQueuesOnlySelectedSection(t *testing.T) {
+	tdb := newMintConversationTestDB()
+	s := newMintConversationServer(tdb)
+	reg := mintConversationHandleReg()
+	t.Setenv("ANTHROPIC_API_KEY", "anthropic-test-key")
+	dispatcher := stubHostedGenesisMicroVMDispatcher(t, s)
+	now := time.Date(2026, 7, 23, 11, 30, 30, 0, time.UTC)
+	candidate := controlplaneCompleteReviewCandidate(t, hostedgenesis.DeclarationCandidateBinding{
+		InstanceSlug: soulInstanceBootstrapTestInstanceSlug, RegistrationID: reg.ID, AgentID: reg.AgentID,
+		ConversationID: mintConversationTestConversationID, SourceTurnID: "turn-live-review", Model: "anthropic:claude-sonnet-4-6",
+	}, now)
+	candidate = liveShapedNullCapabilitiesReviewCandidate(t, candidate)
+
+	expectMintConversationInstanceKey(t, tdb, mintConversationInstanceReadTestRawKey, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationRegistration(t, tdb, reg)
+	stubSoulInstanceBootstrapDomainAndInstance(t, tdb, reg.DomainNormalized, soulInstanceBootstrapTestInstanceSlug)
+	stubMintConversationIdentity(t, tdb, nil, theoryErrors.ErrItemNotFound)
+	conv := models.SoulAgentMintConversation{
+		AgentID: reg.AgentID, ConversationID: mintConversationTestConversationID, Model: "anthropic:claude-sonnet-4-6",
+		Messages: encodeMintConversationBlob(`[{"role":"user","content":"define yourself"},{"role":"assistant","content":` + jsonString(candidate.Review.ReviewText) + `}]`),
+		Status:   models.SoulMintConversationStatusAssistantTurnReady, LatestTurnID: "turn-live-review", CreatedAt: now,
+	}
+	tdb.qConv.On("First", mock.AnythingOfType("*models.SoulAgentMintConversation")).Return(nil).Run(func(args mock.Arguments) {
+		target, ok := args.Get(0).(*models.SoulAgentMintConversation)
+		if !ok {
+			t.Fatal("conversation mock target has unexpected type")
+		}
+		*target = conv
+	}).Once()
+	tdb.qHosted.On("First", mock.AnythingOfType("*models.HostedGenesisSession")).Return(nil).Run(func(args mock.Arguments) {
+		session := hostedGenesisSessionFromLegacyConversationForTest(tdb, conv)
+		session.DeclarationCandidate = candidate.Clone()
+		session.CandidateRevision = candidate.Revision
+		session.CandidateHash = candidate.CandidateHash
+		session.CandidatePhase = string(candidate.Phase)
+		target, ok := args.Get(0).(*models.HostedGenesisSession)
+		if !ok {
+			t.Fatal("hosted genesis session mock target has unexpected type")
+		}
+		*target = session
+	}).Once()
+	expectSoulInstanceMintConversationDebit(t, tdb, reg.AgentID, false)
+
+	resp, err := s.handleSoulInstanceMintConversation(newSoulInstanceBootstrapContext(
+		map[string]string{"authorization": "Bearer " + mintConversationInstanceReadTestRawKey},
+		mustMarshalJSON(t, soulMintConversationRequest{
+			ConversationID: mintConversationTestConversationID,
+			Message:        "Revise boundaries: retain the owner-supplied B10 and regenerate the exact review.",
+			CandidateAction: &hostedgenesis.DeclarationCandidateAction{
+				Action: "edit", Section: hostedgenesis.DeclarationSectionBoundaries,
+				CandidateRevision: candidate.Revision, CandidateHash: candidate.CandidateHash, ReviewHash: candidate.Review.ReviewHash,
+			},
+		}),
+		map[string]string{"id": reg.ID},
+	))
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Status != http.StatusAccepted {
+		t.Fatalf("exact advertised edit returned %d: %#v", resp.Status, resp)
+	}
+	var out hostedGenesisConversationResponse
+	if err := json.Unmarshal(resp.Body, &out); err != nil {
+		t.Fatal(err)
+	}
+	got := out.Conversation.DeclarationCandidate
+	if got == nil || got.Phase != hostedgenesis.DeclarationCandidatePhaseSection ||
+		got.CurrentSection != hostedgenesis.DeclarationSectionBoundaries || got.Revision != candidate.Revision+1 ||
+		len(got.CompletedSections) != 5 || got.Review != nil {
+		t.Fatalf("exact edit did not reopen only boundaries: %#v", got)
+	}
+	if dispatcher.queueCalls != 1 || dispatcher.calls != 0 || dispatcher.lastQueue.TurnID == "" {
+		t.Fatalf("edit must queue one AppTheory MicroVM actor turn only: %#v", dispatcher)
+	}
+}
+
+func liveShapedNullCapabilitiesReviewCandidate(t *testing.T, candidate *hostedgenesis.DeclarationCandidate) *hostedgenesis.DeclarationCandidate {
+	t.Helper()
+	legacy := candidate.Clone()
+	legacy.Capabilities = nil
+	legacy.CanonicalJSON = strings.Replace(legacy.CanonicalJSON, `"capabilities":[]`, `"capabilities":null`, 1)
+	if legacy.CanonicalJSON == candidate.CanonicalJSON {
+		t.Fatal("review fixture did not create the deployed null capabilities shape")
+	}
+	canonicalDigest := sha256.Sum256([]byte(legacy.CanonicalJSON))
+	legacy.CandidateHash = fmt.Sprintf("sha256:%x", canonicalDigest)
+	reviewText := fmt.Sprintf(
+		"Hosted Genesis owner review\n\nReview the exact canonical JSON below. Structural affirmation binds this review text, these canonical bytes, and the candidate revision.\n\nCandidate revision: %d\nCandidate hash: %s\nCanonical JSON byte length: %d\n-----BEGIN HOSTED GENESIS CANONICAL JSON-----\n%s\n-----END HOSTED GENESIS CANONICAL JSON-----\n",
+		legacy.Revision, legacy.CandidateHash, len(legacy.CanonicalJSON), legacy.CanonicalJSON,
+	)
+	reviewDigest := sha256.Sum256([]byte(reviewText))
+	legacy.Review.CandidateHash = legacy.CandidateHash
+	legacy.Review.ReviewHash = fmt.Sprintf("sha256:%x", reviewDigest)
+	legacy.Review.ReviewText = reviewText
+	if err := legacy.Validate(); err == nil {
+		t.Fatal("deployed null-capabilities representation should be invalid before exact edit repair")
+	}
+	return legacy
 }
 
 func assertControlplaneReviewCandidateCanAffirm(t *testing.T, candidate *hostedgenesis.DeclarationCandidate, turnID string, now time.Time) {

--- a/internal/hostedgenesis/candidate.go
+++ b/internal/hostedgenesis/candidate.go
@@ -193,7 +193,7 @@ type DeclarationCandidate struct {
 	CompletedSections []DeclarationSection              `json:"completed_sections,omitempty"`
 	FiveBodies        FiveBodyDeclaration               `json:"five_bodies"`
 	SelfDescription   soul.SelfDescriptionV2            `json:"self_description"`
-	Capabilities      []soul.CapabilityV2               `json:"capabilities,omitempty"`
+	Capabilities      []soul.CapabilityV2               `json:"capabilities"`
 	Transparency      DeclarationTransparency           `json:"transparency"`
 	Revision          int64                             `json:"revision"`
 	SectionHashes     map[string]string                 `json:"section_hashes,omitempty"`
@@ -469,6 +469,9 @@ func applyDeclarationToolPayload(updated *DeclarationCandidate, section Declarat
 	if bindingIssue := declarationPayloadBindingIssue(section, payload.CandidateRevision, payload.CandidateHash, request); bindingIssue != nil {
 		return []DeclarationValidationIssue{*bindingIssue}
 	}
+	if boundsIssue := declarationSectionPayloadBoundsIssue(section, payload.Section); boundsIssue != nil {
+		return []DeclarationValidationIssue{*boundsIssue}
+	}
 	setCandidateSection(updated, section, normalizeFiveBodySection(payload.Section))
 	if err := validateDeclarationSection(section, updated.FiveBodies); err != nil {
 		return []DeclarationValidationIssue{issueForCode(section, DeclarationValidationCodeFromError(err))}
@@ -485,6 +488,9 @@ func applyDeclarationSoulPayload(updated *DeclarationCandidate, request Declarat
 	if bindingIssue := declarationPayloadBindingIssue(section, payload.CandidateRevision, payload.CandidateHash, request); bindingIssue != nil {
 		return []DeclarationValidationIssue{*bindingIssue}
 	}
+	if boundsIssue := declarationSoulPayloadBoundsIssue(payload.Section); boundsIssue != nil {
+		return []DeclarationValidationIssue{*boundsIssue}
+	}
 	updated.FiveBodies.Soul = NormalizeFiveBodyDeclaration(FiveBodyDeclaration{Soul: payload.Section}).Soul
 	updated.SelfDescription = normalizeCandidateSelfDescription(payload.SelfDescription, updated.FiveBodies, updated.Model)
 	updated.Transparency = normalizeCandidateTransparency(payload.Transparency)
@@ -494,6 +500,45 @@ func applyDeclarationSoulPayload(updated *DeclarationCandidate, request Declarat
 		issues = append(issues, issueForCode(section, DeclarationValidationCodeFromError(err)))
 	}
 	return issues
+}
+
+func declarationSectionPayloadBoundsIssue(section DeclarationSection, payload FiveBodySection) *DeclarationValidationIssue {
+	path := "fiveBodies." + string(section)
+	if utf8.RuneCountInString(strings.TrimSpace(payload.Summary)) > fiveBodySummaryMaxRunes {
+		value := issue(section, path+".summary", DeclarationCodeInvalid)
+		return &value
+	}
+	if len(payload.Notes) > fiveBodyEvidenceMaxItems {
+		value := issue(section, path+".notes", DeclarationCodeInvalid)
+		return &value
+	}
+	for _, note := range payload.Notes {
+		if utf8.RuneCountInString(strings.TrimSpace(note)) > fiveBodyRefusalFieldMaxRunes {
+			value := issue(section, path+".notes", DeclarationCodeInvalid)
+			return &value
+		}
+	}
+	return nil
+}
+
+func declarationSoulPayloadBoundsIssue(payload FiveBodySoulBody) *DeclarationValidationIssue {
+	section := DeclarationSectionSoul
+	if boundsIssue := declarationSectionPayloadBoundsIssue(section, FiveBodySection{Summary: payload.Summary, Notes: payload.Notes}); boundsIssue != nil {
+		return boundsIssue
+	}
+	if len(payload.Refusals) > fiveBodyRefusalsMaxItems {
+		value := issue(section, "fiveBodies.soul.refusals", DeclarationCodeSoulRefusalsBad)
+		return &value
+	}
+	for _, refusal := range payload.Refusals {
+		if utf8.RuneCountInString(strings.TrimSpace(refusal.Bypass)) > fiveBodyRefusalFieldMaxRunes ||
+			utf8.RuneCountInString(strings.TrimSpace(refusal.Invariant)) > fiveBodyRefusalFieldMaxRunes ||
+			utf8.RuneCountInString(strings.TrimSpace(refusal.ClosestSafePath)) > fiveBodyRefusalFieldMaxRunes {
+			value := issue(section, "fiveBodies.soul.refusals", DeclarationCodeSoulRefusalsBad)
+			return &value
+		}
+	}
+	return nil
 }
 
 func declarationPayloadBindingIssue(section DeclarationSection, revision *int64, candidateHash string, request DeclarationToolRequest) *DeclarationValidationIssue {
@@ -823,10 +868,11 @@ func (c *DeclarationCandidate) refreshCanonical() error {
 	doc := canonicalProducedDeclarations{
 		SchemaVersion: c.SchemaVersion, GuidanceVersion: c.GuidanceVersion,
 		FiveBodies: c.FiveBodies, SelfDescription: c.SelfDescription,
-		Capabilities: append([]soul.CapabilityV2(nil), c.Capabilities...),
+		Capabilities: make([]soul.CapabilityV2, len(c.Capabilities)),
 		Boundaries:   FiveBodyBoundariesDeterministic(c.FiveBodies.Soul.Refusals, c.EstablishedAt),
 		Transparency: c.Transparency,
 	}
+	copy(doc.Capabilities, c.Capabilities)
 	if len(c.CompletedSections) == len(declarationSectionOrder) {
 		review, err := BuildAdversarialReviewV2(c.FiveBodies)
 		if err != nil {
@@ -864,6 +910,9 @@ func FiveBodyBoundariesDeterministic(refusals []FiveBodyRefusalRule, established
 func ValidateDeclarationCandidateComplete(candidate *DeclarationCandidate) error {
 	if candidate == nil || len(candidate.CompletedSections) != len(declarationSectionOrder) {
 		return NewDeclarationValidationError(DeclarationCodeInvalid)
+	}
+	if candidate.Capabilities == nil {
+		return NewDeclarationValidationError(DeclarationCodeCapabilities)
 	}
 	if err := ValidateFiveBodyDeclaration(candidate.FiveBodies); err != nil {
 		return err
@@ -995,7 +1044,16 @@ func applyDeclarationCandidateEdit(candidate *DeclarationCandidate, action Decla
 	candidate.Affirmation = nil
 	candidate.SourceTurnID = strings.TrimSpace(sourceTurnID)
 	candidate.UpdatedAt = now.UTC()
-	return nil
+	// capabilities is a required array in the v2 contract. Early M11 rows could
+	// lose an intentionally empty slice through an omitempty persistence round
+	// trip even though the stored soul-section hash was computed over [].
+	// Structural edit invalidates the old review, so Host can safely restore the
+	// required empty representation before regenerating canonical bytes. Any
+	// unrelated section/hash corruption still fails candidate validation.
+	if candidate.Capabilities == nil {
+		candidate.Capabilities = []soul.CapabilityV2{}
+	}
+	return candidate.refreshCanonical()
 }
 
 func applyDeclarationCandidateAffirmation(candidate *DeclarationCandidate, action DeclarationCandidateAction, sourceTurnID string, now time.Time) error {
@@ -1069,6 +1127,9 @@ func validateDeclarationCandidateCore(c *DeclarationCandidate) error {
 	}
 	if c.Revision < 0 || len(c.ToolRecords) > MaxDeclarationToolRecords || len(c.ProviderAttempts) > MaxDeclarationProviderAttempts {
 		return errors.New("declaration candidate revision is invalid")
+	}
+	if c.Capabilities == nil {
+		return errors.New("declaration candidate capabilities array is required")
 	}
 	return nil
 }

--- a/internal/hostedgenesis/candidate_test.go
+++ b/internal/hostedgenesis/candidate_test.go
@@ -2,9 +2,11 @@ package hostedgenesis
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/equaltoai/lesser-host/internal/soul"
 )
@@ -27,6 +29,92 @@ func TestDeclarationCandidateMalformedSectionCanBeRevisedInPlace(t *testing.T) {
 	}, time.Unix(102, 0))
 	if !good.result.Accepted || good.next == nil || good.next.Revision != 1 || good.next.CurrentSection != DeclarationSectionPhilosophy {
 		t.Fatalf("same-section revision did not advance: %#v", good)
+	}
+}
+
+func TestDeclarationCandidateRejectsOverLimitBoundariesWithoutTruncation(t *testing.T) {
+	candidate := testDeclarationCandidate(t)
+	overLimit := strings.Repeat("B1-B9 owner boundary evidence. ", 96) +
+		"B10. Fail closed, preserve exact evidence, and require an owner-approved recovery plan."
+	if utf8.RuneCountInString(overLimit) <= fiveBodySummaryMaxRunes {
+		t.Fatal("over-limit B10 fixture does not cross the canonical summary bound")
+	}
+	got := applyCandidatePayload(t, candidate, DeclarationToolIdentityPut, "identity", declarationSectionPayload{Section: testFiveBody().Identity}, time.Unix(101, 0))
+	candidate = got.next
+	candidate = acceptCandidateSection(t, candidate, DeclarationToolPhilosophyPut, "philosophy", declarationSectionPayload{Section: testFiveBody().Philosophy}, 2)
+	candidate = acceptCandidateSection(t, candidate, DeclarationToolDisciplinePut, "discipline", declarationSectionPayload{Section: testFiveBody().Discipline}, 3)
+
+	rejected := applyCandidatePayload(t, candidate, DeclarationToolBoundariesPut, "boundaries-over-limit", declarationSectionPayload{
+		Section: FiveBodySection{Summary: overLimit, Notes: []string{"B1-B10 remain owner supplied."}},
+	}, time.Unix(104, 0))
+	if rejected.next != nil || rejected.result.Accepted || len(rejected.result.Errors) != 1 {
+		t.Fatalf("over-limit boundaries were not rejected intact: %#v", rejected)
+	}
+	if got := rejected.result.Errors[0]; got.Section != DeclarationSectionBoundaries || got.Path != "fiveBodies.boundaries.summary" || got.Code != DeclarationCodeInvalid {
+		t.Fatalf("unexpected over-limit repair issue: %#v", got)
+	}
+	if candidate.Revision != 3 || candidate.CurrentSection != DeclarationSectionBoundaries || candidate.FiveBodies.Boundaries.Summary != "" {
+		t.Fatalf("over-limit rejection mutated candidate: %#v", candidate)
+	}
+}
+
+func TestDeclarationCandidateRejectsAllLossyProviderBounds(t *testing.T) {
+	longField := strings.Repeat("x", fiveBodyRefusalFieldMaxRunes+1)
+	tests := []struct {
+		name string
+		got  *DeclarationValidationIssue
+		path string
+		code DeclarationValidationCode
+	}{
+		{
+			name: "too many notes",
+			got: declarationSectionPayloadBoundsIssue(DeclarationSectionIdentity, FiveBodySection{
+				Summary: "identity", Notes: make([]string, fiveBodyEvidenceMaxItems+1),
+			}),
+			path: "fiveBodies.identity.notes", code: DeclarationCodeInvalid,
+		},
+		{
+			name: "over-limit note",
+			got: declarationSectionPayloadBoundsIssue(DeclarationSectionPhilosophy, FiveBodySection{
+				Summary: "philosophy", Notes: []string{longField},
+			}),
+			path: "fiveBodies.philosophy.notes", code: DeclarationCodeInvalid,
+		},
+		{
+			name: "too many refusals",
+			got: declarationSoulPayloadBoundsIssue(FiveBodySoulBody{
+				Summary: "soul", Refusals: make([]FiveBodyRefusalRule, fiveBodyRefusalsMaxItems+1),
+			}),
+			path: "fiveBodies.soul.refusals", code: DeclarationCodeSoulRefusalsBad,
+		},
+		{
+			name: "over-limit bypass",
+			got: declarationSoulPayloadBoundsIssue(FiveBodySoulBody{
+				Summary: "soul", Refusals: []FiveBodyRefusalRule{{Bypass: longField}},
+			}),
+			path: "fiveBodies.soul.refusals", code: DeclarationCodeSoulRefusalsBad,
+		},
+		{
+			name: "over-limit invariant",
+			got: declarationSoulPayloadBoundsIssue(FiveBodySoulBody{
+				Summary: "soul", Refusals: []FiveBodyRefusalRule{{Invariant: longField}},
+			}),
+			path: "fiveBodies.soul.refusals", code: DeclarationCodeSoulRefusalsBad,
+		},
+		{
+			name: "over-limit safe path",
+			got: declarationSoulPayloadBoundsIssue(FiveBodySoulBody{
+				Summary: "soul", Refusals: []FiveBodyRefusalRule{{ClosestSafePath: longField}},
+			}),
+			path: "fiveBodies.soul.refusals", code: DeclarationCodeSoulRefusalsBad,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.got == nil || test.got.Path != test.path || test.got.Code != test.code {
+				t.Fatalf("lossy provider bound did not fail closed: %#v", test.got)
+			}
+		})
 	}
 }
 
@@ -150,6 +238,76 @@ func TestDeclarationCandidateReviewAffirmationAndDeterministicBytes(t *testing.T
 	}
 	assertCandidateEditInvalidatesReview(t, candidate)
 	assertCandidateFinalizationIsDeterministic(t, affirmed, beforeJSON, beforeHash)
+}
+
+func TestDeclarationCandidateExactBoundariesEditRegeneratesReviewAndStalesOldActions(t *testing.T) {
+	reviewed := completeTestDeclarationCandidate(t)
+	oldAction := DeclarationCandidateAction{
+		Action: "edit", Section: DeclarationSectionBoundaries,
+		CandidateRevision: reviewed.Revision, CandidateHash: reviewed.CandidateHash, ReviewHash: reviewed.Review.ReviewHash,
+	}
+	edited, err := ApplyDeclarationCandidateAction(reviewed, oldAction, "turn-boundaries-edit", time.Unix(301, 0))
+	if err != nil {
+		t.Fatalf("exact advertised boundaries edit rejected: %v", err)
+	}
+	if edited.Phase != DeclarationCandidatePhaseSection || edited.CurrentSection != DeclarationSectionBoundaries ||
+		edited.Revision != 6 || len(edited.CompletedSections) != len(declarationSectionOrder) || edited.Review != nil {
+		t.Fatalf("review did not reopen exact boundaries section: %#v", edited)
+	}
+
+	revisedSummary := "B1. Owner authority. B2. External effects. B3. Destructive work. B4. Identity truthfulness. " +
+		"B5. Privacy and secrets. B6. Access controls. B7. Harm prevention. B8. Fraud refusal. " +
+		"B9. High-consequence advice. B10. Fail closed, preserve evidence, and require a recovery plan."
+	regenerated := acceptCandidateSection(t, edited, DeclarationToolBoundariesPut, "boundaries-revision", declarationSectionPayload{
+		Section: FiveBodySection{Summary: revisedSummary, Notes: []string{"All owner-supplied B1-B10 limits are retained."}},
+	}, 7)
+	if regenerated.Phase != DeclarationCandidatePhaseReview || regenerated.Review == nil || regenerated.Revision != 7 {
+		t.Fatalf("revised boundaries did not regenerate deterministic review: %#v", regenerated)
+	}
+	if regenerated.CandidateHash == reviewed.CandidateHash || regenerated.Review.ReviewHash == oldAction.ReviewHash ||
+		!strings.Contains(regenerated.Review.ReviewText, "B10. Fail closed") {
+		t.Fatalf("regenerated review did not bind the revised B1-B10 content: %#v", regenerated.Review)
+	}
+	if _, err := ApplyDeclarationCandidateAction(regenerated, oldAction, "turn-stale-action", time.Unix(302, 0)); err == nil {
+		t.Fatal("action from the prior review did not fail closed")
+	}
+}
+
+func TestDeclarationCandidateExactEditRepairsRequiredEmptyCapabilitiesRepresentation(t *testing.T) {
+	payload := testSoulPayload()
+	payload.Capabilities = []soul.CapabilityV2{}
+	reviewed := completeTestDeclarationCandidateWithSoul(t, payload)
+	legacy := reviewed.Clone()
+	legacy.Capabilities = nil
+	legacy.CanonicalJSON = strings.Replace(legacy.CanonicalJSON, `"capabilities":[]`, `"capabilities":null`, 1)
+	if legacy.CanonicalJSON == reviewed.CanonicalJSON {
+		t.Fatal("empty-capability fixture did not create the deployed null representation")
+	}
+	legacy.CandidateHash = hashText(legacy.CanonicalJSON)
+	reviewText := fmt.Sprintf(
+		"Hosted Genesis owner review\n\nReview the exact canonical JSON below. Structural affirmation binds this review text, these canonical bytes, and the candidate revision.\n\nCandidate revision: %d\nCandidate hash: %s\n%s%d\n%s\n%s\n%s\n",
+		legacy.Revision, legacy.CandidateHash, declarationOwnerReviewCanonicalLength, len(legacy.CanonicalJSON),
+		declarationOwnerReviewCanonicalBegin, legacy.CanonicalJSON, declarationOwnerReviewCanonicalEnd,
+	)
+	legacy.Review.CandidateHash = legacy.CandidateHash
+	legacy.Review.ReviewHash = hashText(reviewText)
+	legacy.Review.ReviewText = reviewText
+	if err := legacy.Validate(); err == nil {
+		t.Fatal("deployed null-capability representation should fail the required-array invariant")
+	}
+
+	action := DeclarationCandidateAction{
+		Action: "edit", Section: DeclarationSectionBoundaries,
+		CandidateRevision: legacy.Revision, CandidateHash: legacy.CandidateHash, ReviewHash: legacy.Review.ReviewHash,
+	}
+	edited, err := ApplyDeclarationCandidateAction(legacy, action, "turn-live-shaped-edit", time.Unix(301, 0))
+	if err != nil {
+		t.Fatalf("exact live-shaped edit did not repair the required empty array: %v", err)
+	}
+	if edited.Capabilities == nil || edited.Revision != 6 || edited.Phase != DeclarationCandidatePhaseSection ||
+		!strings.Contains(edited.CanonicalJSON, `"capabilities":[]`) || strings.Contains(edited.CanonicalJSON, `"capabilities":null`) {
+		t.Fatalf("required empty capability array was not restored: %#v", edited)
+	}
 }
 
 func assertCandidateRejectsStaleAffirmation(t *testing.T, candidate *DeclarationCandidate) {
@@ -336,13 +494,17 @@ func testDeclarationCandidate(t *testing.T) *DeclarationCandidate {
 }
 
 func completeTestDeclarationCandidate(t *testing.T) *DeclarationCandidate {
+	return completeTestDeclarationCandidateWithSoul(t, testSoulPayload())
+}
+
+func completeTestDeclarationCandidateWithSoul(t *testing.T, soulPayload declarationSoulPayload) *DeclarationCandidate {
 	t.Helper()
 	candidate := testDeclarationCandidate(t)
 	candidate = acceptCandidateSection(t, candidate, DeclarationToolIdentityPut, "identity", declarationSectionPayload{Section: testFiveBody().Identity}, 1)
 	candidate = acceptCandidateSection(t, candidate, DeclarationToolPhilosophyPut, "philosophy", declarationSectionPayload{Section: testFiveBody().Philosophy}, 2)
 	candidate = acceptCandidateSection(t, candidate, DeclarationToolDisciplinePut, "discipline", declarationSectionPayload{Section: testFiveBody().Discipline}, 3)
 	candidate = acceptCandidateSection(t, candidate, DeclarationToolBoundariesPut, "boundaries", declarationSectionPayload{Section: testFiveBody().Boundaries}, 4)
-	return acceptCandidateSection(t, candidate, DeclarationToolSoulPut, "soul", testSoulPayload(), 5)
+	return acceptCandidateSection(t, candidate, DeclarationToolSoulPut, "soul", soulPayload, 5)
 }
 
 func acceptCandidateSection(t *testing.T, candidate *DeclarationCandidate, tool, callID string, payload any, wantRevision int64) *DeclarationCandidate {

--- a/internal/hostedgenesis/declarations_test.go
+++ b/internal/hostedgenesis/declarations_test.go
@@ -33,7 +33,7 @@ func TestMergeDeclaredCapabilitiesRejectsInvalidDeclaredNames(t *testing.T) {
 }
 
 func TestValidateAndNormalizeProducedCapabilitiesAllowsEmptyAndSanitizesInvalid(t *testing.T) {
-	if got, err := ValidateAndNormalizeProducedCapabilities(nil); err != nil || len(got) != 0 {
+	if got, err := ValidateAndNormalizeProducedCapabilities(nil); err != nil || got == nil || len(got) != 0 {
 		t.Fatalf("expected empty produced capabilities to be valid, got %#v %v", got, err)
 	}
 	if got, err := ValidateAndNormalizeProducedCapabilities([]soul.CapabilityV2{{Capability: "simulacrum.hosted-first-default", Scope: "retired", ClaimLevel: "self-declared"}}); err != nil || len(got) != 0 {

--- a/internal/store/hosted_genesis_sessions_test.go
+++ b/internal/store/hosted_genesis_sessions_test.go
@@ -192,6 +192,10 @@ func TestStore_TypedCandidateFinalizationPublishesExactBytesOnce(t *testing.T) {
 	require.NoError(t, db.Model(conversation).Create())
 	current, err := st.GetHostedGenesisSession(ctx, session.InstanceSlug, session.ConversationID)
 	require.NoError(t, err)
+	require.NotNil(t, current.DeclarationCandidate.Capabilities)
+	require.Empty(t, current.DeclarationCandidate.Capabilities)
+	require.Contains(t, current.DeclarationCandidate.CanonicalJSON, `"capabilities":[]`)
+	require.NoError(t, current.DeclarationCandidate.Validate())
 	canonicalJSON, canonicalHash := current.DeclarationCandidate.CanonicalJSON, current.DeclarationCandidate.CandidateHash
 	finalized, err := hostedgenesis.FinalizeDeclarationCandidate(current.DeclarationCandidate, current.LatestTurnID, current.DeclarationCandidate.Affirmation.AffirmedAt)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

- fail closed on over-limit Hosted Genesis section payloads instead of silently truncating owner-supplied declaration content
- preserve the v2 contract's required top-level `capabilities` array through TableTheory persistence and repair the legacy empty-array representation only during an exact owner-authorized edit
- keep exact review/action bindings while reopening the selected section and regenerating the deterministic review on the revised section
- advertise the actual typed tool limits identically to the OpenAI and Anthropic AppTheory MicroVM paths

## Root cause

The live review row had originally hashed the soul section with an explicitly empty capabilities array. The candidate field used `omitempty`; TableTheory therefore omitted the empty slice on persistence, and readback reconstructed it as nil. The next exact structural edit validated the soul-section hash against `null` rather than `[]` and returned 409 before any provider dispatch. Keeping all five sections completed while reopening one section is an intentional valid re-review state and was not the conflict.

Separately, section normalization truncated a summary above 2,400 Unicode characters before validation, which could discard a trailing B10 while retaining a B1-B10 claim. The provider now receives the exact limits and Host rejects an over-limit payload for bounded same-section repair rather than truncating it.

## Validation

- exact live-shaped candidate/review edit replay
- focused Hosted Genesis, LLM, Control plane, and store regressions
- `go build ./...`
- `go test ./...`
- `go vet ./...`
- governed-package `golangci-lint` (0 issues)
- web lint, typecheck, 286 tests, build, contract sync, CSP checks
- CDK 71 tests and lab synth
- Solidity lint, 198 Hardhat tests, full production-contract Slither sweep
- exact-head Gov-infra rubric: PASS 43/43, fail 0, blocked 0

## Framework path

No framework bypass or replacement. The implementation retains AppTheory v1.17.0 `runtime/microvm` controller/registry/provider lifecycle and TableTheory v2.0.3 guarded `UpdateWithBuilder` / `IfExists` / `AtVersion` / `Condition` persistence.

Refs #977. Project 48 / #940.
