### PR TITLE
chore: ignore remaining materialized agent roots after namespace publish v13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 .claude/
 .codex/
 .agents/
+.kimi-code/
+.theorymcp/
 opencode.json
 contracts/venv/
 .DS_Store


### PR DESCRIPTION
## Summary

Adds `.kimi-code/` and `.theorymcp/` to `.gitignore`, joining the existing untracked materialized roots per the fleet convention of 2026-08-01 (namespace publish v13). Nothing materialized was tracked in this repo, so this is `.gitignore`-only.

- 1 file, 2 insertions
- Held local commit `f4757b04e11ca7833dd152af38a0d15b3afd54e5`, GPG-signed, DCO clean

## Validation

- `git status` confirms no tracked materialized files; ignore rules cover future installs