### PR TITLE
fix(store): register usage metering dedup model + registry guard

### DIFF
--- a/internal/store/db.go
+++ b/internal/store/db.go
@@ -37,6 +37,7 @@ func registeredModels() []any {
 		&models.TipHostState{},
 		&models.TipRegistryOperation{},
 		&models.UsageLedgerEntry{},
+		&models.UsageMeteringDedup{},
 		&models.User{},
 		&models.OperatorSession{},
 		&models.InstanceBudgetMonth{},

--- a/internal/store/model_registry_test.go
+++ b/internal/store/model_registry_test.go
@@ -1,0 +1,173 @@
+package store
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const lesserHostModulePath = "github.com/equaltoai/lesser-host"
+
+var tableNameRegistryExclusions = map[string]string{
+	// hostedGenesisFailureShapeProbe is an any-typed compatibility reader for
+	// one legacy attribute shape, not a durable model written by the control plane.
+	lesserHostModulePath + "/internal/store.hostedGenesisFailureShapeProbe": "compatibility-only read probe",
+}
+
+func TestRegisteredModelsCoverProductionTableNameTypes(t *testing.T) {
+	repositoryRoot := findRepositoryRoot(t)
+	productionTypes := findProductionTableNameTypes(t, repositoryRoot)
+	registeredTypes := make(map[string]struct{}, len(registeredModels()))
+	for _, registered := range registeredModels() {
+		modelType := reflect.TypeOf(registered)
+		if modelType.Kind() == reflect.Pointer {
+			modelType = modelType.Elem()
+		}
+		registeredTypes[qualifiedTypeName(modelType.PkgPath(), modelType.Name())] = struct{}{}
+	}
+
+	var failures []string
+	for typeName, reason := range tableNameRegistryExclusions {
+		if strings.TrimSpace(reason) == "" {
+			failures = append(failures, fmt.Sprintf("registry exclusion %s has no reason", typeName))
+		}
+		if _, ok := productionTypes[typeName]; !ok {
+			failures = append(failures, fmt.Sprintf("registry exclusion %s is stale", typeName))
+		}
+	}
+	for typeName, location := range productionTypes {
+		if _, ok := registeredTypes[typeName]; ok {
+			continue
+		}
+		if _, ok := tableNameRegistryExclusions[typeName]; ok {
+			continue
+		}
+		failures = append(failures, fmt.Sprintf(
+			"%s at %s implements TableName() but is neither registered nor explicitly excluded",
+			typeName,
+			location,
+		))
+	}
+
+	sort.Strings(failures)
+	for _, failure := range failures {
+		t.Error(failure)
+	}
+}
+
+func findRepositoryRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get working directory: %v", err)
+	}
+	for {
+		if _, statErr := os.Stat(filepath.Join(dir, "go.mod")); statErr == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("find repository root: go.mod not found")
+		}
+		dir = parent
+	}
+}
+
+func findProductionTableNameTypes(t *testing.T, repositoryRoot string) map[string]string {
+	t.Helper()
+	types := make(map[string]string)
+	internalRoot := filepath.Join(repositoryRoot, "internal")
+	err := filepath.WalkDir(internalRoot, func(path string, entry fs.DirEntry, walkErr error) error {
+		return recordProductionTableNameTypes(repositoryRoot, path, entry, walkErr, types)
+	})
+	if err != nil {
+		t.Fatalf("sweep production TableName methods: %v", err)
+	}
+	return types
+}
+
+func recordProductionTableNameTypes(repositoryRoot string, path string, entry fs.DirEntry, walkErr error, types map[string]string) error {
+	if walkErr != nil {
+		return walkErr
+	}
+	if entry.IsDir() || filepath.Ext(path) != ".go" || strings.HasSuffix(path, "_test.go") {
+		return nil
+	}
+
+	fileSet := token.NewFileSet()
+	parsed, err := parser.ParseFile(fileSet, path, nil, 0)
+	if err != nil {
+		return fmt.Errorf("parse %s: %w", path, err)
+	}
+	packagePath, err := productionPackagePath(repositoryRoot, path)
+	if err != nil {
+		return err
+	}
+	relativeFile, err := filepath.Rel(repositoryRoot, path)
+	if err != nil {
+		return fmt.Errorf("resolve source path for %s: %w", path, err)
+	}
+
+	for _, declaration := range parsed.Decls {
+		method, ok := declaration.(*ast.FuncDecl)
+		if !ok || !isTableNameMethod(method) {
+			continue
+		}
+		receiverName, ok := receiverTypeName(method.Recv.List[0].Type)
+		if !ok {
+			return fmt.Errorf("resolve TableName receiver in %s", path)
+		}
+		position := fileSet.Position(method.Pos())
+		types[qualifiedTypeName(packagePath, receiverName)] = fmt.Sprintf("%s:%d", filepath.ToSlash(relativeFile), position.Line)
+	}
+	return nil
+}
+
+func productionPackagePath(repositoryRoot string, path string) (string, error) {
+	relativeDir, err := filepath.Rel(repositoryRoot, filepath.Dir(path))
+	if err != nil {
+		return "", fmt.Errorf("resolve package path for %s: %w", path, err)
+	}
+	return lesserHostModulePath + "/" + filepath.ToSlash(relativeDir), nil
+}
+
+func isTableNameMethod(method *ast.FuncDecl) bool {
+	if method.Recv == nil || len(method.Recv.List) != 1 || method.Name.Name != "TableName" {
+		return false
+	}
+	if method.Type.Params != nil && method.Type.Params.NumFields() != 0 {
+		return false
+	}
+	if method.Type.Results == nil || method.Type.Results.NumFields() != 1 {
+		return false
+	}
+	result, ok := method.Type.Results.List[0].Type.(*ast.Ident)
+	return ok && result.Name == "string"
+}
+
+func receiverTypeName(expression ast.Expr) (string, bool) {
+	switch receiver := expression.(type) {
+	case *ast.Ident:
+		return receiver.Name, true
+	case *ast.StarExpr:
+		return receiverTypeName(receiver.X)
+	case *ast.IndexExpr:
+		return receiverTypeName(receiver.X)
+	case *ast.IndexListExpr:
+		return receiverTypeName(receiver.X)
+	default:
+		return "", false
+	}
+}
+
+func qualifiedTypeName(packagePath string, typeName string) string {
+	return packagePath + "." + typeName
+}


### PR DESCRIPTION
Closes #1017

## Summary

`UsageMeteringDedup` — production-used (`internal/controlplane/handlers_comm_webhooks.go`) but missing from `registeredModels()` — is now registered (`internal/store/db.go:40`), restoring registry-driven persistence-audit coverage (76 → 77 models). Adds a source-sweeping guard test (`internal/store/model_registry_test.go`, +173) requiring every production `TableName()` type to be registered or explicitly excluded as a non-model.

## Decision record (implementer's consumer analysis)

- Sole direct consumer of the registry: `tabletheory.LambdaInit` (`internal/store/db.go:105`), configured `AutoMigrate: false` — reflect-parses and caches model metadata only; **no DynamoDB table creation or migration**.
- The shared state table stays CDK-owned (`cdk/lib/lesser-host-stack.ts:93-101`).
- Runtime impact: one additional valid model pre-registered during cold start. Existing test fixtures and seed behavior unchanged.
- The AST sweep found 78 production `TableName()` types: 77 registered + 1 documented exclusion (`hostedGenesisFailureShapeProbe`, a compatibility-only read probe).

## Validation

- **Mutation proof:** removing only the `UsageMeteringDedup` registration fails the guard (`MUTATION_RC=1`); restoring it passes.
- gofmt 858+1 files clean; `go build ./...` 68 packages; `go vet ./...` clean; full `go test ./...` 58 tested packages, 0 failures; `golangci-lint run`: exactly the 2 known vendored `flatted` gocognit false positives, 0 host-code diagnostics; gov-infra rubric PASS 43/43.

Surfaced by claude's round-2 adversarial review of #1016 (recorded there as a suggested follow-up; per fleet convention discovered gaps are fixed in-wave, not backlogged).
